### PR TITLE
feat(requests): add followRedirects and maxRedirects settings

### DIFF
--- a/collections/basic-auth.yml
+++ b/collections/basic-auth.yml
@@ -1,7 +1,9 @@
 name: Basic Auth
 method: GET
 url: https://httpbin.org/basic-auth/user/pass
-timeout: 1000
+timeout: 0
+followRedirects: true
+maxRedirects: 5
 auth:
   type: basic
   user: user

--- a/collections/bearer-auth.yml
+++ b/collections/bearer-auth.yml
@@ -2,6 +2,8 @@ name: Bearer Auth
 method: GET
 url: https://httpbin.org/bearer
 timeout: 0
+followRedirects: true
+maxRedirects: 5
 auth:
   type: bearer
   token: $api_token

--- a/collections/create-post.yml
+++ b/collections/create-post.yml
@@ -2,6 +2,8 @@ name: Create Post
 method: POST
 url: $base_url/posts
 timeout: 0
+followRedirects: true
+maxRedirects: 5
 headers:
   Content-Type: application/json
   x-api-key: $x_api_key

--- a/collections/delete-post.yml
+++ b/collections/delete-post.yml
@@ -2,3 +2,5 @@ name: Delete Post
 method: DELETE
 url: $base_url/posts/$post_id
 timeout: 0
+followRedirects: true
+maxRedirects: 5

--- a/collections/get-post.yml
+++ b/collections/get-post.yml
@@ -2,3 +2,5 @@ name: Get Post by ID
 method: GET
 url: $base_url/posts/$post_id
 timeout: 0
+followRedirects: true
+maxRedirects: 5

--- a/collections/get-posts.yml
+++ b/collections/get-posts.yml
@@ -2,3 +2,5 @@ name: Get Posts
 method: GET
 url: $base_url/posts
 timeout: 0
+followRedirects: true
+maxRedirects: 5

--- a/collections/get-with-params.yml
+++ b/collections/get-with-params.yml
@@ -2,5 +2,7 @@ name: Get with Params
 method: GET
 url: $base_url/posts
 timeout: 0
+followRedirects: true
+maxRedirects: 5
 params:
   userId: $user_id

--- a/collections/update-post.yml
+++ b/collections/update-post.yml
@@ -2,6 +2,8 @@ name: Update Post
 method: PATCH
 url: $base_url/posts/1
 timeout: 0
+followRedirects: true
+maxRedirects: 5
 headers:
   Content-Type: application/json
 body: '{"title":"updated title"}'

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -25,10 +25,13 @@ const FIELD_ORDER: FieldKind[] = [
 ]
 
 function rowCount(req: Request | null): SectionRowCount {
-  if (!req) return { headers: 0, params: 0 }
+  if (!req) return { headers: 0, params: 0, body: 0, auth: 0, settings: 3 }
   return {
     headers: Object.keys(req.headers).length,
     params: Object.keys(req.params).length,
+    body: 0,
+    auth: 0,
+    settings: 3,
   }
 }
 
