### PR TITLE
fix(ui): url params encoding, dirty flag, response layout, timeline styles

### DIFF
--- a/src/ui/CenterText.tsx
+++ b/src/ui/CenterText.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react"
+
+export interface WordSegment {
+  text: string
+  color: string
+}
+
+export function splitWords(segments: WordSegment[]): WordSegment[] {
+  const words: WordSegment[] = []
+  for (const seg of segments) {
+    const raw = seg.text.split(/\s+/)
+    for (const w of raw) {
+      if (w) words.push({ text: w + " ", color: seg.color })
+    }
+  }
+  if (words.length > 0) {
+    words[words.length - 1].text = words[words.length - 1].text.trimEnd()
+  }
+  return words
+}
+
+export function CenterText({
+  segments,
+}: {
+  segments: WordSegment[]
+}): ReactNode {
+  const words = splitWords(segments)
+  return (
+    <box style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center" }}>
+      {words.map((w, i) => (
+        <text key={i} wrapMode="none" fg={w.color}>
+          {w.text}
+        </text>
+      ))}
+    </box>
+  )
+}

--- a/src/ui/GradientBadge.tsx
+++ b/src/ui/GradientBadge.tsx
@@ -1,0 +1,36 @@
+import { interpolateGradient } from "./gradient"
+
+export function GradientBadge({
+  colors,
+  fg,
+  children,
+}: {
+  colors: string[]
+  fg: string
+  children: string
+}) {
+  const chars = [...children]
+  const n = chars.length
+
+  return (
+    <box>
+      <text>
+        <span bg={colors[0]} fg={fg}>
+          {" "}
+        </span>
+        {chars.map((c, i) => {
+          const t = n > 1 ? i / (n - 1) : 0
+          const bg = interpolateGradient(colors, t)
+          return (
+            <span key={i} bg={bg} fg={fg}>
+              {c}
+            </span>
+          )
+        })}
+        <span bg={colors[colors.length - 1]} fg={fg}>
+          {" "}
+        </span>
+      </text>
+    </box>
+  )
+}

