### PR TITLE
feat(request): configurable timeout per request with Settings tab

### DIFF
--- a/collections/basic-auth.yml
+++ b/collections/basic-auth.yml
@@ -1,6 +1,7 @@
 name: Basic Auth
 method: GET
 url: https://httpbin.org/basic-auth/user/pass
+timeout: 1000
 auth:
   type: basic
   user: user

--- a/collections/bearer-auth.yml
+++ b/collections/bearer-auth.yml
@@ -1,6 +1,7 @@
 name: Bearer Auth
 method: GET
 url: https://httpbin.org/bearer
+timeout: 0
 auth:
   type: bearer
   token: $api_token

--- a/collections/create-post.yml
+++ b/collections/create-post.yml
@@ -1,6 +1,7 @@
 name: Create Post
 method: POST
 url: $base_url/posts
+timeout: 0
 headers:
   Content-Type: application/json
   x-api-key: $x_api_key

--- a/collections/delete-post.yml
+++ b/collections/delete-post.yml
@@ -1,3 +1,4 @@
 name: Delete Post
 method: DELETE
 url: $base_url/posts/$post_id
+timeout: 0

--- a/collections/get-post.yml
+++ b/collections/get-post.yml
@@ -1,3 +1,4 @@
 name: Get Post by ID
 method: GET
 url: $base_url/posts/$post_id
+timeout: 0

--- a/collections/get-posts.yml
+++ b/collections/get-posts.yml
@@ -1,3 +1,4 @@
 name: Get Posts
 method: GET
 url: $base_url/posts
+timeout: 0

--- a/collections/get-with-params.yml
+++ b/collections/get-with-params.yml
@@ -1,5 +1,6 @@
 name: Get with Params
 method: GET
 url: $base_url/posts
+timeout: 0
 params:
   userId: $user_id

--- a/collections/update-post.yml
+++ b/collections/update-post.yml
@@ -1,6 +1,7 @@
 name: Update Post
 method: PATCH
 url: $base_url/posts/1
+timeout: 0
 headers:
   Content-Type: application/json
 body: '{"title":"updated title"}'

--- a/src/converters/openapi/map.ts
+++ b/src/converters/openapi/map.ts
@@ -203,6 +203,7 @@ export function mapCollection(n: Normalized): Collection {
         name: reqName,
         method,
         url,
+        timeout: 0,
         headers,
         params,
         body: undefined,

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, writeFile } from "node:fs/promises"
 import { basename, join } from "node:path"
 import * as yaml from "js-yaml"
 import { lang } from "../lang"
@@ -41,14 +41,24 @@ export async function loadCollection(dir: string): Promise<Collection> {
       throw new Error(`filestore.loadCollection: ${msg}`, { cause: e })
     }
     const reqId = name.slice(0, -4)
+    let req
     try {
-      requests.push(lang.parseRequest(reqId, content))
+      req = lang.parseRequest(reqId, content)
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       throw new Error(
         `filestore.loadCollection: failed to parse "${name}": ${msg}`,
         { cause: e },
       )
+    }
+    requests.push(req)
+
+    if (!/^timeout:\s/m.test(content)) {
+      try {
+        await writeFile(join(dir, name), lang.serializeRequest(req), "utf8")
+      } catch {
+        /* migration non-critical, next save handles it */
+      }
     }
   }
 

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -16,7 +16,13 @@ import {
 } from "../ui/editMode"
 import type { UseRequestDraftResult } from "./useRequestDraft"
 