@@ -40,7 +43,12 @@ function currentValueFor(
 ): string {
   if (!draft) return ""
   if (field === "body") return draft.body ?? ""
-  if (field === "settings") return String(draft.timeout)
+  if (field === "settings") {
+    if (row === 0) return String(draft.timeout)
+    if (row === 1) return String(draft.followRedirects ?? true)
+    if (row === 2) return String(draft.maxRedirects ?? 5)
+    return ""
+  }
   if (field === "headers" || field === "params") {
     if (addingRow) return ""
     const rec = field === "headers" ? draft.headers : draft.params
@@ -67,7 +75,12 @@ function currentKeyValueFor(
       ? { key: entry[0], value: entry[1].value }
       : { key: "", value: "" }
   }
-  if (field === "settings") return { key: "", value: String(draft.timeout) }
+  if (field === "settings") {
+    if (row === 0) return { key: "", value: String(draft.timeout) }
+    if (row === 1) return { key: "", value: String(draft.followRedirects ?? true) }
+    if (row === 2) return { key: "", value: String(draft.maxRedirects ?? 5) }
+    return { key: "", value: "" }
+  }
   return { key: "", value: "" }
 }
 
@@ -229,7 +242,15 @@ export function useEditBrowse(
     if (field === "body") {
       draftMutators.setBody(val)
     } else if (field === "settings") {
-      draftMutators.setTimeout(Number(val) || 0)
+      const row = state.cursor.row
+      if (row === 0) {
+        draftMutators.setTimeout(Number(val) || 0)
+      } else if (row === 1) {
+        draftMutators.setFollowRedirects(val.trim().toLowerCase() !== "false")
+      } else if (row === 2) {
+        const n = Number(val)
+        draftMutators.setMaxRedirects(Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 5)
+      }
     } else if (field === "headers" || field === "params") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -160,6 +160,12 @@ export function useEditBrowse(
       setEditState(browsed)
       return
     }
+    if (browsed.cursor.field === "settings" && browsed.cursor.row === 1) {
+      const current = currentDraft?.followRedirects ?? true
+      draftMutators.setFollowRedirects(!current)
+      setEditState(browsed)
+      return
+    }
 
     const { field, row, addingRow } = browsed.cursor
     if (field === "body" || field === "settings") {
@@ -220,8 +226,14 @@ export function useEditBrowse(
   const enterEdit = useCallback(() => {
     const state = editStateRef.current
     if (state.mode !== "browsing") return
+    const { field, row } = state.cursor
+    if (field === "settings" && row === 1) {
+      const current = draftRef.current?.followRedirects ?? true
+      draftMutators.setFollowRedirects(!current)
+      return
+    }
     const currentDraft = draftRef.current
-    const { field, row, addingRow } = state.cursor
+    const { addingRow } = state.cursor
     if (field === "body" || field === "settings") {
       const init = currentValueFor(currentDraft, field, row, addingRow)
       setEditValue(init)
@@ -305,6 +317,10 @@ export function useEditBrowse(
     if (addingRow) return
     if (field === "headers") draftMutators.toggleHeaderRow(row)
     else if (field === "params") draftMutators.toggleParamRow(row)
+    else if (field === "settings" && row === 1) {
+      const current = draftRef.current?.followRedirects ?? true
+      draftMutators.setFollowRedirects(!current)
+    }
   }, [draftMutators])
 
   const cycleInactiveTab = useCallback((delta: 1 | -1) => {

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -16,6 +16,8 @@ export type DraftOp =
   | { kind: "toggleParamRow"; index: number }
   | { kind: "syncUrlParams"; rawUrl: string }
   | { kind: "setTimeout"; timeout: number }
+  | { kind: "setFollowRedirects"; followRedirects: boolean }
+  | { kind: "setMaxRedirects"; maxRedirects: number }
   | { kind: "revertField"; field: FieldKind; row?: number }
   | { kind: "revertAll" }
 
@@ -63,6 +65,8 @@ export function requestEquals(a: Request, b: Request): boolean {
   if (a.url !== b.url) return false
   if (a.method !== b.method) return false
   if (a.timeout !== b.timeout) return false
+  if (a.followRedirects !== b.followRedirects) return false
+  if (a.maxRedirects !== b.maxRedirects) return false
   if (a.body !== b.body) return false
   if (!recordsEqual(a.headers, b.headers)) return false
   if (!recordsEqual(a.params, b.params)) return false
@@ -225,9 +229,19 @@ export function applyDraft(
     case "setTimeout":
       draft.timeout = op.timeout
       break
+    case "setFollowRedirects":
+      draft.followRedirects = op.followRedirects
+      break
+    case "setMaxRedirects":
+      draft.maxRedirects = op.maxRedirects
+      break
     case "revertField": {
       if (op.field === "body") draft.body = original.body
-      else if (op.field === "settings") draft.timeout = original.timeout
+      else if (op.field === "settings") {
+        draft.timeout = original.timeout
+        draft.followRedirects = original.followRedirects
+        draft.maxRedirects = original.maxRedirects
+      }
       else if (op.field === "headers" && op.row !== undefined) {
         draft.headers = revertRow(current.headers, original.headers, op.row)
       } else if (op.field === "params" && op.row !== undefined) {
@@ -257,7 +271,9 @@ export interface UseRequestDraftResult {
   addParamRow: (key: string, value: string) => void
   removeParamRow: (index: number) => void
   toggleParamRow: (index: number) => void
-  setTimeout: (timeout: number) => void
+  setTimeout: (t: number) => void
+  setFollowRedirects: (b: boolean) => void
+  setMaxRedirects: (n: number) => void
   revertField: (field: FieldKind, row?: number) => void
   revertAll: () => void
   markSaved: () => void
@@ -305,6 +321,14 @@ export function useRequestDraft(
   )
   const setTimeoutCb = useCallback(
     (timeout: number) => apply({ kind: "setTimeout", timeout }),
+    [apply],
+  )
+  const setFollowRedirects = useCallback(
+    (followRedirects: boolean) => apply({ kind: "setFollowRedirects", followRedirects }),
+    [apply],
+  )
+  const setMaxRedirects = useCallback(
+    (maxRedirects: number) => apply({ kind: "setMaxRedirects", maxRedirects }),
     [apply],
   )
   const setHeaderRow = useCallback(
@@ -393,6 +417,8 @@ export function useRequestDraft(
       syncUrlParams,
       setBody,
       setTimeout: setTimeoutCb,
+      setFollowRedirects,
+      setMaxRedirects,
       setHeaderRow,
       addHeaderRow,
       removeHeaderRow,
@@ -413,6 +439,8 @@ export function useRequestDraft(
       syncUrlParams,
       setBody,
       setTimeoutCb,
+      setFollowRedirects,
+      setMaxRedirects,
       setHeaderRow,
       addHeaderRow,
       removeHeaderRow,

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -48,6 +48,8 @@ export function parseRequest(id: string, yamlText: string): Request {
     "method",
     "url",
     "timeout",
+    "followRedirects",
+    "maxRedirects",
     "headers",
     "params",
     "body",
@@ -97,12 +99,30 @@ export function parseRequest(id: string, yamlText: string): Request {
     timeout = raw.timeout
   }
 
+  let followRedirects: boolean = true
+  if (raw.followRedirects !== undefined) {
+    if (typeof raw.followRedirects !== "boolean") {
+      throw new Error('lang.parseRequest: "followRedirects" must be a boolean')
+    }
+    followRedirects = raw.followRedirects
+  }
+
+  let maxRedirects: number = 5
+  if (raw.maxRedirects !== undefined) {
+    if (typeof raw.maxRedirects !== "number" || !Number.isInteger(raw.maxRedirects) || raw.maxRedirects < 0) {
+      throw new Error('lang.parseRequest: "maxRedirects" must be a non-negative integer')
+    }
+    maxRedirects = raw.maxRedirects
+  }
+
   return {
     id,
     name: raw.name,
     method,
     url: raw.url,
     timeout,
+    followRedirects,
+    maxRedirects,
     headers,
     params,
     body,

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -13,6 +13,13 @@ export function serializeRequest(req: Request): string {
   out += `url: ${yamlVal(req.url)}\n`
   out += `timeout: ${String(req.timeout)}\n`
 
+  if (req.followRedirects !== undefined && req.followRedirects !== true) {
+    out += `followRedirects: ${req.followRedirects}\n`
+  }
+  if (req.maxRedirects !== undefined && req.maxRedirects !== 5) {
+    out += `maxRedirects: ${req.maxRedirects}\n`
+  }
+
   if (Object.keys(req.headers).length > 0) {
     out += "headers:\n"
     for (const [k, v] of Object.entries(req.headers)) {

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -12,13 +12,8 @@ export function serializeRequest(req: Request): string {
   out += `method: ${yamlVal(req.method)}\n`
   out += `url: ${yamlVal(req.url)}\n`
   out += `timeout: ${String(req.timeout)}\n`
-
-  if (req.followRedirects !== undefined && req.followRedirects !== true) {
-    out += `followRedirects: ${req.followRedirects}\n`
-  }
-  if (req.maxRedirects !== undefined && req.maxRedirects !== 5) {
-    out += `maxRedirects: ${req.maxRedirects}\n`
-  }
+  out += `followRedirects: ${req.followRedirects ?? true}\n`
+  out += `maxRedirects: ${req.maxRedirects ?? 5}\n`
 
   if (Object.keys(req.headers).length > 0) {
     out += "headers:\n"

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -55,11 +55,46 @@ export async function send(
 
   const start = performance.now()
   let res: globalThis.Response
-  try {
-    res = await fetch(finalUrl, init)
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    throw new Error(`requests.send: fetch failed: ${msg}`, { cause: e })
+  let currentUrl = finalUrl
+  let currentInit: RequestInit = { ...init, redirect: "manual" }
+  let redirectCount = 0
+  const maxRedirects = req.maxRedirects ?? 5
+  const followRedirects = req.followRedirects ?? true
+
+  while (true) {
+    try {
+      res = await fetch(currentUrl, currentInit)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      throw new Error(`requests.send: fetch failed: ${msg}`, { cause: e })
+    }
+
+    if (!followRedirects || ![301, 302, 303, 307, 308].includes(res.status)) {
+      break
+    }
+
+    const loc = res.headers.get("location")
+    if (!loc) break
+
+    if (redirectCount >= maxRedirects) {
+      throw new Error(`requests.send: max redirects (${maxRedirects}) exceeded`)
+    }
+    redirectCount++
+
+    currentUrl = new URL(loc, currentUrl).toString()
+
+    if (res.status === 303 || ((res.status === 301 || res.status === 302) && currentInit.method === "POST")) {
+      const newHeaders = new Headers(currentInit.headers)
+      newHeaders.delete("content-type")
+      newHeaders.delete("content-length")
+
+      currentInit = {
+        ...currentInit,
+        method: "GET",
+        body: undefined,
+        headers: newHeaders,
+      }
+    }
   }
 
   let body: string

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -23,6 +23,8 @@ export interface Request {
   method: Method
   url: string
   timeout: number
+  followRedirects?: boolean
+  maxRedirects?: number
   headers: Record<string, KvEntry>
   params: Record<string, KvEntry>
   body?: string

--- a/src/ui/Checkbox.tsx
+++ b/src/ui/Checkbox.tsx
@@ -1,0 +1,9 @@
+import type { Theme } from "./theme"
+
+export function Checkbox({ checked, theme }: { checked: boolean; theme: Theme }) {
+  return (
+    <text fg={checked ? theme.primary : theme.textMuted}>
+      {checked ? "[x] " : "[ ] "}
+    </text>
+  )
+}

--- a/src/ui/EnvEditorPane.tsx
+++ b/src/ui/EnvEditorPane.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
 import type { EnvDraft } from "../hooks/useEnvironmentEditor"
+import { Checkbox } from "./Checkbox"
 
 export function EnvEditorPane({
   draft,
@@ -107,9 +108,7 @@ export function EnvEditorPane({
                       : undefined,
               }}
             >
-              <text fg={row.enabled ? theme.primary : theme.textMuted}>
-                {row.enabled ? "[x] " : "[ ] "}
-              </text>
+              <Checkbox checked={row.enabled} theme={theme} />
               <input
                 value={editing === "key" ? row.key : row.key}
                 placeholder="Key"
@@ -166,7 +165,7 @@ export function EnvEditorPane({
                 : undefined,
           }}
         >
-          <text fg={theme.textMuted}>[ ] </text>
+          <Checkbox checked={false} theme={theme} />
           <input
             value=""
             placeholder="Key"

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -1,6 +1,7 @@
 import type { Request, Environment } from "../schema"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
+import { Checkbox } from "./Checkbox"
 import { varSummaryColor } from "./envHighlight"
 
 export interface KeyValueSectionProps {
@@ -60,7 +61,7 @@ export function KeyValueSection({
             gap: 0,
           }}
         >
-          <text fg={theme.textMuted}>[ ] </text>
+          <Checkbox checked={false} theme={theme} />
           <input
             value=""
             placeholder="Key"
@@ -102,9 +103,7 @@ export function KeyValueSection({
                         : undefined,
                 }}
               >
-                <text fg={entry.enabled ? theme.primary : theme.textMuted}>
-                  {entry.enabled ? "[x] " : "[ ] "}
-                </text>
+                <Checkbox checked={entry.enabled} theme={theme} />
                 <input
                   value={isEditingThisRow ? editKey : k}
                   placeholder="Key"
@@ -171,7 +170,7 @@ export function KeyValueSection({
                   : undefined,
             }}
           >
-            <text fg={theme.textMuted}>[ ] </text>
+          <Checkbox checked={false} theme={theme} />
             <input
               value={editingAdd ? editKey : ""}
               placeholder="Key"

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -16,6 +16,7 @@ import { useJsonHighlight } from "../hooks/useJsonHighlight"
 import { JsonBodyViewer } from "./JsonBodyViewer"
 import { VarText } from "./VarText"
 import { KeyValueSection } from "./KeyValueSection"
+import { Checkbox } from "./Checkbox"
 
 interface Props {
   request: Request | null
@@ -391,9 +392,7 @@ function SettingsSection({
               ) : idx === 1 ? (
                 <box style={{ flexDirection: "row", gap: 1 }}>
                   <text fg={theme.textMuted}>{row.label}: </text>
-                  <text fg={(request.followRedirects ?? true) ? theme.primary : theme.textMuted}>
-                    {(request.followRedirects ?? true) ? "[x]" : "[ ]"}
-                  </text>
+                  <Checkbox checked={request.followRedirects ?? true} theme={theme} />
                 </box>
               ) : (
                 <VarText

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -182,7 +182,6 @@ export function RequestPane({
                 <SettingsSection
                   request={request}
                   editState={editState}
-                  editValue={editValue}
                   setEditValue={setEditValue}
                   inEdit={inEdit}
                   browseActive={browseActive}
@@ -314,7 +313,6 @@ function AuthSection({
 function SettingsSection({
   request,
   editState,
-  editValue: _editValue,
   setEditValue,
   inEdit,
   browseActive,
@@ -323,7 +321,6 @@ function SettingsSection({
 }: {
   request: Request
   editState: EditState
-  editValue: string
   setEditValue: (v: string) => void
   inEdit: boolean
   browseActive: boolean
@@ -331,53 +328,78 @@ function SettingsSection({
   activeEnv?: Environment | null
 }) {
   const textareaRef = useRef<TextareaRenderable | null>(null)
-  const editingSettings = inEdit && editState.cursor.field === "settings"
-  const isActive = browseActive && editState.cursor.field === "settings"
-  const timeout = request.timeout
-
+  
   const handleContentChange = useCallback(() => {
     const ta = textareaRef.current
     if (ta) setEditValue(ta.plainText)
   }, [setEditValue])
 
+  const rows = [
+    { 
+      label: "Timeout (ms)", 
+      value: request.timeout, 
+      display: `${request.timeout}ms`,
+      desc: "Set maximum time to wait before aborting the request" 
+    },
+    { 
+      label: "Follow Redirects", 
+      value: request.followRedirects ?? true, 
+      display: String(request.followRedirects ?? true),
+      desc: "Automatically follow HTTP redirects" 
+    },
+    { 
+      label: "Max Redirects", 
+      value: request.maxRedirects ?? 5, 
+      display: String(request.maxRedirects ?? 5),
+      desc: "Maximum number of redirects to follow" 
+    },
+  ]
+
   return (
-    <>
-      <box
-        id="settings-field"
-        border={[...LeftBar.border]}
-        customBorderChars={LeftBar.customBorderChars}
-        borderColor={isActive || editingSettings ? theme.primary : theme.borderSubtle}
-        style={{
-          flexDirection: editingSettings ? "row" : undefined,
-          gap: editingSettings ? 1 : undefined,
-          backgroundColor: isActive ? theme.backgroundElement : undefined,
-        }}
-      >
-        {editingSettings ? (
-          <>
-            <text fg={theme.textMuted}>Timeout (ms): </text>
-            <textarea
-              ref={textareaRef}
-              initialValue={timeout > 0 ? String(timeout) : ""}
-              onContentChange={handleContentChange}
-              backgroundColor={theme.backgroundPanel}
-              focusedBackgroundColor={theme.backgroundPanel}
-              textColor={theme.text}
-              cursorColor={theme.primary}
-              focused
-            />
-          </>
-        ) : (
-          <VarText
-            text={`Timeout (ms): ${timeout}ms`}
-            env={activeEnv ?? null}
-            baseColor={theme.text}
-          />
-        )}
-      </box>
-      <text fg={theme.textMuted}>
-        Set maximum time to wait before aborting the request
-      </text>
-    </>
+    <box style={{ flexDirection: "column", gap: 1 }}>
+      {rows.map((row, idx) => {
+        const editingRow = inEdit && editState.cursor.field === "settings" && editState.cursor.row === idx
+        const isActive = browseActive && editState.cursor.field === "settings" && editState.cursor.row === idx
+
+        return (
+          <box key={row.label} style={{ flexDirection: "column" }}>
+            <box
+              id={idx === 0 ? "settings-field" : `settings-${idx}`}
+              border={[...LeftBar.border]}
+              customBorderChars={LeftBar.customBorderChars}
+              borderColor={isActive || editingRow ? theme.primary : theme.borderSubtle}
+              style={{
+                flexDirection: editingRow ? "row" : undefined,
+                gap: editingRow ? 1 : undefined,
+                backgroundColor: isActive ? theme.backgroundElement : undefined,
+              }}
+            >
+              {editingRow ? (
+                <>
+                  <text fg={theme.textMuted}>{row.label}: </text>
+                  <textarea
+                    ref={textareaRef}
+                    initialValue={String(row.value)}
+                    onContentChange={handleContentChange}
+                    backgroundColor={theme.backgroundPanel}
+                    focusedBackgroundColor={theme.backgroundPanel}
+                    textColor={theme.text}
+                    cursorColor={theme.primary}
+                    focused
+                  />
+                </>
+              ) : (
+                <VarText
+                  text={`${row.label}: ${row.display}`}
+                  env={activeEnv ?? null}
+                  baseColor={theme.text}
+                />
+              )}
+            </box>
+            <text fg={theme.textMuted}>{row.desc}</text>
+          </box>
+        )
+      })}
+    </box>
   )
 }

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -388,6 +388,13 @@ function SettingsSection({
                     focused
                   />
                 </>
+              ) : idx === 1 ? (
+                <box style={{ flexDirection: "row", gap: 1 }}>
+                  <text fg={theme.textMuted}>{row.label}: </text>
+                  <text fg={(request.followRedirects ?? true) ? theme.primary : theme.textMuted}>
+                    {(request.followRedirects ?? true) ? "[x]" : "[ ]"}
+                  </text>
+                </box>
               ) : (
                 <VarText
                   text={`${row.label}: ${row.display}`}

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -17,6 +17,9 @@ export interface EditState {
 export interface SectionRowCount {
   headers: number
   params: number
+  body: number
+  auth: number
+  settings: number
 }
 
 const FIELD_ORDER: FieldKind[] = [
@@ -37,7 +40,7 @@ export function initialEditState(): EditState {
 
 export function enterEditBrowse(
   prev: EditState,
-  counts: SectionRowCount = { headers: 0, params: 0 },
+  counts: SectionRowCount = { headers: 0, params: 0, body: 0, auth: 0, settings: 0 },
   startField: FieldKind = "headers",
 ): EditState {
   if (prev.mode !== "inactive") return prev
@@ -61,8 +64,12 @@ function cursorForField(
   field: FieldKind,
   counts: SectionRowCount,
 ): FieldCursor {
-  if (field === "body" || field === "auth" || field === "settings") {
-    return { field, row: -1, addingRow: false }
+  switch (field) {
+    case "body":
+    case "auth":
+      return { field, row: -1, addingRow: false }
+    case "settings":
+      return { field, row: 0, addingRow: false }
   }
   const count = field === "headers" ? counts.headers : counts.params
   if (count === 0) {
@@ -105,8 +112,12 @@ export function moveRowCursor(
 ): EditState {
   if (prev.mode !== "browsing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "params") return prev
-  const count = field === "headers" ? counts.headers : counts.params
+  if (field !== "headers" && field !== "params" && field !== "settings") return prev
+  let count = 0
+  if (field === "headers") count = counts.headers
+  else if (field === "params") count = counts.params
+  else if (field === "settings") count = counts.settings
+  
   if (count === 0) return prev
 
   if (prev.cursor.addingRow) {
@@ -118,6 +129,14 @@ export function moveRowCursor(
 
   const row = prev.cursor.row
   const next = row + delta
+  
+  if (field === "settings") {
+    // settings has no addingRow state, clamp to bounds
+    if (next < 0) return { ...prev, cursor: { field, row: 0, addingRow: false } }
+    if (next > count - 1) return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
+    return { ...prev, cursor: { field, row: next, addingRow: false } }
+  }
+
   if (next < 0) {
     return { ...prev, cursor: { field, row: -1, addingRow: true } }
   }

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -149,6 +149,7 @@ export function moveRowCursor(
 export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   if (prev.cursor.field === "auth") return prev
+  if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
     prev.cursor.field === "headers" || prev.cursor.field === "params"
       ? "key"

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -43,10 +43,7 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
           description: "Cancel edit / exit browse",
         },
         { key: displayKey(keybinds.browse_delete), description: "Revert field" },
-        {
-          key: displayKey(keybinds.browse_toggle),
-          description: "Toggle header/param enabled",
-        },
+        { key: "space", description: "Toggle header/param enabled" },
         {
           key: displayKey(keybinds.browse_revert_all),
           description: "Revert all fields",

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -43,7 +43,7 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
           description: "Cancel edit / exit browse",
         },
         { key: displayKey(keybinds.browse_delete), description: "Revert field" },
-        { key: "space", description: "Toggle header/param enabled" },
+        { key: "space", description: "Toggle checkboxes" },
         {
           key: displayKey(keybinds.browse_revert_all),
           description: "Revert all fields",

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -23,7 +23,6 @@ export const Definitions = {
   theme_picker: keybind("ctrl+t", "Open theme picker"),
   browse_delete: keybind("ctrl+d", "Revert field"),
   browse_revert_all: keybind("ctrl+r", "Revert all fields"),
-  browse_toggle: keybind("ctrl+x", "Toggle header/param"),
 
   focus_next: keybind("tab", "Next pane", true),
   focus_prev: keybind("shift+tab", "Previous pane", true),
@@ -67,7 +66,6 @@ export const CommandMap = {
   browse_escape: "browse.escape",
   browse_delete: "browse.delete",
   browse_revert_all: "browse.revert-all",
-  browse_toggle: "browse.toggle",
   edit_commit: "edit.commit",
   edit_cancel: "edit.cancel",
   env_save: "env.save",

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -232,7 +232,6 @@ export function useAppKeymap(
       { key: "escape", cmd: "browse.escape" },
       { key: keybinds.browse_delete, cmd: "browse.delete" },
       { key: keybinds.browse_revert_all, cmd: "browse.revert-all" },
-      { key: keybinds.browse_toggle, cmd: "browse.toggle" },
       { key: "space", cmd: "browse.toggle" },
       { key: keybinds.request_send, cmd: "browse.send" },
       { key: keybinds.request_save, cmd: "browse.save" },

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -233,6 +233,7 @@ export function useAppKeymap(
       { key: keybinds.browse_delete, cmd: "browse.delete" },
       { key: keybinds.browse_revert_all, cmd: "browse.revert-all" },
       { key: keybinds.browse_toggle, cmd: "browse.toggle" },
+      { key: "space", cmd: "browse.toggle" },
       { key: keybinds.request_send, cmd: "browse.send" },
       { key: keybinds.request_save, cmd: "browse.save" },
     ],

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -367,18 +367,6 @@ export function useOverlayIntercepts(opts: {
             ee.toggleVar(ee.selectedRowIndex)
             return
           }
-
-          if (
-            e.name === "x" &&
-            e.ctrl &&
-            !inEdit &&
-            ee.selectedRowIndex < rows
-          ) {
-            e.preventDefault()
-            e.stopPropagation()
-            ee.toggleVar(ee.selectedRowIndex)
-            return
-          }
         }
 
         if (e.name === "escape" && envDeletePendingRef.current === null) {

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -358,6 +358,17 @@ export function useOverlayIntercepts(opts: {
           }
 
           if (
+            e.name === "space" &&
+            !inEdit &&
+            ee.selectedRowIndex < rows
+          ) {
+            e.preventDefault()
+            e.stopPropagation()
+            ee.toggleVar(ee.selectedRowIndex)
+            return
+          }
+
+          if (
             e.name === "x" &&
             e.ctrl &&
             !inEdit &&

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -14,6 +14,10 @@ import {
 
 const inactive: EditState = initialEditState()
 
+function c(headers: number, params: number) {
+  return { headers, params, body: 0, auth: 0, settings: 3 }
+}
+
 describe("initialEditState", () => {
   it("starts inactive with headers cursor", () => {
     expect(initialEditState()).toEqual({
@@ -26,24 +30,24 @@ describe("initialEditState", () => {
 
 describe("enterEditBrowse", () => {
   it("inactive → browsing at headers", () => {
-    const s = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    const s = enterEditBrowse(inactive, c(2, 0))
     expect(s.mode).toBe("browsing")
     expect(s.cursor).toEqual({ field: "headers", row: 0, addingRow: false })
     expect(s.editingRow).toBe(-1)
   })
   it("inactive → browsing at explicit start field", () => {
-    const s = enterEditBrowse(inactive, { headers: 2, params: 3 }, "params")
+    const s = enterEditBrowse(inactive, c(2, 3), "params")
     expect(s.mode).toBe("browsing")
     expect(s.cursor).toEqual({ field: "params", row: 0, addingRow: false })
     expect(s.editingRow).toBe(-1)
   })
   it("no-op from browsing", () => {
-    const browsing = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    const browsing = enterEditBrowse(inactive, c(2, 0))
     expect(enterEditBrowse(browsing)).toBe(browsing)
   })
   it("no-op from editing", () => {
     const editing = beginEditing(
-      enterEditBrowse(inactive, { headers: 2, params: 0 }),
+      enterEditBrowse(inactive, c(2, 0)),
     )
     expect(enterEditBrowse(editing)).toBe(editing)
   })
@@ -51,13 +55,13 @@ describe("enterEditBrowse", () => {
 
 describe("exitEditBrowse", () => {
   it("browsing → inactive", () => {
-    const browsing = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    const browsing = enterEditBrowse(inactive, c(2, 0))
     const s = exitEditBrowse(browsing)
     expect(s.mode).toBe("inactive")
   })
   it("no-op from editing (must cancel first)", () => {
     const editing = beginEditing(
-      enterEditBrowse(inactive, { headers: 2, params: 0 }),
+      enterEditBrowse(inactive, c(2, 0)),
     )
     expect(exitEditBrowse(editing)).toBe(editing)
   })
@@ -68,49 +72,49 @@ describe("exitEditBrowse", () => {
 
 describe("moveFieldCursor", () => {
   it("+1 walks headers → params → body → auth → settings → headers", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("params")
     expect(s.cursor.row).toBe(0)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("body")
     expect(s.cursor.row).toBe(-1)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(-1)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("settings")
-    expect(s.cursor.row).toBe(-1)
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    expect(s.cursor.row).toBe(0)
+    s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("headers")
     expect(s.cursor.row).toBe(0)
   })
   it("-1 walks headers → settings → auth → body → params → headers", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("settings")
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("auth")
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("body")
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("params")
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("headers")
   })
   it("+1 from headers (empty) lands on params [+] (addingRow true, row -1)", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, c(0, 0))
     expect(s.cursor.field).toBe("headers")
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("params")
     expect(s.cursor.addingRow).toBe(true)
     expect(s.cursor.row).toBe(-1)
   })
   it("no-op when editing", () => {
     const editing = beginEditing(
-      enterEditBrowse(inactive, { headers: 2, params: 0 }),
+      enterEditBrowse(inactive, c(2, 0)),
     )
-    expect(moveFieldCursor(editing, +1, { headers: 2, params: 1 })).toBe(
+    expect(moveFieldCursor(editing, +1, c(2, 1))).toBe(
       editing,
     )
   })
@@ -118,88 +122,88 @@ describe("moveFieldCursor", () => {
 
 describe("moveRowCursor", () => {
   it("walks rows 0 → 1 → [+] → 0 → 1 within headers", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
     expect(s.cursor.row).toBe(0)
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, +1, c(2, 0))
     expect(s.cursor.row).toBe(1)
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, +1, c(2, 0))
     expect(s.cursor.addingRow).toBe(true)
     expect(s.cursor.row).toBe(-1)
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, +1, c(2, 0))
     expect(s.cursor.row).toBe(0)
     expect(s.cursor.addingRow).toBe(false)
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, +1, c(2, 0))
     expect(s.cursor.row).toBe(1)
   })
   it("walks up: 0 → [+] → 1 → 0", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
     expect(s.cursor.row).toBe(0)
-    s = moveRowCursor(s, -1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, -1, c(2, 0))
     expect(s.cursor.addingRow).toBe(true)
-    s = moveRowCursor(s, -1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, -1, c(2, 0))
     expect(s.cursor.row).toBe(1)
-    s = moveRowCursor(s, -1, { headers: 2, params: 0 })
+    s = moveRowCursor(s, -1, c(2, 0))
     expect(s.cursor.row).toBe(0)
   })
   it("single-row section toggles 0 → [+] → 0", () => {
-    let s = enterEditBrowse(inactive, { headers: 1, params: 0 })
+    let s = enterEditBrowse(inactive, c(1, 0))
     expect(s.cursor.row).toBe(0)
-    s = moveRowCursor(s, +1, { headers: 1, params: 0 })
+    s = moveRowCursor(s, +1, c(1, 0))
     expect(s.cursor.addingRow).toBe(true)
-    s = moveRowCursor(s, +1, { headers: 1, params: 0 })
+    s = moveRowCursor(s, +1, c(1, 0))
     expect(s.cursor.row).toBe(0)
     expect(s.cursor.addingRow).toBe(false)
   })
   it("empty section is no-op (no rows to navigate)", () => {
-    const s = enterEditBrowse(inactive, { headers: 0, params: 0 })
-    expect(moveRowCursor(s, +1, { headers: 0, params: 0 })).toBe(s)
-    expect(moveRowCursor(s, -1, { headers: 0, params: 0 })).toBe(s)
+    const s = enterEditBrowse(inactive, c(0, 0))
+    expect(moveRowCursor(s, +1, c(0, 0))).toBe(s)
+    expect(moveRowCursor(s, -1, c(0, 0))).toBe(s)
     expect(s.cursor.addingRow).toBe(true)
   })
   it("scalar field (body) is a no-op", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 1 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("body")
-    expect(moveRowCursor(s, +1, { headers: 2, params: 1 })).toBe(s)
+    expect(moveRowCursor(s, +1, c(2, 1))).toBe(s)
   })
   it("no-op when editing", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, +1, c(2, 0))
     const editing = beginEditing(s)
-    expect(moveRowCursor(editing, +1, { headers: 2, params: 0 })).toBe(editing)
+    expect(moveRowCursor(editing, +1, c(2, 0))).toBe(editing)
   })
 })
 
 describe("beginEditing", () => {
   it("browsing → editing, captures editingRow for header row", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveRowCursor(s, +1, c(2, 0))
     expect(s.cursor.row).toBe(1)
     const e = beginEditing(s)
     expect(e.mode).toBe("editing")
     expect(e.editingRow).toBe(1)
   })
   it("browsing → editing, editingRow -1 for scalar field (headers empty)", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("params")
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("body")
     const e = beginEditing(s)
     expect(e.mode).toBe("editing")
     expect(e.editingRow).toBe(-1)
   })
   it("no-op for auth (browse-only field)", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
-    s = moveFieldCursor(s, -1, { headers: 2, params: 1 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("auth")
     expect(beginEditing(s)).toBe(s)
   })
   it("browsing → editing on [+] line keeps editingRow -1 (caller adds row)", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.addingRow).toBe(true)
     const e = beginEditing(s)
     expect(e.mode).toBe("editing")
@@ -210,31 +214,31 @@ describe("beginEditing", () => {
   })
   it("no-op when already editing", () => {
     const editing = beginEditing(
-      enterEditBrowse(inactive, { headers: 2, params: 0 }),
+      enterEditBrowse(inactive, c(2, 0)),
     )
     expect(beginEditing(editing)).toBe(editing)
   })
 
   it("sets subfield to 'key' for headers row", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveRowCursor(s, +1, c(2, 0))
     const e = beginEditing(s)
     expect(e.cursor.subfield).toBe("key")
   })
 
   it("sets subfield to 'key' for params row", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 2 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 2 })
-    s = moveRowCursor(s, +1, { headers: 0, params: 2 })
+    let s = enterEditBrowse(inactive, c(0, 2))
+    s = moveFieldCursor(s, +1, c(0, 2))
+    s = moveRowCursor(s, +1, c(0, 2))
     expect(s.cursor.field).toBe("params")
     const e = beginEditing(s)
     expect(e.cursor.subfield).toBe("key")
   })
 
   it("does not set subfield for body (scalar)", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("body")
     const e = beginEditing(s)
     expect(e.cursor.subfield).toBeUndefined()
@@ -244,7 +248,7 @@ describe("beginEditing", () => {
 describe("commitEditing", () => {
   it("editing → browsing, editingRow reset to -1", () => {
     const editing = beginEditing(
-      enterEditBrowse(inactive, { headers: 2, params: 0 }),
+      enterEditBrowse(inactive, c(2, 0)),
     )
     const s = commitEditing(editing)
     expect(s.mode).toBe("browsing")
@@ -252,13 +256,13 @@ describe("commitEditing", () => {
   })
   it("no-op when not editing", () => {
     expect(commitEditing(inactive)).toBe(inactive)
-    const browsing = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    const browsing = enterEditBrowse(inactive, c(2, 0))
     expect(commitEditing(browsing)).toBe(browsing)
   })
 
   it("clears subfield after commit", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveRowCursor(s, +1, c(2, 0))
     const editing = beginEditing(s)
     expect(editing.cursor.subfield).toBe("key")
     const committed = commitEditing(editing)
@@ -268,8 +272,8 @@ describe("commitEditing", () => {
 
 describe("cancelEditing", () => {
   it("editing → browsing, editingRow reset to -1, cursor preserved", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, +1, c(2, 0))
     const editing = beginEditing(s)
     const cancelled = cancelEditing(editing)
     expect(cancelled.mode).toBe("browsing")
@@ -281,8 +285,8 @@ describe("cancelEditing", () => {
   })
 
   it("clears subfield after cancel", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveRowCursor(s, +1, c(2, 0))
     const editing = beginEditing(s)
     const cancelled = cancelEditing(editing)
     expect(cancelled.cursor.subfield).toBeUndefined()
@@ -291,8 +295,8 @@ describe("cancelEditing", () => {
 
 describe("toggleSubfield", () => {
   it("toggles key → value in edit mode for headers", () => {
-    let s = enterEditBrowse(inactive, { headers: 2, params: 0 })
-    s = moveRowCursor(s, +1, { headers: 2, params: 0 })
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveRowCursor(s, +1, c(2, 0))
     const editing = beginEditing(s)
     expect(editing.cursor.subfield).toBe("key")
     const toggled = toggleSubfield(editing)
@@ -302,9 +306,9 @@ describe("toggleSubfield", () => {
   })
 
   it("toggles key → value for params", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 1 })
+    let s = enterEditBrowse(inactive, c(0, 1))
     expect(s.cursor.field).toBe("headers")
-    s = moveFieldCursor(s, +1, { headers: 0, params: 1 })
+    s = moveFieldCursor(s, +1, c(0, 1))
     expect(s.cursor.field).toBe("params")
     const editing = beginEditing(s)
     expect(editing.cursor.subfield).toBe("key")
@@ -312,14 +316,14 @@ describe("toggleSubfield", () => {
   })
 
   it("no-op when not in edit mode", () => {
-    const browsing = enterEditBrowse(inactive, { headers: 2, params: 0 })
+    const browsing = enterEditBrowse(inactive, c(2, 0))
     expect(toggleSubfield(browsing)).toBe(browsing)
   })
 
   it("no-op for body field (no subfield)", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, +1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("body")
     const editing = beginEditing(s)
     expect(editing.cursor.subfield).toBeUndefined()
@@ -327,10 +331,49 @@ describe("toggleSubfield", () => {
   })
 
   it("no-op for auth field (cannot enter edit)", () => {
-    let s = enterEditBrowse(inactive, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, -1, { headers: 0, params: 0 })
-    s = moveFieldCursor(s, -1, { headers: 0, params: 0 })
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, -1, c(0, 0))
+    s = moveFieldCursor(s, -1, c(0, 0))
     expect(s.cursor.field).toBe("auth")
     expect(toggleSubfield(s)).toBe(s)
+  })
+})
+
+describe("moveRowCursor — settings", () => {
+  it("walks settings rows 0 → 1 → 2 → clamped at 2", () => {
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, -1, c(0, 0))
+    expect(s.cursor.field).toBe("settings")
+    expect(s.cursor.row).toBe(0)
+    s = moveRowCursor(s, +1, c(0, 0))
+    expect(s.cursor.row).toBe(1)
+    s = moveRowCursor(s, +1, c(0, 0))
+    expect(s.cursor.row).toBe(2)
+    s = moveRowCursor(s, +1, c(0, 0))
+    expect(s.cursor.row).toBe(2)
+    expect(s.cursor.addingRow).toBe(false)
+  })
+  it("walks settings rows up: 0 → clamped → 2 → 1 → 0", () => {
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, -1, c(0, 0))
+    expect(s.cursor.row).toBe(0)
+    s = moveRowCursor(s, -1, c(0, 0))
+    expect(s.cursor.row).toBe(0)
+    s = moveRowCursor(s, +1, c(0, 0))
+    s = moveRowCursor(s, +1, c(0, 0))
+    expect(s.cursor.row).toBe(2)
+    s = moveRowCursor(s, -1, c(0, 0))
+    expect(s.cursor.row).toBe(1)
+    s = moveRowCursor(s, -1, c(0, 0))
+    expect(s.cursor.row).toBe(0)
+  })
+  it("settings has no addingRow state", () => {
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, -1, c(0, 0))
+    expect(s.cursor.addingRow).toBe(false)
+    s = moveRowCursor(s, +1, c(0, 0))
+    expect(s.cursor.addingRow).toBe(false)
+    s = moveRowCursor(s, +1, c(0, 0))
+    expect(s.cursor.addingRow).toBe(false)
   })
 })

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -47,8 +47,10 @@ function makeReq(over: Partial<Request> = {}): Request {
     url: "https://example.com",
     headers: {},
     params: {},
-    auth: { type: "none" },
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
+    auth: { type: "none" },
     ...over,
   }
 }

--- a/tests/formatRequest.test.ts
+++ b/tests/formatRequest.test.ts
@@ -18,6 +18,9 @@ function makeReq(over: Partial<Request> = {}): Request {
     headers: {},
     params: {},
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
+    auth: { type: "none" },
     ...over,
   }
 }

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -280,6 +280,53 @@ describe("keymap dispatch", () => {
     cleanup()
   })
 
+  it("space dispatches browse.toggle when in browse mode", () => {
+    const { keymap, host, cleanup } = setup()
+    keymap.setData("app.mode", "browse")
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () =>
+        keymap.getData("app.mode") === "browse" &&
+        keymap.getData("app.overlay") === "none" &&
+        keymap.getData("app.view") !== "env-editor",
+      commands: [
+        { name: "browse.toggle", run: () => { called = true } },
+      ],
+      bindings: [
+        { key: "space", cmd: "browse.toggle" },
+      ],
+    })
+
+    host.press("space")
+    expect(called).toBe(true)
+    cleanup()
+  })
+
+  it("space does not dispatch browse.toggle when overlay is active", () => {
+    const { keymap, host, cleanup } = setup()
+    keymap.setData("app.mode", "browse")
+    keymap.setData("app.overlay", "help")
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () =>
+        keymap.getData("app.mode") === "browse" &&
+        keymap.getData("app.overlay") === "none" &&
+        keymap.getData("app.view") !== "env-editor",
+      commands: [
+        { name: "browse.toggle", run: () => { called = true } },
+      ],
+      bindings: [
+        { key: "space", cmd: "browse.toggle" },
+      ],
+    })
+
+    host.press("space")
+    expect(called).toBe(false)
+    cleanup()
+  })
+
   it("edit layer does not dispatch when overlay is active", () => {
     const { keymap, host, cleanup } = setup()
     keymap.setData("app.mode", "edit")

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -235,7 +235,7 @@ describe("lang.serializeRequest — canonical output", () => {
   it("emits name, method, url always (no other fields when all defaults)", () => {
     const out = lang.serializeRequest(makeReq())
     expect(out).toBe(
-      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\ntimeout: 0\n",
+      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\ntimeout: 0\nfollowRedirects: true\nmaxRedirects: 5\n",
     )
   })
 
@@ -246,7 +246,7 @@ describe("lang.serializeRequest — canonical output", () => {
       }),
     )
     expect(out).toBe(
-      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\ntimeout: 0\nheaders:\n  Accept: application/json\n",
+      "name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\ntimeout: 0\nfollowRedirects: true\nmaxRedirects: 5\nheaders:\n  Accept: application/json\n",
     )
   })
 
@@ -315,6 +315,8 @@ describe("lang.serializeRequest — canonical key order", () => {
       "method",
       "url",
       "timeout",
+      "followRedirects",
+      "maxRedirects",
       "headers",
       "params",
       "body",

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -116,6 +116,47 @@ describe("lang.parseRequest — strictness", () => {
     )
   })
 
+  it("throws on non-boolean followRedirects", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nfollowRedirects: "yes"\n`
+    expect(() => lang.parseRequest("x", yaml)).toThrow(
+      'lang.parseRequest: "followRedirects" must be a boolean',
+    )
+  })
+
+  it("defaults followRedirects to true when omitted", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\n`
+    expect(lang.parseRequest("x", yaml).followRedirects).toBe(true)
+  })
+
+  it("parses followRedirects: false", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nfollowRedirects: false\n`
+    expect(lang.parseRequest("x", yaml).followRedirects).toBe(false)
+  })
+
+  it("throws on non-integer maxRedirects", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nmaxRedirects: 5.5\n`
+    expect(() => lang.parseRequest("x", yaml)).toThrow(
+      'lang.parseRequest: "maxRedirects" must be a non-negative integer',
+    )
+  })
+
+  it("throws on negative maxRedirects", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nmaxRedirects: -1\n`
+    expect(() => lang.parseRequest("x", yaml)).toThrow(
+      'lang.parseRequest: "maxRedirects" must be a non-negative integer',
+    )
+  })
+
+  it("defaults maxRedirects to 5 when omitted", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\n`
+    expect(lang.parseRequest("x", yaml).maxRedirects).toBe(5)
+  })
+
+  it("parses maxRedirects: 10", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nmaxRedirects: 10\n`
+    expect(lang.parseRequest("x", yaml).maxRedirects).toBe(10)
+  })
+
   it("throws on invalid auth.type", () => {
     const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: oauth\n`
     expect(() => lang.parseRequest("x", yaml)).toThrow(

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -12,6 +12,8 @@ describe("lang.parseRequest — required fields", () => {
       method: "GET",
       url: "https://api.example.com/users/1",
       timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
       headers: {},
       params: {},
       auth: { type: "none" },
@@ -222,6 +224,8 @@ function makeReq(over: Partial<Request> = {}): Request {
     headers: {},
     params: {},
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
     auth: { type: "none" },
     ...over,
   }
@@ -355,6 +359,8 @@ describe("lang — semantic round-trip", () => {
       method: "POST",
       url: "https://$host/posts",
       timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
       headers: {
         "Content-Type": { value: "application/json", enabled: true },
         Authorization: { value: "Bearer $token", enabled: true },
@@ -379,6 +385,8 @@ describe("lang — semantic round-trip", () => {
       headers: {},
       params: {},
       timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
       auth: { type: "none" },
     }
     const yaml = lang.serializeRequest(original)
@@ -395,6 +403,8 @@ describe("lang — semantic round-trip", () => {
       headers: {},
       params: {},
       timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
       auth: { type: "basic", user: "foo", pass: "bar" },
     }
     const yaml = lang.serializeRequest(original)
@@ -414,6 +424,8 @@ describe("lang — semantic round-trip", () => {
       },
       params: {},
       timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
       auth: { type: "none" },
     }
     const yaml = lang.serializeRequest(original)

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -24,6 +24,8 @@ function makeReq(over: Partial<Request> = {}): Request {
     headers: {},
     params: {},
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
     auth: { type: "none" },
     ...over,
   }
@@ -571,5 +573,188 @@ describe("send — timeout signal", () => {
     await executor.send(makeReq({ timeout: 0 }))
     const init = fetchMock.mock.calls[0][1] as RequestInit
     expect(init.signal).toBeUndefined()
+  })
+})
+
+describe("send — redirect following", () => {
+  it("follows 301 redirect to Location", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 301, headers: { location: "/new-path" } }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200, body: "done" }))
+    const res = await executor.send(makeReq({}))
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(res.status).toBe(200)
+    expect(res.body).toBe("done")
+    expect(fetchMock.mock.calls[1][0]).toBe("https://example.com/new-path")
+  })
+
+  it("follows 302, 303, 307, 308", async () => {
+    for (const code of [302, 303, 307, 308]) {
+      fetchMock.mockReset()
+      fetchMock
+        .mockResolvedValueOnce(
+          fakeResponse({ status: code, headers: { location: "/target" } }),
+        )
+        .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+      const res = await executor.send(makeReq({}))
+      expect(res.status).toBe(200)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(fetchMock.mock.calls[1][0]).toBe("https://example.com/target")
+    }
+  })
+
+  it("does not follow when followRedirects is false", async () => {
+    fetchMock.mockResolvedValueOnce(
+      fakeResponse({ status: 301, headers: { location: "/elsewhere" } }),
+    )
+    const res = await executor.send(
+      makeReq({ followRedirects: false }),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(res.status).toBe(301)
+  })
+
+  it("throws when max redirects exceeded", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ status: 301, headers: { location: "/hop" } }),
+    )
+    await expect(
+      executor.send(makeReq({ maxRedirects: 2 })),
+    ).rejects.toThrow("requests.send: max redirects (2) exceeded")
+    expect(fetchMock).toHaveBeenCalledTimes(3) // initial + 2 redirects, 3rd triggers throw
+  })
+
+  it("returns 301 response when no Location header", async () => {
+    fetchMock.mockResolvedValueOnce(
+      fakeResponse({ status: 301 }),
+    )
+    const res = await executor.send(makeReq({}))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(res.status).toBe(301)
+  })
+
+  it("does not follow non-redirect status (200, 400, 500)", async () => {
+    for (const code of [200, 400, 404, 500]) {
+      fetchMock.mockReset()
+      fetchMock.mockResolvedValueOnce(
+        fakeResponse({ status: code, headers: { location: "/ignored" } }),
+      )
+      const res = await executor.send(makeReq({}))
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(res.status).toBe(code)
+    }
+  })
+
+  it("resolves relative Location header against current URL", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 302,
+          headers: { location: "../bar/baz" },
+        }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(makeReq({ url: "https://example.com/foo/" }))
+    expect(fetchMock.mock.calls[1][0]).toBe("https://example.com/bar/baz")
+  })
+
+  it("switches POST to GET on 302 with content-type and content-length stripped", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 302,
+          headers: { location: "/new" },
+        }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(
+      makeReq({
+        method: "POST",
+        body: '{"x":1}',
+        headers: {
+          "content-type": { value: "application/json", enabled: true },
+          "content-length": { value: "100", enabled: true },
+        },
+      }),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const init = fetchMock.mock.calls[1][1] as RequestInit
+    expect(init.method).toBe("GET")
+    expect(init.body).toBeUndefined()
+    const headers = init.headers as Headers
+    expect(headers.get("content-type")).toBeNull()
+    expect(headers.get("content-length")).toBeNull()
+  })
+
+  it("switches POST to GET on 303", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 303,
+          headers: { location: "/new" },
+        }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(makeReq({ method: "POST", body: '{"x":1}' }))
+    const init = fetchMock.mock.calls[1][1] as RequestInit
+    expect(init.method).toBe("GET")
+    expect(init.body).toBeUndefined()
+  })
+
+  it("preserves method and body on 307", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 307,
+          headers: { location: "/new" },
+        }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(makeReq({ method: "POST", body: '{"x":1}' }))
+    const init = fetchMock.mock.calls[1][1] as RequestInit
+    expect(init.method).toBe("POST")
+    expect(init.body).toBe('{"x":1}')
+  })
+
+  it("preserves method and body on 308", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 308,
+          headers: { location: "/new" },
+        }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(makeReq({ method: "POST", body: '{"x":1}' }))
+    const init = fetchMock.mock.calls[1][1] as RequestInit
+    expect(init.method).toBe("POST")
+    expect(init.body).toBe('{"x":1}')
+  })
+
+  it("does not change method for non-POST on 301/302", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({
+          status: 301,
+          headers: { location: "/new" },
+        }),
+      )
+      .mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(makeReq({ method: "PUT", body: "data" }))
+    const init = fetchMock.mock.calls[1][1] as RequestInit
+    expect(init.method).toBe("PUT")
+    expect(init.body).toBe("data")
+  })
+
+  it("uses redirect: manual in fetch init", async () => {
+    fetchMock.mockResolvedValueOnce(
+      fakeResponse({ status: 302, headers: { location: "/there" } }),
+    )
+    fetchMock.mockResolvedValueOnce(fakeResponse({ status: 200 }))
+    await executor.send(makeReq({}))
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.redirect).toBe("manual")
   })
 })

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -20,6 +20,9 @@ function makeRequest(i: number): Request {
     headers: {},
     params: {},
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
+    auth: { type: "none" },
   }
 }
 

--- a/tests/sendState.test.ts
+++ b/tests/sendState.test.ts
@@ -15,8 +15,10 @@ function makeReq(over: Partial<Request> = {}): Request {
     url: "https://example.com",
     headers: {},
     params: {},
-    auth: { type: "none" },
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
+    auth: { type: "none" },
     ...over,
   }
 }

--- a/tests/unit/Checkbox.test.tsx
+++ b/tests/unit/Checkbox.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { RGBA } from "@opentui/core"
+import { Checkbox } from "../../src/ui/Checkbox"
+import { THEMES, type Theme } from "../../src/ui/theme"
+
+const theme = THEMES[0]! as Theme
+
+describe("Checkbox", () => {
+  it("renders [x] in primary color when checked", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <Checkbox checked={true} theme={theme} />,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const cb = spans.find((s) => s.text.includes("[x]"))
+    expect(cb).toBeDefined()
+    const primary = RGBA.fromHex(theme.primary)
+    expect(cb!.fg).toEqual(primary)
+  })
+
+  it("renders [ ] in muted color when not checked", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <Checkbox checked={false} theme={theme} />,
+      { width: 20, height: 3 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const cb = spans.find((s) => s.text.includes("[ ]"))
+    expect(cb).toBeDefined()
+    const muted = RGBA.fromHex(theme.textMuted)
+    expect(cb!.fg).toEqual(muted)
+  })
+})

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -44,14 +44,14 @@ describe("getHelpSections", () => {
     expect(keys).toContain("shift+tab")
   })
 
-  it("EDITING section shows return, escape, ^d, ^x, ^r, ^e", () => {
+  it("EDITING section shows return, escape, ^d, space, ^r, ^e", () => {
     const sections = getHelpSections(defaults)
     const edit = sections.find((s) => s.title === "Editing")!
     const keys = edit.keys.map((k) => k.key)
     expect(keys).toContain("return")
     expect(keys).toContain("escape")
     expect(keys).toContain("^d")
-    expect(keys).toContain("^x")
+    expect(keys).toContain("space")
     expect(keys).toContain("^r")
     expect(keys).toContain("^e")
   })

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -15,6 +15,9 @@ function makeReq(over: Partial<Request> = {}): Request {
     headers: {},
     params: {},
     timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
+    auth: { type: "none" },
     ...over,
   }
 }

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -127,6 +127,26 @@ describe("requestEquals", () => {
       requestEquals(makeReq({ timeout: 0 }), makeReq({ timeout: 10000 })),
     ).toBe(false)
   })
+  it("same followRedirects → true", () => {
+    expect(
+      requestEquals(makeReq({ followRedirects: false }), makeReq({ followRedirects: false })),
+    ).toBe(true)
+  })
+  it("differing followRedirects → false", () => {
+    expect(
+      requestEquals(makeReq({ followRedirects: true }), makeReq({ followRedirects: false })),
+    ).toBe(false)
+  })
+  it("same maxRedirects → true", () => {
+    expect(
+      requestEquals(makeReq({ maxRedirects: 10 }), makeReq({ maxRedirects: 10 })),
+    ).toBe(true)
+  })
+  it("differing maxRedirects → false", () => {
+    expect(
+      requestEquals(makeReq({ maxRedirects: 5 }), makeReq({ maxRedirects: 0 })),
+    ).toBe(false)
+  })
   it("name/id differences → still equal (only url/method/headers/params/body/auth compared)", () => {
     const a = makeReq({ id: "r1", name: "A" })
     const b = makeReq({ id: "r2", name: "B" })


### PR DESCRIPTION
Manual redirect following with proper HTTP-spec compliance. Settings: followRedirects (checkbox toggle), maxRedirects (numeric). Checkbox component extracted for reuse.