--- a/src/ui/JsonBodyViewer.tsx
+++ b/src/ui/JsonBodyViewer.tsx
@@ -31,7 +31,7 @@ export function JsonBodyViewer({
 
   return (
     <line-number
-      minWidth={3}
+      minWidth={5}
       paddingRight={1}
       fg={theme.textMuted}
       bg={theme.backgroundPanel}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -141,7 +141,7 @@ export function ResponsePane({
                       if (body === "") return (
                         <text fg={theme.textMuted}>(no body)</text>
                       )
-                      return <JsonBodyViewer body={body} theme={theme} readOnly />
+                      return <JsonBodyViewer key={body} body={body} theme={theme} readOnly />
                     })()}
                   </box>
                 ) : (

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -87,11 +87,8 @@ export function ResponsePane({
       style={{
         flexGrow: 1,
         flexDirection: "column",
-        paddingTop: 0,
-        paddingBottom: 1,
         paddingLeft: 1,
         paddingRight: 1,
-        gap: 1,
         flexBasis: 0,
         minHeight: 0,
         backgroundColor: theme.backgroundPanel,
@@ -121,7 +118,7 @@ export function ResponsePane({
           <text fg={theme.error}> {state.error.message}</text>
         </box>
       ) : (
-        <>
+        <box style={{ flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
           <Tabs
             tabs={TAB_DEFS}
             activeId={activeTab}
@@ -139,19 +136,6 @@ export function ResponsePane({
               >
                 {activeTab === "body" ? (
                   <box style={{ flexDirection: "column", gap: 1 }}>
-                    {state.response.statusText !== "" && (
-                      <box style={{ flexDirection: "row" }}>
-                        <GradientBadge
-                          colors={[
-                            statusColor(state.response.status, theme),
-                            theme.primary,
-                          ]}
-                          fg={theme.background}
-                        >
-                          {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""} • ${Math.round(state.response.timeMs)}ms • ${formatSize(new TextEncoder().encode(state.response.body).length)}`}
-                        </GradientBadge>
-                      </box>
-                    )}
                     {(() => {
                       const body = formatBody(state.response)
                       if (body === "") return (
@@ -184,7 +168,17 @@ export function ResponsePane({
               </scrollbox>
             )}
           </Tabs>
-        </>
+          {state.response.statusText !== "" && (
+            <box style={{ flexDirection: "row", justifyContent: "flex-end", flexShrink: 0, paddingTop: 1, paddingRight: 1 }}>
+              <GradientBadge
+                colors={[statusColor(state.response.status, theme), theme.primary]}
+                fg={theme.background}
+              >
+                {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""} • ${Math.round(state.response.timeMs)}ms • ${formatSize(new TextEncoder().encode(state.response.body).length)}`}
+              </GradientBadge>
+            </box>
+          )}
+        </box>
       )}
     </box>
   )

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -145,7 +145,6 @@ export function ResponsePane({
                           colors={[
                             statusColor(state.response.status, theme),
                             theme.primary,
-                            theme.secondary,
                           ]}
                           fg={theme.background}
                         >

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -8,7 +8,7 @@ import { Tabs, type TabDef } from "./Tabs"
 import { useTheme } from "./theme"
 import { FullBorder, LeftBar } from "./borders"
 import { JsonBodyViewer } from "./JsonBodyViewer"
-import { Badge } from "./Badge"
+import { GradientBadge } from "./GradientBadge"
 import { Tips } from "./Tips"
 import { TimelineTab } from "./timeline/TimelineTab"
 
@@ -141,9 +141,16 @@ export function ResponsePane({
                   <box style={{ flexDirection: "column", gap: 1 }}>
                     {state.response.statusText !== "" && (
                       <box style={{ flexDirection: "row" }}>
-                        <Badge bg={statusColor(state.response.status, theme)} fg={theme.background}>
-                          {state.response.status} {state.response.statusText} • {Math.round(state.response.timeMs)}ms • {formatSize(new TextEncoder().encode(state.response.body).length)}
-                        </Badge>
+                        <GradientBadge
+                          colors={[
+                            statusColor(state.response.status, theme),
+                            theme.primary,
+                            theme.secondary,
+                          ]}
+                          fg={theme.background}
+                        >
+                          {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""} • ${Math.round(state.response.timeMs)}ms • ${formatSize(new TextEncoder().encode(state.response.body).length)}`}
+                        </GradientBadge>
                       </box>
                     )}
                     {(() => {

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -125,26 +125,6 @@ export function ResponsePane({
           <Tabs
             tabs={TAB_DEFS}
             activeId={activeTab}
-            rightChildren={
-              <box style={{ flexDirection: "row", gap: 0 }}>
-                <Badge
-                  bg={statusColor(state.response.status, theme)}
-                  fg={theme.background}
-                >
-                  {state.response.statusText !== ""
-                    ? `${state.response.status} ${state.response.statusText}`
-                    : `${state.response.status}`}
-                </Badge>
-                <Badge bg={theme.info} fg={theme.background}>
-                  {Math.round(state.response.timeMs)}ms
-                </Badge>
-                <Badge bg={theme.backgroundElement} fg={theme.text}>
-                  {formatSize(
-                    new TextEncoder().encode(state.response.body).length
-                  )}
-                </Badge>
-              </box>
-            }
           >
             {activeTab === "timeline" ? (
               <TimelineTab
@@ -158,11 +138,28 @@ export function ResponsePane({
                 style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
               >
                 {activeTab === "body" ? (
-                  (() => {
-                    const body = formatBody(state.response)
-                    if (body === "") return null
-                    return <JsonBodyViewer body={body} theme={theme} readOnly />
-                  })()
+                  <box style={{ flexDirection: "column", gap: 1 }}>
+                    {state.response.statusText !== "" && (
+                      <box style={{ flexDirection: "row", gap: 0, paddingLeft: 1 }}>
+                        <Badge bg={statusColor(state.response.status, theme)} fg={theme.background}>
+                          {state.response.status} {state.response.statusText}
+                        </Badge>
+                        <Badge bg={theme.info} fg={theme.background}>
+                          {Math.round(state.response.timeMs)}ms
+                        </Badge>
+                        <Badge bg={theme.backgroundElement} fg={theme.text}>
+                          {formatSize(new TextEncoder().encode(state.response.body).length)}
+                        </Badge>
+                      </box>
+                    )}
+                    {(() => {
+                      const body = formatBody(state.response)
+                      if (body === "") return (
+                        <text fg={theme.textMuted}>(no body)</text>
+                      )
+                      return <JsonBodyViewer body={body} theme={theme} readOnly />
+                    })()}
+                  </box>
                 ) : (
                   responseHeaders.map(({ key, value }, i) => {
                     if (i < responseHeaders.length - 1) {

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -140,15 +140,9 @@ export function ResponsePane({
                 {activeTab === "body" ? (
                   <box style={{ flexDirection: "column", gap: 1 }}>
                     {state.response.statusText !== "" && (
-                      <box style={{ flexDirection: "row", gap: 0, paddingLeft: 1 }}>
+                      <box style={{ flexDirection: "row" }}>
                         <Badge bg={statusColor(state.response.status, theme)} fg={theme.background}>
-                          {state.response.status} {state.response.statusText}
-                        </Badge>
-                        <Badge bg={theme.info} fg={theme.background}>
-                          {Math.round(state.response.timeMs)}ms
-                        </Badge>
-                        <Badge bg={theme.backgroundElement} fg={theme.text}>
-                          {formatSize(new TextEncoder().encode(state.response.body).length)}
+                          {state.response.status} {state.response.statusText} • {Math.round(state.response.timeMs)}ms • {formatSize(new TextEncoder().encode(state.response.body).length)}
                         </Badge>
                       </box>
                     )}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -132,6 +132,7 @@ export function ResponsePane({
               <scrollbox
                 ref={scrollRef}
                 scrollY
+                scrollbarOptions={{ visible: false }}
                 style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
               >
                 {activeTab === "body" ? (

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { useTheme } from "./theme"
+import { CenterText } from "./CenterText"
 
 const TIPS = [
   "send the request with {^↩} — works from any pane",
@@ -55,7 +56,11 @@ export function Tips() {
   const theme = useTheme()
 
   const [tip] = useState(() => TIPS[Math.floor(Math.random() * TIPS.length)] ?? TIPS[0])
-  const parts = useMemo(() => parseTip(tip), [tip])
+  const parts = parseTip(tip)
+  const segments = [
+    { text: "● Tip", color: theme.secondary },
+    ...parts.map((p) => ({ text: p.text, color: p.isKey ? theme.primary : theme.textMuted })),
+  ]
 
   return (
     <box
@@ -68,20 +73,7 @@ export function Tips() {
         paddingRight: 4,
       }}
     >
-      <box
-        style={{
-          flexDirection: "row",
-          gap: 0,
-          flexShrink: 0,
-        }}
-      >
-        <text fg={theme.secondary}>● Tip </text>
-        {parts.map((part, i) => (
-          <text key={i} fg={part.isKey ? theme.primary : theme.textMuted}>
-            {part.text}
-          </text>
-        ))}
-      </box>
+      <CenterText segments={segments} />
     </box>
   )
 }

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -32,6 +32,7 @@ export function UrlBar({
   const [spinnerIdx, setSpinnerIdx] = useState(0)
   const [inputValue, setInputValue] = useState(url)
   const prevFocused = useRef(focused)
+  const initDisplayRef = useRef("")
 
   useEffect(() => {
     if (!sending) return
@@ -43,10 +44,15 @@ export function UrlBar({
 
   useEffect(() => {
     if (focused && !prevFocused.current) {
-      setInputValue(buildDisplayUrl(url, params))
+      const displayUrl = buildDisplayUrl(url, params)
+      setInputValue(displayUrl)
+      initDisplayRef.current = displayUrl
     }
     if (!focused && prevFocused.current) {
-      onDefocus(inputValue)
+      const displayUrl = buildDisplayUrl(url, params)
+      if (inputValue !== displayUrl) {
+        onDefocus(inputValue)
+      }
     }
     prevFocused.current = focused
   }, [focused])
@@ -60,6 +66,7 @@ export function UrlBar({
   const handleInput = useCallback(
     (val: string) => {
       setInputValue(val)
+      if (val === initDisplayRef.current) return
       setUrl(val)
     },
     [setUrl],

--- a/src/ui/gradient.ts
+++ b/src/ui/gradient.ts
@@ -1,0 +1,38 @@
+export function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace("#", "")
+  return {
+    r: parseInt(h.substring(0, 2), 16),
+    g: parseInt(h.substring(2, 4), 16),
+    b: parseInt(h.substring(4, 6), 16),
+  }
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n)))
+      .toString(16)
+      .padStart(2, "0")
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+export function lerpColor(a: string, b: string, t: number): string {
+  const ca = hexToRgb(a)
+  const cb = hexToRgb(b)
+  return rgbToHex(
+    ca.r + (cb.r - ca.r) * t,
+    ca.g + (cb.g - ca.g) * t,
+    ca.b + (cb.b - ca.b) * t,
+  )
+}
+
+export function interpolateGradient(stops: string[], t: number): string {
+  if (stops.length === 0) return "#000000"
+  if (stops.length === 1) return stops[0]
+  if (t <= 0) return stops[0]
+  if (t >= 1) return stops[stops.length - 1]
+
+  const segment = t * (stops.length - 1)
+  const i = Math.floor(segment)
+  const localT = segment - i
+  return lerpColor(stops[i], stops[i + 1], localT)
+}

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -10,6 +10,10 @@ import {
 } from "./formatTimeline"
 import { methodColor } from "../formatRequest"
 
+function shortMethod(m: string): string {
+  return m === "DELETE" ? "DEL" : m
+}
+
 function formatRequestHeaders(entry: TimelineEntryType): string[] {
   const lines: string[] = []
   for (const [k, v] of Object.entries(entry.request.headers)) {
@@ -58,7 +62,7 @@ export function TimelineEntry({
   const rowFg = isSelected ? theme.text : theme.textMuted
 
   const method = entryMethod(entry)
-  const methodStr = method.padEnd(5)
+  const methodStr = (method === "PATCH" ? shortMethod(method).padEnd(7) : shortMethod(method).padEnd(5))
   const statusStr = status !== null ? (status === 0 ? "ERR " : `${status} `) : "--- "
   const urlStr = formatRequestUrl(entry)
   const timingStr = hasError ? "ERR" : entryTiming(entry)
@@ -128,7 +132,7 @@ export function TimelineEntry({
           <box style={{ flexDirection: "column", gap: 0, paddingLeft: 2 }}>
             <text fg={theme.text}>
               {" "}
-              {entryMethod(entry)} {formatRequestUrl(entry)}
+              {shortMethod(entryMethod(entry))} {formatRequestUrl(entry)}
             </text>
             {authSummary(entry.request.auth) && (
               <text fg={theme.textMuted}>

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -69,7 +69,7 @@ export function TimelineEntry({
   const reltimeStr = relativeTime(entry.timestamp)
 
   const ROW_PADDING = 2
-  const FIXED_ELEMENTS = 22
+  const FIXED_ELEMENTS = 24
   const urlMaxLength = containerWidth > 0
     ? Math.max(10, containerWidth - ROW_PADDING - FIXED_ELEMENTS)
     : 999

--- a/src/ui/timeline/TimelineTab.tsx
+++ b/src/ui/timeline/TimelineTab.tsx
@@ -35,7 +35,7 @@ export function TimelineTab({
         setTimeout(measure, 10)
         return
       }
-      const w = box.width - 1
+      const w = box.width
       if (w !== containerWidthRef.current) {
         containerWidthRef.current = w
         setContainerWidth(w)
@@ -93,6 +93,7 @@ export function TimelineTab({
     <scrollbox
       ref={scrollRef}
       scrollY
+      scrollbarOptions={{ visible: false }}
       style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
     >
       {entries.map((entry, idx) => (

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -7,13 +7,13 @@ export function buildDisplayUrl(
   if (!url) return url
 
   let baseUrl: string
-  const existingParams = new URLSearchParams()
+  const existingParams: Array<[string, string]> = []
 
   try {
     const u = new URL(url)
     baseUrl = normBaseUrl(u.origin, u.pathname)
     u.searchParams.forEach((v, k) => {
-      existingParams.set(k, v)
+      existingParams.push([k, v])
     })
   } catch {
     const questionIdx = url.indexOf("?")
@@ -21,7 +21,7 @@ export function buildDisplayUrl(
       baseUrl = url.slice(0, questionIdx)
       try {
         const sp = new URLSearchParams(url.slice(questionIdx + 1))
-        sp.forEach((v, k) => existingParams.set(k, v))
+        sp.forEach((v, k) => existingParams.push([k, v]))
       } catch {
         return url
       }
@@ -30,21 +30,29 @@ export function buildDisplayUrl(
     }
   }
 
-  const merged = new URLSearchParams()
+  const merged: Array<[string, string]> = []
 
-  for (const [k, v] of existingParams.entries()) {
+  for (const [k, v] of existingParams) {
     if (!(k in params)) {
-      merged.set(k, v)
+      merged.push([k, v])
     }
   }
 
   for (const [k, entry] of Object.entries(params)) {
     if (!entry.enabled) continue
-    merged.set(k, entry.value)
+    merged.push([k, entry.value])
   }
 
-  const qs = merged.toString()
-  return qs ? `${baseUrl}?${qs}` : baseUrl
+  if (merged.length === 0) return baseUrl
+
+  const qs = merged
+    .map(([k, v]) => `${encQuery(k)}=${encQuery(v)}`)
+    .join("&")
+  return `${baseUrl}?${qs}`
+}
+
+function encQuery(s: string): string {
+  return s.replace(/[&#]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
 }
 
 export function parseUrlAndParams(raw: string): {

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -63,8 +63,6 @@ describe("ResponsePane scrollbox", () => {
     expect(bodyLines.length).toBeGreaterThan(0)
     expect(bodyLines.length).toBeLessThan(100)
 
-    // scroll indicator present (proves overflow rendering)
-    expect(frame).toMatch(/[▀▄▌]/)
   })
 })
 

--- a/tests/unit/CenterText.test.tsx
+++ b/tests/unit/CenterText.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { CenterText, splitWords } from "../../src/ui/CenterText"
+
+describe("splitWords", () => {
+  it("splits single segment into words with trailing space", () => {
+    const result = splitWords([{ text: "hello world", color: "#fff" }])
+    expect(result).toEqual([
+      { text: "hello ", color: "#fff" },
+      { text: "world", color: "#fff" },
+    ])
+  })
+
+  it("preserves isKey highlighting per segment", () => {
+    const result = splitWords([
+      { text: "press ", color: "#aaa" },
+      { text: "Enter", color: "#0f0" },
+      { text: " to continue", color: "#aaa" },
+    ])
+    expect(result).toEqual([
+      { text: "press ", color: "#aaa" },
+      { text: "Enter ", color: "#0f0" },
+      { text: "to ", color: "#aaa" },
+      { text: "continue", color: "#aaa" },
+    ])
+  })
+
+  it("handles single word", () => {
+    const result = splitWords([{ text: "hello", color: "#fff" }])
+    expect(result).toEqual([{ text: "hello", color: "#fff" }])
+  })
+
+  it("handles empty input", () => {
+    const result = splitWords([])
+    expect(result).toEqual([])
+  })
+
+  it("trims trailing space from last word", () => {
+    const result = splitWords([
+      { text: "tip", color: "#fff" },
+      { text: " here", color: "#aaa" },
+    ])
+    const last = result[result.length - 1]
+    expect(last.text).not.toMatch(/ $/)
+  })
+})
+
+describe("CenterText", () => {
+  it("renders words as inline text elements in a row", async () => {
+    const segments = [
+      { text: "hello world", color: "#ffffff" },
+    ]
+    const { renderOnce, captureSpans } = await testRender(
+      <CenterText segments={segments} />,
+      { width: 40, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap(l => l.spans)
+    const fullText = spans.map(s => s.text).join("")
+    expect(fullText).toContain("hello ")
+    expect(fullText).toContain("world")
+  })
+
+  it("renders multiple segments with different colors", async () => {
+    const segments = [
+      { text: "press ", color: "#aaa" },
+      { text: "Enter", color: "#0f0" },
+      { text: " to continue", color: "#aaa" },
+    ]
+    const { renderOnce, captureSpans } = await testRender(
+      <CenterText segments={segments} />,
+      { width: 60, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap(l => l.spans)
+    const fullText = spans.map(s => s.text).join("")
+    expect(fullText).toContain("press Enter to continue")
+  })
+
+  it("renders centered in the available width", async () => {
+    const segments = [{ text: "tip", color: "#fff" }]
+    const { renderOnce, captureCharFrame } = await testRender(
+      <CenterText segments={segments} />,
+      { width: 20, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    const lines = frame.split("\n").filter(l => l.trim().length > 0)
+    const nonEmpty = lines[0]
+    expect(nonEmpty?.trim()).toBe("tip")
+    // tip should be roughly centered (padded with spaces on both sides)
+    expect(nonEmpty?.startsWith(" ")).toBe(true)
+  })
+
+  it("handles empty segments", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <CenterText segments={[]} />,
+      { width: 40, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    expect(frame.lines.length).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/tests/unit/GradientBadge.test.tsx
+++ b/tests/unit/GradientBadge.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { RGBA } from "@opentui/core"
+import { GradientBadge } from "../../src/ui/GradientBadge"
+
+function rgbaFromHex(hex: string): RGBA {
+  return RGBA.fromHex(hex)
+}
+
+describe("GradientBadge", () => {
+  it("renders text content", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <GradientBadge colors={["#ff0000", "#0000ff"]} fg="#ffffff">
+        OK
+      </GradientBadge>,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("OK")
+  })
+
+  it("first char background matches first gradient color", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <GradientBadge colors={["#ff0000", "#00ff00", "#0000ff"]} fg="#ffffff">
+        ABC
+      </GradientBadge>,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+
+    const frame = captureSpans()
+    const allSpans = frame.lines.flatMap((l) => l.spans)
+    // left pad + A merge (both bg=#ff0000) → text " A"
+    const spanA = allSpans.find((s) => s.text.startsWith(" A"))
+    expect(spanA).toBeDefined()
+    expect(spanA!.bg.equals(rgbaFromHex("#ff0000"))).toBe(true)
+  })
+
+  it("middle char has interpolated color in 3-stop gradient", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <GradientBadge colors={["#ff0000", "#00ff00", "#0000ff"]} fg="#ffffff">
+        ABC
+      </GradientBadge>,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+
+    const frame = captureSpans()
+    const allSpans = frame.lines.flatMap((l) => l.spans)
+    // B at t=0.5 → #00ff00, standalone span (different bg from neighbors)
+    const spanB = allSpans.find((s) => s.text === "B")
+    expect(spanB).toBeDefined()
+    expect(spanB!.bg.equals(rgbaFromHex("#00ff00"))).toBe(true)
+  })
+
+  it("last char background matches last gradient color", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <GradientBadge colors={["#ff0000", "#00ff00", "#0000ff"]} fg="#ffffff">
+        ABC
+      </GradientBadge>,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+
+    const frame = captureSpans()
+    const allSpans = frame.lines.flatMap((l) => l.spans)
+    // C + right pad merge (both bg=#0000ff) → text "C"
+    const spanC = allSpans.find((s) => s.text.includes("C"))
+    expect(spanC).toBeDefined()
+    expect(spanC!.bg.equals(rgbaFromHex("#0000ff"))).toBe(true)
+  })
+
+  it("left padding span uses first color", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <GradientBadge colors={["#ff0000", "#00ff00", "#0000ff"]} fg="#ffffff">
+        ABC
+      </GradientBadge>,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+
+    const frame = captureSpans()
+    const allSpans = frame.lines.flatMap((l) => l.spans)
+    // first span = left pad + A merged, starts with space
+    const firstSpan = allSpans[0]
+    expect(firstSpan).toBeDefined()
+    expect(firstSpan!.text.startsWith(" ")).toBe(true)
+    expect(firstSpan!.bg.equals(rgbaFromHex("#ff0000"))).toBe(true)
+  })
+
+  it("applies foreground color to all spans", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <GradientBadge colors={["#ff0000", "#00ff00", "#0000ff"]} fg="#ff00ff">
+        ABC
+      </GradientBadge>,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+
+    const frame = captureSpans()
+    const allSpans = frame.lines.flatMap((l) => l.spans)
+    // OpenTUI appends a fill-to-width span with default fg; skip it
+    const target = rgbaFromHex("#ff00ff")
+    let checked = 0
+    for (const span of allSpans) {
+      if (span.text.trim() === "" && !span.fg.equals(target)) continue
+      expect(span.fg.equals(target)).toBe(true)
+      checked++
+    }
+    expect(checked).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/tests/unit/gradient.test.ts
+++ b/tests/unit/gradient.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "bun:test"
+import {
+  hexToRgb,
+  rgbToHex,
+  lerpColor,
+  interpolateGradient,
+} from "../../src/ui/gradient"
+
+describe("hexToRgb", () => {
+  it("parses #ff0000", () => {
+    expect(hexToRgb("#ff0000")).toEqual({ r: 255, g: 0, b: 0 })
+  })
+
+  it("parses #00ff00", () => {
+    expect(hexToRgb("#00ff00")).toEqual({ r: 0, g: 255, b: 0 })
+  })
+
+  it("parses #0000ff", () => {
+    expect(hexToRgb("#0000ff")).toEqual({ r: 0, g: 0, b: 255 })
+  })
+
+  it("parses #ffffff", () => {
+    expect(hexToRgb("#ffffff")).toEqual({ r: 255, g: 255, b: 255 })
+  })
+
+  it("parses #000000", () => {
+    expect(hexToRgb("#000000")).toEqual({ r: 0, g: 0, b: 0 })
+  })
+})
+
+describe("rgbToHex", () => {
+  it("converts rgb to hex", () => {
+    expect(rgbToHex(255, 0, 0)).toBe("#ff0000")
+  })
+
+  it("converts green", () => {
+    expect(rgbToHex(0, 255, 0)).toBe("#00ff00")
+  })
+
+  it("clamps values below 0", () => {
+    expect(rgbToHex(-10, 0, 0)).toBe("#000000")
+  })
+
+  it("clamps values above 255", () => {
+    expect(rgbToHex(300, 0, 0)).toBe("#ff0000")
+  })
+
+  it("rounds fractional values", () => {
+    expect(rgbToHex(127.4, 127.6, 0)).toBe("#7f8000")
+  })
+})
+
+describe("lerpColor", () => {
+  it("returns first color at t=0", () => {
+    expect(lerpColor("#ff0000", "#00ff00", 0)).toBe("#ff0000")
+  })
+
+  it("returns second color at t=1", () => {
+    expect(lerpColor("#ff0000", "#00ff00", 1)).toBe("#00ff00")
+  })
+
+  it("returns midpoint at t=0.5", () => {
+    // lerp(255, 0, 0.5) = 127.5 → round → 128 = 0x80
+    expect(lerpColor("#ff0000", "#0000ff", 0.5)).toBe("#800080")
+  })
+
+  it("interpolates red channel only", () => {
+    expect(lerpColor("#ff0000", "#000000", 0.5)).toBe("#800000")
+  })
+
+  it("interpolates all channels", () => {
+    expect(lerpColor("#000000", "#ffffff", 0.5)).toBe("#808080")
+  })
+})
+
+describe("interpolateGradient", () => {
+  it("returns single stop for any t", () => {
+    expect(interpolateGradient(["#ff0000"], 0)).toBe("#ff0000")
+    expect(interpolateGradient(["#ff0000"], 0.5)).toBe("#ff0000")
+    expect(interpolateGradient(["#ff0000"], 1)).toBe("#ff0000")
+  })
+
+  it("returns first stop at t=0", () => {
+    expect(interpolateGradient(["#ff0000", "#00ff00", "#0000ff"], 0)).toBe(
+      "#ff0000",
+    )
+  })
+
+  it("returns last stop at t=1", () => {
+    expect(interpolateGradient(["#ff0000", "#00ff00", "#0000ff"], 1)).toBe(
+      "#0000ff",
+    )
+  })
+
+  it("returns midpoint of two stops at t=0.5", () => {
+    expect(interpolateGradient(["#ff0000", "#0000ff"], 0.5)).toBe("#800080")
+  })
+
+  it("returns first segment midpoint with 3 stops at t=0.25", () => {
+    // 3 stops: positions 0, 0.5, 1
+    // t=0.25 → halfway between stop 0 (red) and stop 1 (green)
+    expect(interpolateGradient(["#ff0000", "#00ff00", "#0000ff"], 0.25)).toBe(
+      "#808000",
+    )
+  })
+
+  it("returns second segment midpoint with 3 stops at t=0.75", () => {
+    // t=0.75 → halfway between stop 1 (green) and stop 2 (blue)
+    expect(interpolateGradient(["#ff0000", "#00ff00", "#0000ff"], 0.75)).toBe(
+      "#008080",
+    )
+  })
+
+  it("handles empty stops list", () => {
+    expect(interpolateGradient([], 0.5)).toBe("#000000")
+  })
+
+  it("clamps t below 0", () => {
+    expect(interpolateGradient(["#ff0000", "#00ff00"], -0.5)).toBe("#ff0000")
+  })
+
+  it("clamps t above 1", () => {
+    expect(interpolateGradient(["#ff0000", "#00ff00"], 1.5)).toBe("#00ff00")
+  })
+})

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -86,7 +86,7 @@ describe("buildDisplayUrl", () => {
       token: { value: "$API_KEY", enabled: true },
     }
     expect(buildDisplayUrl("https://example.com/data", params)).toBe(
-      "https://example.com/data?token=%24API_KEY",
+      "https://example.com/data?token=$API_KEY",
     )
   })
 


### PR DESCRIPTION
## Summary

11 commits improving URL bar behavior, response layout, and UI components.

### URL bar fixes
- **Percent-encoding fix**: stop encoding `$` → `%24` in param values. Build query string manually, encode only `&` and `#`.
- **Dirty flag fix**: prevent focusing URL bar from marking request dirty. Guard `handleInput` against programmatic `onInput`; skip `onDefocus` when no change.

### Response pane
- Move response badges (status, time, size) into body tab
- GradientBadge component with per-character gradient
- Fix JsonBodyViewer remount on body change
- Consistent body text left spacing (wider gutter)

### Timeline
- Abbreviate DELETE → DEL
- Widen PATCH padding

### New components
- CenterText — centered wrapped text with word splitting
- GradientBadge + gradient utilities (lerp, hexToRgb, etc.)

## Files changed

```
src/ui/CenterText.tsx             |  37 +++++++++++
src/ui/GradientBadge.tsx          |  36 +++++++++++
src/ui/JsonBodyViewer.tsx         |   2 +-
src/ui/ResponsePane.tsx           |  54 +++++++---------
src/ui/Tips.tsx                   |  24 +++-----
src/ui/UrlBar.tsx                 |  11 +++-
src/ui/gradient.ts                |  38 ++++++++++++
src/ui/timeline/TimelineEntry.tsx |  10 ++-
src/ui/timeline/TimelineTab.tsx   |   3 +-
src/ui/urlParams.ts               |  26 +++++---
tests/scrollbox.test.tsx          |   2 -
tests/unit/CenterText.test.tsx    | 106 ++++++++++++++++++++++++++++++++
tests/unit/GradientBadge.test.tsx | 113 ++++++++++++++++++++++++++++++++++
tests/unit/gradient.test.ts       | 125 ++++++++++++++++++++++++++++++++++++++
tests/unit/urlParams.test.ts      |   2 +-
15 files changed, 523 insertions(+), 66 deletions(-)
```