### PR TITLE
feat(ui): color $var references by env resolution status

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -541,6 +541,7 @@ function AppInner({
               onDefocus={draft.syncUrlParams}
               focused={focus === "urlbar"}
               sending={responseState.status === "sending"}
+              activeEnv={envState.activeEnv}
             />
             {layout === "side-by-side" ? (
               <box
@@ -560,6 +561,7 @@ function AppInner({
                   setEditValue={eb.setEditValue}
                   focused={focus === "request"}
                   activeTab={eb.activeTab}
+                  activeEnv={envState.activeEnv}
                 />
                 <ResponsePane
                   state={responseState}
@@ -577,6 +579,7 @@ function AppInner({
                   setEditValue={eb.setEditValue}
                   focused={focus === "request"}
                   activeTab={eb.activeTab}
+                  activeEnv={envState.activeEnv}
                 />
                 <ResponsePane
                   state={responseState}

--- a/src/ui/JsonBodyViewer.tsx
+++ b/src/ui/JsonBodyViewer.tsx
@@ -2,29 +2,32 @@ import { useEffect, useRef } from "react"
 import type { TextareaRenderable } from "@opentui/core"
 import type { Theme } from "./theme-data"
 import { highlightTextarea } from "./useJsonHighlight"
+import type { Environment } from "../schema"
 
 export function JsonBodyViewer({
   body,
   theme,
   id,
   readOnly = false,
+  activeEnv,
 }: {
   body: string
   theme: Theme
   id?: string
   readOnly?: boolean
+  activeEnv?: Environment | null
 }) {
   const ref = useRef<TextareaRenderable | null>(null)
 
   useEffect(() => {
     const ta = ref.current
     if (ta) {
-      highlightTextarea(ta, body, theme)
+      highlightTextarea(ta, body, theme, activeEnv ?? null)
       if (readOnly) {
         ta.focusable = false
       }
     }
-  }, [body, theme, readOnly])
+  }, [body, theme, readOnly, activeEnv])
 
   return (
     <line-number

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -1,6 +1,10 @@
-import type { ScrollBoxRenderable, TextareaRenderable, LineNumberRenderable } from "@opentui/core"
+import type {
+  ScrollBoxRenderable,
+  TextareaRenderable,
+  LineNumberRenderable,
+} from "@opentui/core"
 import { useEffect, useMemo, useRef } from "react"
-import type { Request } from "../schema"
+import type { Request, Environment } from "../schema"
 import { formatBody, formatAuth } from "./formatRequest"
 import type { EditState, FieldKind } from "./editMode"
 
@@ -10,6 +14,8 @@ import type { Theme } from "./theme"
 import { FullBorder, LeftBar } from "./borders"
 import { useJsonHighlight } from "./useJsonHighlight"
 import { JsonBodyViewer } from "./JsonBodyViewer"
+import { VarText } from "./VarText"
+import { varSummaryColor } from "./envHighlight"
 
 interface Props {
   request: Request | null
@@ -20,6 +26,7 @@ interface Props {
   setEditValue: (v: string) => void
   focused?: boolean
   activeTab: FieldKind
+  activeEnv?: Environment | null
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -38,6 +45,7 @@ export function RequestPane({
   setEditValue,
   focused = false,
   activeTab,
+  activeEnv,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -128,6 +136,7 @@ export function RequestPane({
                   setEditValue={setEditValue}
                   browseActive={browseActive}
                   theme={theme}
+                  activeEnv={activeEnv}
                 />
               )}
               {activeTab === "params" && (
@@ -141,6 +150,7 @@ export function RequestPane({
                   setEditValue={setEditValue}
                   browseActive={browseActive}
                   theme={theme}
+                  activeEnv={activeEnv}
                 />
               )}
               {activeTab === "body" && (
@@ -152,6 +162,7 @@ export function RequestPane({
                   inEdit={inEdit}
                   browseActive={browseActive}
                   theme={theme}
+                  activeEnv={activeEnv}
                 />
               )}
               {activeTab === "auth" && (
@@ -159,6 +170,7 @@ export function RequestPane({
                   request={request}
                   editState={editState}
                   theme={theme}
+                  activeEnv={activeEnv}
                 />
               )}
             </scrollbox>
@@ -181,6 +193,7 @@ interface KeyValueSectionProps {
   setEditValue: (v: string) => void
   browseActive: boolean
   theme: Theme
+  activeEnv?: Environment | null
 }
 
 function KeyValueSection({
@@ -193,6 +206,7 @@ function KeyValueSection({
   setEditValue,
   browseActive,
   theme,
+  activeEnv,
 }: KeyValueSectionProps) {
   const rec = kind === "headers" ? request.headers : request.params
   const rows = Object.entries(rec)
@@ -205,9 +219,7 @@ function KeyValueSection({
   const stripeG = Math.round(
     (((panelNum >> 8) & 0xff) + ((elemNum >> 8) & 0xff)) / 2,
   )
-  const stripeB = Math.round(
-    ((panelNum & 0xff) + (elemNum & 0xff)) / 2,
-  )
+  const stripeB = Math.round(((panelNum & 0xff) + (elemNum & 0xff)) / 2)
   const stripeBg = `#${stripeR.toString(16).padStart(2, "0")}${stripeG.toString(16).padStart(2, "0")}${stripeB.toString(16).padStart(2, "0")}`
 
   const inEdit = editState.mode === "editing"
@@ -284,7 +296,16 @@ function KeyValueSection({
                     isEditingThisRow ? theme.backgroundElement : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
-                  textColor={dimmed ? theme.textMuted : theme.text}
+                  textColor={
+                    isEditingThisRow
+                      ? theme.text
+                      : varSummaryColor(
+                          k,
+                          activeEnv ?? null,
+                          theme,
+                          dimmed ? theme.textMuted : theme.text,
+                        )
+                  }
                   cursorColor={theme.primary}
                   style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
                 />
@@ -300,11 +321,18 @@ function KeyValueSection({
                   }
                   focusedBackgroundColor={theme.borderSubtle}
                   textColor={
-                    dimmed
-                      ? theme.textMuted
-                      : cursorOnThisRow || isEditingThisRow
-                        ? theme.text
-                        : theme.textMuted
+                    isEditingThisRow
+                      ? theme.text
+                      : varSummaryColor(
+                          entry.value,
+                          activeEnv ?? null,
+                          theme,
+                          dimmed
+                            ? theme.textMuted
+                            : cursorOnThisRow
+                              ? theme.text
+                              : theme.textMuted,
+                        )
                   }
                   cursorColor={theme.primary}
                   style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
@@ -329,9 +357,7 @@ function KeyValueSection({
               placeholder="Key"
               onInput={editingAdd ? setEditKey : undefined}
               focused={editingAdd && editState.cursor.subfield === "key"}
-              backgroundColor={
-                editingAdd ? theme.backgroundElement : undefined
-              }
+              backgroundColor={editingAdd ? theme.backgroundElement : undefined}
               focusedBackgroundColor={theme.borderSubtle}
               textColor={
                 editingAdd || (cursorHere && editState.cursor.addingRow)
@@ -345,12 +371,8 @@ function KeyValueSection({
               value={editingAdd ? editValue : ""}
               placeholder="Value"
               onInput={editingAdd ? setEditValue : undefined}
-              focused={
-                editingAdd && editState.cursor.subfield === "value"
-              }
-              backgroundColor={
-                editingAdd ? theme.backgroundElement : undefined
-              }
+              focused={editingAdd && editState.cursor.subfield === "value"}
+              backgroundColor={editingAdd ? theme.backgroundElement : undefined}
               focusedBackgroundColor={theme.borderSubtle}
               textColor={
                 editingAdd || (cursorHere && editState.cursor.addingRow)
@@ -375,6 +397,7 @@ function BodySection({
   inEdit,
   browseActive: _browseActive,
   theme,
+  activeEnv,
 }: {
   request: Request
   editState: EditState
@@ -383,6 +406,7 @@ function BodySection({
   inEdit: boolean
   browseActive: boolean
   theme: Theme
+  activeEnv?: Environment | null
 }) {
   const body = formatBody(request.body)
   const textareaRef = useRef<TextareaRenderable | null>(null)
@@ -433,17 +457,26 @@ function BodySection({
     )
   }
 
-  return <JsonBodyViewer body={body} theme={theme} id="body-field" />
+  return (
+    <JsonBodyViewer
+      body={body}
+      theme={theme}
+      id="body-field"
+      activeEnv={activeEnv ?? null}
+    />
+  )
 }
 
 function AuthSection({
   request,
   editState,
   theme,
+  activeEnv,
 }: {
   request: Request
   editState: EditState
   theme: Theme
+  activeEnv?: Environment | null
 }) {
   const auth = formatAuth(request.auth)
   const isActive =
@@ -458,7 +491,11 @@ function AuthSection({
         backgroundColor: isActive ? theme.backgroundElement : undefined,
       }}
     >
-      <text fg={isActive ? theme.text : theme.textMuted}>{" " + auth}</text>
+      <VarText
+        text={` ${auth}`}
+        env={activeEnv ?? null}
+        baseColor={isActive ? theme.text : theme.textMuted}
+      />
     </box>
   )
 }

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -3,8 +3,9 @@ import { Badge } from "./Badge"
 import { methodColor } from "./formatRequest"
 import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
-import type { Method, KvEntry } from "../schema"
+import type { Method, KvEntry, Environment } from "../schema"
 import { buildDisplayUrl } from "./urlParams"
+import { VarText } from "./VarText"
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
@@ -16,6 +17,7 @@ export function UrlBar({
   onDefocus,
   focused = false,
   sending = false,
+  activeEnv,
 }: {
   method: string
   url: string
@@ -24,6 +26,7 @@ export function UrlBar({
   onDefocus: (rawUrl: string) => void
   focused?: boolean
   sending?: boolean
+  activeEnv?: Environment | null
 }) {
   const theme = useTheme()
   const [spinnerIdx, setSpinnerIdx] = useState(0)
@@ -105,7 +108,7 @@ export function UrlBar({
                 flexGrow: 1,
               }}
             >
-              <text fg={theme.text}> {displayUrl}</text>
+              <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />
             </box>
           )}
           <box

--- a/src/ui/VarText.tsx
+++ b/src/ui/VarText.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from "react"
+import { splitEnvVars } from "./envHighlight"
+import { useTheme } from "./theme"
+import type { Environment } from "../schema"
+
+export function VarText({
+  text,
+  env,
+  baseColor,
+}: {
+  text: string
+  env: Environment | null
+  baseColor?: string
+}) {
+  const theme = useTheme()
+  const segments = useMemo(() => splitEnvVars(text, env), [text, env])
+  const defaultColor = baseColor ?? theme.text
+
+  return (
+    <box style={{ flexDirection: "row", gap: 0 }}>
+      {segments.map((seg, i) => (
+        <text
+          key={i}
+          fg={
+            seg.isVar
+              ? seg.exists
+                ? theme.primary
+                : theme.error
+              : defaultColor
+          }
+        >
+          {seg.text}
+        </text>
+      ))}
+    </box>
+  )
+}

--- a/src/ui/envHighlight.ts
+++ b/src/ui/envHighlight.ts
@@ -1,0 +1,67 @@
+import type { Environment } from "../schema"
+
+const VAR_RE = /\$(\w+)/g
+
+export interface EnvSegment {
+  text: string
+  isVar: boolean
+  exists: boolean
+}
+
+export function splitEnvVars(
+  text: string,
+  env: Environment | null,
+): EnvSegment[] {
+  VAR_RE.lastIndex = 0
+  const segments: EnvSegment[] = []
+  let lastEnd = 0
+  let match: RegExpExecArray | null
+  while ((match = VAR_RE.exec(text)) !== null) {
+    if (match.index > lastEnd) {
+      segments.push({
+        text: text.slice(lastEnd, match.index),
+        isVar: false,
+        exists: false,
+      })
+    }
+    const varName = match[1]!
+    const exists = env !== null && varName in env.vars
+    segments.push({ text: match[0], isVar: true, exists })
+    lastEnd = match.index + match[0].length
+  }
+  if (lastEnd < text.length) {
+    segments.push({
+      text: text.slice(lastEnd),
+      isVar: false,
+      exists: false,
+    })
+  }
+  return segments
+}
+
+export function envVarStatus(
+  value: string,
+  env: Environment | null,
+): "none" | "missing" | "resolved" {
+  VAR_RE.lastIndex = 0
+  if (!VAR_RE.test(value)) return "none"
+  if (env === null) return "missing"
+  VAR_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = VAR_RE.exec(value)) !== null) {
+    if (!(match[1]! in env.vars)) return "missing"
+  }
+  return "resolved"
+}
+
+export function varSummaryColor(
+  value: string,
+  env: Environment | null,
+  theme: { primary: string; error: string },
+  baseColor: string,
+): string {
+  const status = envVarStatus(value, env)
+  if (status === "none") return baseColor
+  if (status === "missing") return theme.error
+  return theme.primary
+}

--- a/src/ui/useJsonHighlight.ts
+++ b/src/ui/useJsonHighlight.ts
@@ -3,6 +3,7 @@ import { SyntaxStyle } from "@opentui/core"
 import type { TextareaRenderable, LineNumberRenderable } from "@opentui/core"
 import type { Theme } from "./theme-data"
 import { highlightJsonTokens } from "./syntax"
+import type { Environment } from "../schema"
 
 function createJsonSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({
@@ -13,6 +14,8 @@ function createJsonSyntaxStyle(theme: Theme): SyntaxStyle {
     "json.null": { fg: theme.info },
     "json.bracket": { fg: theme.textMuted },
     "json.text": { fg: theme.text },
+    "env.resolved": { fg: theme.primary },
+    "env.missing": { fg: theme.error },
   })
 }
 
@@ -29,29 +32,46 @@ export function highlightTextarea(
   textarea: TextareaRenderable,
   content: string,
   theme: Theme,
+  env?: Environment | null,
 ): void {
+  const style = createJsonSyntaxStyle(theme)
+  textarea.clearAllHighlights()
+  textarea.syntaxStyle = style
+
   try {
     JSON.parse(content)
-  } catch {
-    return
-  }
-  if (content.length > 100_000) return
-  const style = createJsonSyntaxStyle(theme)
-  try {
-    textarea.clearAllHighlights()
-    textarea.syntaxStyle = style
-    const tokens = highlightJsonTokens(content, theme)
-    for (const token of tokens) {
-      const styleId = styleIdForFg(token.fg, theme, style)
-      textarea.addHighlightByCharRange({
-        start: token.offset,
-        end: token.offset + token.text.length,
-        styleId,
-        priority: 1,
-      })
+    if (content.length <= 100_000) {
+      const tokens = highlightJsonTokens(content, theme)
+      for (const token of tokens) {
+        const styleId = styleIdForFg(token.fg, theme, style)
+        textarea.addHighlightByCharRange({
+          start: token.offset,
+          end: token.offset + token.text.length,
+          styleId,
+          priority: 1,
+        })
+      }
     }
   } catch {
-    // highlight failed
+    // not valid JSON — still add $var highlights below
+  }
+
+  if (env) {
+    const varRe = /\$\w+/g
+    let match: RegExpExecArray | null
+    while ((match = varRe.exec(content)) !== null) {
+      const varName = match[0].slice(1)
+      const exists = varName in env.vars
+      const styleId = exists
+        ? style.getStyleId("env.resolved")!
+        : style.getStyleId("env.missing")!
+      textarea.addHighlightByCharRange({
+        start: match.index,
+        end: match.index + match[0].length,
+        styleId,
+        priority: 2,
+      })
+    }
   }
 }
 

--- a/tests/unit/VarText.test.tsx
+++ b/tests/unit/VarText.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { RGBA } from "@opentui/core"
+import { VarText } from "../../src/ui/VarText"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
+import type { Environment } from "../../src/schema"
+
+function env(vars: Record<string, string>): Environment {
+  return { name: "test-env", vars }
+}
+
+describe("VarText", () => {
+  it("renders plain text without variables", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText text="hello world" env={null} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const fullText = spans.map((s) => s.text).join("")
+    expect(fullText).toContain("hello world")
+  })
+
+  it("renders resolved variable in primary color", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText text="$host" env={env({ host: "localhost" })} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const varSpan = spans.find((s) => s.text.includes("$host"))
+    expect(varSpan).toBeDefined()
+
+    const theme = THEMES[0]!
+    const primaryRgba = hexToRgba(theme.primary)
+    expect(varSpan!.fg.equals(primaryRgba)).toBe(true)
+  })
+
+  it("renders unresolved variable in error color when env is null", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText text="$token" env={null} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const varSpan = spans.find((s) => s.text.includes("$token"))
+    expect(varSpan).toBeDefined()
+
+    const theme = THEMES[0]!
+    const errorRgba = hexToRgba(theme.error)
+    expect(varSpan!.fg.equals(errorRgba)).toBe(true)
+  })
+
+  it("renders unresolved variable in error color when var missing from env", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText text="$missing" env={env({})} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const varSpan = spans.find((s) => s.text.includes("$missing"))
+    expect(varSpan).toBeDefined()
+
+    const theme = THEMES[0]!
+    const errorRgba = hexToRgba(theme.error)
+    expect(varSpan!.fg.equals(errorRgba)).toBe(true)
+  })
+
+  it("renders mixed resolved and unresolved vars with correct colors", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText text="$good / $bad" env={env({ good: "ok" })} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+
+    const theme = THEMES[0]!
+    const primaryRgba = hexToRgba(theme.primary)
+    const errorRgba = hexToRgba(theme.error)
+
+    const goodSpan = spans.find((s) => s.text === "$good")
+    expect(goodSpan).toBeDefined()
+    expect(goodSpan!.fg.equals(primaryRgba)).toBe(true)
+
+    const badSpan = spans.find((s) => s.text === "$bad")
+    expect(badSpan).toBeDefined()
+    expect(badSpan!.fg.equals(errorRgba)).toBe(true)
+  })
+
+  it("uses baseColor for non-variable text", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText
+          text="plain $var tail"
+          env={env({ var: "x" })}
+          baseColor="#aabbcc"
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+
+    const baseRgba = hexToRgba("#aabbcc")
+    const plainSpan = spans.find((s) => s.text === "plain ")
+    expect(plainSpan).toBeDefined()
+    expect(plainSpan!.fg.equals(baseRgba)).toBe(true)
+
+    const tailSpan = spans.find((s) => s.text === " tail")
+    expect(tailSpan).toBeDefined()
+    expect(tailSpan!.fg.equals(baseRgba)).toBe(true)
+  })
+
+  it("renders URL-style string with multiple variables", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText
+          text="$baseUrl/api/$resource"
+          env={env({ baseUrl: "https://api.example.com", resource: "users" })}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+
+    const theme = THEMES[0]!
+    const primaryRgba = hexToRgba(theme.primary)
+
+    const baseUrlSpan = spans.find((s) => s.text === "$baseUrl")
+    expect(baseUrlSpan).toBeDefined()
+    expect(baseUrlSpan!.fg.equals(primaryRgba)).toBe(true)
+
+    const resourceSpan = spans.find((s) => s.text === "$resource")
+    expect(resourceSpan).toBeDefined()
+    expect(resourceSpan!.fg.equals(primaryRgba)).toBe(true)
+  })
+
+  it("does not render when text is empty", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText text="" env={null} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    // Should not crash, may or may not contain any text
+    expect(frame.length).toBeGreaterThanOrEqual(0)
+  })
+
+  it("renders variable adjacent to punctuation", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText
+          text='{"token":"$bearer"}'
+          env={env({ bearer: "abc123" })}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+
+    const theme = THEMES[0]!
+    const primaryRgba = hexToRgba(theme.primary)
+
+    const varSpan = spans.find((s) => s.text === "$bearer")
+    expect(varSpan).toBeDefined()
+    expect(varSpan!.fg.equals(primaryRgba)).toBe(true)
+  })
+})
+
+function hexToRgba(hex: string): RGBA {
+  return RGBA.fromInts(
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+  )
+}

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "bun:test"
+import {
+  splitEnvVars,
+  envVarStatus,
+  varSummaryColor,
+} from "../../src/ui/envHighlight"
+import type { Environment } from "../../src/schema"
+
+function env(vars: Record<string, string>): Environment {
+  return { name: "test-env", vars }
+}
+
+function theme() {
+  return { primary: "#fab283", error: "#e06c75" }
+}
+
+describe("splitEnvVars", () => {
+  it("returns single plain segment for text without variables", () => {
+    const result = splitEnvVars("plain text", env({}))
+    expect(result).toEqual([{ text: "plain text", isVar: false, exists: false }])
+  })
+
+  it("returns empty array for empty string", () => {
+    expect(splitEnvVars("", env({}))).toEqual([])
+  })
+
+  it("splits a resolved variable correctly", () => {
+    const result = splitEnvVars("$host/api/users", env({ host: "localhost" }))
+    expect(result).toEqual([
+      { text: "$host", isVar: true, exists: true },
+      { text: "/api/users", isVar: false, exists: false },
+    ])
+  })
+
+  it("splits an unresolved variable correctly", () => {
+    const result = splitEnvVars("$token", env({}))
+    expect(result).toEqual([{ text: "$token", isVar: true, exists: false }])
+  })
+
+  it("marks all vars as unresolved when env is null", () => {
+    const result = splitEnvVars("$host/$path", null)
+    expect(result).toEqual([
+      { text: "$host", isVar: true, exists: false },
+      { text: "/", isVar: false, exists: false },
+      { text: "$path", isVar: true, exists: false },
+    ])
+  })
+
+  it("handles multiple variables mixed with plain text", () => {
+    const result = splitEnvVars(
+      "prefix $a middle $b suffix",
+      env({ a: "1", b: "2" }),
+    )
+    expect(result).toEqual([
+      { text: "prefix ", isVar: false, exists: false },
+      { text: "$a", isVar: true, exists: true },
+      { text: " middle ", isVar: false, exists: false },
+      { text: "$b", isVar: true, exists: true },
+      { text: " suffix", isVar: false, exists: false },
+    ])
+  })
+
+  it("handles adjacent variables", () => {
+    const result = splitEnvVars("$a$b", env({ a: "x", b: "y" }))
+    expect(result).toEqual([
+      { text: "$a", isVar: true, exists: true },
+      { text: "$b", isVar: true, exists: true },
+    ])
+  })
+
+  it("resolves some variables and not others", () => {
+    const result = splitEnvVars("$good $bad", env({ good: "ok" }))
+    expect(result).toEqual([
+      { text: "$good", isVar: true, exists: true },
+      { text: " ", isVar: false, exists: false },
+      { text: "$bad", isVar: true, exists: false },
+    ])
+  })
+
+  it("does not match $ followed by non-word char", () => {
+    const result = splitEnvVars("$var $ stuff", env({ var: "x" }))
+    expect(result[0]!).toEqual({ text: "$var", isVar: true, exists: true })
+    expect(result[1]!).toEqual({ text: " $ stuff", isVar: false, exists: false })
+  })
+
+  it("does not match lone $ at end of string", () => {
+    const result = splitEnvVars("test $", env({}))
+    expect(result).toEqual([{ text: "test $", isVar: false, exists: false }])
+  })
+
+  it("matches $var in URL-like strings", () => {
+    const result = splitEnvVars(
+      "$baseUrl/api/$resource",
+      env({ baseUrl: "https://api.example.com", resource: "users" }),
+    )
+    expect(result).toEqual([
+      { text: "$baseUrl", isVar: true, exists: true },
+      { text: "/api/", isVar: false, exists: false },
+      { text: "$resource", isVar: true, exists: true },
+    ])
+  })
+
+  it("handles $ with underscores", () => {
+    const result = splitEnvVars("$api_key", env({ api_key: "abc" }))
+    expect(result).toEqual([{ text: "$api_key", isVar: true, exists: true }])
+  })
+
+  it("handles $ with digits", () => {
+    const result = splitEnvVars("$port8080", env({ port8080: "8080" }))
+    expect(result).toEqual([{ text: "$port8080", isVar: true, exists: true }])
+  })
+})
+
+describe("envVarStatus", () => {
+  it('returns "none" when text has no variables', () => {
+    expect(envVarStatus("plain text", env({}))).toBe("none")
+  })
+
+  it('returns "missing" when env is null', () => {
+    expect(envVarStatus("$var", null)).toBe("missing")
+  })
+
+  it('returns "missing" when variable not in env', () => {
+    expect(envVarStatus("$missing", env({}))).toBe("missing")
+  })
+
+  it('returns "resolved" when all variables exist', () => {
+    expect(envVarStatus("$x $y", env({ x: "1", y: "2" }))).toBe("resolved")
+  })
+
+  it('returns "missing" when any variable is missing', () => {
+    expect(envVarStatus("$x $missing", env({ x: "1" }))).toBe("missing")
+  })
+
+  it("handles empty string", () => {
+    expect(envVarStatus("", env({}))).toBe("none")
+  })
+})
+
+describe("varSummaryColor", () => {
+  const t = theme()
+  const base = "#cccccc"
+
+  it("returns baseColor when no variables present", () => {
+    expect(varSummaryColor("plain", env({}), t, base)).toBe(base)
+  })
+
+  it("returns error when env is null", () => {
+    expect(varSummaryColor("$var", null, t, base)).toBe(t.error)
+  })
+
+  it("returns error when variable is missing", () => {
+    expect(varSummaryColor("$missing", env({}), t, base)).toBe(t.error)
+  })
+
+  it("returns primary when all variables exist", () => {
+    expect(varSummaryColor("$x", env({ x: "1" }), t, base)).toBe(t.primary)
+  })
+
+  it("returns error when any variable is missing", () => {
+    expect(varSummaryColor("$good $bad", env({ good: "ok" }), t, base)).toBe(
+      t.error,
+    )
+  })
+
+  it("returns baseColor for empty string", () => {
+    expect(varSummaryColor("", env({}), t, base)).toBe(base)
+  })
+
+  it("returns primary for multiple resolved variables", () => {
+    expect(
+      varSummaryColor("$a $b $c", env({ a: "1", b: "2", c: "3" }), t, base),
+    ).toBe(t.primary)
+  })
+})


### PR DESCRIPTION
- primary color for resolved variables
- error color for unresolved or no-env variables
- VarText component for per-variable coloring (url, auth)
- varSummaryColor for input field summary coloring (headers, params)
- textarea per-character highlights for body $var patterns
- fixes global regex lastIndex bug in envHighlight utilities