-const FIELD_ORDER: FieldKind[] = ["headers", "params", "body", "auth"]
+const FIELD_ORDER: FieldKind[] = [
+  "headers",
+  "params",
+  "body",
+  "auth",
+  "settings",
+]
 
 function rowCount(req: Request | null): SectionRowCount {
   if (!req) return { headers: 0, params: 0 }
@@ -34,6 +40,7 @@ function currentValueFor(
 ): string {
   if (!draft) return ""
   if (field === "body") return draft.body ?? ""
+  if (field === "settings") return String(draft.timeout)
   if (field === "headers" || field === "params") {
     if (addingRow) return ""
     const rec = field === "headers" ? draft.headers : draft.params
@@ -56,8 +63,11 @@ function currentKeyValueFor(
     const rec = field === "headers" ? draft.headers : draft.params
     const entries = Object.entries(rec)
     const entry = entries[row]
-    return entry ? { key: entry[0], value: entry[1].value } : { key: "", value: "" }
+    return entry
+      ? { key: entry[0], value: entry[1].value }
+      : { key: "", value: "" }
   }
+  if (field === "settings") return { key: "", value: String(draft.timeout) }
   return { key: "", value: "" }
 }
 
@@ -139,7 +149,7 @@ export function useEditBrowse(
     }
 
     const { field, row, addingRow } = browsed.cursor
-    if (field === "body") {
+    if (field === "body" || field === "settings") {
       const init = currentValueFor(currentDraft, field, row, addingRow)
       setEditValue(init)
     } else if (field === "headers" || field === "params") {
@@ -199,7 +209,7 @@ export function useEditBrowse(
     if (state.mode !== "browsing") return
     const currentDraft = draftRef.current
     const { field, row, addingRow } = state.cursor
-    if (field === "body") {
+    if (field === "body" || field === "settings") {
       const init = currentValueFor(currentDraft, field, row, addingRow)
       setEditValue(init)
     } else if (field === "headers" || field === "params") {
@@ -218,6 +228,8 @@ export function useEditBrowse(
     const val = editValueRef.current
     if (field === "body") {
       draftMutators.setBody(val)
+    } else if (field === "settings") {
+      draftMutators.setTimeout(Number(val) || 0)
     } else if (field === "headers" || field === "params") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()
@@ -252,7 +264,7 @@ export function useEditBrowse(
     const state = editStateRef.current
     if (state.mode !== "browsing") return
     const { field, addingRow, row } = state.cursor
-    if (field === "body") {
+    if (field === "body" || field === "settings") {
       draftMutators.revertField(field)
     } else if (field === "headers" || field === "params") {
       if (addingRow) return

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -15,6 +15,7 @@ export type DraftOp =
   | { kind: "removeParamRow"; index: number }
   | { kind: "toggleParamRow"; index: number }
   | { kind: "syncUrlParams"; rawUrl: string }
+  | { kind: "setTimeout"; timeout: number }
   | { kind: "revertField"; field: FieldKind; row?: number }
   | { kind: "revertAll" }
 
@@ -61,6 +62,7 @@ function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
 export function requestEquals(a: Request, b: Request): boolean {
   if (a.url !== b.url) return false
   if (a.method !== b.method) return false
+  if (a.timeout !== b.timeout) return false
   if (a.body !== b.body) return false
   if (!recordsEqual(a.headers, b.headers)) return false
   if (!recordsEqual(a.params, b.params)) return false
@@ -220,8 +222,12 @@ export function applyDraft(
     case "toggleParamRow":
       draft.params = toggleRow(current.params, op.index)
       break
+    case "setTimeout":
+      draft.timeout = op.timeout
+      break
     case "revertField": {
       if (op.field === "body") draft.body = original.body
+      else if (op.field === "settings") draft.timeout = original.timeout
       else if (op.field === "headers" && op.row !== undefined) {
         draft.headers = revertRow(current.headers, original.headers, op.row)
       } else if (op.field === "params" && op.row !== undefined) {
@@ -251,6 +257,7 @@ export interface UseRequestDraftResult {
   addParamRow: (key: string, value: string) => void
   removeParamRow: (index: number) => void
   toggleParamRow: (index: number) => void
+  setTimeout: (timeout: number) => void
   revertField: (field: FieldKind, row?: number) => void
   revertAll: () => void
   markSaved: () => void
@@ -294,6 +301,10 @@ export function useRequestDraft(
   )
   const setBody = useCallback(
     (body: string) => apply({ kind: "setBody", body }),
+    [apply],
+  )
+  const setTimeoutCb = useCallback(
+    (timeout: number) => apply({ kind: "setTimeout", timeout }),
     [apply],
   )
   const setHeaderRow = useCallback(
@@ -381,6 +392,7 @@ export function useRequestDraft(
       setUrl,
       syncUrlParams,
       setBody,
+      setTimeout: setTimeoutCb,
       setHeaderRow,
       addHeaderRow,
       removeHeaderRow,
@@ -400,6 +412,7 @@ export function useRequestDraft(
       setUrl,
       syncUrlParams,
       setBody,
+      setTimeoutCb,
       setHeaderRow,
       addHeaderRow,
       removeHeaderRow,

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -47,6 +47,7 @@ export function parseRequest(id: string, yamlText: string): Request {
     "name",
     "method",
     "url",
+    "timeout",
     "headers",
     "params",
     "body",
@@ -88,11 +89,20 @@ export function parseRequest(id: string, yamlText: string): Request {
 
   const auth = parseAuth(raw.auth)
 
+  let timeout = 0
+  if (raw.timeout !== undefined) {
+    if (typeof raw.timeout !== "number" || !Number.isFinite(raw.timeout)) {
+      throw new Error('lang.parseRequest: "timeout" must be a finite number')
+    }
+    timeout = raw.timeout
+  }
+
   return {
     id,
     name: raw.name,
     method,
     url: raw.url,
+    timeout,
     headers,
     params,
     body,
@@ -100,12 +110,13 @@ export function parseRequest(id: string, yamlText: string): Request {
   }
 }
 
-function parseKvMap(value: unknown, field: string): Record<string, import("../schema").KvEntry> {
+function parseKvMap(
+  value: unknown,
+  field: string,
+): Record<string, import("../schema").KvEntry> {
   if (value === undefined) return {}
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(
-      `lang.parseRequest: ${field} must be a map`,
-    )
+    throw new Error(`lang.parseRequest: ${field} must be a map`)
   }
   const out: Record<string, import("../schema").KvEntry> = {}
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -11,6 +11,7 @@ export function serializeRequest(req: Request): string {
   out += `name: ${yamlVal(req.name)}\n`
   out += `method: ${yamlVal(req.method)}\n`
   out += `url: ${yamlVal(req.url)}\n`
+  out += `timeout: ${String(req.timeout)}\n`
 
   if (Object.keys(req.headers).length > 0) {
     out += "headers:\n"

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -38,11 +38,19 @@ export async function send(
     headersInst.set(ah.name, ah.value)
   }
 
+  let effectiveSignal = signal
+  if (req.timeout > 0) {
+    const timeoutSignal = AbortSignal.timeout(req.timeout)
+    effectiveSignal = signal
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+  }
+
   const init: RequestInit = {
     method: substituted.method,
     headers: headersInst,
     body: substituted.body,
-    signal,
+    signal: effectiveSignal,
   }
 
   const start = performance.now()

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -7,10 +7,7 @@ export type SubstitutedRequest = Omit<Request, "headers" | "params"> & {
   params: Record<string, string>
 }
 
-export function substitute(
-  req: Request,
-  env: Environment,
-): SubstitutedRequest {
+export function substitute(req: Request, env: Environment): SubstitutedRequest {
   const resolve = (s: string, field: string): string =>
     s.replace(VAR_RE, (_, name) => {
       if (!(name in env.vars)) {
@@ -41,6 +38,7 @@ export function substitute(
     name: req.name,
     method: req.method,
     url: resolve(req.url, "url"),
+    timeout: req.timeout,
     headers,
     params,
     body: req.body !== undefined ? resolve(req.body, "body") : undefined,

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -22,6 +22,7 @@ export interface Request {
   name: string
   method: Method
   url: string
+  timeout: number
   headers: Record<string, KvEntry>
   params: Record<string, KvEntry>
   body?: string

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -3,7 +3,7 @@ import type {
   TextareaRenderable,
   LineNumberRenderable,
 } from "@opentui/core"
-import { useEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { Request, Environment } from "../schema"
 import { formatBody, formatAuth } from "./formatRequest"
 import type { EditState, FieldKind } from "./editMode"
@@ -34,6 +34,7 @@ const BASE_TAB_DEFS: TabDef[] = [
   { id: "params", label: "Params" },
   { id: "body", label: "Body" },
   { id: "auth", label: "Auth" },
+  { id: "settings", label: "Settings" },
 ]
 
 export function RequestPane({
@@ -73,6 +74,7 @@ export function RequestPane({
     const hasBody = request.body !== undefined && request.body !== ""
     const hasAuth =
       request.auth?.type !== undefined && request.auth.type !== "none"
+    const hasTimeout = request.timeout > 0
     return BASE_TAB_DEFS.map((tab) => {
       if (tab.id === "headers") {
         return {
@@ -91,6 +93,9 @@ export function RequestPane({
       }
       if (tab.id === "auth") {
         return { ...tab, label: hasAuth ? "Auth \u2022" : "Auth" }
+      }
+      if (tab.id === "settings") {
+        return { ...tab, label: hasTimeout ? "Settings \u2022" : "Settings" }
       }
       return tab
     })
@@ -169,6 +174,18 @@ export function RequestPane({
                 <AuthSection
                   request={request}
                   editState={editState}
+                  theme={theme}
+                  activeEnv={activeEnv}
+                />
+              )}
+              {activeTab === "settings" && (
+                <SettingsSection
+                  request={request}
+                  editState={editState}
+                  editValue={editValue}
+                  setEditValue={setEditValue}
+                  inEdit={inEdit}
+                  browseActive={browseActive}
                   theme={theme}
                   activeEnv={activeEnv}
                 />
@@ -290,6 +307,72 @@ function AuthSection({
         env={activeEnv ?? null}
         baseColor={isActive ? theme.text : theme.textMuted}
       />
+    </box>
+  )
+}
+
+function SettingsSection({
+  request,
+  editState,
+  editValue: _editValue,
+  setEditValue,
+  inEdit,
+  browseActive,
+  theme,
+  activeEnv,
+}: {
+  request: Request
+  editState: EditState
+  editValue: string
+  setEditValue: (v: string) => void
+  inEdit: boolean
+  browseActive: boolean
+  theme: Theme
+  activeEnv?: Environment | null
+}) {
+  const textareaRef = useRef<TextareaRenderable | null>(null)
+  const editingSettings = inEdit && editState.cursor.field === "settings"
+  const isActive = browseActive && editState.cursor.field === "settings"
+  const timeout = request.timeout
+
+  const handleContentChange = useCallback(() => {
+    const ta = textareaRef.current
+    if (ta) setEditValue(ta.plainText)
+  }, [setEditValue])
+
+  return (
+    <box
+      id="settings-field"
+      border={[...LeftBar.border]}
+      customBorderChars={LeftBar.customBorderChars}
+      borderColor={isActive || editingSettings ? theme.primary : theme.borderSubtle}
+      style={{
+        flexDirection: editingSettings ? "row" : undefined,
+        gap: editingSettings ? 1 : undefined,
+        backgroundColor: isActive ? theme.backgroundElement : undefined,
+      }}
+    >
+      {editingSettings ? (
+        <>
+          <text fg={theme.textMuted}>Timeout (ms): </text>
+          <textarea
+            ref={textareaRef}
+            initialValue={timeout > 0 ? String(timeout) : ""}
+            onContentChange={handleContentChange}
+            backgroundColor={theme.backgroundPanel}
+            focusedBackgroundColor={theme.backgroundPanel}
+            textColor={theme.text}
+            cursorColor={theme.primary}
+            focused
+          />
+        </>
+      ) : (
+        <VarText
+          text={`Timeout (ms): ${timeout}ms`}
+          env={activeEnv ?? null}
+          baseColor={isActive ? theme.text : theme.textMuted}
+        />
+      )}
     </box>
   )
 }

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -341,38 +341,43 @@ function SettingsSection({
   }, [setEditValue])
 
   return (
-    <box
-      id="settings-field"
-      border={[...LeftBar.border]}
-      customBorderChars={LeftBar.customBorderChars}
-      borderColor={isActive || editingSettings ? theme.primary : theme.borderSubtle}
-      style={{
-        flexDirection: editingSettings ? "row" : undefined,
-        gap: editingSettings ? 1 : undefined,
-        backgroundColor: isActive ? theme.backgroundElement : undefined,
-      }}
-    >
-      {editingSettings ? (
-        <>
-          <text fg={theme.textMuted}>Timeout (ms): </text>
-          <textarea
-            ref={textareaRef}
-            initialValue={timeout > 0 ? String(timeout) : ""}
-            onContentChange={handleContentChange}
-            backgroundColor={theme.backgroundPanel}
-            focusedBackgroundColor={theme.backgroundPanel}
-            textColor={theme.text}
-            cursorColor={theme.primary}
-            focused
+    <>
+      <box
+        id="settings-field"
+        border={[...LeftBar.border]}
+        customBorderChars={LeftBar.customBorderChars}
+        borderColor={isActive || editingSettings ? theme.primary : theme.borderSubtle}
+        style={{
+          flexDirection: editingSettings ? "row" : undefined,
+          gap: editingSettings ? 1 : undefined,
+          backgroundColor: isActive ? theme.backgroundElement : undefined,
+        }}
+      >
+        {editingSettings ? (
+          <>
+            <text fg={theme.textMuted}>Timeout (ms): </text>
+            <textarea
+              ref={textareaRef}
+              initialValue={timeout > 0 ? String(timeout) : ""}
+              onContentChange={handleContentChange}
+              backgroundColor={theme.backgroundPanel}
+              focusedBackgroundColor={theme.backgroundPanel}
+              textColor={theme.text}
+              cursorColor={theme.primary}
+              focused
+            />
+          </>
+        ) : (
+          <VarText
+            text={`Timeout (ms): ${timeout}ms`}
+            env={activeEnv ?? null}
+            baseColor={theme.text}
           />
-        </>
-      ) : (
-        <VarText
-          text={`Timeout (ms): ${timeout}ms`}
-          env={activeEnv ?? null}
-          baseColor={isActive ? theme.text : theme.textMuted}
-        />
-      )}
-    </box>
+        )}
+      </box>
+      <text fg={theme.textMuted}>
+        Set maximum time to wait before aborting the request
+      </text>
+    </>
   )
 }

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,4 +1,4 @@
-export type FieldKind = "headers" | "params" | "body" | "auth"
+export type FieldKind = "headers" | "params" | "body" | "auth" | "settings"
 export type Mode = "inactive" | "browsing" | "editing"
 
 export interface FieldCursor {
@@ -19,7 +19,13 @@ export interface SectionRowCount {
   params: number
 }
 
-const FIELD_ORDER: FieldKind[] = ["headers", "params", "body", "auth"]
+const FIELD_ORDER: FieldKind[] = [
+  "headers",
+  "params",
+  "body",
+  "auth",
+  "settings",
+]
 
 export function initialEditState(): EditState {
   return {
@@ -55,7 +61,7 @@ function cursorForField(
   field: FieldKind,
   counts: SectionRowCount,
 ): FieldCursor {
-  if (field === "body" || field === "auth") {
+  if (field === "body" || field === "auth" || field === "settings") {
     return { field, row: -1, addingRow: false }
   }
   const count = field === "headers" ? counts.headers : counts.params

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -4,7 +4,6 @@ import { RequestPane } from "../src/ui/RequestPane"
 import { ThemeProvider } from "../src/ui/theme"
 import type { Request } from "../src/schema"
 
-
 const testRequest: Request = {
   id: "test",
   name: "test",
@@ -13,6 +12,7 @@ const testRequest: Request = {
   body: '{"name":"hello","count":42}',
   headers: {},
   params: {},
+  timeout: 0,
 }
 
 const editStateInactive = {
@@ -33,7 +33,6 @@ const editStateBrowse = {
   editingRow: -1,
 }
 
-
 describe("BodySection — edit mode", () => {
   it("renders body content in edit mode", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
@@ -46,7 +45,6 @@ describe("BodySection — edit mode", () => {
             editValue={testRequest.body!}
             setEditKey={() => {}}
             setEditValue={() => {}}
-
             focused={true}
             activeTab="body"
           />
@@ -72,7 +70,6 @@ describe("BodySection — edit mode", () => {
             editValue={testRequest.body!}
             setEditKey={() => {}}
             setEditValue={() => {}}
-
             focused={true}
             activeTab="body"
           />
@@ -98,7 +95,6 @@ describe("BodySection — edit mode", () => {
             editValue=""
             setEditKey={() => {}}
             setEditValue={() => {}}
-
             focused={true}
             activeTab="body"
           />
@@ -130,7 +126,6 @@ describe("BodySection — edit mode", () => {
             editValue=""
             setEditKey={() => {}}
             setEditValue={() => {}}
-
             focused={false}
             activeTab="body"
           />
@@ -154,7 +149,6 @@ describe("BodySection — edit mode", () => {
             editValue="raw text content"
             setEditKey={() => {}}
             setEditValue={() => {}}
-
             focused={true}
             activeTab="body"
           />

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -67,7 +67,7 @@ describe("exitEditBrowse", () => {
 })
 
 describe("moveFieldCursor", () => {
-  it("+1 walks headers → params → body → auth → headers", () => {
+  it("+1 walks headers → params → body → auth → settings → headers", () => {
     let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
     s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("params")
@@ -79,11 +79,16 @@ describe("moveFieldCursor", () => {
     expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(-1)
     s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    expect(s.cursor.field).toBe("settings")
+    expect(s.cursor.row).toBe(-1)
+    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("headers")
     expect(s.cursor.row).toBe(0)
   })
-  it("-1 walks headers → auth → body → params → headers", () => {
+  it("-1 walks headers → settings → auth → body → params → headers", () => {
     let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    expect(s.cursor.field).toBe("settings")
     s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("auth")
     s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
@@ -187,6 +192,7 @@ describe("beginEditing", () => {
   })
   it("no-op for auth (browse-only field)", () => {
     let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
     s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
     expect(s.cursor.field).toBe("auth")
     expect(beginEditing(s)).toBe(s)
@@ -322,6 +328,7 @@ describe("toggleSubfield", () => {
 
   it("no-op for auth field (cannot enter edit)", () => {
     let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
+    s = moveFieldCursor(s, -1, { headers: 0, params: 0 })
     s = moveFieldCursor(s, -1, { headers: 0, params: 0 })
     expect(s.cursor.field).toBe("auth")
     expect(toggleSubfield(s)).toBe(s)

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -48,6 +48,7 @@ function makeReq(over: Partial<Request> = {}): Request {
     headers: {},
     params: {},
     auth: { type: "none" },
+    timeout: 0,
     ...over,
   }
 }

--- a/tests/formatRequest.test.ts
+++ b/tests/formatRequest.test.ts
@@ -17,6 +17,7 @@ function makeReq(over: Partial<Request> = {}): Request {
     url: "https://example.com",
     headers: {},
     params: {},
+    timeout: 0,
     ...over,
   }
 }
@@ -80,9 +81,9 @@ describe("formatParams", () => {
     expect(formatParams({})).toEqual([])
   })
   it("renders single param as 'Key: Value'", () => {
-    expect(
-      formatParams({ verbose: { value: "true", enabled: true } }),
-    ).toEqual(["verbose: true"])
+    expect(formatParams({ verbose: { value: "true", enabled: true } })).toEqual(
+      ["verbose: true"],
+    )
   })
   it("sorts multiple params alphabetically by key", () => {
     expect(

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -11,6 +11,7 @@ describe("lang.parseRequest — required fields", () => {
       name: "Get user",
       method: "GET",
       url: "https://api.example.com/users/1",
+      timeout: 0,
       headers: {},
       params: {},
       auth: { type: "none" },
@@ -69,7 +70,9 @@ describe("lang.parseRequest — defaults", () => {
   it("parses provided headers, params, body", () => {
     const yaml = `name: Foo\nmethod: POST\nurl: https://example.com\nheaders:\n  Accept: application/json\nparams:\n  verbose: "true"\nbody: '{"limit": 10}'\n`
     const req = lang.parseRequest("x", yaml)
-    expect(req.headers).toEqual({ Accept: { value: "application/json", enabled: true } })
+    expect(req.headers).toEqual({
+      Accept: { value: "application/json", enabled: true },
+    })
     expect(req.params).toEqual({ verbose: { value: "true", enabled: true } })
     expect(req.body).toBe('{"limit": 10}')
   })
@@ -201,7 +204,10 @@ describe("lang.parseRequest — env var preservation", () => {
     const yaml = `name: Foo\nmethod: GET\nurl: https://$host/users/$id\nheaders:\n  Authorization: "Bearer $token"\nbody: '{"id": "$id"}'\nauth:\n  type: bearer\n  token: "$token"\n`
     const req = lang.parseRequest("x", yaml)
     expect(req.url).toBe("https://$host/users/$id")
-    expect(req.headers.Authorization).toEqual({ value: "Bearer $token", enabled: true })
+    expect(req.headers.Authorization).toEqual({
+      value: "Bearer $token",
+      enabled: true,
+    })
     expect(req.body).toBe('{"id": "$id"}')
     expect(req.auth).toEqual({ type: "bearer", token: "$token" })
   })
@@ -215,6 +221,7 @@ function makeReq(over: Partial<Request> = {}): Request {
     url: "https://api.example.com/users/1",
     headers: {},
     params: {},
+    timeout: 0,
     auth: { type: "none" },
     ...over,
   }
@@ -224,21 +231,25 @@ describe("lang.serializeRequest — canonical output", () => {
   it("emits name, method, url always (no other fields when all defaults)", () => {
     const out = lang.serializeRequest(makeReq())
     expect(out).toBe(
-      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\n",
+      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\ntimeout: 0\n",
     )
   })
 
   it("emits headers when non-empty, omits empty params/body/auth", () => {
     const out = lang.serializeRequest(
-      makeReq({ headers: { Accept: { value: "application/json", enabled: true } } }),
+      makeReq({
+        headers: { Accept: { value: "application/json", enabled: true } },
+      }),
     )
     expect(out).toBe(
-      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\nheaders:\n  Accept: application/json\n",
+      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\ntimeout: 0\nheaders:\n  Accept: application/json\n",
     )
   })
 
   it("emits params when non-empty", () => {
-    const out = lang.serializeRequest(makeReq({ params: { verbose: { value: "true", enabled: true } } }))
+    const out = lang.serializeRequest(
+      makeReq({ params: { verbose: { value: "true", enabled: true } } }),
+    )
     expect(out).toContain("params:\n  verbose: 'true'\n")
     expect(out).not.toContain("headers")
     expect(out).not.toContain("body")
@@ -299,6 +310,7 @@ describe("lang.serializeRequest — canonical key order", () => {
       "name",
       "method",
       "url",
+      "timeout",
       "headers",
       "params",
       "body",
@@ -342,6 +354,7 @@ describe("lang — semantic round-trip", () => {
       name: "Create post",
       method: "POST",
       url: "https://$host/posts",
+      timeout: 0,
       headers: {
         "Content-Type": { value: "application/json", enabled: true },
         Authorization: { value: "Bearer $token", enabled: true },
@@ -365,6 +378,7 @@ describe("lang — semantic round-trip", () => {
       url: "https://example.com",
       headers: {},
       params: {},
+      timeout: 0,
       auth: { type: "none" },
     }
     const yaml = lang.serializeRequest(original)
@@ -380,6 +394,7 @@ describe("lang — semantic round-trip", () => {
       url: "https://example.com/item/1",
       headers: {},
       params: {},
+      timeout: 0,
       auth: { type: "basic", user: "foo", pass: "bar" },
     }
     const yaml = lang.serializeRequest(original)
@@ -398,6 +413,7 @@ describe("lang — semantic round-trip", () => {
         "X-Debug": { value: "true", enabled: false },
       },
       params: {},
+      timeout: 0,
       auth: { type: "none" },
     }
     const yaml = lang.serializeRequest(original)

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -538,3 +538,38 @@ describe("send — abort signal", () => {
     expect((caught as Error).message).toMatch(/fetch failed/)
   })
 })
+
+describe("send — timeout signal", () => {
+  it("creates timeout AbortSignal when timeout > 0, no caller signal", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(makeReq({ timeout: 5000 }))
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    expect(init.signal!.aborted).toBe(false)
+  })
+
+  it("combines signals when timeout > 0 and caller signal present", async () => {
+    const controller = new AbortController()
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(makeReq({ timeout: 5000 }), undefined, controller.signal)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    expect(init.signal).not.toBe(controller.signal)
+    expect(init.signal!.aborted).toBe(false)
+  })
+
+  it("passes caller signal directly when timeout === 0", async () => {
+    const controller = new AbortController()
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(makeReq({ timeout: 0 }), undefined, controller.signal)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBe(controller.signal)
+  })
+
+  it("no signal when timeout === 0 and no caller signal", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(makeReq({ timeout: 0 }))
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.signal).toBeUndefined()
+  })
+})

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -23,6 +23,7 @@ function makeReq(over: Partial<Request> = {}): Request {
     url: "https://example.com",
     headers: {},
     params: {},
+    timeout: 0,
     auth: { type: "none" },
     ...over,
   }
@@ -40,14 +41,18 @@ describe("substitute — pure $var replacement", () => {
   })
 
   it("substitutes $x in header values (not keys)", () => {
-    const req = makeReq({ headers: { Authorization: { value: "Bearer $token", enabled: true } } })
+    const req = makeReq({
+      headers: { Authorization: { value: "Bearer $token", enabled: true } },
+    })
     const out = substitute(req, makeEnv({ token: "abc123" }))
     expect(out.headers.Authorization).toBe("Bearer abc123")
     expect(Object.keys(out.headers)).toEqual(["Authorization"])
   })
 
   it("substitutes $x in param values (not keys)", () => {
-    const req = makeReq({ params: { verbose: { value: "$flag", enabled: true } } })
+    const req = makeReq({
+      params: { verbose: { value: "$flag", enabled: true } },
+    })
     const out = substitute(req, makeEnv({ flag: "true" }))
     expect(out.params.verbose).toBe("true")
     expect(Object.keys(out.params)).toEqual(["verbose"])
@@ -101,7 +106,9 @@ describe("substitute — pure $var replacement", () => {
   })
 
   it("throws on unresolved variable in header value (field name included)", () => {
-    const req = makeReq({ headers: { Authorization: { value: "Bearer $token", enabled: true } } })
+    const req = makeReq({
+      headers: { Authorization: { value: "Bearer $token", enabled: true } },
+    })
     expect(() => substitute(req, makeEnv({}))).toThrow(
       'requests.substitute: unresolved variable "token" in headers.Authorization',
     )
@@ -115,7 +122,10 @@ describe("substitute — pure $var replacement", () => {
   })
 
   it("does not mutate the input request", () => {
-    const req = makeReq({ url: "https://$host/x", headers: { A: { value: "$v", enabled: true } } })
+    const req = makeReq({
+      url: "https://$host/x",
+      headers: { A: { value: "$v", enabled: true } },
+    })
     const original = JSON.parse(JSON.stringify(req))
     substitute(req, makeEnv({ host: "h", v: "1" }))
     expect(req).toEqual(original)
@@ -207,7 +217,9 @@ function fakeResponse(opts: {
 describe("send — URL and query params", () => {
   it("merges params into URL as query string", async () => {
     fetchMock.mockResolvedValueOnce(fakeResponse({}))
-    await executor.send(makeReq({ params: { verbose: { value: "true", enabled: true } } }))
+    await executor.send(
+      makeReq({ params: { verbose: { value: "true", enabled: true } } }),
+    )
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/?verbose=true")
   })
@@ -215,7 +227,10 @@ describe("send — URL and query params", () => {
   it("appends params to existing query string", async () => {
     fetchMock.mockResolvedValueOnce(fakeResponse({}))
     await executor.send(
-      makeReq({ url: "https://example.com/?a=1", params: { b: { value: "2", enabled: true } } }),
+      makeReq({
+        url: "https://example.com/?a=1",
+        params: { b: { value: "2", enabled: true } },
+      }),
     )
     expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/?a=1&b=2")
   })
@@ -264,7 +279,11 @@ describe("send — method, body, headers", () => {
 
   it("passes user headers to fetch init", async () => {
     fetchMock.mockResolvedValueOnce(fakeResponse({}))
-    await executor.send(makeReq({ headers: { Accept: { value: "application/json", enabled: true } } }))
+    await executor.send(
+      makeReq({
+        headers: { Accept: { value: "application/json", enabled: true } },
+      }),
+    )
     const init = fetchMock.mock.calls[0][1] as RequestInit
     const headers = init.headers as Headers
     expect(headers.get("Accept")).toBe("application/json")

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -19,6 +19,7 @@ function makeRequest(i: number): Request {
     url: `http://example.com/${i}`,
     headers: {},
     params: {},
+    timeout: 0,
   }
 }
 
@@ -82,6 +83,7 @@ describe("RequestPane scrollbox", () => {
       headers: manyHeaders,
       params: {} as Record<string, KvEntry>,
       body: "" as string | undefined,
+      timeout: 0,
     }
 
     const { renderOnce, captureCharFrame } = await testRender(
@@ -127,6 +129,7 @@ describe("RequestPane scrollbox", () => {
       headers,
       params: {} as Record<string, KvEntry>,
       body: "" as string | undefined,
+      timeout: 0,
     }
 
     const editState: EditState = {
@@ -253,6 +256,7 @@ describe("App layout stability", () => {
       headers: manyHeaders,
       params: {} as Record<string, KvEntry>,
       body: "" as string | undefined,
+      timeout: 0,
     }
 
     const longBody = JSON.stringify(
@@ -294,7 +298,6 @@ describe("App layout stability", () => {
               editValue=""
               setEditKey={() => {}}
               setEditValue={() => {}}
-  
               focused={false}
               activeTab="headers"
             />

--- a/tests/sendState.test.ts
+++ b/tests/sendState.test.ts
@@ -16,6 +16,7 @@ function makeReq(over: Partial<Request> = {}): Request {
     headers: {},
     params: {},
     auth: { type: "none" },
+    timeout: 0,
     ...over,
   }
 }

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -105,7 +105,11 @@ function makeEntry(over: Partial<TimelineEntry> = {}): TimelineEntry {
 describe("entryMethod", () => {
   it("returns method from entry", () => {
     expect(entryMethod(makeEntry())).toBe("GET")
-    expect(entryMethod(makeEntry({ request: { ...makeEntry().request, method: "POST" } }))).toBe("POST")
+    expect(
+      entryMethod(
+        makeEntry({ request: { ...makeEntry().request, method: "POST" } }),
+      ),
+    ).toBe("POST")
   })
 })
 
@@ -116,10 +120,32 @@ describe("entryStatus", () => {
 
   it("returns status code from response", () => {
     expect(
-      entryStatus(makeEntry({ response: { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 10, size: 0 } }))
+      entryStatus(
+        makeEntry({
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: "",
+            timeMs: 10,
+            size: 0,
+          },
+        }),
+      ),
     ).toBe(200)
     expect(
-      entryStatus(makeEntry({ response: { status: 404, statusText: "Not Found", headers: {}, body: "", timeMs: 10, size: 0 } }))
+      entryStatus(
+        makeEntry({
+          response: {
+            status: 404,
+            statusText: "Not Found",
+            headers: {},
+            body: "",
+            timeMs: 10,
+            size: 0,
+          },
+        }),
+      ),
     ).toBe(404)
   })
 
@@ -131,12 +157,25 @@ describe("entryStatus", () => {
 describe("entryTiming", () => {
   it("returns ms from response", () => {
     expect(
-      entryTiming(makeEntry({ response: { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 150, size: 0 } }))
+      entryTiming(
+        makeEntry({
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: "",
+            timeMs: 150,
+            size: 0,
+          },
+        }),
+      ),
     ).toBe("150ms")
   })
 
   it("returns ERR for error entries", () => {
-    expect(entryTiming(makeEntry({ error: { message: "timeout" } }))).toBe("ERR")
+    expect(entryTiming(makeEntry({ error: { message: "timeout" } }))).toBe(
+      "ERR",
+    )
   })
 
   it('returns "-" when no response', () => {
@@ -152,14 +191,38 @@ describe("entryIsError", () => {
   it("returns false when no error", () => {
     expect(entryIsError(makeEntry())).toBe(false)
     expect(
-      entryIsError(makeEntry({ response: { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 10, size: 0 } }))
+      entryIsError(
+        makeEntry({
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: "",
+            timeMs: 10,
+            size: 0,
+          },
+        }),
+      ),
     ).toBe(false)
   })
 })
 
 describe("entrySize", () => {
   it("returns size from response", () => {
-    expect(entrySize(makeEntry({ response: { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 10, size: 42 } }))).toBe(42)
+    expect(
+      entrySize(
+        makeEntry({
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: "",
+            timeMs: 10,
+            size: 42,
+          },
+        }),
+      ),
+    ).toBe(42)
   })
 
   it("returns null when no response", () => {
@@ -182,6 +245,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: '{"key":"val"}',
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -214,6 +278,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: undefined,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -227,7 +292,12 @@ describe("buildTimelineEntry", () => {
       request: req,
       envName: "dev",
     }
-    const entry = buildTimelineEntry(req, result, "dev", "https://api.example.com/v1/path")
+    const entry = buildTimelineEntry(
+      req,
+      result,
+      "dev",
+      "https://api.example.com/v1/path",
+    )
     expect(entry.request.url).toBe("https://api.example.com/v1/path")
   })
 
@@ -241,6 +311,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: undefined,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "error" as const,
@@ -265,6 +336,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: longBody,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -294,6 +366,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: undefined,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -324,6 +397,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -352,6 +426,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -379,6 +454,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: "",
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,
@@ -408,6 +484,7 @@ describe("buildTimelineEntry", () => {
       params: {},
       body: undefined,
       auth: undefined,
+      timeout: 0,
     }
     const result = {
       status: "done" as const,

--- a/tests/unit/statusBar.test.ts
+++ b/tests/unit/statusBar.test.ts
@@ -78,6 +78,7 @@ describe("statusBarText", () => {
           url: "/items/1",
           headers: {},
           params: {},
+          timeout: 0,
         },
       },
       envLabel: "dev",
@@ -147,6 +148,7 @@ describe("statusBarText", () => {
           url: "/users",
           headers: {},
           params: {},
+          timeout: 0,
         },
         error: new Error("Connection refused"),
       },
@@ -285,7 +287,9 @@ describe("statusBarText", () => {
       kb: defaults,
       spinnerFrame: "⠋",
     })
-    expect(r.right).toBe("[^return] send · [^s] save · [^l] layout · [tab] focus · [f1] help · [^c] quit")
+    expect(r.right).toBe(
+      "[^return] send · [^s] save · [^l] layout · [tab] focus · [f1] help · [^c] quit",
+    )
   })
 
   it("right reflects custom keybinds for help_toggle", () => {
@@ -300,7 +304,9 @@ describe("statusBarText", () => {
       kb: custom,
       spinnerFrame: "⠋",
     })
-    expect(r.right).toBe("[^return] send · [^s] save · [^l] layout · [tab] focus · [f1] help · [^c] quit")
+    expect(r.right).toBe(
+      "[^return] send · [^s] save · [^l] layout · [tab] focus · [f1] help · [^c] quit",
+    )
   })
 
   it("each section is a string", () => {

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -114,6 +114,16 @@ describe("requestEquals", () => {
   it("both auth undefined → true", () => {
     expect(requestEquals(makeReq(), makeReq())).toBe(true)
   })
+  it("same timeout → true", () => {
+    expect(
+      requestEquals(makeReq({ timeout: 5000 }), makeReq({ timeout: 5000 })),
+    ).toBe(true)
+  })
+  it("differing timeout → false", () => {
+    expect(
+      requestEquals(makeReq({ timeout: 0 }), makeReq({ timeout: 10000 })),
+    ).toBe(false)
+  })
   it("name/id differences → still equal (only url/method/headers/params/body/auth compared)", () => {
     const a = makeReq({ id: "r1", name: "A" })
     const b = makeReq({ id: "r2", name: "B" })
@@ -146,6 +156,15 @@ describe("applyDraft", () => {
     const next = applyDraft(map, "r1", original, { kind: "setBody", body: "" })
     expect(next.has("r1")).toBe(true)
     expect(next.get("r1")!.body).toBe("")
+  })
+  it("setTimeout updates timeout on draft", () => {
+    const original = makeReq({ timeout: 0 })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, {
+      kind: "setTimeout",
+      timeout: 30000,
+    })
+    expect(next.get("r1")!.timeout).toBe(30000)
   })
   it("setHeaderRow replaces i-th entry by insertion order", () => {
     const original = makeReq({
@@ -294,6 +313,17 @@ describe("applyDraft", () => {
       field: "body",
     })
     expect(next.get("r1")!.body).toBe("orig")
+  })
+  it("revertField settings restores timeout from original", () => {
+    const original = makeReq({ timeout: 5000 })
+    const map = new Map<string, Request>([
+      ["r1", { ...original, timeout: 30000 }],
+    ])
+    const next = applyDraft(map, "r1", original, {
+      kind: "revertField",
+      field: "settings",
+    })
+    expect(next.get("r1")!.timeout).toBe(5000)
   })
   it("revertField headers row i restores that row from original", () => {
     const original = makeReq({

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "bun:test"
-import { parseRow, requestEquals, applyDraft } from "../src/hooks/useRequestDraft"
+import {
+  parseRow,
+  requestEquals,
+  applyDraft,
+} from "../src/hooks/useRequestDraft"
 import type { Request } from "../src/schema"
 
 function makeReq(over: Partial<Request> = {}): Request {
@@ -10,6 +14,7 @@ function makeReq(over: Partial<Request> = {}): Request {
     url: "https://example.com",
     headers: {},
     params: {},
+    timeout: 0,
     ...over,
   }
 }
@@ -79,8 +84,18 @@ describe("requestEquals", () => {
     expect(requestEquals(a, b)).toBe(false)
   })
   it("same headers different insertion order → true (deep record compare)", () => {
-    const a = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: true } } })
-    const b = makeReq({ headers: { B: { value: "2", enabled: true }, A: { value: "1", enabled: true } } })
+    const a = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: true },
+      },
+    })
+    const b = makeReq({
+      headers: {
+        B: { value: "2", enabled: true },
+        A: { value: "1", enabled: true },
+      },
+    })
     expect(requestEquals(a, b)).toBe(true)
   })
   it("differing params → false", () => {
@@ -133,7 +148,12 @@ describe("applyDraft", () => {
     expect(next.get("r1")!.body).toBe("")
   })
   it("setHeaderRow replaces i-th entry by insertion order", () => {
-    const original = makeReq({ headers: { B: { value: "2", enabled: true }, A: { value: "1", enabled: true } } })
+    const original = makeReq({
+      headers: {
+        B: { value: "2", enabled: true },
+        A: { value: "1", enabled: true },
+      },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "setHeaderRow",
@@ -141,10 +161,18 @@ describe("applyDraft", () => {
       key: "B",
       value: "2-modified",
     })
-    expect(next.get("r1")!.headers).toEqual({ B: { value: "2-modified", enabled: true }, A: { value: "1", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      B: { value: "2-modified", enabled: true },
+      A: { value: "1", enabled: true },
+    })
   })
   it("setHeaderRow replaces i-th entry (second row)", () => {
-    const original = makeReq({ headers: { B: { value: "2", enabled: true }, A: { value: "1", enabled: true } } })
+    const original = makeReq({
+      headers: {
+        B: { value: "2", enabled: true },
+        A: { value: "1", enabled: true },
+      },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "setHeaderRow",
@@ -152,10 +180,18 @@ describe("applyDraft", () => {
       key: "A",
       value: "1-modified",
     })
-    expect(next.get("r1")!.headers).toEqual({ B: { value: "2", enabled: true }, A: { value: "1-modified", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      B: { value: "2", enabled: true },
+      A: { value: "1-modified", enabled: true },
+    })
   })
   it("setHeaderRow with empty key removes the row", () => {
-    const original = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: true } } })
+    const original = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: true },
+      },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "setHeaderRow",
@@ -163,10 +199,17 @@ describe("applyDraft", () => {
       key: "",
       value: "",
     })
-    expect(next.get("r1")!.headers).toEqual({ B: { value: "2", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      B: { value: "2", enabled: true },
+    })
   })
   it("setHeaderRow with duplicate key overwrites existing entry", () => {
-    const original = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: true } } })
+    const original = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: true },
+      },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "setHeaderRow",
@@ -174,7 +217,9 @@ describe("applyDraft", () => {
       key: "B",
       value: "2-modified",
     })
-    expect(next.get("r1")!.headers).toEqual({ B: { value: "2-modified", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      B: { value: "2-modified", enabled: true },
+    })
   })
   it("addHeaderRow appends", () => {
     const original = makeReq({ headers: { A: { value: "1", enabled: true } } })
@@ -184,16 +229,26 @@ describe("applyDraft", () => {
       key: "B",
       value: "2",
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: true }, B: { value: "2", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: true },
+      B: { value: "2", enabled: true },
+    })
   })
   it("removeHeaderRow deletes by sorted index", () => {
-    const original = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: true } } })
+    const original = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: true },
+      },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "removeHeaderRow",
       index: 0,
     })
-    expect(next.get("r1")!.headers).toEqual({ B: { value: "2", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      B: { value: "2", enabled: true },
+    })
   })
   it("removeHeaderRow on last row leaves empty record", () => {
     const original = makeReq({ headers: { A: { value: "1", enabled: true } } })
@@ -219,7 +274,10 @@ describe("applyDraft", () => {
       key: "p",
       value: "3",
     })
-    expect(next.get("r1")!.params).toEqual({ q: { value: "2", enabled: true }, p: { value: "3", enabled: true } })
+    expect(next.get("r1")!.params).toEqual({
+      q: { value: "2", enabled: true },
+      p: { value: "3", enabled: true },
+    })
     next = applyDraft(next, "r1", original, {
       kind: "removeParamRow",
       index: 0,
@@ -238,28 +296,56 @@ describe("applyDraft", () => {
     expect(next.get("r1")!.body).toBe("orig")
   })
   it("revertField headers row i restores that row from original", () => {
-    const original = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: true } } })
+    const original = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: true },
+      },
+    })
     const map = new Map<string, Request>([
-      ["r1", { ...original, headers: { A: { value: "1-edited", enabled: true }, B: { value: "2", enabled: true } } }],
+      [
+        "r1",
+        {
+          ...original,
+          headers: {
+            A: { value: "1-edited", enabled: true },
+            B: { value: "2", enabled: true },
+          },
+        },
+      ],
     ])
     const next = applyDraft(map, "r1", original, {
       kind: "revertField",
       field: "headers",
       row: 0,
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: true }, B: { value: "2", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: true },
+      B: { value: "2", enabled: true },
+    })
   })
   it("revertField headers row i removes row if original had fewer rows (added row)", () => {
     const original = makeReq({ headers: { A: { value: "1", enabled: true } } })
     const map = new Map<string, Request>([
-      ["r1", { ...original, headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: true } } }],
+      [
+        "r1",
+        {
+          ...original,
+          headers: {
+            A: { value: "1", enabled: true },
+            B: { value: "2", enabled: true },
+          },
+        },
+      ],
     ])
     const next = applyDraft(map, "r1", original, {
       kind: "revertField",
       field: "headers",
       row: 1,
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: true },
+    })
   })
   it("revertAll drops the map entry", () => {
     const original = makeReq()
@@ -302,7 +388,9 @@ describe("applyDraft", () => {
       kind: "toggleHeaderRow",
       index: 0,
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: false } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: false },
+    })
   })
   it("toggleHeaderRow flips enabled from false to true", () => {
     const original = makeReq({ headers: { A: { value: "1", enabled: false } } })
@@ -311,16 +399,22 @@ describe("applyDraft", () => {
       kind: "toggleHeaderRow",
       index: 0,
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: true },
+    })
   })
   it("toggleParamRow flips enabled", () => {
-    const original = makeReq({ params: { q: { value: "search", enabled: true } } })
+    const original = makeReq({
+      params: { q: { value: "search", enabled: true } },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "toggleParamRow",
       index: 0,
     })
-    expect(next.get("r1")!.params).toEqual({ q: { value: "search", enabled: false } })
+    expect(next.get("r1")!.params).toEqual({
+      q: { value: "search", enabled: false },
+    })
   })
   it("toggle on out-of-range index is no-op", () => {
     const original = makeReq({ headers: { A: { value: "1", enabled: true } } })
@@ -329,7 +423,9 @@ describe("applyDraft", () => {
       kind: "toggleHeaderRow",
       index: 99,
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: true },
+    })
   })
   it("setHeaderRow preserves existing enabled state", () => {
     const original = makeReq({ headers: { A: { value: "1", enabled: false } } })
@@ -340,7 +436,9 @@ describe("applyDraft", () => {
       key: "A",
       value: "modified",
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "modified", enabled: false } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "modified", enabled: false },
+    })
   })
   it("addHeaderRow defaults to enabled: true", () => {
     const original = makeReq({ headers: {} })
@@ -350,28 +448,54 @@ describe("applyDraft", () => {
       key: "X-New",
       value: "v",
     })
-    expect(next.get("r1")!.headers).toEqual({ "X-New": { value: "v", enabled: true } })
+    expect(next.get("r1")!.headers).toEqual({
+      "X-New": { value: "v", enabled: true },
+    })
   })
   it("removeHeaderRow still works with KvEntry", () => {
-    const original = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: false } } })
+    const original = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: false },
+      },
+    })
     const map = new Map<string, Request>()
     const next = applyDraft(map, "r1", original, {
       kind: "removeHeaderRow",
       index: 0,
     })
-    expect(next.get("r1")!.headers).toEqual({ B: { value: "2", enabled: false } })
+    expect(next.get("r1")!.headers).toEqual({
+      B: { value: "2", enabled: false },
+    })
   })
   it("revertField headers row i restores original enabled state", () => {
-    const original = makeReq({ headers: { A: { value: "1", enabled: true }, B: { value: "2", enabled: false } } })
+    const original = makeReq({
+      headers: {
+        A: { value: "1", enabled: true },
+        B: { value: "2", enabled: false },
+      },
+    })
     const map = new Map<string, Request>([
-      ["r1", { ...original, headers: { A: { value: "1-edited", enabled: false }, B: { value: "2", enabled: false } } }],
+      [
+        "r1",
+        {
+          ...original,
+          headers: {
+            A: { value: "1-edited", enabled: false },
+            B: { value: "2", enabled: false },
+          },
+        },
+      ],
     ])
     const next = applyDraft(map, "r1", original, {
       kind: "revertField",
       field: "headers",
       row: 0,
     })
-    expect(next.get("r1")!.headers).toEqual({ A: { value: "1", enabled: true }, B: { value: "2", enabled: false } })
+    expect(next.get("r1")!.headers).toEqual({
+      A: { value: "1", enabled: true },
+      B: { value: "2", enabled: false },
+    })
   })
 })
 


### PR DESCRIPTION
Adds per-request `timeout` field (ms) editable via new Settings tab.

**Changes:**

- `Request.timeout: number` (0 = disabled) in schema
- Parse/serialize round-trip in YAML files
- Settings tab in request pane with inline editing
- `AbortSignal.timeout()` + `AbortSignal.any()` wiring in send pipeline
- Migration writes `timeout: 0` to existing files on load
- Cursor navigation includes settings field

**Tests:** 779 pass (8 new), lint + typecheck clean.