### PR TITLE
Extract URL pane and add tab navigation

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -12,6 +12,7 @@ import { useEnvironments } from "./useEnvironments"
 import { filestore } from "../filestore"
 import { cycleFocus, hintForFocus, type Focus } from "./focus"
 import { HelpOverlay } from "./HelpOverlay"
+import { UrlPane } from "./UrlPane"
 
 type SaveState =
   | { kind: "idle" }
@@ -55,9 +56,16 @@ export function App({
     draft.draft,
     draft,
     {
-      enabled: () => focusRef.current === "request" && !helpVisibleRef.current,
-      onEnterEditBrowse: () => setFocus("request"),
+      enabled: () =>
+        (focusRef.current === "request" || focusRef.current === "url") &&
+        !helpVisibleRef.current,
+      onEnterEditBrowse: () => {
+        if (focusRef.current === "sidebar") {
+          setFocus("request")
+        }
+      },
       blocked: () => helpVisibleRef.current,
+      initialField: () => (focusRef.current === "url" ? "url" : "headers"),
     },
   )
   sidebarEnabledRef.current = !isActive && focus === "sidebar"
@@ -183,6 +191,13 @@ export function App({
             focused={focus === "sidebar"}
           />
           <box style={{ flexDirection: "column", flexGrow: 1 }}>
+            <UrlPane
+              request={draft.draft}
+              editState={editState}
+              editValue={editValue}
+              setEditValue={setEditValue}
+              focused={focus === "url"}
+            />
             <RequestPane
               request={draft.draft}
               editState={editState}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -1,13 +1,12 @@
 import { TextAttributes } from "@opentui/core"
 import type { Request } from "../schema"
 import {
-  methodColor,
   formatHeaders,
   formatParams,
   formatBody,
   formatAuth,
 } from "./formatRequest"
-import type { EditState, FieldKind } from "./editMode"
+import type { EditState } from "./editMode"
 import type { UseRequestDraftResult } from "./useRequestDraft"
 
 interface Props {
@@ -19,18 +18,6 @@ interface Props {
   focused?: boolean
 }
 
-function isFieldActive(editState: EditState, field: FieldKind): boolean {
-  return editState.mode !== "inactive" && editState.cursor.field === field
-}
-
-function labelActive(
-  editState: EditState,
-  field: FieldKind,
-): { fg: string; attributes?: number } {
-  if (!isFieldActive(editState, field)) return { fg: "#888" }
-  return { fg: "#000", attributes: TextAttributes.INVERSE }
-}
-
 export function RequestPane({
   request,
   editState,
@@ -39,7 +26,6 @@ export function RequestPane({
   draft,
   focused = false,
 }: Props) {
-  const methodFg = request ? methodColor(request.method) : ""
   const headers = request ? formatHeaders(request.headers) : []
   const params = request ? formatParams(request.params) : []
   const body = request ? formatBody(request.body) : ""
@@ -47,6 +33,15 @@ export function RequestPane({
   const title = `Request${draft.isDirty ? "*" : ""}`
   const inEdit = editState.mode === "editing"
   const browseActive = editState.mode === "browsing"
+
+  const activeTab = editState.cursor.field === "url" ? "headers" : editState.cursor.field
+
+  const tabs = [
+    { id: "headers", label: "Headers" },
+    { id: "params", label: "Params" },
+    { id: "body", label: "Body" },
+    { id: "auth", label: "Auth" },
+  ] as const
 
   return (
     <box
@@ -62,174 +57,181 @@ export function RequestPane({
     >
       {request ? (
         <>
-          <text
-            fg={methodFg}
-            attributes={
-              browseActive && editState.cursor.field === "url"
-                ? TextAttributes.INVERSE
-                : 0
-            }
-          >
-            {request.method}{" "}
-          </text>
-          {inEdit && editState.cursor.field === "url" ? (
-            <input
-              value={editValue}
-              onInput={setEditValue}
-              backgroundColor="#222"
-              focusedBackgroundColor="#333"
-              textColor="#fff"
-              cursorColor="#0f0"
-              focused
-            />
-          ) : (
-            <text
-              fg={methodFg}
-              attributes={
-                browseActive && editState.cursor.field === "url"
-                  ? TextAttributes.INVERSE
-                  : 0
-              }
-            >
-              {request.url}
-            </text>
-          )}
-
-          <text {...labelActive(editState, "headers")}>Headers</text>
-          {headers.length === 0 &&
-          !(browseActive && editState.cursor.field === "headers") ? (
-            <text fg="#888">{"  (none)"}</text>
-          ) : (
-            <>
-              {headers.map((line, i) => {
-                const cursorHere =
-                  browseActive &&
-                  editState.cursor.field === "headers" &&
-                  !editState.cursor.addingRow &&
-                  editState.cursor.row === i
-                const editingHere =
-                  inEdit &&
-                  editState.cursor.field === "headers" &&
-                  !editState.cursor.addingRow &&
-                  editState.cursor.row === i
-                if (editingHere) {
-                  return (
-                    <input
-                      key={i}
-                      value={editValue}
-                      onInput={setEditValue}
-                      backgroundColor="#222"
-                      focusedBackgroundColor="#333"
-                      textColor="#fff"
-                      cursorColor="#0f0"
-                      focused
-                    />
-                  )
-                }
-                return (
-                  <text
-                    key={i}
-                    fg="#888"
-                    attributes={cursorHere ? TextAttributes.INVERSE : 0}
-                  >
-                    {"  " + line}
-                  </text>
-                )
-              })}
-              {browseActive && editState.cursor.field === "headers" && (
-                <text
-                  fg="#888"
-                  attributes={
-                    editState.cursor.addingRow ? TextAttributes.INVERSE : 0
-                  }
-                >
-                  {"  [+] add header"}
+          <box style={{ flexDirection: "row", gap: 2 }}>
+            {tabs.map((tab) => {
+              const isSelected = activeTab === tab.id
+              const fg = isSelected ? "#000" : "#888"
+              const attributes = isSelected ? TextAttributes.INVERSE : 0
+              return (
+                <text key={tab.id} fg={fg} attributes={attributes}>
+                  {`  ${tab.label}  `}
                 </text>
-              )}
-            </>
-          )}
+              )
+            })}
+          </box>
 
-          <text {...labelActive(editState, "params")}>Params</text>
-          {params.length === 0 &&
-          !(browseActive && editState.cursor.field === "params") ? (
-            <text fg="#888">{"  (none)"}</text>
-          ) : (
-            <>
-              {params.map((line, i) => {
-                const cursorHere =
-                  browseActive &&
-                  editState.cursor.field === "params" &&
-                  !editState.cursor.addingRow &&
-                  editState.cursor.row === i
-                const editingHere =
-                  inEdit &&
-                  editState.cursor.field === "params" &&
-                  !editState.cursor.addingRow &&
-                  editState.cursor.row === i
-                if (editingHere) {
-                  return (
-                    <input
-                      key={i}
-                      value={editValue}
-                      onInput={setEditValue}
-                      backgroundColor="#222"
-                      focusedBackgroundColor="#333"
-                      textColor="#fff"
-                      cursorColor="#0f0"
-                      focused
-                    />
-                  )
-                }
-                return (
+          <box style={{ flexDirection: "column", flexGrow: 1, paddingTop: 1, gap: 1 }}>
+            {activeTab === "headers" && (
+              <>
+                {headers.length === 0 &&
+                !(browseActive && editState.cursor.field === "headers") ? (
+                  <text fg="#888">{"  (none)"}</text>
+                ) : (
+                  <>
+                    {headers.map((line, i) => {
+                      const cursorHere =
+                        browseActive &&
+                        editState.cursor.field === "headers" &&
+                        !editState.cursor.addingRow &&
+                        editState.cursor.row === i
+                      const editingHere =
+                        inEdit &&
+                        editState.cursor.field === "headers" &&
+                        !editState.cursor.addingRow &&
+                        editState.cursor.row === i
+                      if (editingHere) {
+                        return (
+                          <input
+                            key={i}
+                            value={editValue}
+                            onInput={setEditValue}
+                            backgroundColor="#222"
+                            focusedBackgroundColor="#333"
+                            textColor="#fff"
+                            cursorColor="#0f0"
+                            focused
+                          />
+                        )
+                      }
+                      return (
+                        <text
+                          key={i}
+                          fg="#888"
+                          attributes={cursorHere ? TextAttributes.INVERSE : 0}
+                        >
+                          {"  " + line}
+                        </text>
+                      )
+                    })}
+                    {browseActive && editState.cursor.field === "headers" && (
+                      <text
+                        fg="#888"
+                        attributes={
+                          editState.cursor.addingRow ? TextAttributes.INVERSE : 0
+                        }
+                      >
+                        {"  [+] add header"}
+                      </text>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+
+            {activeTab === "params" && (
+              <>
+                {params.length === 0 &&
+                !(browseActive && editState.cursor.field === "params") ? (
+                  <text fg="#888">{"  (none)"}</text>
+                ) : (
+                  <>
+                    {params.map((line, i) => {
+                      const cursorHere =
+                        browseActive &&
+                        editState.cursor.field === "params" &&
+                        !editState.cursor.addingRow &&
+                        editState.cursor.row === i
+                      const editingHere =
+                        inEdit &&
+                        editState.cursor.field === "params" &&
+                        !editState.cursor.addingRow &&
+                        editState.cursor.row === i
+                      if (editingHere) {
+                        return (
+                          <input
+                            key={i}
+                            value={editValue}
+                            onInput={setEditValue}
+                            backgroundColor="#222"
+                            focusedBackgroundColor="#333"
+                            textColor="#fff"
+                            cursorColor="#0f0"
+                            focused
+                          />
+                        )
+                      }
+                      return (
+                        <text
+                          key={i}
+                          fg="#888"
+                          attributes={cursorHere ? TextAttributes.INVERSE : 0}
+                        >
+                          {"  " + line}
+                        </text>
+                      )
+                    })}
+                    {browseActive && editState.cursor.field === "params" && (
+                      <text
+                        fg="#888"
+                        attributes={
+                          editState.cursor.addingRow ? TextAttributes.INVERSE : 0
+                        }
+                      >
+                        {"  [+] add param"}
+                      </text>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+
+            {activeTab === "body" && (
+              <>
+                {inEdit && editState.cursor.field === "body" ? (
+                  <input
+                    value={editValue}
+                    onInput={setEditValue}
+                    backgroundColor="#222"
+                    focusedBackgroundColor="#333"
+                    textColor="#fff"
+                    cursorColor="#0f0"
+                    focused
+                  />
+                ) : body === "" ? (
+                  <text fg="#888">{"  (none)"}</text>
+                ) : (
                   <text
-                    key={i}
-                    fg="#888"
-                    attributes={cursorHere ? TextAttributes.INVERSE : 0}
+                    attributes={
+                      browseActive && editState.cursor.field === "body"
+                        ? TextAttributes.INVERSE
+                        : 0
+                    }
                   >
-                    {"  " + line}
+                    {body}
                   </text>
-                )
-              })}
-              {browseActive && editState.cursor.field === "params" && (
-                <text
-                  fg="#888"
-                  attributes={
-                    editState.cursor.addingRow ? TextAttributes.INVERSE : 0
-                  }
-                >
-                  {"  [+] add param"}
-                </text>
-              )}
-            </>
-          )}
+                )}
+              </>
+            )}
 
-          <text {...labelActive(editState, "body")}>Body</text>
-          {inEdit && editState.cursor.field === "body" ? (
-            <input
-              value={editValue}
-              onInput={setEditValue}
-              backgroundColor="#222"
-              focusedBackgroundColor="#333"
-              textColor="#fff"
-              cursorColor="#0f0"
-              focused
-            />
-          ) : body === "" ? (
-            <text fg="#888">{"  (none)"}</text>
-          ) : (
-            <text
-              attributes={
-                browseActive && editState.cursor.field === "body"
-                  ? TextAttributes.INVERSE
-                  : 0
-              }
-            >
-              {body}
-            </text>
-          )}
+            {activeTab === "auth" && (
+              <>
+                {auth === "" ? (
+                  <text fg="#888">{"  (none)"}</text>
+                ) : (
+                  <text
+                    attributes={
+                      browseActive && editState.cursor.field === "auth"
+                        ? TextAttributes.INVERSE
+                        : 0
+                    }
+                  >
+                    {"  " + auth}
+                  </text>
+                )}
+              </>
+            )}
+          </box>
 
-          <text fg="#888">Auth</text>
-          <text fg="#888">{"  " + auth}</text>
           <text fg="#888">[s] Send</text>
         </>
       ) : (

--- a/src/ui/UrlPane.tsx
+++ b/src/ui/UrlPane.tsx
@@ -1,0 +1,68 @@
+import { TextAttributes } from "@opentui/core"
+import type { Request } from "../schema"
+import { methodColor } from "./formatRequest"
+import type { EditState } from "./editMode"
+
+interface Props {
+  request: Request | null
+  editState: EditState
+  editValue: string
+  setEditValue: (v: string) => void
+  focused?: boolean
+}
+
+export function UrlPane({
+  request,
+  editState,
+  editValue,
+  setEditValue,
+  focused = false,
+}: Props) {
+  const methodFg = request ? methodColor(request.method) : ""
+  const inEdit = editState.mode === "editing" && editState.cursor.field === "url"
+  const browseActive = editState.mode === "browsing" && editState.cursor.field === "url"
+
+  return (
+    <box
+      style={{
+        border: true,
+        borderColor: focused ? "#61dafb" : undefined,
+        flexDirection: "row",
+        padding: 1,
+        height: 3,
+      }}
+      title={focused ? "▸ URL" : "URL"}
+    >
+      {request ? (
+        <>
+          <text
+            fg={methodFg}
+            attributes={browseActive ? TextAttributes.INVERSE : 0}
+          >
+            {request.method}{" "}
+          </text>
+          {inEdit ? (
+            <input
+              value={editValue}
+              onInput={setEditValue}
+              backgroundColor="#222"
+              focusedBackgroundColor="#333"
+              textColor="#fff"
+              cursorColor="#0f0"
+              focused
+            />
+          ) : (
+            <text
+              fg={methodFg}
+              attributes={browseActive ? TextAttributes.INVERSE : 0}
+            >
+              {request.url}
+            </text>
+          )}
+        </>
+      ) : (
+        <text fg="#888">(no request selected)</text>
+      )}
+    </box>
+  )
+}

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,4 +1,4 @@
-export type FieldKind = "url" | "headers" | "params" | "body"
+export type FieldKind = "url" | "headers" | "params" | "body" | "auth"
 export type Mode = "inactive" | "browsing" | "editing"
 
 export interface FieldCursor {
@@ -18,21 +18,25 @@ export interface SectionRowCount {
   params: number
 }
 
-const FIELD_ORDER: FieldKind[] = ["url", "headers", "params", "body"]
+const REQUEST_FIELDS: FieldKind[] = ["headers", "params", "body", "auth"]
 
 export function initialEditState(): EditState {
   return {
     mode: "inactive",
-    cursor: { field: "url", row: -1, addingRow: false },
+    cursor: { field: "headers", row: -1, addingRow: false },
     editingRow: -1,
   }
 }
 
-export function enterEditBrowse(prev: EditState): EditState {
+export function enterEditBrowse(
+  prev: EditState,
+  initialField: FieldKind = "headers",
+  counts: SectionRowCount = { headers: 0, params: 0 },
+): EditState {
   if (prev.mode !== "inactive") return prev
   return {
     mode: "browsing",
-    cursor: { field: "url", row: -1, addingRow: false },
+    cursor: cursorForField(initialField, counts),
     editingRow: -1,
   }
 }
@@ -42,15 +46,11 @@ export function exitEditBrowse(prev: EditState): EditState {
   return { ...prev, mode: "inactive" }
 }
 
-function fieldIndex(field: FieldKind): number {
-  return FIELD_ORDER.indexOf(field)
-}
-
 function cursorForField(
   field: FieldKind,
   counts: SectionRowCount,
 ): FieldCursor {
-  if (field === "url" || field === "body") {
+  if (field === "url" || field === "body" || field === "auth") {
     return { field, row: -1, addingRow: false }
   }
   const count = field === "headers" ? counts.headers : counts.params
@@ -66,9 +66,14 @@ export function moveFieldCursor(
   counts: SectionRowCount,
 ): EditState {
   if (prev.mode !== "browsing") return prev
-  const idx = fieldIndex(prev.cursor.field)
-  const nextIdx = (idx + delta + FIELD_ORDER.length) % FIELD_ORDER.length
-  const nextField = FIELD_ORDER[nextIdx]!
+  const currentField = prev.cursor.field
+  if (currentField === "url") return prev
+
+  const idx = REQUEST_FIELDS.indexOf(currentField)
+  if (idx === -1) return prev
+
+  const nextIdx = (idx + delta + REQUEST_FIELDS.length) % REQUEST_FIELDS.length
+  const nextField = REQUEST_FIELDS[nextIdx]!
   return {
     ...prev,
     cursor: cursorForField(nextField, counts),

--- a/src/ui/focus.ts
+++ b/src/ui/focus.ts
@@ -1,6 +1,6 @@
-export type Focus = "sidebar" | "request" | "response"
+export type Focus = "sidebar" | "url" | "request" | "response"
 
-const FOCUS_ORDER: Focus[] = ["sidebar", "request", "response"]
+const FOCUS_ORDER: Focus[] = ["sidebar", "url", "request", "response"]
 
 export function cycleFocus(current: Focus, delta: 1 | -1): Focus {
   const idx = FOCUS_ORDER.indexOf(current)
@@ -13,11 +13,20 @@ export function hintForFocus(
   mode: "inactive" | "browsing" | "editing",
 ): string {
   if (focus === "sidebar") {
-    return "[↑/↓] select · [e] edit · [s] send · [w] save · [Tab] → Request"
+    return "[↑/↓] select · [e] edit · [s] send · [w] save · [Tab] → URL"
+  }
+  if (focus === "url") {
+    if (mode === "browsing") {
+      return "[e/Enter] edit · [Esc] back · [Tab] → Request"
+    }
+    if (mode === "editing") {
+      return "[Enter] commit · [Esc] cancel"
+    }
+    return "[e] enter edit · [Tab] → Request"
   }
   if (focus === "request") {
     if (mode === "browsing") {
-      return "[↑/↓/Enter] edit · [d] revert · [R] revert all · [Esc] back · [Tab] → Response"
+      return "[←/→] tabs · [↑/↓/Enter] edit · [d] revert · [R] revert all · [Esc] back · [Tab] → Response"
     }
     if (mode === "editing") {
       return "[Enter] commit · [Esc] cancel"

--- a/src/ui/useEditBrowse.ts
+++ b/src/ui/useEditBrowse.ts
@@ -60,6 +60,7 @@ export function useEditBrowse(
     enabled?: () => boolean
     onEnterEditBrowse?: () => void
     blocked?: () => boolean
+    initialField?: () => FieldKind
   },
 ): UseEditBrowseResult {
   const [editState, setEditState] = useState<EditState>(initialEditState())
@@ -127,7 +128,8 @@ export function useEditBrowse(
 
     if (editState.mode === "inactive") {
       if (key.name === "e") {
-        setEditState((prev) => enterEditBrowse(prev))
+        const initField = opts?.initialField?.() ?? "headers"
+        setEditState((prev) => enterEditBrowse(prev, initField, counts))
         opts?.onEnterEditBrowse?.()
       }
       return
@@ -147,6 +149,7 @@ export function useEditBrowse(
       if (key.name === "escape") {
         setEditState((prev) => exitEditBrowse(prev))
       } else if (key.name === "e" || key.name === "return") {
+        if (editState.cursor.field === "auth") return
         const init = currentValueFor(
           draft,
           editState.cursor.field,
@@ -155,18 +158,14 @@ export function useEditBrowse(
         )
         setEditValue(init)
         setEditState((prev) => beginEditing(prev))
+      } else if (key.name === "left") {
+        setEditState((prev) => moveFieldCursor(prev, -1, counts))
+      } else if (key.name === "right") {
+        setEditState((prev) => moveFieldCursor(prev, +1, counts))
       } else if (key.name === "up") {
-        setEditState((prev) => {
-          const moved = moveRowCursor(prev, -1, counts)
-          if (moved === prev) return moveFieldCursor(prev, -1, counts)
-          return moved
-        })
+        setEditState((prev) => moveRowCursor(prev, -1, counts))
       } else if (key.name === "down") {
-        setEditState((prev) => {
-          const moved = moveRowCursor(prev, +1, counts)
-          if (moved === prev) return moveFieldCursor(prev, +1, counts)
-          return moved
-        })
+        setEditState((prev) => moveRowCursor(prev, +1, counts))
       } else if (key.name === "d") {
         onRevertField()
       } else if (key.name === "R" || (key.shift && key.name === "r")) {

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -14,21 +14,26 @@ import {
 const inactive: EditState = initialEditState()
 
 describe("initialEditState", () => {
-  it("starts inactive with url cursor", () => {
+  it("starts inactive with headers cursor", () => {
     expect(initialEditState()).toEqual({
       mode: "inactive",
-      cursor: { field: "url", row: -1, addingRow: false },
+      cursor: { field: "headers", row: -1, addingRow: false },
       editingRow: -1,
     })
   })
 })
 
 describe("enterEditBrowse", () => {
-  it("inactive → browsing at url", () => {
-    const s = enterEditBrowse(inactive)
+  it("inactive → browsing at headers by default", () => {
+    const s = enterEditBrowse(inactive, "headers", { headers: 2, params: 1 })
+    expect(s.mode).toBe("browsing")
+    expect(s.cursor).toEqual({ field: "headers", row: 0, addingRow: false })
+    expect(s.editingRow).toBe(-1)
+  })
+  it("inactive → browsing at url when specified", () => {
+    const s = enterEditBrowse(inactive, "url")
     expect(s.mode).toBe("browsing")
     expect(s.cursor).toEqual({ field: "url", row: -1, addingRow: false })
-    expect(s.editingRow).toBe(-1)
   })
   it("no-op from browsing", () => {
     const browsing = enterEditBrowse(inactive)
@@ -56,12 +61,10 @@ describe("exitEditBrowse", () => {
 })
 
 describe("moveFieldCursor", () => {
-  it("+1 walks url → headers → params → body → url", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+  it("+1 walks headers → params → body → auth → headers", () => {
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 1 })
+    // starts at headers
     expect(s.cursor.field).toBe("headers")
-    expect(s.cursor.row).toBe(0)
-    expect(s.cursor.addingRow).toBe(false)
     s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("params")
     expect(s.cursor.row).toBe(0)
@@ -69,23 +72,30 @@ describe("moveFieldCursor", () => {
     expect(s.cursor.field).toBe("body")
     expect(s.cursor.row).toBe(-1)
     s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
-    expect(s.cursor.field).toBe("url")
+    expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(-1)
+    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    expect(s.cursor.field).toBe("headers")
   })
-  it("-1 walks url → body → params → headers → url", () => {
-    let s = enterEditBrowse(inactive)
+  it("-1 walks headers → auth → body → params → headers", () => {
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 1 })
+    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    expect(s.cursor.field).toBe("auth")
     s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("body")
     s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("params")
     s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("headers")
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
-    expect(s.cursor.field).toBe("url")
+  })
+  it("url field is a no-op when calling moveFieldCursor", () => {
+    const s = enterEditBrowse(inactive, "url")
+    const before = s
+    expect(moveFieldCursor(s, +1, { headers: 2, params: 1 })).toBe(before)
   })
   it("entering empty headers lands on [+] (addingRow true, row -1)", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, "params", { headers: 0, params: 0 })
+    s = moveFieldCursor(s, -1, { headers: 0, params: 0 })
     expect(s.cursor.field).toBe("headers")
     expect(s.cursor.addingRow).toBe(true)
     expect(s.cursor.row).toBe(-1)
@@ -100,9 +110,7 @@ describe("moveFieldCursor", () => {
 
 describe("moveRowCursor", () => {
   it("walks rows 0 → 1 → [+] → wraps to 0 within headers", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
-    expect(s.cursor.row).toBe(0)
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 0 })
     s = moveRowCursor(s, +1, { headers: 2, params: 0 })
     expect(s.cursor.row).toBe(1)
     s = moveRowCursor(s, +1, { headers: 2, params: 0 })
@@ -113,8 +121,7 @@ describe("moveRowCursor", () => {
     expect(s.cursor.addingRow).toBe(false)
   })
   it("walks up: 0 → [+] → 1 → 0", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 0 })
     expect(s.cursor.row).toBe(0)
     s = moveRowCursor(s, -1, { headers: 2, params: 0 })
     expect(s.cursor.addingRow).toBe(true)
@@ -124,9 +131,7 @@ describe("moveRowCursor", () => {
     expect(s.cursor.row).toBe(0)
   })
   it("single-row section toggles 0 ↔ [+]", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 1, params: 0 })
-    expect(s.cursor.row).toBe(0)
+    let s = enterEditBrowse(inactive, "headers", { headers: 1, params: 0 })
     s = moveRowCursor(s, +1, { headers: 1, params: 0 })
     expect(s.cursor.addingRow).toBe(true)
     s = moveRowCursor(s, +1, { headers: 1, params: 0 })
@@ -134,26 +139,23 @@ describe("moveRowCursor", () => {
     expect(s.cursor.addingRow).toBe(false)
   })
   it("empty section is a no-op (stuck on [+])", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    const s = enterEditBrowse(inactive, "params", { headers: 0, params: 0 })
     const before = s
     expect(moveRowCursor(s, +1, { headers: 0, params: 0 })).toBe(before)
     expect(moveRowCursor(s, -1, { headers: 0, params: 0 })).toBe(before)
   })
-  it("scalar field (url/body) is a no-op", () => {
-    const browsing = enterEditBrowse(inactive)
-    expect(moveRowCursor(browsing, +1, { headers: 2, params: 1 })).toBe(
-      browsing,
+  it("scalar field (url/body/auth) is a no-op", () => {
+    const browsingBody = enterEditBrowse(inactive, "body")
+    expect(moveRowCursor(browsingBody, +1, { headers: 2, params: 1 })).toBe(
+      browsingBody,
     )
-    let s = moveFieldCursor(browsing, +1, { headers: 2, params: 1 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
-    expect(s.cursor.field).toBe("body")
-    expect(moveRowCursor(s, +1, { headers: 2, params: 1 })).toBe(s)
+    const browsingAuth = enterEditBrowse(inactive, "auth")
+    expect(moveRowCursor(browsingAuth, +1, { headers: 2, params: 1 })).toBe(
+      browsingAuth,
+    )
   })
   it("no-op when editing", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
+    const s = enterEditBrowse(inactive)
     const editing = beginEditing(s)
     expect(moveRowCursor(editing, +1, { headers: 2, params: 0 })).toBe(editing)
   })
@@ -161,8 +163,7 @@ describe("moveRowCursor", () => {
 
 describe("beginEditing", () => {
   it("browsing → editing, captures editingRow for header row", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 0 })
     s = moveRowCursor(s, +1, { headers: 2, params: 0 })
     expect(s.cursor.row).toBe(1)
     const e = beginEditing(s)
@@ -170,14 +171,14 @@ describe("beginEditing", () => {
     expect(e.editingRow).toBe(1)
   })
   it("browsing → editing, editingRow -1 for url scalar", () => {
-    const browsing = enterEditBrowse(inactive)
+    const browsing = enterEditBrowse(inactive, "url")
     const e = beginEditing(browsing)
     expect(e.mode).toBe("editing")
     expect(e.editingRow).toBe(-1)
   })
   it("browsing → editing on [+] line keeps editingRow -1 (caller adds row)", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 0 })
+    s = moveRowCursor(s, -1, { headers: 2, params: 0 })
     expect(s.cursor.addingRow).toBe(true)
     const e = beginEditing(s)
     expect(e.mode).toBe("editing")
@@ -208,8 +209,8 @@ describe("commitEditing", () => {
 
 describe("cancelEditing", () => {
   it("editing → browsing, editingRow reset to -1, cursor preserved", () => {
-    let s = enterEditBrowse(inactive)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, "headers", { headers: 2, params: 0 })
+    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
     const editing = beginEditing(s)
     const cancelled = cancelEditing(editing)
     expect(cancelled.mode).toBe("browsing")

--- a/tests/unit/cycleFocus.test.ts
+++ b/tests/unit/cycleFocus.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from "bun:test"
 import { cycleFocus } from "../../src/ui/focus"
 
 describe("cycleFocus — forward (delta +1)", () => {
-  it("sidebar → request", () => {
-    expect(cycleFocus("sidebar", 1)).toBe("request")
+  it("sidebar → url", () => {
+    expect(cycleFocus("sidebar", 1)).toBe("url")
+  })
+
+  it("url → request", () => {
+    expect(cycleFocus("url", 1)).toBe("request")
   })
 
   it("request → response", () => {
@@ -20,18 +24,24 @@ describe("cycleFocus — reverse (delta -1)", () => {
     expect(cycleFocus("sidebar", -1)).toBe("response")
   })
 
-  it("request → sidebar", () => {
-    expect(cycleFocus("request", -1)).toBe("sidebar")
-  })
-
   it("response → request", () => {
     expect(cycleFocus("response", -1)).toBe("request")
+  })
+
+  it("request → url", () => {
+    expect(cycleFocus("request", -1)).toBe("url")
+  })
+
+  it("url → sidebar", () => {
+    expect(cycleFocus("url", -1)).toBe("sidebar")
   })
 })
 
 describe("cycleFocus — round-trip", () => {
-  it("forward wraps through all 3", () => {
+  it("forward wraps through all 4", () => {
     let f = cycleFocus("sidebar", 1)
+    expect(f).toBe("url")
+    f = cycleFocus(f, 1)
     expect(f).toBe("request")
     f = cycleFocus(f, 1)
     expect(f).toBe("response")
@@ -39,11 +49,13 @@ describe("cycleFocus — round-trip", () => {
     expect(f).toBe("sidebar")
   })
 
-  it("reverse wraps through all 3", () => {
+  it("reverse wraps through all 4", () => {
     let f = cycleFocus("sidebar", -1)
     expect(f).toBe("response")
     f = cycleFocus(f, -1)
     expect(f).toBe("request")
+    f = cycleFocus(f, -1)
+    expect(f).toBe("url")
     f = cycleFocus(f, -1)
     expect(f).toBe("sidebar")
   })

--- a/tests/unit/hintForFocus.test.ts
+++ b/tests/unit/hintForFocus.test.ts
@@ -9,6 +9,15 @@ describe("hintForFocus — sidebar", () => {
     expect(hint).toContain("send")
     expect(hint).toContain("save")
     expect(hint).toContain("Tab")
+    expect(hint).toContain("URL")
+  })
+})
+
+describe("hintForFocus — url", () => {
+  it("shows edit, Esc, Tab for URL pane", () => {
+    const hint = hintForFocus("url", "inactive")
+    expect(hint).toContain("edit")
+    expect(hint).toContain("Tab")
     expect(hint).toContain("Request")
   })
 })


### PR DESCRIPTION
Split the URL field into a dedicated pane with its own focus state, add the auth tab to the request pane, and enable left/right arrow navigation between request field tabs (headers, params, body, auth).