### PR TITLE
feat(auth): inline auth editor with api_key support

### DIFF
--- a/collections/basic-auth.yml
+++ b/collections/basic-auth.yml
@@ -4,7 +4,3 @@ url: https://httpbin.org/basic-auth/user/pass
 timeout: 0
 followRedirects: true
 maxRedirects: 5
-auth:
-  type: basic
-  user: user
-  pass: pass

--- a/collections/basic-auth.yml
+++ b/collections/basic-auth.yml
@@ -4,3 +4,6 @@ url: https://httpbin.org/basic-auth/user/pass
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+auth:
+  type: bearer
+  token: sdfsdfsdf

--- a/collections/environments/development.env
+++ b/collections/environments/development.env
@@ -1,4 +1,4 @@
-_color=success
+_color=text
 base_url=https://jsonplaceholder.typicode.com
 post_id=1
 user_id=1

--- a/src/converters/openapi/map.ts
+++ b/src/converters/openapi/map.ts
@@ -80,6 +80,12 @@ function schemeToAuth(scheme: Record<string, unknown>): Auth | null {
   if (type === "http" && schemeName === "basic") {
     return { type: "basic", user: "$USER", pass: "$PASS" }
   }
+  if (type === "apiKey") {
+    const name = typeof scheme.name === "string" ? scheme.name : "X-API-Key"
+    const inV = scheme.in
+    const placement = inV === "query" ? "query" : "header"
+    return { type: "api_key", key: name, value: "$API_KEY", placement }
+  }
   return null
 }
 

--- a/src/env/load.ts
+++ b/src/env/load.ts
@@ -69,6 +69,7 @@ export async function loadEnvironment(
     name,
     vars,
     color,
-    disabledVars: Object.keys(disabledVars).length > 0 ? disabledVars : undefined,
+    disabledVars:
+      Object.keys(disabledVars).length > 0 ? disabledVars : undefined,
   }
 }

--- a/src/filestore/index.ts
+++ b/src/filestore/index.ts
@@ -8,7 +8,14 @@ import {
   clearAllTimeline,
 } from "./timeline"
 
-export { loadSettings, saveSettings, loadTimeline, saveTimelineEntry, clearTimelineForRequest, clearAllTimeline }
+export {
+  loadSettings,
+  saveSettings,
+  loadTimeline,
+  saveTimelineEntry,
+  clearTimelineForRequest,
+  clearAllTimeline,
+}
 export type { CollectionSettings }
 
 export interface Filestore {

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -104,7 +104,8 @@ function currentKeyValueFor(
   }
   if (field === "settings") {
     if (row === 0) return { key: "", value: String(draft.timeout) }
-    if (row === 1) return { key: "", value: String(draft.followRedirects ?? true) }
+    if (row === 1)
+      return { key: "", value: String(draft.followRedirects ?? true) }
     if (row === 2) return { key: "", value: String(draft.maxRedirects ?? 5) }
     return { key: "", value: "" }
   }
@@ -192,7 +193,12 @@ export function useEditBrowse(
       return
     }
     if (browsed.cursor.field === "auth") {
-      const init = currentValueFor(currentDraft, browsed.cursor.field, browsed.cursor.row, false)
+      const init = currentValueFor(
+        currentDraft,
+        browsed.cursor.field,
+        browsed.cursor.row,
+        false,
+      )
       setEditValue(init)
       setEditState(beginEditing(browsed))
       return
@@ -310,7 +316,8 @@ export function useEditBrowse(
           else if (row === 2) draftMutators.setAuthField("basic", "pass", val)
         } else if (currentAuth.type === "api_key") {
           if (row === 1) draftMutators.setAuthField("api_key", "key", val)
-          else if (row === 2) draftMutators.setAuthField("api_key", "value", val)
+          else if (row === 2)
+            draftMutators.setAuthField("api_key", "value", val)
         }
       }
     } else if (field === "settings") {
@@ -321,7 +328,9 @@ export function useEditBrowse(
         draftMutators.setFollowRedirects(val.trim().toLowerCase() !== "false")
       } else if (row === 2) {
         const n = Number(val)
-        draftMutators.setMaxRedirects(Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 5)
+        draftMutators.setMaxRedirects(
+          Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 5,
+        )
       }
     } else if (field === "headers" || field === "params") {
       const key = editKeyRef.current.trim()

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -25,12 +25,19 @@ const FIELD_ORDER: FieldKind[] = [
 ]
 
 function rowCount(req: Request | null): SectionRowCount {
-  if (!req) return { headers: 0, params: 0, body: 0, auth: 0, settings: 3 }
+  if (!req) return { headers: 0, params: 0, body: 0, auth: 1, settings: 3 }
+  let authRows = 1 // type selector row always present
+  const a = req.auth
+  if (a) {
+    if (a.type === "bearer") authRows = 2
+    else if (a.type === "basic") authRows = 3
+    else if (a.type === "api_key") authRows = 4
+  }
   return {
     headers: Object.keys(req.headers).length,
     params: Object.keys(req.params).length,
     body: 0,
-    auth: 0,
+    auth: authRows,
     settings: 3,
   }
 }
@@ -43,6 +50,26 @@ function currentValueFor(
 ): string {
   if (!draft) return ""
   if (field === "body") return draft.body ?? ""
+  if (field === "auth") {
+    const a = draft.auth
+    if (!a || a.type === "none") return ""
+    if (a.type === "bearer") {
+      if (row === 0) return ""
+      if (row === 1) return a.token
+    }
+    if (a.type === "basic") {
+      if (row === 0) return ""
+      if (row === 1) return a.user
+      if (row === 2) return a.pass
+    }
+    if (a.type === "api_key") {
+      if (row === 0) return ""
+      if (row === 1) return a.key
+      if (row === 2) return a.value
+      if (row === 3) return a.placement
+    }
+    return ""
+  }
   if (field === "settings") {
     if (row === 0) return String(draft.timeout)
     if (row === 1) return String(draft.followRedirects ?? true)
@@ -80,6 +107,10 @@ function currentKeyValueFor(
     if (row === 1) return { key: "", value: String(draft.followRedirects ?? true) }
     if (row === 2) return { key: "", value: String(draft.maxRedirects ?? 5) }
     return { key: "", value: "" }
+  }
+  if (field === "auth") {
+    const val = currentValueFor(draft, field, row, false)
+    return { key: "", value: val }
   }
   return { key: "", value: "" }
 }
@@ -156,8 +187,14 @@ export function useEditBrowse(
     if (state.mode !== "inactive") return
 
     const browsed = enterEditBrowse(state, c, tab)
-    if (browsed.cursor.field === "auth") {
+    if (browsed.cursor.field === "auth" && browsed.cursor.row === 0) {
       setEditState(browsed)
+      return
+    }
+    if (browsed.cursor.field === "auth") {
+      const init = currentValueFor(currentDraft, browsed.cursor.field, browsed.cursor.row, false)
+      setEditValue(init)
+      setEditState(beginEditing(browsed))
       return
     }
     if (browsed.cursor.field === "settings" && browsed.cursor.row === 1) {
@@ -233,6 +270,15 @@ export function useEditBrowse(
       return
     }
     const currentDraft = draftRef.current
+    if (field === "auth") {
+      if (row === 0) {
+        return
+      }
+      const init = currentValueFor(currentDraft, field, row, false)
+      setEditValue(init)
+      setEditState((prev) => beginEditing(prev))
+      return
+    }
     const { addingRow } = state.cursor
     if (field === "body" || field === "settings") {
       const init = currentValueFor(currentDraft, field, row, addingRow)
@@ -253,6 +299,20 @@ export function useEditBrowse(
     const val = editValueRef.current
     if (field === "body") {
       draftMutators.setBody(val)
+    } else if (field === "auth") {
+      const row = state.cursor.row
+      const currentAuth = draftRef.current?.auth
+      if (currentAuth) {
+        if (currentAuth.type === "bearer" && row === 1) {
+          draftMutators.setAuthField("bearer", "token", val)
+        } else if (currentAuth.type === "basic") {
+          if (row === 1) draftMutators.setAuthField("basic", "user", val)
+          else if (row === 2) draftMutators.setAuthField("basic", "pass", val)
+        } else if (currentAuth.type === "api_key") {
+          if (row === 1) draftMutators.setAuthField("api_key", "key", val)
+          else if (row === 2) draftMutators.setAuthField("api_key", "value", val)
+        }
+      }
     } else if (field === "settings") {
       const row = state.cursor.row
       if (row === 0) {
@@ -297,6 +357,10 @@ export function useEditBrowse(
     const state = editStateRef.current
     if (state.mode !== "browsing") return
     const { field, addingRow, row } = state.cursor
+    if (field === "auth") {
+      draftMutators.revertField(field, row)
+      return
+    }
     if (field === "body" || field === "settings") {
       draftMutators.revertField(field)
     } else if (field === "headers" || field === "params") {

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -297,7 +297,10 @@ export function useEnvironmentEditor({
   const deleteVar = useCallback((index: number) => {
     const prev = draftRef.current
     if (!prev) return
-    const next = { ...prev, varRows: prev.varRows.filter((_, i) => i !== index) }
+    const next = {
+      ...prev,
+      varRows: prev.varRows.filter((_, i) => i !== index),
+    }
     draftRef.current = next
     setDraft(next)
     setSelectedRowIndex((prev) => {
@@ -416,7 +419,13 @@ export function useEnvironmentEditor({
     } finally {
       setSaving(false)
     }
-  }, [environmentsDir, activeEnvName, onActiveEnvChanged, closeEditor, localNames])
+  }, [
+    environmentsDir,
+    activeEnvName,
+    onActiveEnvChanged,
+    closeEditor,
+    localNames,
+  ])
 
   const cloneEnvAction = useCallback(
     async (targetName: string) => {

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -24,6 +24,8 @@ export type DraftOp =
   | { kind: "setAuthField"; authType: string; field: string; value: string }
   | { kind: "setApiKeyPlacement"; placement: "header" | "query" }
 
+const authTypeCache = new Map<string, Record<string, Auth>>()
+
 export function parseRow(input: string): { key: string; value: string } {
   const trimmed = input.trim()
   if (trimmed === "") return { key: "", value: "" }
@@ -242,23 +244,25 @@ export function applyDraft(
       draft.maxRedirects = op.maxRedirects
       break
     case "setAuthType": {
-      if (op.authType === "none") {
+      const curAuth = current.auth
+      if (curAuth && curAuth.type !== "none") {
+        const idCache = authTypeCache.get(id) ?? {}
+        idCache[curAuth.type] = curAuth
+        authTypeCache.set(id, idCache)
+      }
+      const cached = authTypeCache.get(id)?.[op.authType]
+      if (cached && cached.type === op.authType) {
+        draft.auth = { ...cached }
+      } else if (original.auth?.type === op.authType) {
+        draft.auth = { ...original.auth }
+      } else if (op.authType === "none") {
         draft.auth = { type: "none" }
       } else if (op.authType === "bearer") {
-        draft.auth =
-          original.auth?.type === "bearer"
-            ? { ...original.auth }
-            : { type: "bearer", token: "" }
+        draft.auth = { type: "bearer", token: "" }
       } else if (op.authType === "basic") {
-        draft.auth =
-          original.auth?.type === "basic"
-            ? { ...original.auth }
-            : { type: "basic", user: "", pass: "" }
+        draft.auth = { type: "basic", user: "", pass: "" }
       } else if (op.authType === "api_key") {
-        draft.auth =
-          original.auth?.type === "api_key"
-            ? { ...original.auth }
-            : { type: "api_key", key: "", value: "", placement: "header" }
+        draft.auth = { type: "api_key", key: "", value: "", placement: "header" }
       }
       break
     }
@@ -443,6 +447,7 @@ export function useRequestDraft(
     if (!selectedRequest) return
     const currentDraft =
       mapRef.current.get(selectedRequest.id) ?? selectedRequest
+    authTypeCache.delete(selectedRequest.id)
     setOriginalMap((prev) => {
       const next = new Map(prev)
       next.set(selectedRequest.id, { ...currentDraft })

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -245,16 +245,20 @@ export function applyDraft(
       if (op.authType === "none") {
         draft.auth = { type: "none" }
       } else if (op.authType === "bearer") {
-        draft.auth = { type: "bearer", token: "" }
+        draft.auth =
+          original.auth?.type === "bearer"
+            ? { ...original.auth }
+            : { type: "bearer", token: "" }
       } else if (op.authType === "basic") {
-        draft.auth = { type: "basic", user: "", pass: "" }
+        draft.auth =
+          original.auth?.type === "basic"
+            ? { ...original.auth }
+            : { type: "basic", user: "", pass: "" }
       } else if (op.authType === "api_key") {
-        draft.auth = {
-          type: "api_key",
-          key: "",
-          value: "",
-          placement: "header",
-        }
+        draft.auth =
+          original.auth?.type === "api_key"
+            ? { ...original.auth }
+            : { type: "api_key", key: "", value: "", placement: "header" }
       }
       break
     }

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -20,6 +20,9 @@ export type DraftOp =
   | { kind: "setMaxRedirects"; maxRedirects: number }
   | { kind: "revertField"; field: FieldKind; row?: number }
   | { kind: "revertAll" }
+  | { kind: "setAuthType"; authType: "none" | "bearer" | "basic" | "api_key" }
+  | { kind: "setAuthField"; authType: string; field: string; value: string }
+  | { kind: "setApiKeyPlacement"; placement: "header" | "query" }
 
 export function parseRow(input: string): { key: string; value: string } {
   const trimmed = input.trim()
@@ -57,6 +60,9 @@ function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
   if (a.type === "bearer" && b.type === "bearer") return a.token === b.token
   if (a.type === "basic" && b.type === "basic") {
     return a.user === b.user && a.pass === b.pass
+  }
+  if (a.type === "api_key" && b.type === "api_key") {
+    return a.key === b.key && a.value === b.value && a.placement === b.placement
   }
   return false
 }
@@ -235,6 +241,32 @@ export function applyDraft(
     case "setMaxRedirects":
       draft.maxRedirects = op.maxRedirects
       break
+    case "setAuthType": {
+      if (op.authType === "none") {
+        draft.auth = { type: "none" }
+      } else if (op.authType === "bearer") {
+        draft.auth = { type: "bearer", token: "" }
+      } else if (op.authType === "basic") {
+        draft.auth = { type: "basic", user: "", pass: "" }
+      } else if (op.authType === "api_key") {
+        draft.auth = { type: "api_key", key: "", value: "", placement: "header" }
+      }
+      break
+    }
+    case "setAuthField": {
+      const currentAuth = draft.auth
+      if (!currentAuth || currentAuth.type !== op.authType) break
+      if (currentAuth.type === "none") break
+      ;(currentAuth as Record<string, unknown>)[op.field] = op.value
+      break
+    }
+    case "setApiKeyPlacement": {
+      const currentAuth = draft.auth
+      if (currentAuth?.type === "api_key") {
+        ;(currentAuth as { placement: "header" | "query" }).placement = op.placement
+      }
+      break
+    }
     case "revertField": {
       if (op.field === "body") draft.body = original.body
       else if (op.field === "settings") {
@@ -246,6 +278,11 @@ export function applyDraft(
         draft.headers = revertRow(current.headers, original.headers, op.row)
       } else if (op.field === "params" && op.row !== undefined) {
         draft.params = revertRow(current.params, original.params, op.row)
+      }
+      else if (op.field === "auth") {
+        if (op.row === undefined || op.row === 0) {
+          draft.auth = original.auth
+        }
       }
       break
     }
@@ -276,6 +313,9 @@ export interface UseRequestDraftResult {
   setMaxRedirects: (n: number) => void
   revertField: (field: FieldKind, row?: number) => void
   revertAll: () => void
+  setAuthType: (t: "none" | "bearer" | "basic" | "api_key") => void
+  setAuthField: (authType: string, field: string, value: string) => void
+  setApiKeyPlacement: (placement: "header" | "query") => void
   markSaved: () => void
 }
 
@@ -365,6 +405,18 @@ export function useRequestDraft(
     (index: number) => apply({ kind: "toggleParamRow", index }),
     [apply],
   )
+  const setAuthTypeCb = useCallback(
+    (authType: "none" | "bearer" | "basic" | "api_key") => apply({ kind: "setAuthType", authType }),
+    [apply],
+  )
+  const setAuthFieldCb = useCallback(
+    (authType: string, field: string, value: string) => apply({ kind: "setAuthField", authType, field, value }),
+    [apply],
+  )
+  const setApiKeyPlacementCb = useCallback(
+    (placement: "header" | "query") => apply({ kind: "setApiKeyPlacement", placement }),
+    [apply],
+  )
   const revertField = useCallback(
     (field: FieldKind, row?: number) =>
       apply({ kind: "revertField", field, row }),
@@ -429,6 +481,9 @@ export function useRequestDraft(
       toggleParamRow,
       revertField,
       revertAll,
+      setAuthType: setAuthTypeCb,
+      setAuthField: setAuthFieldCb,
+      setApiKeyPlacement: setApiKeyPlacementCb,
       markSaved,
     }),
     [
@@ -451,6 +506,9 @@ export function useRequestDraft(
       toggleParamRow,
       revertField,
       revertAll,
+      setAuthTypeCb,
+      setAuthFieldCb,
+      setApiKeyPlacementCb,
       markSaved,
     ],
   )

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -249,7 +249,12 @@ export function applyDraft(
       } else if (op.authType === "basic") {
         draft.auth = { type: "basic", user: "", pass: "" }
       } else if (op.authType === "api_key") {
-        draft.auth = { type: "api_key", key: "", value: "", placement: "header" }
+        draft.auth = {
+          type: "api_key",
+          key: "",
+          value: "",
+          placement: "header",
+        }
       }
       break
     }
@@ -263,7 +268,8 @@ export function applyDraft(
     case "setApiKeyPlacement": {
       const currentAuth = draft.auth
       if (currentAuth?.type === "api_key") {
-        ;(currentAuth as { placement: "header" | "query" }).placement = op.placement
+        ;(currentAuth as { placement: "header" | "query" }).placement =
+          op.placement
       }
       break
     }
@@ -273,13 +279,11 @@ export function applyDraft(
         draft.timeout = original.timeout
         draft.followRedirects = original.followRedirects
         draft.maxRedirects = original.maxRedirects
-      }
-      else if (op.field === "headers" && op.row !== undefined) {
+      } else if (op.field === "headers" && op.row !== undefined) {
         draft.headers = revertRow(current.headers, original.headers, op.row)
       } else if (op.field === "params" && op.row !== undefined) {
         draft.params = revertRow(current.params, original.params, op.row)
-      }
-      else if (op.field === "auth") {
+      } else if (op.field === "auth") {
         if (op.row === undefined || op.row === 0) {
           draft.auth = original.auth
         }
@@ -364,7 +368,8 @@ export function useRequestDraft(
     [apply],
   )
   const setFollowRedirects = useCallback(
-    (followRedirects: boolean) => apply({ kind: "setFollowRedirects", followRedirects }),
+    (followRedirects: boolean) =>
+      apply({ kind: "setFollowRedirects", followRedirects }),
     [apply],
   )
   const setMaxRedirects = useCallback(
@@ -406,15 +411,18 @@ export function useRequestDraft(
     [apply],
   )
   const setAuthTypeCb = useCallback(
-    (authType: "none" | "bearer" | "basic" | "api_key") => apply({ kind: "setAuthType", authType }),
+    (authType: "none" | "bearer" | "basic" | "api_key") =>
+      apply({ kind: "setAuthType", authType }),
     [apply],
   )
   const setAuthFieldCb = useCallback(
-    (authType: string, field: string, value: string) => apply({ kind: "setAuthField", authType, field, value }),
+    (authType: string, field: string, value: string) =>
+      apply({ kind: "setAuthField", authType, field, value }),
     [apply],
   )
   const setApiKeyPlacementCb = useCallback(
-    (placement: "header" | "query") => apply({ kind: "setApiKeyPlacement", placement }),
+    (placement: "header" | "query") =>
+      apply({ kind: "setApiKeyPlacement", placement }),
     [apply],
   )
   const revertField = useCallback(

--- a/src/hooks/useResponse.ts
+++ b/src/hooks/useResponse.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import type { Dispatch, SetStateAction } from "react"
 import type { Environment, Request, Response } from "../schema"
 import { executor } from "../requests"
-import { startSend, finishSend, failSend, type SendState } from "../ui/sendState"
+import {
+  startSend,
+  finishSend,
+  failSend,
+  type SendState,
+} from "../ui/sendState"
 
 type CachedResult =
   | { status: "done"; response: Response }
@@ -54,7 +59,15 @@ export function useResponse(
       if (prev.status === "sending") return prev
       const controller = new AbortController()
       abortRef.current = controller
-      void runSend(req, env ?? undefined, controller.signal, setState, cacheRef, abortRef, onCompleteRef)
+      void runSend(
+        req,
+        env ?? undefined,
+        controller.signal,
+        setState,
+        cacheRef,
+        abortRef,
+        onCompleteRef,
+      )
       return startSend(prev, req)
     })
   }, [selectedRequest, env])
@@ -73,7 +86,9 @@ async function runSend(
   setState: Dispatch<SetStateAction<SendState>>,
   cacheRef: React.RefObject<Map<string, CachedResult>>,
   abortRef: React.RefObject<AbortController | null>,
-  onCompleteRef: React.RefObject<((req: Request, result: SendCompleteResult) => void) | undefined>,
+  onCompleteRef: React.RefObject<
+    ((req: Request, result: SendCompleteResult) => void) | undefined
+  >,
 ): Promise<void> {
   try {
     const res = await executor.send(req, env, signal)

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -15,6 +15,7 @@ type RawAuth =
   | { type: "none"; [k: string]: unknown }
   | { type: "bearer"; token: string; [k: string]: unknown }
   | { type: "basic"; user: string; pass: string; [k: string]: unknown }
+  | { type: "api_key"; key: string; value: string; placement?: string; [k: string]: unknown }
   | { type: string; [k: string]: unknown }
 
 interface RawRequest {
@@ -180,6 +181,15 @@ function parseAuth(value: unknown): Auth {
       )
     }
     return { type: "basic", user: a.user, pass: a.pass }
+  }
+  if (a.type === "api_key") {
+    if (typeof a.key !== "string" || typeof a.value !== "string") {
+      throw new Error(
+        'lang.parseRequest: auth.api_key requires "key" and "value"',
+      )
+    }
+    const placement = a.placement === "query" ? "query" : "header"
+    return { type: "api_key", key: a.key, value: a.value, placement }
   }
   throw new Error(
     `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|bearer|basic|api_key`,

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -15,7 +15,13 @@ type RawAuth =
   | { type: "none"; [k: string]: unknown }
   | { type: "bearer"; token: string; [k: string]: unknown }
   | { type: "basic"; user: string; pass: string; [k: string]: unknown }
-  | { type: "api_key"; key: string; value: string; placement?: string; [k: string]: unknown }
+  | {
+      type: "api_key"
+      key: string
+      value: string
+      placement?: string
+      [k: string]: unknown
+    }
   | { type: string; [k: string]: unknown }
 
 interface RawRequest {
@@ -110,8 +116,14 @@ export function parseRequest(id: string, yamlText: string): Request {
 
   let maxRedirects: number = 5
   if (raw.maxRedirects !== undefined) {
-    if (typeof raw.maxRedirects !== "number" || !Number.isInteger(raw.maxRedirects) || raw.maxRedirects < 0) {
-      throw new Error('lang.parseRequest: "maxRedirects" must be a non-negative integer')
+    if (
+      typeof raw.maxRedirects !== "number" ||
+      !Number.isInteger(raw.maxRedirects) ||
+      raw.maxRedirects < 0
+    ) {
+      throw new Error(
+        'lang.parseRequest: "maxRedirects" must be a non-negative integer',
+      )
     }
     maxRedirects = raw.maxRedirects
   }

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -182,6 +182,6 @@ function parseAuth(value: unknown): Auth {
     return { type: "basic", user: a.user, pass: a.pass }
   }
   throw new Error(
-    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|bearer|basic`,
+    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|bearer|basic|api_key`,
   )
 }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -57,5 +57,7 @@ export function serializeRequest(req: Request): string {
 function authToObj(auth: Auth): Record<string, unknown> {
   if (auth.type === "none") return { type: "none" }
   if (auth.type === "bearer") return { type: "bearer", token: auth.token }
-  return { type: "basic", user: auth.user, pass: auth.pass }
+  if (auth.type === "basic") return { type: "basic", user: auth.user, pass: auth.pass }
+  if (auth.type === "api_key") return { type: "api_key", key: auth.key, value: auth.value, placement: auth.placement }
+  return { type: "none" }
 }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -57,7 +57,14 @@ export function serializeRequest(req: Request): string {
 function authToObj(auth: Auth): Record<string, unknown> {
   if (auth.type === "none") return { type: "none" }
   if (auth.type === "bearer") return { type: "bearer", token: auth.token }
-  if (auth.type === "basic") return { type: "basic", user: auth.user, pass: auth.pass }
-  if (auth.type === "api_key") return { type: "api_key", key: auth.key, value: auth.value, placement: auth.placement }
+  if (auth.type === "basic")
+    return { type: "basic", user: auth.user, pass: auth.pass }
+  if (auth.type === "api_key")
+    return {
+      type: "api_key",
+      key: auth.key,
+      value: auth.value,
+      placement: auth.placement,
+    }
   return { type: "none" }
 }

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -32,6 +32,13 @@ export async function send(
     })
   }
 
+  const authForParams = substituted.auth
+  if (authForParams?.type === "api_key" && authForParams.placement === "query") {
+    const up = new URL(finalUrl)
+    up.searchParams.append(authForParams.key, authForParams.value)
+    finalUrl = up.toString()
+  }
+
   const headersInst = new Headers(headers)
   const ah = authHeader(substituted.auth)
   if (ah) {
@@ -131,8 +138,14 @@ function authHeader(
   if (auth.type === "bearer") {
     return { name: "Authorization", value: `Bearer ${auth.token}` }
   }
-  const encoded = Buffer.from(`${auth.user}:${auth.pass}`).toString("base64")
-  return { name: "Authorization", value: `Basic ${encoded}` }
+  if (auth.type === "basic") {
+    const encoded = Buffer.from(`${auth.user}:${auth.pass}`).toString("base64")
+    return { name: "Authorization", value: `Basic ${encoded}` }
+  }
+  if (auth.type === "api_key" && auth.placement === "header") {
+    return { name: auth.key, value: auth.value }
+  }
+  return null
 }
 
 function filterKv(entries: Record<string, KvEntry>): Record<string, string> {

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -33,7 +33,10 @@ export async function send(
   }
 
   const authForParams = substituted.auth
-  if (authForParams?.type === "api_key" && authForParams.placement === "query") {
+  if (
+    authForParams?.type === "api_key" &&
+    authForParams.placement === "query"
+  ) {
     const up = new URL(finalUrl)
     up.searchParams.append(authForParams.key, authForParams.value)
     finalUrl = up.toString()
@@ -90,7 +93,11 @@ export async function send(
 
     currentUrl = new URL(loc, currentUrl).toString()
 
-    if (res.status === 303 || ((res.status === 301 || res.status === 302) && currentInit.method === "POST")) {
+    if (
+      res.status === 303 ||
+      ((res.status === 301 || res.status === 302) &&
+        currentInit.method === "POST")
+    ) {
       const newHeaders = new Headers(currentInit.headers)
       newHeaders.delete("content-type")
       newHeaders.delete("content-length")

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -54,6 +54,14 @@ function substituteAuth(
   if (auth.type === "bearer") {
     return { type: "bearer", token: resolve(auth.token, "auth.token") }
   }
+  if (auth.type === "api_key") {
+    return {
+      type: "api_key",
+      key: resolve(auth.key, "auth.key"),
+      value: resolve(auth.value, "auth.value"),
+      placement: auth.placement,
+    }
+  }
   return {
     type: "basic",
     user: resolve(auth.user, "auth.user"),

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -16,7 +16,12 @@ export type Auth =
   | { type: "none" }
   | { type: "bearer"; token: string }
   | { type: "basic"; user: string; pass: string }
-  | { type: "api_key"; key: string; value: string; placement: "header" | "query" }
+  | {
+      type: "api_key"
+      key: string
+      value: string
+      placement: "header" | "query"
+    }
 
 export interface Request {
   id: string

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -16,6 +16,7 @@ export type Auth =
   | { type: "none" }
   | { type: "bearer"; token: string }
   | { type: "basic"; user: string; pass: string }
+  | { type: "api_key"; key: string; value: string; placement: "header" | "query" }
 
 export interface Request {
   id: string

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -47,7 +47,9 @@ export function App({
   )
 
   const [envNames, setEnvNames] = useState<string[]>(initialEnvList)
-  const [envColors, setEnvColors] = useState<Record<string, string | undefined>>({})
+  const [envColors, setEnvColors] = useState<
+    Record<string, string | undefined>
+  >({})
 
   useEffect(() => {
     listEnvironmentsWithColors(environmentsDir).then((items) => {

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -403,7 +403,6 @@ export function AppInner({
                     activeTab={eb.activeTab}
                     activeEnv={envState.activeEnv}
                     onAuthTypeChange={draft.setAuthType}
-                    onAuthFieldChange={draft.setAuthField}
                     onApiKeyPlacementChange={draft.setApiKeyPlacement}
                     onSelectOpenChange={setSelectOpen}
                   />
@@ -426,7 +425,6 @@ export function AppInner({
                     activeTab={eb.activeTab}
                     activeEnv={envState.activeEnv}
                     onAuthTypeChange={draft.setAuthType}
-                    onAuthFieldChange={draft.setAuthField}
                     onApiKeyPlacementChange={draft.setApiKeyPlacement}
                     onSelectOpenChange={setSelectOpen}
                   />

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -81,7 +81,7 @@ export function AppInner({
   )
   const [confirmSelection, setConfirmSelection] = useState(0)
   const [collectionReloadToken, setCollectionReloadToken] = useState(0)
-  const [selectOpen, setSelectOpen] = useState(false)
+  const [, setSelectOpen] = useState(false)
   const [yamlEditor, setYamlEditor] = useState<{
     visible: boolean
     filePath: string

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -81,6 +81,7 @@ export function AppInner({
   )
   const [confirmSelection, setConfirmSelection] = useState(0)
   const [collectionReloadToken, setCollectionReloadToken] = useState(0)
+  const [selectOpen, setSelectOpen] = useState(false)
   const [yamlEditor, setYamlEditor] = useState<{
     visible: boolean
     filePath: string
@@ -401,6 +402,10 @@ export function AppInner({
                     focused={focus === "request"}
                     activeTab={eb.activeTab}
                     activeEnv={envState.activeEnv}
+                    onAuthTypeChange={draft.setAuthType}
+                    onAuthFieldChange={draft.setAuthField}
+                    onApiKeyPlacementChange={draft.setApiKeyPlacement}
+                    onSelectOpenChange={setSelectOpen}
                   />
                   <ResponsePane
                     state={responseState}
@@ -420,6 +425,10 @@ export function AppInner({
                     focused={focus === "request"}
                     activeTab={eb.activeTab}
                     activeEnv={envState.activeEnv}
+                    onAuthTypeChange={draft.setAuthType}
+                    onAuthFieldChange={draft.setAuthField}
+                    onApiKeyPlacementChange={draft.setApiKeyPlacement}
+                    onSelectOpenChange={setSelectOpen}
                   />
                   <ResponsePane
                     state={responseState}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -60,7 +60,7 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
     type: "api_key",
     fieldDefs: [
       { row: 1, label: "Key", field: "key", isSecret: false },
-      { row: 2, label: "Value", field: "value", isSecret: false },
+      { row: 2, label: "Value", field: "value", isSecret: true },
       {
         row: 3,
         label: "Add To",
@@ -74,7 +74,19 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
 
 function getFieldValue(auth: Auth, field: string): string {
   if (auth.type === "none") return ""
-  return ((auth as Record<string, unknown>)[field] as string) ?? ""
+  if (auth.type === "bearer") return auth.token
+  if (auth.type === "basic") {
+    if (field === "user") return auth.user
+    if (field === "pass") return auth.pass
+    return ""
+  }
+  if (auth.type === "api_key") {
+    if (field === "key") return auth.key
+    if (field === "value") return auth.value
+    if (field === "placement") return auth.placement
+    return ""
+  }
+  return ""
 }
 
 export interface AuthEditorProps {
@@ -82,12 +94,10 @@ export interface AuthEditorProps {
   editState: EditState
   inEdit: boolean
   browseActive: boolean
-  editValue: string
   setEditValue: (v: string) => void
   theme: Theme
   activeEnv?: Environment | null
   onAuthTypeChange: (t: "none" | "bearer" | "basic" | "api_key") => void
-  onAuthFieldChange: (authType: string, field: string, value: string) => void
   onApiKeyPlacementChange: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
 }

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -174,9 +174,10 @@ export function AuthEditor({
             <Select
               items={AUTH_TYPE_ITEMS}
               value={type}
-              onChange={(id) =>
+              onChange={(id) => {
+                if (id === type) return
                 onAuthTypeChange(id as "none" | "bearer" | "basic" | "api_key")
-              }
+              }}
               focused={isTypeSelectorActive}
               badge={false}
               onOpenChange={handleTypeSelectOpen}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -170,7 +170,7 @@ export function AuthEditor({
           }}
         >
           <box style={{ flexDirection: "row", gap: 1 }}>
-            <text fg={theme.textMuted}>Type:</text>
+            <text fg={theme.text}>Type:</text>
             <Select
               items={AUTH_TYPE_ITEMS}
               value={type}
@@ -243,7 +243,7 @@ export function AuthEditor({
                 </>
               ) : def.isPlacement ? (
                 <box style={{ flexDirection: "row", gap: 1 }}>
-                  <text fg={theme.textMuted}>{def.label}: </text>
+                  <text fg={theme.text}>{def.label}: </text>
                   <Select
                     items={PLACEMENT_ITEMS}
                     value={fieldValue || "header"}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -136,16 +136,6 @@ export function AuthEditor({
     [onSelectOpenChange],
   )
 
-  const descFor = (field: string): string => {
-    if (field === "token") return "(bearer token)"
-    if (field === "user") return "(basic username)"
-    if (field === "pass") return "(basic password)"
-    if (field === "key") return "(api key name/custom header)"
-    if (field === "value") return "(api key value)"
-    if (field === "placement") return "(api key placement)"
-    return ""
-  }
-
   return (
     <box style={{ flexDirection: "column", gap: 1 }}>
       <box
@@ -184,7 +174,6 @@ export function AuthEditor({
             />
           </box>
         </box>
-        <text fg={theme.textMuted}>Authentication method</text>
       </box>
 
       {fieldDefs.map((def) => {
@@ -263,7 +252,6 @@ export function AuthEditor({
                 />
               )}
             </box>
-            <text fg={theme.textMuted}>{descFor(def.field)}</text>
           </box>
         )
       })}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -1,0 +1,240 @@
+import type { TextareaRenderable } from "@opentui/core"
+import { useCallback, useRef } from "react"
+import type { Auth, Environment } from "../schema"
+import type { EditState } from "./editMode"
+import { Select, type SelectItem } from "./Select"
+import type { Theme } from "./theme"
+import { LeftBar } from "./borders"
+import { VarText } from "./VarText"
+
+const AUTH_TYPE_ITEMS: SelectItem[] = [
+  { id: "none", label: "None" },
+  { id: "bearer", label: "Bearer Token" },
+  { id: "basic", label: "Basic Auth" },
+  { id: "api_key", label: "API Key" },
+]
+
+const PLACEMENT_ITEMS: SelectItem[] = [
+  { id: "header", label: "Header" },
+  { id: "query", label: "Query Params" },
+]
+
+interface FieldDef {
+  row: number
+  label: string
+  field: string
+  isSecret: boolean
+  isPlacement?: boolean
+}
+
+interface AuthRows {
+  type: string
+  fieldDefs: FieldDef[]
+}
+
+function maskIfSecret(value: string, isSecret: boolean): string {
+  if (!isSecret || value === "") return value
+  return "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022"
+}
+
+function getAuthRows(auth: Auth | undefined): AuthRows {
+  if (!auth || auth.type === "none") {
+    return { type: "none", fieldDefs: [] }
+  }
+  if (auth.type === "bearer") {
+    return {
+      type: "bearer",
+      fieldDefs: [{ row: 1, label: "Token", field: "token", isSecret: true }],
+    }
+  }
+  if (auth.type === "basic") {
+    return {
+      type: "basic",
+      fieldDefs: [
+        { row: 1, label: "Username", field: "user", isSecret: false },
+        { row: 2, label: "Password", field: "pass", isSecret: true },
+      ],
+    }
+  }
+  return {
+    type: "api_key",
+    fieldDefs: [
+      { row: 1, label: "Key", field: "key", isSecret: false },
+      { row: 2, label: "Value", field: "value", isSecret: false },
+      {
+        row: 3,
+        label: "Add To",
+        field: "placement",
+        isSecret: false,
+        isPlacement: true,
+      },
+    ],
+  }
+}
+
+function getFieldValue(auth: Auth, field: string): string {
+  if (auth.type === "none") return ""
+  return ((auth as Record<string, unknown>)[field] as string) ?? ""
+}
+
+export interface AuthEditorProps {
+  request: { auth?: Auth }
+  editState: EditState
+  inEdit: boolean
+  browseActive: boolean
+  editValue: string
+  setEditValue: (v: string) => void
+  theme: Theme
+  activeEnv?: Environment | null
+  onAuthTypeChange: (t: "none" | "bearer" | "basic" | "api_key") => void
+  onAuthFieldChange: (authType: string, field: string, value: string) => void
+  onApiKeyPlacementChange: (placement: "header" | "query") => void
+  onSelectOpenChange?: (open: boolean) => void
+}
+
+export function AuthEditor({
+  request,
+  editState,
+  inEdit,
+  browseActive,
+  setEditValue,
+  theme,
+  activeEnv,
+  onAuthTypeChange,
+  onApiKeyPlacementChange,
+  onSelectOpenChange,
+}: AuthEditorProps) {
+  const textareaRef = useRef<TextareaRenderable | null>(null)
+
+  const handleContentChange = useCallback(() => {
+    const ta = textareaRef.current
+    if (ta) setEditValue(ta.plainText)
+  }, [setEditValue])
+
+  const { type, fieldDefs } = getAuthRows(request.auth)
+
+  const isTypeSelectorActive =
+    browseActive &&
+    editState.cursor.field === "auth" &&
+    editState.cursor.row === 0
+
+  const descFor = (field: string): string => {
+    if (field === "token") return "(bearer token)"
+    if (field === "user") return "(basic username)"
+    if (field === "pass") return "(basic password)"
+    if (field === "key") return "(api key name/custom header)"
+    if (field === "value") return "(api key value)"
+    if (field === "placement") return "(api key placement)"
+    return ""
+  }
+
+  return (
+    <box style={{ flexDirection: "column", gap: 1 }}>
+      <box style={{ flexDirection: "column" }}>
+        <box
+          id="auth-field"
+          border={[...LeftBar.border]}
+          customBorderChars={LeftBar.customBorderChars}
+          borderColor={
+            isTypeSelectorActive ? theme.primary : theme.borderSubtle
+          }
+          style={{
+            backgroundColor: isTypeSelectorActive
+              ? theme.backgroundElement
+              : undefined,
+            paddingLeft: 1,
+          }}
+        >
+          <box style={{ flexDirection: "row", gap: 1 }}>
+            <text fg={theme.textMuted}>Type:</text>
+            <Select
+              items={AUTH_TYPE_ITEMS}
+              value={type}
+              onChange={(id) =>
+                onAuthTypeChange(id as "none" | "bearer" | "basic" | "api_key")
+              }
+              focused={isTypeSelectorActive}
+              badge={false}
+              onOpenChange={onSelectOpenChange}
+            />
+          </box>
+        </box>
+        <text fg={theme.textMuted}>Authentication method</text>
+      </box>
+
+      {fieldDefs.map((def) => {
+        const isActive =
+          browseActive &&
+          editState.cursor.field === "auth" &&
+          editState.cursor.row === def.row
+        const isEditingRow =
+          inEdit &&
+          editState.cursor.field === "auth" &&
+          editState.cursor.row === def.row
+        const fieldValue = request.auth
+          ? getFieldValue(request.auth, def.field)
+          : ""
+        const displayValue = def.isSecret
+          ? maskIfSecret(fieldValue, true)
+          : fieldValue
+
+        return (
+          <box key={def.field} style={{ flexDirection: "column" }}>
+            <box
+              id={`auth-${def.field}`}
+              border={[...LeftBar.border]}
+              customBorderChars={LeftBar.customBorderChars}
+              borderColor={
+                isActive || isEditingRow ? theme.primary : theme.borderSubtle
+              }
+              style={{
+                flexDirection:
+                  isEditingRow && !def.isPlacement ? "row" : undefined,
+                gap: isEditingRow && !def.isPlacement ? 1 : undefined,
+                backgroundColor: isActive ? theme.backgroundElement : undefined,
+                paddingLeft: 1,
+              }}
+            >
+              {isEditingRow && !def.isPlacement ? (
+                <>
+                  <text fg={theme.textMuted}>{def.label}: </text>
+                  <textarea
+                    ref={textareaRef}
+                    initialValue={fieldValue}
+                    onContentChange={handleContentChange}
+                    backgroundColor={theme.backgroundPanel}
+                    focusedBackgroundColor={theme.backgroundPanel}
+                    textColor={theme.text}
+                    cursorColor={theme.primary}
+                    focused
+                  />
+                </>
+              ) : def.isPlacement ? (
+                <box style={{ flexDirection: "row", gap: 1 }}>
+                  <text fg={theme.textMuted}>{def.label}: </text>
+                  <Select
+                    items={PLACEMENT_ITEMS}
+                    value={fieldValue || "header"}
+                    onChange={(id) =>
+                      onApiKeyPlacementChange(id as "header" | "query")
+                    }
+                    focused={isActive}
+                    badge={false}
+                    onOpenChange={onSelectOpenChange}
+                  />
+                </box>
+              ) : (
+                <VarText
+                  text={`${def.label}: ${displayValue}`}
+                  env={activeEnv ?? null}
+                  baseColor={theme.text}
+                />
+              )}
+            </box>
+            <text fg={theme.textMuted}>{descFor(def.field)}</text>
+          </box>
+        )
+      })}
+    </box>
+  )
+}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -1,5 +1,5 @@
 import type { TextareaRenderable } from "@opentui/core"
-import { useCallback, useRef } from "react"
+import { useCallback, useRef, useState } from "react"
 import type { Auth, Environment } from "../schema"
 import type { EditState } from "./editMode"
 import { Select, type SelectItem } from "./Select"
@@ -105,6 +105,8 @@ export function AuthEditor({
   onSelectOpenChange,
 }: AuthEditorProps) {
   const textareaRef = useRef<TextareaRenderable | null>(null)
+  const [typeSelectOpen, setTypeSelectOpen] = useState(false)
+  const [placementSelectOpen, setPlacementSelectOpen] = useState(false)
 
   const handleContentChange = useCallback(() => {
     const ta = textareaRef.current
@@ -118,6 +120,22 @@ export function AuthEditor({
     editState.cursor.field === "auth" &&
     editState.cursor.row === 0
 
+  const handleTypeSelectOpen = useCallback(
+    (open: boolean) => {
+      setTypeSelectOpen(open)
+      onSelectOpenChange?.(open)
+    },
+    [onSelectOpenChange],
+  )
+
+  const handlePlacementSelectOpen = useCallback(
+    (open: boolean) => {
+      setPlacementSelectOpen(open)
+      onSelectOpenChange?.(open)
+    },
+    [onSelectOpenChange],
+  )
+
   const descFor = (field: string): string => {
     if (field === "token") return "(bearer token)"
     if (field === "user") return "(basic username)"
@@ -130,7 +148,12 @@ export function AuthEditor({
 
   return (
     <box style={{ flexDirection: "column", gap: 1 }}>
-      <box style={{ flexDirection: "column" }}>
+      <box
+        style={{
+          flexDirection: "column",
+          zIndex: typeSelectOpen ? 1 : undefined,
+        }}
+      >
         <box
           id="auth-field"
           border={[...LeftBar.border]}
@@ -139,6 +162,7 @@ export function AuthEditor({
             isTypeSelectorActive ? theme.primary : theme.borderSubtle
           }
           style={{
+            zIndex: typeSelectOpen ? 1 : undefined,
             backgroundColor: isTypeSelectorActive
               ? theme.backgroundElement
               : undefined,
@@ -155,7 +179,7 @@ export function AuthEditor({
               }
               focused={isTypeSelectorActive}
               badge={false}
-              onOpenChange={onSelectOpenChange}
+              onOpenChange={handleTypeSelectOpen}
             />
           </box>
         </box>
@@ -179,7 +203,14 @@ export function AuthEditor({
           : fieldValue
 
         return (
-          <box key={def.field} style={{ flexDirection: "column" }}>
+          <box
+            key={def.field}
+            style={{
+              flexDirection: "column",
+              zIndex:
+                def.isPlacement && placementSelectOpen ? 1 : undefined,
+            }}
+          >
             <box
               id={`auth-${def.field}`}
               border={[...LeftBar.border]}
@@ -220,7 +251,7 @@ export function AuthEditor({
                     }
                     focused={isActive}
                     badge={false}
-                    onOpenChange={onSelectOpenChange}
+                    onOpenChange={handlePlacementSelectOpen}
                   />
                 </box>
               ) : (

--- a/src/ui/CenterText.tsx
+++ b/src/ui/CenterText.tsx
@@ -26,7 +26,13 @@ export function CenterText({
 }): ReactNode {
   const words = splitWords(segments)
   return (
-    <box style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center" }}>
+    <box
+      style={{
+        flexDirection: "row",
+        flexWrap: "wrap",
+        justifyContent: "center",
+      }}
+    >
       {words.map((w, i) => (
         <text key={i} wrapMode="none" fg={w.color}>
           {w.text}

--- a/src/ui/Checkbox.tsx
+++ b/src/ui/Checkbox.tsx
@@ -1,6 +1,12 @@
 import type { Theme } from "./theme"
 
-export function Checkbox({ checked, theme }: { checked: boolean; theme: Theme }) {
+export function Checkbox({
+  checked,
+  theme,
+}: {
+  checked: boolean
+  theme: Theme
+}) {
   return (
     <text fg={checked ? theme.primary : theme.textMuted}>
       {checked ? "[x] " : "[ ] "}

--- a/src/ui/ConfirmOverlay.tsx
+++ b/src/ui/ConfirmOverlay.tsx
@@ -16,30 +16,30 @@ export function ConfirmOverlay({
 
   return (
     <Overlay visible={visible} width={50} gap={1} padding={2}>
-        <box
-          style={{
-            flexDirection: "row",
-            justifyContent: "space-between",
-          }}
-        >
-          <text fg={theme.text}>Confirm</text>
-          <text fg={theme.textMuted}>esc</text>
-        </box>
-        <text fg={theme.text}>{message}</text>
-        <box
-          style={{
-            flexDirection: "row",
-            alignSelf: "flex-end",
-            gap: 1,
-            paddingRight: 1,
-          }}
-        >
-          <text fg={theme.primary}>Y</text>
-          <text fg={theme.textMuted}>Confirm</text>
-          <text fg={theme.textMuted}> · </text>
-          <text fg={theme.primary}>N</text>
-          <text fg={theme.textMuted}>Cancel</text>
-        </box>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
+      >
+        <text fg={theme.text}>Confirm</text>
+        <text fg={theme.textMuted}>esc</text>
+      </box>
+      <text fg={theme.text}>{message}</text>
+      <box
+        style={{
+          flexDirection: "row",
+          alignSelf: "flex-end",
+          gap: 1,
+          paddingRight: 1,
+        }}
+      >
+        <text fg={theme.primary}>Y</text>
+        <text fg={theme.textMuted}>Confirm</text>
+        <text fg={theme.textMuted}> · </text>
+        <text fg={theme.primary}>N</text>
+        <text fg={theme.textMuted}>Cancel</text>
+      </box>
     </Overlay>
   )
 }

--- a/src/ui/EnvEditorPane.tsx
+++ b/src/ui/EnvEditorPane.tsx
@@ -182,9 +182,7 @@ export function EnvEditorPane({
           />
         </box>
       </scrollbox>
-      {error && (
-        <text fg={theme.error}>Error: {error}</text>
-      )}
+      {error && <text fg={theme.error}>Error: {error}</text>}
       {saving && <text fg={theme.info}>Saving...</text>}
     </box>
   )

--- a/src/ui/HelpOverlay.tsx
+++ b/src/ui/HelpOverlay.tsx
@@ -49,10 +49,13 @@ export function HelpOverlay({
                 <text fg={theme.text}>{section.title}</text>
               </box>
               {section.keys.map((k, i) => (
-                <box key={i} paddingLeft={4} paddingRight={4} style={{ flexDirection: "row" }}>
-                  <text fg={theme.primary}>
-                    {k.key.padEnd(11)}
-                  </text>
+                <box
+                  key={i}
+                  paddingLeft={4}
+                  paddingRight={4}
+                  style={{ flexDirection: "row" }}
+                >
+                  <text fg={theme.primary}>{k.key.padEnd(11)}</text>
                   <text fg={theme.textMuted}>{k.description}</text>
                 </box>
               ))}

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -170,7 +170,7 @@ export function KeyValueSection({
                   : undefined,
             }}
           >
-          <Checkbox checked={false} theme={theme} />
+            <Checkbox checked={false} theme={theme} />
             <input
               value={editingAdd ? editKey : ""}
               placeholder="Key"

--- a/src/ui/PickerOverlay.tsx
+++ b/src/ui/PickerOverlay.tsx
@@ -96,7 +96,9 @@ export function PickerOverlay({
             const isActive = i === activeIndex
             const isSelected = i === previewIndex
             const indicator = item.indicator ?? "●"
-            const indicatorFg = item.indicatorColor ?? (isActive ? theme.primary : theme.textMuted)
+            const indicatorFg =
+              item.indicatorColor ??
+              (isActive ? theme.primary : theme.textMuted)
             return (
               <box
                 key={i}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -30,7 +30,6 @@ interface Props {
   activeTab: FieldKind
   activeEnv?: Environment | null
   onAuthTypeChange?: (t: "none" | "bearer" | "basic" | "api_key") => void
-  onAuthFieldChange?: (authType: string, field: string, value: string) => void
   onApiKeyPlacementChange?: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
 }
@@ -54,7 +53,6 @@ export function RequestPane({
   activeTab,
   activeEnv,
   onAuthTypeChange,
-  onAuthFieldChange,
   onApiKeyPlacementChange,
   onSelectOpenChange,
 }: Props) {
@@ -196,12 +194,10 @@ export function RequestPane({
                   editState={editState}
                   inEdit={inEdit}
                   browseActive={browseActive}
-                  editValue={editValue}
                   setEditValue={setEditValue}
                   theme={theme}
                   activeEnv={activeEnv}
                   onAuthTypeChange={onAuthTypeChange ?? (() => {})}
-                  onAuthFieldChange={onAuthFieldChange ?? (() => {})}
                   onApiKeyPlacementChange={
                     onApiKeyPlacementChange ?? (() => {})
                   }

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -5,7 +5,7 @@ import type {
 } from "@opentui/core"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { Request, Environment } from "../schema"
-import { formatBody, formatAuth } from "./formatRequest"
+import { formatBody } from "./formatRequest"
 import type { EditState, FieldKind } from "./editMode"
 
 import { Tabs, type TabDef } from "./Tabs"
@@ -17,6 +17,7 @@ import { JsonBodyViewer } from "./JsonBodyViewer"
 import { VarText } from "./VarText"
 import { KeyValueSection } from "./KeyValueSection"
 import { Checkbox } from "./Checkbox"
+import { AuthEditor } from "./AuthEditor"
 
 interface Props {
   request: Request | null
@@ -28,6 +29,10 @@ interface Props {
   focused?: boolean
   activeTab: FieldKind
   activeEnv?: Environment | null
+  onAuthTypeChange?: (t: "none" | "bearer" | "basic" | "api_key") => void
+  onAuthFieldChange?: (authType: string, field: string, value: string) => void
+  onApiKeyPlacementChange?: (placement: "header" | "query") => void
+  onSelectOpenChange?: (open: boolean) => void
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -48,6 +53,10 @@ export function RequestPane({
   focused = false,
   activeTab,
   activeEnv,
+  onAuthTypeChange,
+  onAuthFieldChange,
+  onApiKeyPlacementChange,
+  onSelectOpenChange,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -67,6 +76,16 @@ export function RequestPane({
       scrollRef.current?.scrollChildIntoView(`${field}-field`)
     }
   }, [editState.cursor])
+
+  const handleSelectOpenChange = useCallback(
+    (open: boolean) => {
+      onSelectOpenChange?.(open)
+      if (open) {
+        scrollRef.current?.scrollChildIntoView("auth-field")
+      }
+    },
+    [onSelectOpenChange],
+  )
 
   const tabs = useMemo(() => {
     if (!request) return BASE_TAB_DEFS
@@ -172,11 +191,21 @@ export function RequestPane({
                 />
               )}
               {activeTab === "auth" && (
-                <AuthSection
+                <AuthEditor
                   request={request}
                   editState={editState}
+                  inEdit={inEdit}
+                  browseActive={browseActive}
+                  editValue={editValue}
+                  setEditValue={setEditValue}
                   theme={theme}
                   activeEnv={activeEnv}
+                  onAuthTypeChange={onAuthTypeChange ?? (() => {})}
+                  onAuthFieldChange={onAuthFieldChange ?? (() => {})}
+                  onApiKeyPlacementChange={
+                    onApiKeyPlacementChange ?? (() => {})
+                  }
+                  onSelectOpenChange={handleSelectOpenChange}
                 />
               )}
               {activeTab === "settings" && (
@@ -278,39 +307,6 @@ function BodySection({
   )
 }
 
-function AuthSection({
-  request,
-  editState,
-  theme,
-  activeEnv,
-}: {
-  request: Request
-  editState: EditState
-  theme: Theme
-  activeEnv?: Environment | null
-}) {
-  const auth = formatAuth(request.auth)
-  const isActive =
-    editState.mode === "browsing" && editState.cursor.field === "auth"
-  return (
-    <box
-      id="auth-field"
-      border={[...LeftBar.border]}
-      customBorderChars={LeftBar.customBorderChars}
-      borderColor={isActive ? theme.primary : theme.borderSubtle}
-      style={{
-        backgroundColor: isActive ? theme.backgroundElement : undefined,
-      }}
-    >
-      <VarText
-        text={` ${auth}`}
-        env={activeEnv ?? null}
-        baseColor={isActive ? theme.text : theme.textMuted}
-      />
-    </box>
-  )
-}
-
 function SettingsSection({
   request,
   editState,
@@ -329,38 +325,44 @@ function SettingsSection({
   activeEnv?: Environment | null
 }) {
   const textareaRef = useRef<TextareaRenderable | null>(null)
-  
+
   const handleContentChange = useCallback(() => {
     const ta = textareaRef.current
     if (ta) setEditValue(ta.plainText)
   }, [setEditValue])
 
   const rows = [
-    { 
-      label: "Timeout (ms)", 
-      value: request.timeout, 
+    {
+      label: "Timeout (ms)",
+      value: request.timeout,
       display: `${request.timeout}ms`,
-      desc: "Set maximum time to wait before aborting the request" 
+      desc: "Set maximum time to wait before aborting the request",
     },
-    { 
-      label: "Follow Redirects", 
-      value: request.followRedirects ?? true, 
+    {
+      label: "Follow Redirects",
+      value: request.followRedirects ?? true,
       display: String(request.followRedirects ?? true),
-      desc: "Automatically follow HTTP redirects" 
+      desc: "Automatically follow HTTP redirects",
     },
-    { 
-      label: "Max Redirects", 
-      value: request.maxRedirects ?? 5, 
+    {
+      label: "Max Redirects",
+      value: request.maxRedirects ?? 5,
       display: String(request.maxRedirects ?? 5),
-      desc: "Maximum number of redirects to follow" 
+      desc: "Maximum number of redirects to follow",
     },
   ]
 
   return (
     <box style={{ flexDirection: "column", gap: 1 }}>
       {rows.map((row, idx) => {
-        const editingRow = inEdit && editState.cursor.field === "settings" && editState.cursor.row === idx
-        const isActive = browseActive && editState.cursor.field === "settings" && editState.cursor.row === idx
+        const editingRow =
+          inEdit &&
+          editState.cursor.field === "settings" &&
+          editState.cursor.row === idx
+        const isActive =
+          browseActive &&
+          editState.cursor.field === "settings" &&
+          editState.cursor.row === idx
 
         return (
           <box key={row.label} style={{ flexDirection: "column" }}>
@@ -368,7 +370,9 @@ function SettingsSection({
               id={idx === 0 ? "settings-field" : `settings-${idx}`}
               border={[...LeftBar.border]}
               customBorderChars={LeftBar.customBorderChars}
-              borderColor={isActive || editingRow ? theme.primary : theme.borderSubtle}
+              borderColor={
+                isActive || editingRow ? theme.primary : theme.borderSubtle
+              }
               style={{
                 flexDirection: editingRow ? "row" : undefined,
                 gap: editingRow ? 1 : undefined,
@@ -392,7 +396,10 @@ function SettingsSection({
               ) : idx === 1 ? (
                 <box style={{ flexDirection: "row", gap: 1 }}>
                   <text fg={theme.textMuted}>{row.label}: </text>
-                  <Checkbox checked={request.followRedirects ?? true} theme={theme} />
+                  <Checkbox
+                    checked={request.followRedirects ?? true}
+                    theme={theme}
+                  />
                 </box>
               ) : (
                 <VarText

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -395,11 +395,11 @@ function SettingsSection({
                 </>
               ) : idx === 1 ? (
                 <box style={{ flexDirection: "row", gap: 1 }}>
-                  <text fg={theme.textMuted}>{row.label}: </text>
-                  <Checkbox
-                    checked={request.followRedirects ?? true}
-                    theme={theme}
-                  />
+              <text fg={theme.text}>{row.label}: </text>
+              <Checkbox
+                checked={request.followRedirects ?? true}
+                theme={theme}
+              />
                 </box>
               ) : (
                 <VarText

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -39,7 +39,9 @@ export function ResponsePane({
   const focusedRef = useRef(focused)
   focusedRef.current = focused
 
-  const [activeTab, setActiveTab] = useState<"body" | "headers" | "timeline">("body")
+  const [activeTab, setActiveTab] = useState<"body" | "headers" | "timeline">(
+    "body",
+  )
   const [spinnerIdx, setSpinnerIdx] = useState(0)
   const isDone = state.status === "done"
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -78,9 +80,10 @@ export function ResponsePane({
   const borderColor = focused ? theme.primary : theme.borderSubtle
 
   const responseHeaders = isDone ? formatHeaders(state.response) : []
-  const maxKeyLen = responseHeaders.length > 0
-    ? Math.max(...responseHeaders.map((h) => h.key.length))
-    : 0
+  const maxKeyLen =
+    responseHeaders.length > 0
+      ? Math.max(...responseHeaders.map((h) => h.key.length))
+      : 0
 
   return (
     <box
@@ -119,15 +122,9 @@ export function ResponsePane({
         </box>
       ) : (
         <box style={{ flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
-          <Tabs
-            tabs={TAB_DEFS}
-            activeId={activeTab}
-          >
+          <Tabs tabs={TAB_DEFS} activeId={activeTab}>
             {activeTab === "timeline" ? (
-              <TimelineTab
-                entries={timelineEntries ?? []}
-                focused={focused}
-              />
+              <TimelineTab entries={timelineEntries ?? []} focused={focused} />
             ) : (
               <scrollbox
                 ref={scrollRef}
@@ -139,28 +136,51 @@ export function ResponsePane({
                   <box style={{ flexDirection: "column", gap: 1 }}>
                     {(() => {
                       const body = formatBody(state.response)
-                      if (body === "") return (
-                        <text fg={theme.textMuted}>(no body)</text>
+                      if (body === "")
+                        return <text fg={theme.textMuted}>(no body)</text>
+                      return (
+                        <JsonBodyViewer
+                          key={body}
+                          body={body}
+                          theme={theme}
+                          readOnly
+                        />
                       )
-                      return <JsonBodyViewer key={body} body={body} theme={theme} readOnly />
                     })()}
                   </box>
                 ) : (
                   responseHeaders.map(({ key, value }, i) => {
                     if (i < responseHeaders.length - 1) {
                       return (
-                        <box key={key} border={["bottom"]} borderColor={theme.borderDimmest} style={{ flexDirection: "row" }}>
-                          <text fg={theme.textMuted} style={{ minWidth: maxKeyLen + 1, paddingLeft: 1 }}>
+                        <box
+                          key={key}
+                          border={["bottom"]}
+                          borderColor={theme.borderDimmest}
+                          style={{ flexDirection: "row" }}
+                        >
+                          <text
+                            fg={theme.textMuted}
+                            style={{ minWidth: maxKeyLen + 1, paddingLeft: 1 }}
+                          >
                             {key.padEnd(maxKeyLen)}
                           </text>
-                          <text fg={theme.textMuted} wrapMode="none" style={{ flexShrink: 1, minWidth: 5 }}>
+                          <text
+                            fg={theme.textMuted}
+                            wrapMode="none"
+                            style={{ flexShrink: 1, minWidth: 5 }}
+                          >
                             : {value}
                           </text>
                         </box>
                       )
                     }
                     return (
-                      <text key={key} fg={theme.textMuted} wrapMode="none" style={{ paddingLeft: 1 }}>
+                      <text
+                        key={key}
+                        fg={theme.textMuted}
+                        wrapMode="none"
+                        style={{ paddingLeft: 1 }}
+                      >
                         {key.padEnd(maxKeyLen)} : {value}
                       </text>
                     )
@@ -170,9 +190,20 @@ export function ResponsePane({
             )}
           </Tabs>
           {state.response.statusText !== "" && (
-            <box style={{ flexDirection: "row", justifyContent: "flex-end", flexShrink: 0, paddingTop: 1, paddingRight: 1 }}>
+            <box
+              style={{
+                flexDirection: "row",
+                justifyContent: "flex-end",
+                flexShrink: 0,
+                paddingTop: 1,
+                paddingRight: 1,
+              }}
+            >
               <GradientBadge
-                colors={[statusColor(state.response.status, theme), theme.primary]}
+                colors={[
+                  statusColor(state.response.status, theme),
+                  theme.primary,
+                ]}
                 fg={theme.background}
               >
                 {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""} • ${Math.round(state.response.timeMs)}ms • ${formatSize(new TextEncoder().encode(state.response.body).length)}`}

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -157,14 +157,18 @@ export function Select({
     return width !== undefined ? Math.max(width, maxLabel + 6) : maxLabel + 6
   }, [items, width])
 
+  const dropdownMaxHeight = useMemo(
+    () => Math.min(maxDropdownHeight, items.reduce((s, i) => s + (i.description ? 2 : 1), 0)),
+    [maxDropdownHeight, items],
+  )
+
   return (
-    <box
-      style={{
-        flexDirection: "column",
-        ...(width !== undefined ? { width } : {}),
-        ...(open ? { zIndex: 1, position: "relative" as const } : {}),
-      }}
-    >
+      <box
+        style={{
+          flexDirection: "column",
+          ...(width !== undefined ? { width } : {}),
+        }}
+      >
       <box style={{ position: "relative" }}>
         <box
           height={1}
@@ -215,7 +219,7 @@ export function Select({
             <scrollbox
               ref={scrollRef}
               scrollY
-              maxHeight={maxDropdownHeight}
+              maxHeight={dropdownMaxHeight}
               scrollbarOptions={{ visible: false }}
             >
               <box style={{ flexDirection: "column" }}>

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -135,9 +135,10 @@ export function Select({
 
   const selectedItem = items.find((i) => i.id === value)
 
-  const selectedBadgeBg = badge && selectedItem?.color
-    ? (theme as unknown as Record<string, string>)[selectedItem.color]
-    : undefined
+  const selectedBadgeBg =
+    badge && selectedItem?.color
+      ? (theme as unknown as Record<string, string>)[selectedItem.color]
+      : undefined
 
   const indicatorColor = selectedItem
     ? open || selectedBadgeBg
@@ -150,13 +151,20 @@ export function Select({
     for (const item of items) {
       const text = extractText(item.label)
       if (text) maxLabel = Math.max(maxLabel, text.length)
-      if (item.description) maxLabel = Math.max(maxLabel, item.description.length)
+      if (item.description)
+        maxLabel = Math.max(maxLabel, item.description.length)
     }
     return width !== undefined ? Math.max(width, maxLabel + 6) : maxLabel + 6
   }, [items, width])
 
   return (
-    <box style={{ flexDirection: "column", ...(width !== undefined ? { width } : {}) }}>
+    <box
+      style={{
+        flexDirection: "column",
+        ...(width !== undefined ? { width } : {}),
+        ...(open ? { zIndex: 1, position: "relative" as const } : {}),
+      }}
+    >
       <box style={{ position: "relative" }}>
         <box
           height={1}
@@ -232,15 +240,11 @@ export function Select({
                       <box style={{ flexDirection: "column", flexGrow: 1 }}>
                         {renderLabel(
                           item.label,
-                          item.id === value
-                            ? theme.primary
-                            : theme.text,
+                          item.id === value ? theme.primary : theme.text,
                           isHighlighted ? TextAttributes.BOLD : undefined,
                         )}
                         {item.description && (
-                          <text fg={theme.textMuted}>
-                            {item.description}
-                          </text>
+                          <text fg={theme.textMuted}>{item.description}</text>
                         )}
                       </box>
                       {item.id === value && !item.disabled && (

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -121,7 +121,9 @@ export function StatusBar(input: {
   const rightSegments = sections.right.split(" · ").map((seg) => {
     const s = seg.replace(/[[\]]/g, "")
     const sp = s.indexOf(" ")
-    return sp > -1 ? { key: s.slice(0, sp), word: s.slice(sp + 1) } : { key: s, word: "" }
+    return sp > -1
+      ? { key: s.slice(0, sp), word: s.slice(sp + 1) }
+      : { key: s, word: "" }
   })
 
   const envText =
@@ -136,7 +138,8 @@ export function StatusBar(input: {
     : input.envLabel === "" || input.envLabel === "(no env)"
       ? theme.textMuted
       : input.envColor !== undefined
-        ? (theme as unknown as Record<string, string>)[input.envColor] ?? theme.info
+        ? ((theme as unknown as Record<string, string>)[input.envColor] ??
+          theme.info)
         : theme.info
 
   const saveFlash =

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -55,11 +55,16 @@ export function parseTip(tip: string): TipPart[] {
 export function Tips() {
   const theme = useTheme()
 
-  const [tip] = useState(() => TIPS[Math.floor(Math.random() * TIPS.length)] ?? TIPS[0])
+  const [tip] = useState(
+    () => TIPS[Math.floor(Math.random() * TIPS.length)] ?? TIPS[0],
+  )
   const parts = parseTip(tip)
   const segments = [
     { text: "● Tip", color: theme.secondary },
-    ...parts.map((p) => ({ text: p.text, color: p.isKey ? theme.primary : theme.textMuted })),
+    ...parts.map((p) => ({
+      text: p.text,
+      color: p.isKey ? theme.primary : theme.textMuted,
+    })),
   ]
 
   return (

--- a/src/ui/YamlEditorOverlay.tsx
+++ b/src/ui/YamlEditorOverlay.tsx
@@ -114,86 +114,93 @@ export function YamlEditorOverlay({
   if (!visible) return null
 
   return (
-    <Overlay visible={visible} width={90} height="80%" padding={2} gap={1} overflow="hidden">
+    <Overlay
+      visible={visible}
+      width={90}
+      height="80%"
+      padding={2}
+      gap={1}
+      overflow="hidden"
+    >
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          flexShrink: 0,
+          paddingBottom: 1,
+          paddingX: 2,
+        }}
+      >
+        <text fg={theme.primary}>{requestName}.yml</text>
+        <text fg={theme.textMuted}>esc</text>
+      </box>
+      {readError ? (
+        <box
+          style={{
+            flexGrow: 1,
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <text fg={theme.error}>Error: {readError}</text>
+        </box>
+      ) : content !== null ? (
+        <box
+          style={{
+            height: "100%",
+            minHeight: 0,
+            paddingLeft: 1,
+            paddingRight: 1,
+            flexGrow: 1,
+          }}
+        >
+          <line-number
+            ref={lineNumberRef}
+            minWidth={3}
+            paddingRight={1}
+            fg={theme.textMuted}
+            bg={theme.backgroundPanel}
+            style={{ height: "100%", minHeight: 0 }}
+            width="100%"
+          >
+            <textarea
+              ref={textareaRef}
+              initialValue={content}
+              onContentChange={handleContentChange}
+              backgroundColor={theme.backgroundPanel}
+              focusedBackgroundColor={theme.backgroundPanel}
+              textColor={theme.text}
+              cursorColor={theme.primary}
+              focused
+            />
+          </line-number>
+        </box>
+      ) : (
+        <text fg={theme.textMuted}>Loading...</text>
+      )}
+      {saveError && <text fg={theme.error}>Save error: {saveError}</text>}
+      <box
+        style={{
+          flexDirection: "row",
+          flexShrink: 0,
+        }}
+      >
         <box
           style={{
             flexDirection: "row",
-            justifyContent: "space-between",
-            flexShrink: 0,
-            paddingBottom: 1,
+            justifyContent: "flex-end",
             paddingX: 2,
+            flexGrow: 1,
+            gap: 1,
           }}
         >
-          <text fg={theme.primary}>{requestName}.yml</text>
-          <text fg={theme.textMuted}>esc</text>
+          <text fg={theme.primary}>^S</text>
+          <text fg={theme.textMuted}>save</text>
+          <text fg={theme.textMuted}> · </text>
+          <text fg={theme.primary}>esc</text>
+          <text fg={theme.textMuted}>close</text>
         </box>
-        {readError ? (
-          <box
-            style={{
-              flexGrow: 1,
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <text fg={theme.error}>Error: {readError}</text>
-          </box>
-        ) : content !== null ? (
-          <box
-            style={{
-              height: "100%",
-              minHeight: 0,
-              paddingLeft: 1,
-              paddingRight: 1,
-              flexGrow: 1,
-            }}
-          >
-            <line-number
-              ref={lineNumberRef}
-              minWidth={3}
-              paddingRight={1}
-              fg={theme.textMuted}
-              bg={theme.backgroundPanel}
-              style={{ height: "100%", minHeight: 0 }}
-              width="100%"
-            >
-              <textarea
-                ref={textareaRef}
-                initialValue={content}
-                onContentChange={handleContentChange}
-                backgroundColor={theme.backgroundPanel}
-                focusedBackgroundColor={theme.backgroundPanel}
-                textColor={theme.text}
-                cursorColor={theme.primary}
-                focused
-              />
-            </line-number>
-          </box>
-        ) : (
-          <text fg={theme.textMuted}>Loading...</text>
-        )}
-        {saveError && <text fg={theme.error}>Save error: {saveError}</text>}
-        <box
-          style={{
-            flexDirection: "row",
-            flexShrink: 0,
-          }}
-        >
-          <box
-            style={{
-              flexDirection: "row",
-              justifyContent: "flex-end",
-              paddingX: 2,
-              flexGrow: 1,
-              gap: 1,
-            }}
-          >
-            <text fg={theme.primary}>^S</text>
-            <text fg={theme.textMuted}>save</text>
-            <text fg={theme.textMuted}> · </text>
-            <text fg={theme.primary}>esc</text>
-            <text fg={theme.textMuted}>close</text>
-          </box>
-        </box>
+      </box>
     </Overlay>
   )
 }

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -40,7 +40,13 @@ export function initialEditState(): EditState {
 
 export function enterEditBrowse(
   prev: EditState,
-  counts: SectionRowCount = { headers: 0, params: 0, body: 0, auth: 0, settings: 0 },
+  counts: SectionRowCount = {
+    headers: 0,
+    params: 0,
+    body: 0,
+    auth: 0,
+    settings: 0,
+  },
   startField: FieldKind = "headers",
 ): EditState {
   if (prev.mode !== "inactive") return prev
@@ -113,13 +119,19 @@ export function moveRowCursor(
 ): EditState {
   if (prev.mode !== "browsing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "params" && field !== "settings" && field !== "auth") return prev
+  if (
+    field !== "headers" &&
+    field !== "params" &&
+    field !== "settings" &&
+    field !== "auth"
+  )
+    return prev
   let count = 0
   if (field === "headers") count = counts.headers
   else if (field === "params") count = counts.params
   else if (field === "settings") count = counts.settings
   else if (field === "auth") count = counts.auth
-  
+
   if (count === 0) return prev
 
   if (prev.cursor.addingRow) {
@@ -131,11 +143,13 @@ export function moveRowCursor(
 
   const row = prev.cursor.row
   const next = row + delta
-  
+
   if (field === "settings" || field === "auth") {
     // settings has no addingRow state, clamp to bounds
-    if (next < 0) return { ...prev, cursor: { field, row: 0, addingRow: false } }
-    if (next > count - 1) return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
+    if (next < 0)
+      return { ...prev, cursor: { field, row: 0, addingRow: false } }
+    if (next > count - 1)
+      return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
     return { ...prev, cursor: { field, row: next, addingRow: false } }
   }
 

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -66,8 +66,9 @@ function cursorForField(
 ): FieldCursor {
   switch (field) {
     case "body":
-    case "auth":
       return { field, row: -1, addingRow: false }
+    case "auth":
+      return { field, row: 0, addingRow: false }
     case "settings":
       return { field, row: 0, addingRow: false }
   }
@@ -112,11 +113,12 @@ export function moveRowCursor(
 ): EditState {
   if (prev.mode !== "browsing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "params" && field !== "settings") return prev
+  if (field !== "headers" && field !== "params" && field !== "settings" && field !== "auth") return prev
   let count = 0
   if (field === "headers") count = counts.headers
   else if (field === "params") count = counts.params
   else if (field === "settings") count = counts.settings
+  else if (field === "auth") count = counts.auth
   
   if (count === 0) return prev
 
@@ -130,7 +132,7 @@ export function moveRowCursor(
   const row = prev.cursor.row
   const next = row + delta
   
-  if (field === "settings") {
+  if (field === "settings" || field === "auth") {
     // settings has no addingRow state, clamp to bounds
     if (next < 0) return { ...prev, cursor: { field, row: 0, addingRow: false } }
     if (next > count - 1) return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
@@ -148,7 +150,6 @@ export function moveRowCursor(
 
 export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
-  if (prev.cursor.field === "auth") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
     prev.cursor.field === "headers" || prev.cursor.field === "params"

--- a/src/ui/formatRequest.ts
+++ b/src/ui/formatRequest.ts
@@ -34,6 +34,6 @@ export function formatAuth(auth?: Auth): string {
   if (auth === undefined || auth.type === "none") return "(none)"
   if (auth.type === "bearer") return "bearer: \u2022\u2022\u2022\u2022"
   if (auth.type === "basic") return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
-  if (auth.type === "api_key") return `${auth.key}: ${auth.value}`
+  if (auth.type === "api_key") return `api_key: ${auth.key}:\u2022\u2022\u2022\u2022`
   return "(none)"
 }

--- a/src/ui/formatRequest.ts
+++ b/src/ui/formatRequest.ts
@@ -33,5 +33,7 @@ export function formatBody(body?: string): string {
 export function formatAuth(auth?: Auth): string {
   if (auth === undefined || auth.type === "none") return "(none)"
   if (auth.type === "bearer") return "bearer: \u2022\u2022\u2022\u2022"
-  return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
+  if (auth.type === "basic") return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
+  if (auth.type === "api_key") return `${auth.key}: ${auth.value}`
+  return "(none)"
 }

--- a/src/ui/formatRequest.ts
+++ b/src/ui/formatRequest.ts
@@ -33,7 +33,9 @@ export function formatBody(body?: string): string {
 export function formatAuth(auth?: Auth): string {
   if (auth === undefined || auth.type === "none") return "(none)"
   if (auth.type === "bearer") return "bearer: \u2022\u2022\u2022\u2022"
-  if (auth.type === "basic") return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
-  if (auth.type === "api_key") return `api_key: ${auth.key}:\u2022\u2022\u2022\u2022`
+  if (auth.type === "basic")
+    return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
+  if (auth.type === "api_key")
+    return `api_key: ${auth.key}:\u2022\u2022\u2022\u2022`
   return "(none)"
 }

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -42,7 +42,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
           key: keybinds.browse_escape,
           description: "Cancel edit / exit browse",
         },
-        { key: displayKey(keybinds.browse_delete), description: "Revert field" },
+        {
+          key: displayKey(keybinds.browse_delete),
+          description: "Revert field",
+        },
         { key: "space", description: "Toggle checkboxes" },
         {
           key: displayKey(keybinds.browse_revert_all),
@@ -55,9 +58,18 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
       keys: [
         { key: displayKey(keybinds.request_send), description: "Send request" },
         { key: displayKey(keybinds.request_save), description: "Save to disk" },
-        { key: displayKey(keybinds.env_editor), description: "Open environment editor" },
-        { key: displayKey(keybinds.layout_toggle), description: "Toggle layout" },
-        { key: displayKey(keybinds.env_cycle), description: "Cycle environment" },
+        {
+          key: displayKey(keybinds.env_editor),
+          description: "Open environment editor",
+        },
+        {
+          key: displayKey(keybinds.layout_toggle),
+          description: "Toggle layout",
+        },
+        {
+          key: displayKey(keybinds.env_cycle),
+          description: "Cycle environment",
+        },
       ],
     },
     {
@@ -65,16 +77,28 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
       keys: [
         { key: "^c", description: "Quit" },
         { key: keybinds.help_toggle, description: "Toggle help" },
-        { key: displayKey(keybinds.theme_picker), description: "Open theme picker" },
+        {
+          key: displayKey(keybinds.theme_picker),
+          description: "Open theme picker",
+        },
       ],
     },
     {
       title: "Env Editor",
       keys: [
         { key: displayKey(keybinds.env_save), description: "Save environment" },
-        { key: displayKey(keybinds.env_new), description: "Create new environment" },
-        { key: displayKey(keybinds.env_clone), description: "Clone environment" },
-        { key: displayKey(keybinds.env_delete), description: "Delete environment" },
+        {
+          key: displayKey(keybinds.env_new),
+          description: "Create new environment",
+        },
+        {
+          key: displayKey(keybinds.env_clone),
+          description: "Clone environment",
+        },
+        {
+          key: displayKey(keybinds.env_delete),
+          description: "Delete environment",
+        },
       ],
     },
   ]

--- a/src/ui/theme.tsx
+++ b/src/ui/theme.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from "react"
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from "react"
 import type { ReactNode } from "react"
 import { TextAttributes } from "@opentui/core"
 import type { ScrollBoxRenderable } from "@opentui/core"
@@ -94,9 +102,10 @@ export function ThemePickerOverlay({
   }, [])
 
   const filtered = useMemo(
-    () => THEMES.map((t, i) => ({ theme: t, index: i })).filter(
-      ({ theme: t }) => t.name.toLowerCase().includes(search.toLowerCase()),
-    ),
+    () =>
+      THEMES.map((t, i) => ({ theme: t, index: i })).filter(({ theme: t }) =>
+        t.name.toLowerCase().includes(search.toLowerCase()),
+      ),
     [search],
   )
 
@@ -122,7 +131,8 @@ export function ThemePickerOverlay({
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           const pos = filtered.findIndex((f) => f.index === previewIndex)
-          if (pos < filtered.length - 1) setPreviewIndex(filtered[pos + 1]!.index)
+          if (pos < filtered.length - 1)
+            setPreviewIndex(filtered[pos + 1]!.index)
         } else if (name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
@@ -137,73 +147,73 @@ export function ThemePickerOverlay({
 
   return (
     <Overlay visible={visible} width={48} gap={1} padding={1}>
-        <box paddingLeft={4} paddingRight={4}>
-          <box flexDirection="row" justifyContent="space-between">
-            <text fg={theme.text}>Themes</text>
-            <text fg={theme.textMuted}>esc</text>
-          </box>
-          <box paddingTop={1}>
-            <input
-              ref={inputRef}
-              value={search}
-              onInput={(e: string) => setSearch(e)}
-              placeholder="Search themes..."
-              placeholderColor={theme.textMuted}
-              focusedBackgroundColor={theme.backgroundPanel}
-              cursorColor={theme.primary}
-              focusedTextColor={theme.textMuted}
-            />
-          </box>
+      <box paddingLeft={4} paddingRight={4}>
+        <box flexDirection="row" justifyContent="space-between">
+          <text fg={theme.text}>Themes</text>
+          <text fg={theme.textMuted}>esc</text>
         </box>
-        <scrollbox
-          ref={scrollRef}
-          scrollY
-          paddingLeft={1}
-          paddingRight={1}
-          maxHeight={16}
-          scrollbarOptions={{ visible: false }}
-        >
-          <box style={{ flexDirection: "column" }}>
-            {filtered.map(({ theme: t, index: i }) => {
-              const isCurrent = i === activeIndex
-              const isSelected = i === previewIndex
-              return (
-                <box
-                  key={t.name}
-                  id={`theme-${i}`}
-                  style={{
-                    flexDirection: "row",
-                    paddingLeft: isCurrent ? 1 : 3,
-                    paddingRight: 3,
-                    gap: 1,
-                    backgroundColor: isSelected ? theme.primary : undefined,
-                  }}
+        <box paddingTop={1}>
+          <input
+            ref={inputRef}
+            value={search}
+            onInput={(e: string) => setSearch(e)}
+            placeholder="Search themes..."
+            placeholderColor={theme.textMuted}
+            focusedBackgroundColor={theme.backgroundPanel}
+            cursorColor={theme.primary}
+            focusedTextColor={theme.textMuted}
+          />
+        </box>
+      </box>
+      <scrollbox
+        ref={scrollRef}
+        scrollY
+        paddingLeft={1}
+        paddingRight={1}
+        maxHeight={16}
+        scrollbarOptions={{ visible: false }}
+      >
+        <box style={{ flexDirection: "column" }}>
+          {filtered.map(({ theme: t, index: i }) => {
+            const isCurrent = i === activeIndex
+            const isSelected = i === previewIndex
+            return (
+              <box
+                key={t.name}
+                id={`theme-${i}`}
+                style={{
+                  flexDirection: "row",
+                  paddingLeft: isCurrent ? 1 : 3,
+                  paddingRight: 3,
+                  gap: 1,
+                  backgroundColor: isSelected ? theme.primary : undefined,
+                }}
+              >
+                {isCurrent && (
+                  <text fg={isSelected ? "#1a1a1a" : theme.primary}>●</text>
+                )}
+                <text
+                  fg={
+                    isSelected
+                      ? "#1a1a1a"
+                      : isCurrent
+                        ? theme.primary
+                        : theme.text
+                  }
+                  attributes={isSelected ? TextAttributes.BOLD : undefined}
                 >
-                  {isCurrent && (
-                    <text fg={isSelected ? "#1a1a1a" : theme.primary}>●</text>
-                  )}
-                  <text
-                    fg={
-                      isSelected
-                        ? "#1a1a1a"
-                        : isCurrent
-                          ? theme.primary
-                          : theme.text
-                    }
-                    attributes={isSelected ? TextAttributes.BOLD : undefined}
-                  >
-                    {t.name}
-                  </text>
-                </box>
-              )
-            })}
-            {filtered.length === 0 && (
-              <box paddingLeft={3} paddingTop={1}>
-                <text fg={theme.textMuted}>No results found</text>
+                  {t.name}
+                </text>
               </box>
-            )}
-          </box>
-        </scrollbox>
+            )
+          })}
+          {filtered.length === 0 && (
+            <box paddingLeft={3} paddingTop={1}>
+              <text fg={theme.textMuted}>No results found</text>
+            </box>
+          )}
+        </box>
+      </scrollbox>
     </Overlay>
   )
 }

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -1,6 +1,11 @@
 import type { TimelineEntry as TimelineEntryType } from "../../schema"
 import { useTheme } from "../theme"
-import { formatHeaders, formatStatusLine, statusColor, formatSize } from "../format"
+import {
+  formatHeaders,
+  formatStatusLine,
+  statusColor,
+  formatSize,
+} from "../format"
 import {
   entryMethod,
   entryStatus,
@@ -27,7 +32,9 @@ function formatRequestUrl(entry: TimelineEntryType): string {
   const params = entry.request.params
   const enabled = Object.entries(params).filter(([, v]) => v.enabled)
   if (enabled.length === 0) return u
-  const qs = enabled.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v.value)}`).join("&")
+  const qs = enabled
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v.value)}`)
+    .join("&")
   if (u.includes("?")) return `${u}&${qs}`
   return `${u}?${qs}`
 }
@@ -64,20 +71,32 @@ export function TimelineEntry({
   const rowFg = isSelected ? theme.text : theme.textMuted
 
   const method = entryMethod(entry)
-  const methodStr = (method === "PATCH" ? shortMethod(method).padEnd(7) : shortMethod(method).padEnd(5))
-  const statusStr = status !== null ? (status === 0 ? "ERR " : `${status} `) : "--- "
+  const methodStr =
+    method === "PATCH"
+      ? shortMethod(method).padEnd(7)
+      : shortMethod(method).padEnd(5)
+  const statusStr =
+    status !== null ? (status === 0 ? "ERR " : `${status} `) : "--- "
   const urlStr = formatRequestUrl(entry)
   const timingStr = hasError ? "ERR" : entryTiming(entry)
   const reltimeStr = relativeTime(entry.timestamp)
 
   const ROW_PADDING = 2
   const FIXED_ELEMENTS = 24
-  const urlMaxLength = containerWidth > 0
-    ? Math.max(10, containerWidth - ROW_PADDING - FIXED_ELEMENTS)
-    : 999
+  const urlMaxLength =
+    containerWidth > 0
+      ? Math.max(10, containerWidth - ROW_PADDING - FIXED_ELEMENTS)
+      : 999
 
   return (
-    <box id={id} style={{ flexDirection: "column", backgroundColor: rowBg, overflow: "hidden" }}>
+    <box
+      id={id}
+      style={{
+        flexDirection: "column",
+        backgroundColor: rowBg,
+        overflow: "hidden",
+      }}
+    >
       <box
         style={{
           flexDirection: "row",
@@ -143,7 +162,10 @@ export function TimelineEntry({
               </text>
             )}
             {formatRequestHeaders(entry).map((h) => (
-              <text key={h} fg={theme.textMuted}> {h}</text>
+              <text key={h} fg={theme.textMuted}>
+                {" "}
+                {h}
+              </text>
             ))}
             {entry.request.body && (
               <text fg={theme.text}> {entry.request.body}</text>
@@ -170,13 +192,16 @@ export function TimelineEntry({
                       {formatStatusLine(r) + " · " + formatSize(r.size)}
                     </text>
                     {formatHeaders(r).map(({ key, value }) => (
-                      <text key={key} fg={theme.textMuted}> {key}: {value}</text>
+                      <text key={key} fg={theme.textMuted}>
+                        {" "}
+                        {key}: {value}
+                      </text>
                     ))}
                     {r.body && (
                       <text fg={theme.text}>
                         {" "}
-                          {r.body.length > 1000
-                            ? r.body.slice(0, 1000) + "..."
+                        {r.body.length > 1000
+                          ? r.body.slice(0, 1000) + "..."
                           : r.body}
                       </text>
                     )}
@@ -184,13 +209,9 @@ export function TimelineEntry({
                 )
               }
               if (entry.error) {
-                return (
-                  <text fg={theme.error}> {entry.error.message}</text>
-                )
+                return <text fg={theme.error}> {entry.error.message}</text>
               }
-              return (
-                <text fg={theme.textMuted}> No response</text>
-              )
+              return <text fg={theme.textMuted}> No response</text>
             })()}
           </box>
         </box>

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -37,7 +37,9 @@ function authSummary(
 ): string | null {
   if (!auth || auth.type === "none") return null
   if (auth.type === "bearer") return "Bearer token"
-  return `Basic ${auth.user}:****`
+  if (auth.type === "basic") return `Basic ${auth.user}:****`
+  if (auth.type === "api_key") return `${auth.key}: ${auth.value}`
+  return null
 }
 
 export function TimelineEntry({

--- a/src/ui/timeline/TimelineTab.tsx
+++ b/src/ui/timeline/TimelineTab.tsx
@@ -42,7 +42,9 @@ export function TimelineTab({
       }
     }
     setTimeout(measure, 0)
-    return () => { active = false }
+    return () => {
+      active = false
+    }
   }, [termWidth])
 
   useEffect(() => {
@@ -84,7 +86,10 @@ export function TimelineTab({
   if (entries.length === 0) {
     return (
       <box style={{ flexGrow: 1, flexBasis: 0, minHeight: 0 }}>
-        <text fg={theme.textMuted}> No timeline entries yet. Send a request to record history.</text>
+        <text fg={theme.textMuted}>
+          {" "}
+          No timeline entries yet. Send a request to record history.
+        </text>
       </box>
     )
   }

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -48,9 +48,7 @@ export function buildTimelineEntry(
           }
         : undefined,
     error:
-      result.status === "error"
-        ? { message: result.error.message }
-        : undefined,
+      result.status === "error" ? { message: result.error.message } : undefined,
   }
 }
 

--- a/src/ui/timeline/useTimeline.ts
+++ b/src/ui/timeline/useTimeline.ts
@@ -21,7 +21,9 @@ export function useTimeline(
 
   useEffect(() => {
     mountedRef.current = true
-    return () => { mountedRef.current = false }
+    return () => {
+      mountedRef.current = false
+    }
   }, [])
 
   const doLoad = useCallback(async () => {

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -45,14 +45,15 @@ export function buildDisplayUrl(
 
   if (merged.length === 0) return baseUrl
 
-  const qs = merged
-    .map(([k, v]) => `${encQuery(k)}=${encQuery(v)}`)
-    .join("&")
+  const qs = merged.map(([k, v]) => `${encQuery(k)}=${encQuery(v)}`).join("&")
   return `${baseUrl}?${qs}`
 }
 
 function encQuery(s: string): string {
-  return s.replace(/[&#]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+  return s.replace(
+    /[&#]/g,
+    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+  )
 }
 
 export function parseUrlAndParams(raw: string): {

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -27,12 +27,45 @@ export interface UseAppKeymapRefs {
 export interface UseAppKeymapSetters {
   setFocus: (focus: Focus | ((prev: Focus) => Focus)) => void
   setHelpVisible: (v: boolean | ((prev: boolean) => boolean)) => void
-  setLayout: (layout: "stacked" | "side-by-side" | ((prev: "stacked" | "side-by-side") => "stacked" | "side-by-side")) => void
-  setView: (v: "main" | "env-editor" | ((prev: "main" | "env-editor") => "main" | "env-editor")) => void
-  setYamlEditor: (v: { visible: boolean; filePath: string; requestName: string; returnFocus: Focus } | ((prev: { visible: boolean; filePath: string; requestName: string; returnFocus: Focus }) => { visible: boolean; filePath: string; requestName: string; returnFocus: Focus })) => void
+  setLayout: (
+    layout:
+      | "stacked"
+      | "side-by-side"
+      | ((prev: "stacked" | "side-by-side") => "stacked" | "side-by-side"),
+  ) => void
+  setView: (
+    v:
+      | "main"
+      | "env-editor"
+      | ((prev: "main" | "env-editor") => "main" | "env-editor"),
+  ) => void
+  setYamlEditor: (
+    v:
+      | {
+          visible: boolean
+          filePath: string
+          requestName: string
+          returnFocus: Focus
+        }
+      | ((prev: {
+          visible: boolean
+          filePath: string
+          requestName: string
+          returnFocus: Focus
+        }) => {
+          visible: boolean
+          filePath: string
+          requestName: string
+          returnFocus: Focus
+        }),
+  ) => void
   setCollectionReloadToken: (n: number | ((prev: number) => number)) => void
-  setPreviewIndex: (n: number | null | ((prev: number | null) => number | null)) => void
-  setEnvDeletePending: (s: string | null | ((prev: string | null) => string | null)) => void
+  setPreviewIndex: (
+    n: number | null | ((prev: number | null) => number | null),
+  ) => void
+  setEnvDeletePending: (
+    s: string | null | ((prev: string | null) => string | null),
+  ) => void
   setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
   onLayoutChange: (layout: "stacked" | "side-by-side") => void
 }
@@ -100,7 +133,8 @@ export function useAppKeymap(
       {
         name: "request.edit-yaml",
         run: () => {
-          const req = refs.collectionRef.current?.requests[refs.selectedIndexRef.current]
+          const req =
+            refs.collectionRef.current?.requests[refs.selectedIndexRef.current]
           if (!req || !collectionDir) return
           const filePath = join(collectionDir, `${req.id}.yml`)
           setters.setYamlEditor({

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -81,7 +81,7 @@ describe("moveFieldCursor", () => {
     expect(s.cursor.row).toBe(-1)
     s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("auth")
-    expect(s.cursor.row).toBe(-1)
+    expect(s.cursor.row).toBe(0)
     s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("settings")
     expect(s.cursor.row).toBe(0)
@@ -194,12 +194,59 @@ describe("beginEditing", () => {
     expect(e.mode).toBe("editing")
     expect(e.editingRow).toBe(-1)
   })
-  it("no-op for auth (browse-only field)", () => {
-    let s = enterEditBrowse(inactive, c(2, 0))
-    s = moveFieldCursor(s, -1, c(2, 1))
-    s = moveFieldCursor(s, -1, c(2, 1))
+  it("enters edit mode for auth (type selector row)", () => {
+    const counts = { headers: 0, params: 0, body: 0, auth: 2, settings: 3 }
+    let s = enterEditBrowse(inactive, counts)
+    s = moveFieldCursor(s, -1, counts)
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("auth")
-    expect(beginEditing(s)).toBe(s)
+    expect(s.cursor.row).toBe(0)
+    const e = beginEditing(s)
+    expect(e.mode).toBe("editing")
+  })
+
+  it("navigates auth rows for bearer (2 rows)", () => {
+    const counts = { headers: 0, params: 0, body: 0, auth: 2, settings: 3 }
+    let s = enterEditBrowse(inactive, counts)
+    s = moveFieldCursor(s, -1, counts)
+    s = moveFieldCursor(s, -1, counts)
+    expect(s.cursor.field).toBe("auth")
+    expect(s.cursor.row).toBe(0)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(1)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(1) // clamped
+    expect(s.cursor.addingRow).toBe(false)
+  })
+
+  it("navigates auth rows for basic (3 rows)", () => {
+    const counts = { headers: 0, params: 0, body: 0, auth: 3, settings: 3 }
+    let s = enterEditBrowse(inactive, counts)
+    s = moveFieldCursor(s, -1, counts)
+    s = moveFieldCursor(s, -1, counts)
+    expect(s.cursor.row).toBe(0)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(1)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(2)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(2) // clamped
+  })
+
+  it("navigates auth rows for api_key (4 rows)", () => {
+    const counts = { headers: 0, params: 0, body: 0, auth: 4, settings: 3 }
+    let s = enterEditBrowse(inactive, counts)
+    s = moveFieldCursor(s, -1, counts)
+    s = moveFieldCursor(s, -1, counts)
+    expect(s.cursor.row).toBe(0)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(1)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(2)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(3)
+    s = moveRowCursor(s, +1, counts)
+    expect(s.cursor.row).toBe(3) // clamped
   })
   it("browsing → editing on [+] line keeps editingRow -1 (caller adds row)", () => {
     let s = enterEditBrowse(inactive, c(0, 0))
@@ -330,12 +377,16 @@ describe("toggleSubfield", () => {
     expect(toggleSubfield(editing)).toBe(editing)
   })
 
-  it("no-op for auth field (cannot enter edit)", () => {
-    let s = enterEditBrowse(inactive, c(0, 0))
-    s = moveFieldCursor(s, -1, c(0, 0))
-    s = moveFieldCursor(s, -1, c(0, 0))
+  it("beginEditing on auth row 0 (type selector) enters edit mode", () => {
+    const counts = { headers: 0, params: 0, body: 0, auth: 2, settings: 3 }
+    let s = enterEditBrowse(inactive, counts)
+    s = moveFieldCursor(s, -1, counts)
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("auth")
-    expect(toggleSubfield(s)).toBe(s)
+    expect(s.cursor.row).toBe(0)
+    const e = beginEditing(s)
+    expect(e.mode).toBe("editing")
+    expect(e.cursor.subfield).toBeUndefined()
   })
 })
 

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -46,9 +46,7 @@ describe("enterEditBrowse", () => {
     expect(enterEditBrowse(browsing)).toBe(browsing)
   })
   it("no-op from editing", () => {
-    const editing = beginEditing(
-      enterEditBrowse(inactive, c(2, 0)),
-    )
+    const editing = beginEditing(enterEditBrowse(inactive, c(2, 0)))
     expect(enterEditBrowse(editing)).toBe(editing)
   })
 })
@@ -60,9 +58,7 @@ describe("exitEditBrowse", () => {
     expect(s.mode).toBe("inactive")
   })
   it("no-op from editing (must cancel first)", () => {
-    const editing = beginEditing(
-      enterEditBrowse(inactive, c(2, 0)),
-    )
+    const editing = beginEditing(enterEditBrowse(inactive, c(2, 0)))
     expect(exitEditBrowse(editing)).toBe(editing)
   })
   it("no-op from inactive", () => {
@@ -111,12 +107,8 @@ describe("moveFieldCursor", () => {
     expect(s.cursor.row).toBe(-1)
   })
   it("no-op when editing", () => {
-    const editing = beginEditing(
-      enterEditBrowse(inactive, c(2, 0)),
-    )
-    expect(moveFieldCursor(editing, +1, c(2, 1))).toBe(
-      editing,
-    )
+    const editing = beginEditing(enterEditBrowse(inactive, c(2, 0)))
+    expect(moveFieldCursor(editing, +1, c(2, 1))).toBe(editing)
   })
 })
 
@@ -260,9 +252,7 @@ describe("beginEditing", () => {
     expect(beginEditing(inactive)).toBe(inactive)
   })
   it("no-op when already editing", () => {
-    const editing = beginEditing(
-      enterEditBrowse(inactive, c(2, 0)),
-    )
+    const editing = beginEditing(enterEditBrowse(inactive, c(2, 0)))
     expect(beginEditing(editing)).toBe(editing)
   })
 
@@ -294,9 +284,7 @@ describe("beginEditing", () => {
 
 describe("commitEditing", () => {
   it("editing → browsing, editingRow reset to -1", () => {
-    const editing = beginEditing(
-      enterEditBrowse(inactive, c(2, 0)),
-    )
+    const editing = beginEditing(enterEditBrowse(inactive, c(2, 0)))
     const s = commitEditing(editing)
     expect(s.mode).toBe("browsing")
     expect(s.editingRow).toBe(-1)

--- a/tests/env-crud.test.ts
+++ b/tests/env-crud.test.ts
@@ -42,7 +42,11 @@ describe("environment CRUD", () => {
       color: "warning",
     })
     loaded = await env.loadEnvironment(dir, "dev")
-    expect(loaded.vars).toEqual({ port: "3000", host: "localhost", debug: "true" })
+    expect(loaded.vars).toEqual({
+      port: "3000",
+      host: "localhost",
+      debug: "true",
+    })
     expect(loaded.color).toBe("warning")
 
     // 5. Delete cloned

--- a/tests/env-save.test.ts
+++ b/tests/env-save.test.ts
@@ -56,7 +56,11 @@ describe("saveEnvironment", () => {
 
   it("rejects invalid color", async () => {
     await expect(
-      env.saveEnvironment(dir, { name: "test", vars: {}, color: "nonexistent" }),
+      env.saveEnvironment(dir, {
+        name: "test",
+        vars: {},
+        color: "nonexistent",
+      }),
     ).rejects.toThrow('env.save: unknown color "nonexistent"')
   })
 })

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -85,7 +85,9 @@ describe("formatHeaders", () => {
   })
   it("renders single header as key-value pair", () => {
     const res = makeRes({ headers: { "content-type": "application/json" } })
-    expect(formatHeaders(res)).toEqual([{ key: "content-type", value: "application/json" }])
+    expect(formatHeaders(res)).toEqual([
+      { key: "content-type", value: "application/json" },
+    ])
   })
   it("sorts multiple headers alphabetically by key", () => {
     const res = makeRes({

--- a/tests/formatRequest.test.ts
+++ b/tests/formatRequest.test.ts
@@ -134,4 +134,14 @@ describe("formatAuth", () => {
       "basic: alice:\u2022\u2022\u2022\u2022",
     )
   })
+  it("masks api_key value with fixed dots, shows key in cleartext", () => {
+    expect(
+      formatAuth({
+        type: "api_key",
+        key: "X-API-Key",
+        value: "my-secret",
+        placement: "header",
+      }),
+    ).toBe("api_key: X-API-Key:\u2022\u2022\u2022\u2022")
+  })
 })

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -271,7 +271,14 @@ describe("keymap dispatch", () => {
       enabled: () =>
         keymap.getData("app.mode") === "browse" &&
         keymap.getData("app.overlay") === "none",
-      commands: [{ name: "browse.enter", run: () => { called = true } }],
+      commands: [
+        {
+          name: "browse.enter",
+          run: () => {
+            called = true
+          },
+        },
+      ],
       bindings: [{ key: "return", cmd: "browse.enter" }],
     })
 
@@ -291,11 +298,14 @@ describe("keymap dispatch", () => {
         keymap.getData("app.overlay") === "none" &&
         keymap.getData("app.view") !== "env-editor",
       commands: [
-        { name: "browse.toggle", run: () => { called = true } },
+        {
+          name: "browse.toggle",
+          run: () => {
+            called = true
+          },
+        },
       ],
-      bindings: [
-        { key: "space", cmd: "browse.toggle" },
-      ],
+      bindings: [{ key: "space", cmd: "browse.toggle" }],
     })
 
     host.press("space")
@@ -315,11 +325,14 @@ describe("keymap dispatch", () => {
         keymap.getData("app.overlay") === "none" &&
         keymap.getData("app.view") !== "env-editor",
       commands: [
-        { name: "browse.toggle", run: () => { called = true } },
+        {
+          name: "browse.toggle",
+          run: () => {
+            called = true
+          },
+        },
       ],
-      bindings: [
-        { key: "space", cmd: "browse.toggle" },
-      ],
+      bindings: [{ key: "space", cmd: "browse.toggle" }],
     })
 
     host.press("space")
@@ -337,7 +350,14 @@ describe("keymap dispatch", () => {
       enabled: () =>
         keymap.getData("app.mode") === "edit" &&
         keymap.getData("app.overlay") === "none",
-      commands: [{ name: "edit.commit", run: () => { called = true } }],
+      commands: [
+        {
+          name: "edit.commit",
+          run: () => {
+            called = true
+          },
+        },
+      ],
       bindings: [{ key: "return", cmd: "edit.commit" }],
     })
 
@@ -620,7 +640,14 @@ describe("help keybinding (? always-on)", () => {
     let called = false
 
     keymap.registerLayer({
-      commands: [{ name: "app.help", run: () => { called = true } }],
+      commands: [
+        {
+          name: "app.help",
+          run: () => {
+            called = true
+          },
+        },
+      ],
       bindings: [{ key: "f1", cmd: "app.help" }],
     })
 
@@ -635,7 +662,14 @@ describe("help keybinding (? always-on)", () => {
     let called = false
 
     keymap.registerLayer({
-      commands: [{ name: "app.help", run: () => { called = true } }],
+      commands: [
+        {
+          name: "app.help",
+          run: () => {
+            called = true
+          },
+        },
+      ],
       bindings: [{ key: "f1", cmd: "app.help" }],
     })
 
@@ -650,7 +684,14 @@ describe("help keybinding (? always-on)", () => {
     let called = false
 
     keymap.registerLayer({
-      commands: [{ name: "app.help", run: () => { called = true } }],
+      commands: [
+        {
+          name: "app.help",
+          run: () => {
+            called = true
+          },
+        },
+      ],
       bindings: [{ key: "f1", cmd: "app.help" }],
     })
 
@@ -665,7 +706,14 @@ describe("help keybinding (? always-on)", () => {
     let called = false
 
     keymap.registerLayer({
-      commands: [{ name: "app.help", run: () => { called = true } }],
+      commands: [
+        {
+          name: "app.help",
+          run: () => {
+            called = true
+          },
+        },
+      ],
       bindings: [{ key: "f1", cmd: "app.help" }],
     })
 
@@ -689,7 +737,12 @@ describe("env-editor layer", () => {
         keymap.getData("app.view") === "env-editor" &&
         keymap.getData("app.overlay") === "none",
       commands: [
-        { name: "env.save", run: () => { called = true } },
+        {
+          name: "env.save",
+          run: () => {
+            called = true
+          },
+        },
       ],
       bindings: [{ key: "ctrl+s", cmd: "env.save" }],
     })
@@ -710,7 +763,12 @@ describe("env-editor layer", () => {
         keymap.getData("app.view") === "env-editor" &&
         keymap.getData("app.overlay") === "none",
       commands: [
-        { name: "env.new", run: () => { called = true } },
+        {
+          name: "env.new",
+          run: () => {
+            called = true
+          },
+        },
       ],
       bindings: [{ key: "ctrl+n", cmd: "env.new" }],
     })
@@ -731,7 +789,12 @@ describe("env-editor layer", () => {
         keymap.getData("app.view") === "env-editor" &&
         keymap.getData("app.overlay") === "none",
       commands: [
-        { name: "env.clone", run: () => { called = true } },
+        {
+          name: "env.clone",
+          run: () => {
+            called = true
+          },
+        },
       ],
       bindings: [{ key: "ctrl+k", cmd: "env.clone" }],
     })
@@ -752,7 +815,12 @@ describe("env-editor layer", () => {
         keymap.getData("app.view") === "env-editor" &&
         keymap.getData("app.overlay") === "none",
       commands: [
-        { name: "env.delete", run: () => { called = true } },
+        {
+          name: "env.delete",
+          run: () => {
+            called = true
+          },
+        },
       ],
       bindings: [{ key: "ctrl+w", cmd: "env.delete" }],
     })
@@ -773,7 +841,12 @@ describe("env-editor layer", () => {
         keymap.getData("app.view") === "env-editor" &&
         keymap.getData("app.overlay") === "none",
       commands: [
-        { name: "env.save", run: () => { called = true } },
+        {
+          name: "env.save",
+          run: () => {
+            called = true
+          },
+        },
       ],
       bindings: [{ key: "ctrl+s", cmd: "env.save" }],
     })
@@ -794,7 +867,12 @@ describe("env-editor layer", () => {
         keymap.getData("app.view") === "env-editor" &&
         keymap.getData("app.overlay") === "none",
       commands: [
-        { name: "env.save", run: () => { called = true } },
+        {
+          name: "env.save",
+          run: () => {
+            called = true
+          },
+        },
       ],
       bindings: [{ key: "ctrl+s", cmd: "env.save" }],
     })
@@ -818,7 +896,9 @@ describe("env-editor layer", () => {
         {
           name: "env.clone",
           enabled: () => false, // e.g. no selectedEnvName
-          run: () => { called = true },
+          run: () => {
+            called = true
+          },
         },
       ],
       bindings: [{ key: "ctrl+k", cmd: "env.clone" }],

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -217,6 +217,50 @@ describe("lang.parseRequest — auth variants", () => {
     })
   })
 
+  it("parses api_key auth with default placement", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: api_key\n  key: X-API-Key\n  value: abc123\n`
+    expect(lang.parseRequest("x", yaml).auth).toEqual({
+      type: "api_key",
+      key: "X-API-Key",
+      value: "abc123",
+      placement: "header",
+    })
+  })
+
+  it("parses api_key auth with query placement", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: api_key\n  key: api_key\n  value: secret\n  placement: query\n`
+    expect(lang.parseRequest("x", yaml).auth).toEqual({
+      type: "api_key",
+      key: "api_key",
+      value: "secret",
+      placement: "query",
+    })
+  })
+
+  it("api_key throws when key missing", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: api_key\n  value: abc\n`
+    expect(() => lang.parseRequest("x", yaml)).toThrow(
+      'lang.parseRequest: auth.api_key requires "key" and "value"',
+    )
+  })
+
+  it("api_key throws when value missing", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: api_key\n  key: X-Key\n`
+    expect(() => lang.parseRequest("x", yaml)).toThrow(
+      'lang.parseRequest: auth.api_key requires "key" and "value"',
+    )
+  })
+
+  it("parses api_key with $var in key and value", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: api_key\n  key: "$KEY_NAME"\n  value: "$KEY_VALUE"\n`
+    expect(lang.parseRequest("x", yaml).auth).toEqual({
+      type: "api_key",
+      key: "$KEY_NAME",
+      value: "$KEY_VALUE",
+      placement: "header",
+    })
+  })
+
   it("parses explicit none auth", () => {
     const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: none\n`
     expect(lang.parseRequest("x", yaml).auth).toEqual({ type: "none" })

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -366,9 +366,18 @@ describe("lang.serializeRequest — canonical output", () => {
 
   it("emits api_key auth when set", () => {
     const out = lang.serializeRequest(
-      makeReq({ auth: { type: "api_key", key: "X-API-Key", value: "secret123", placement: "header" } }),
+      makeReq({
+        auth: {
+          type: "api_key",
+          key: "X-API-Key",
+          value: "secret123",
+          placement: "header",
+        },
+      }),
     )
-    expect(out).toContain("auth:\n  type: api_key\n  key: X-API-Key\n  value: secret123\n  placement: header\n")
+    expect(out).toContain(
+      "auth:\n  type: api_key\n  key: X-API-Key\n  value: secret123\n  placement: header\n",
+    )
   })
 
   it("does NOT emit id field", () => {
@@ -517,7 +526,12 @@ describe("lang — semantic round-trip", () => {
       timeout: 0,
       followRedirects: true,
       maxRedirects: 5,
-      auth: { type: "api_key", key: "X-API-Key", value: "$KEYVAL", placement: "query" },
+      auth: {
+        type: "api_key",
+        key: "X-API-Key",
+        value: "$KEYVAL",
+        placement: "query",
+      },
     }
     const yaml = lang.serializeRequest(original)
     const reparsed = lang.parseRequest(original.id, yaml)

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -364,6 +364,13 @@ describe("lang.serializeRequest — canonical output", () => {
     expect(out).toContain("auth:\n  type: basic\n  user: foo\n  pass: bar\n")
   })
 
+  it("emits api_key auth when set", () => {
+    const out = lang.serializeRequest(
+      makeReq({ auth: { type: "api_key", key: "X-API-Key", value: "secret123", placement: "header" } }),
+    )
+    expect(out).toContain("auth:\n  type: api_key\n  key: X-API-Key\n  value: secret123\n  placement: header\n")
+  })
+
   it("does NOT emit id field", () => {
     const out = lang.serializeRequest(makeReq({ id: "my-id" }))
     expect(out).not.toContain("id:")
@@ -493,6 +500,24 @@ describe("lang — semantic round-trip", () => {
       followRedirects: true,
       maxRedirects: 5,
       auth: { type: "basic", user: "foo", pass: "bar" },
+    }
+    const yaml = lang.serializeRequest(original)
+    const reparsed = lang.parseRequest(original.id, yaml)
+    expect(reparsed).toEqual(original)
+  })
+
+  it("round-trip preserves api_key auth", () => {
+    const original: Request = {
+      id: "apikey-req",
+      name: "API Key req",
+      method: "GET",
+      url: "https://example.com/data",
+      headers: {},
+      params: {},
+      timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
+      auth: { type: "api_key", key: "X-API-Key", value: "$KEYVAL", placement: "query" },
     }
     const yaml = lang.serializeRequest(original)
     const reparsed = lang.parseRequest(original.id, yaml)

--- a/tests/listWithColors.test.ts
+++ b/tests/listWithColors.test.ts
@@ -32,7 +32,11 @@ describe("listEnvironmentsWithColors", () => {
   })
 
   it("reads _color= from first line", async () => {
-    await writeFile(join(dir, "staging.env"), "_color=warning\napi_key=abc\n", "utf8")
+    await writeFile(
+      join(dir, "staging.env"),
+      "_color=warning\napi_key=abc\n",
+      "utf8",
+    )
     const out = await listEnvironmentsWithColors(dir)
     expect(out).toEqual([{ name: "staging", color: "warning" }])
   })

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -412,7 +412,9 @@ describe("mapCollection — auth resolution", () => {
     const c = mapCollection(
       makeNormalized({
         components: {
-          securitySchemes: { key: { type: "apiKey", in: "query", name: "api_key" } },
+          securitySchemes: {
+            key: { type: "apiKey", in: "query", name: "api_key" },
+          },
         },
         security: [{ key: [] }],
         paths: { "/x": { get: { operationId: "getX" } } },

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -392,7 +392,7 @@ describe("mapCollection — auth resolution", () => {
     })
   })
 
-  it("maps apiKey scheme to none", () => {
+  it("maps apiKey header scheme", () => {
     const c = mapCollection(
       makeNormalized({
         components: { securitySchemes: { key: apiKeyHeader } },
@@ -400,7 +400,30 @@ describe("mapCollection — auth resolution", () => {
         paths: { "/x": { get: { operationId: "getX" } } },
       }),
     )
-    expect(c.requests[0].auth).toEqual({ type: "none" })
+    expect(c.requests[0].auth).toEqual({
+      type: "api_key",
+      key: "X-Api-Key",
+      value: "$API_KEY",
+      placement: "header",
+    })
+  })
+
+  it("maps apiKey query scheme", () => {
+    const c = mapCollection(
+      makeNormalized({
+        components: {
+          securitySchemes: { key: { type: "apiKey", in: "query", name: "api_key" } },
+        },
+        security: [{ key: [] }],
+        paths: { "/x": { get: { operationId: "getX" } } },
+      }),
+    )
+    expect(c.requests[0].auth).toEqual({
+      type: "api_key",
+      key: "api_key",
+      value: "$API_KEY",
+      placement: "query",
+    })
   })
 
   it("maps oauth2 to none", () => {
@@ -492,9 +515,9 @@ describe("mapCollection — auth resolution", () => {
     const c = mapCollection(
       makeNormalized({
         components: {
-          securitySchemes: { key: apiKeyHeader, bearerAuth: bearer },
+          securitySchemes: { oauth: oauth2, bearerAuth: bearer },
         },
-        security: [{ key: [] }, { bearerAuth: [] }],
+        security: [{ oauth: [] }, { bearerAuth: [] }],
         paths: { "/x": { get: { operationId: "getX" } } },
       }),
     )

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -444,6 +444,36 @@ describe("send — auth header", () => {
     const headers = init.headers as Headers
     expect(headers.get("Authorization")).toBe("Bearer from-auth")
   })
+
+  it("adds api_key header when placement is header", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(
+      makeReq({ auth: { type: "api_key", key: "X-API-Key", value: "secret123", placement: "header" } }),
+    )
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = init.headers as Headers
+    expect(headers.get("X-API-Key")).toBe("secret123")
+    expect(headers.get("Authorization")).toBeNull()
+  })
+
+  it("injects api_key as query param when placement is query", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(
+      makeReq({ auth: { type: "api_key", key: "api_key", value: "secret123", placement: "query" } }),
+    )
+    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/?api_key=secret123")
+  })
+
+  it("api_key query param appends to existing query params", async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({}))
+    await executor.send(
+      makeReq({
+        params: { verbose: { value: "true", enabled: true } },
+        auth: { type: "api_key", key: "key", value: "val", placement: "query" },
+      }),
+    )
+    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/?verbose=true&key=val")
+  })
 })
 
 describe("send — error handling", () => {

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -82,21 +82,43 @@ describe("substitute — pure $var replacement", () => {
 
   it("substitutes $x in api_key key and value", () => {
     const req = makeReq({
-      auth: { type: "api_key", key: "$keyName", value: "$keyVal", placement: "header" },
+      auth: {
+        type: "api_key",
+        key: "$keyName",
+        value: "$keyVal",
+        placement: "header",
+      },
     })
-    const out = substitute(req, makeEnv({ keyName: "X-API-Key", keyVal: "secret123" }))
-    expect(out.auth).toEqual({ type: "api_key", key: "X-API-Key", value: "secret123", placement: "header" })
+    const out = substitute(
+      req,
+      makeEnv({ keyName: "X-API-Key", keyVal: "secret123" }),
+    )
+    expect(out.auth).toEqual({
+      type: "api_key",
+      key: "X-API-Key",
+      value: "secret123",
+      placement: "header",
+    })
   })
 
   it("throws on unresolved variable in api_key key", () => {
-    const req = makeReq({ auth: { type: "api_key", key: "$keyName", value: "v", placement: "header" } })
+    const req = makeReq({
+      auth: {
+        type: "api_key",
+        key: "$keyName",
+        value: "v",
+        placement: "header",
+      },
+    })
     expect(() => substitute(req, makeEnv({}))).toThrow(
       'requests.substitute: unresolved variable "keyName" in auth.key',
     )
   })
 
   it("throws on unresolved variable in api_key value", () => {
-    const req = makeReq({ auth: { type: "api_key", key: "k", value: "$val", placement: "header" } })
+    const req = makeReq({
+      auth: { type: "api_key", key: "k", value: "$val", placement: "header" },
+    })
     expect(() => substitute(req, makeEnv({}))).toThrow(
       'requests.substitute: unresolved variable "val" in auth.value',
     )
@@ -448,7 +470,14 @@ describe("send — auth header", () => {
   it("adds api_key header when placement is header", async () => {
     fetchMock.mockResolvedValueOnce(fakeResponse({}))
     await executor.send(
-      makeReq({ auth: { type: "api_key", key: "X-API-Key", value: "secret123", placement: "header" } }),
+      makeReq({
+        auth: {
+          type: "api_key",
+          key: "X-API-Key",
+          value: "secret123",
+          placement: "header",
+        },
+      }),
     )
     const init = fetchMock.mock.calls[0][1] as RequestInit
     const headers = init.headers as Headers
@@ -459,9 +488,18 @@ describe("send — auth header", () => {
   it("injects api_key as query param when placement is query", async () => {
     fetchMock.mockResolvedValueOnce(fakeResponse({}))
     await executor.send(
-      makeReq({ auth: { type: "api_key", key: "api_key", value: "secret123", placement: "query" } }),
+      makeReq({
+        auth: {
+          type: "api_key",
+          key: "api_key",
+          value: "secret123",
+          placement: "query",
+        },
+      }),
     )
-    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/?api_key=secret123")
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://example.com/?api_key=secret123",
+    )
   })
 
   it("api_key query param appends to existing query params", async () => {
@@ -472,7 +510,9 @@ describe("send — auth header", () => {
         auth: { type: "api_key", key: "key", value: "val", placement: "query" },
       }),
     )
-    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/?verbose=true&key=val")
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://example.com/?verbose=true&key=val",
+    )
   })
 })
 
@@ -605,7 +645,11 @@ describe("send — timeout signal", () => {
   it("combines signals when timeout > 0 and caller signal present", async () => {
     const controller = new AbortController()
     fetchMock.mockResolvedValueOnce(fakeResponse({}))
-    await executor.send(makeReq({ timeout: 5000 }), undefined, controller.signal)
+    await executor.send(
+      makeReq({ timeout: 5000 }),
+      undefined,
+      controller.signal,
+    )
     const init = fetchMock.mock.calls[0][1] as RequestInit
     expect(init.signal).toBeInstanceOf(AbortSignal)
     expect(init.signal).not.toBe(controller.signal)
@@ -661,9 +705,7 @@ describe("send — redirect following", () => {
     fetchMock.mockResolvedValueOnce(
       fakeResponse({ status: 301, headers: { location: "/elsewhere" } }),
     )
-    const res = await executor.send(
-      makeReq({ followRedirects: false }),
-    )
+    const res = await executor.send(makeReq({ followRedirects: false }))
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(res.status).toBe(301)
   })
@@ -672,16 +714,14 @@ describe("send — redirect following", () => {
     fetchMock.mockResolvedValue(
       fakeResponse({ status: 301, headers: { location: "/hop" } }),
     )
-    await expect(
-      executor.send(makeReq({ maxRedirects: 2 })),
-    ).rejects.toThrow("requests.send: max redirects (2) exceeded")
+    await expect(executor.send(makeReq({ maxRedirects: 2 }))).rejects.toThrow(
+      "requests.send: max redirects (2) exceeded",
+    )
     expect(fetchMock).toHaveBeenCalledTimes(3) // initial + 2 redirects, 3rd triggers throw
   })
 
   it("returns 301 response when no Location header", async () => {
-    fetchMock.mockResolvedValueOnce(
-      fakeResponse({ status: 301 }),
-    )
+    fetchMock.mockResolvedValueOnce(fakeResponse({ status: 301 }))
     const res = await executor.send(makeReq({}))
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(res.status).toBe(301)

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -80,6 +80,28 @@ describe("substitute — pure $var replacement", () => {
     expect(out.auth).toEqual({ type: "basic", user: "foo", pass: "bar" })
   })
 
+  it("substitutes $x in api_key key and value", () => {
+    const req = makeReq({
+      auth: { type: "api_key", key: "$keyName", value: "$keyVal", placement: "header" },
+    })
+    const out = substitute(req, makeEnv({ keyName: "X-API-Key", keyVal: "secret123" }))
+    expect(out.auth).toEqual({ type: "api_key", key: "X-API-Key", value: "secret123", placement: "header" })
+  })
+
+  it("throws on unresolved variable in api_key key", () => {
+    const req = makeReq({ auth: { type: "api_key", key: "$keyName", value: "v", placement: "header" } })
+    expect(() => substitute(req, makeEnv({}))).toThrow(
+      'requests.substitute: unresolved variable "keyName" in auth.key',
+    )
+  })
+
+  it("throws on unresolved variable in api_key value", () => {
+    const req = makeReq({ auth: { type: "api_key", key: "k", value: "$val", placement: "header" } })
+    expect(() => substitute(req, makeEnv({}))).toThrow(
+      'requests.substitute: unresolved variable "val" in auth.value',
+    )
+  })
+
   it("leaves id, name, method untouched", () => {
     const req = makeReq({ id: "my-id", name: "$name", method: "POST" })
     const out = substitute(req, makeEnv({ name: "should-not-apply" }))

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -65,7 +65,6 @@ describe("ResponsePane scrollbox", () => {
       .filter((l: string) => l.includes("item-"))
     expect(bodyLines.length).toBeGreaterThan(0)
     expect(bodyLines.length).toBeLessThan(100)
-
   })
 })
 

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -116,7 +116,9 @@ describe("saveTimelineEntry", () => {
         name: "Full test",
         method: "POST",
         url: "https://api.example.com/data",
-        headers: { "content-type": { value: "application/json", enabled: true } },
+        headers: {
+          "content-type": { value: "application/json", enabled: true },
+        },
         params: { q: { value: "test", enabled: true } },
         body: '{"key":"val"}',
         auth: { type: "bearer", token: "tok" },

--- a/tests/unit/CenterText.test.tsx
+++ b/tests/unit/CenterText.test.tsx
@@ -47,17 +47,15 @@ describe("splitWords", () => {
 
 describe("CenterText", () => {
   it("renders words as inline text elements in a row", async () => {
-    const segments = [
-      { text: "hello world", color: "#ffffff" },
-    ]
+    const segments = [{ text: "hello world", color: "#ffffff" }]
     const { renderOnce, captureSpans } = await testRender(
       <CenterText segments={segments} />,
       { width: 40, height: 5 },
     )
     await renderOnce()
     const frame = captureSpans()
-    const spans = frame.lines.flatMap(l => l.spans)
-    const fullText = spans.map(s => s.text).join("")
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const fullText = spans.map((s) => s.text).join("")
     expect(fullText).toContain("hello ")
     expect(fullText).toContain("world")
   })
@@ -74,8 +72,8 @@ describe("CenterText", () => {
     )
     await renderOnce()
     const frame = captureSpans()
-    const spans = frame.lines.flatMap(l => l.spans)
-    const fullText = spans.map(s => s.text).join("")
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const fullText = spans.map((s) => s.text).join("")
     expect(fullText).toContain("press Enter to continue")
   })
 
@@ -87,7 +85,7 @@ describe("CenterText", () => {
     )
     await renderOnce()
     const frame = captureCharFrame()
-    const lines = frame.split("\n").filter(l => l.trim().length > 0)
+    const lines = frame.split("\n").filter((l) => l.trim().length > 0)
     const nonEmpty = lines[0]
     expect(nonEmpty?.trim()).toBe("tip")
     // tip should be roughly centered (padded with spaces on both sides)

--- a/tests/unit/DeleteConfirmation.test.tsx
+++ b/tests/unit/DeleteConfirmation.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
-import { registerEnabledFields, registerDefaultKeys } from "@opentui/keymap/addons"
+import {
+  registerEnabledFields,
+  registerDefaultKeys,
+} from "@opentui/keymap/addons"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -74,11 +77,7 @@ describe("Delete confirmation", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay
-            visible
-            message="Delete?"
-            selectedIndex={0}
-          />
+          <ConfirmOverlay visible message="Delete?" selectedIndex={0} />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 10 },
@@ -95,11 +94,7 @@ describe("Delete confirmation", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay
-            visible
-            message="Delete?"
-            selectedIndex={0}
-          />
+          <ConfirmOverlay visible message="Delete?" selectedIndex={0} />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 10 },

--- a/tests/unit/EnvSidebar.test.tsx
+++ b/tests/unit/EnvSidebar.test.tsx
@@ -204,7 +204,11 @@ describe("EnvSidebar", () => {
           envNames={["dev", "staging", "prod"]}
           selectedEnvName={null}
           activeEnvName={undefined}
-          envColors={{ dev: "success", staging: undefined, prod: "nonexistent" }}
+          envColors={{
+            dev: "success",
+            staging: undefined,
+            prod: "nonexistent",
+          }}
           dirty={false}
           onSelectEnv={() => {}}
           onCreate={() => {}}
@@ -230,7 +234,9 @@ describe("EnvSidebar", () => {
     const mutedRGBA = RGBA.fromHex(THEMES[0].textMuted)
     const dot1IsSuccess = dot1.fg.equals(successRGBA)
     const dot2IsSuccess = dot2.fg.equals(successRGBA)
-    expect((dot1IsSuccess && dot2.fg.equals(mutedRGBA)) ||
-           (dot2IsSuccess && dot1.fg.equals(mutedRGBA))).toBe(true)
+    expect(
+      (dot1IsSuccess && dot2.fg.equals(mutedRGBA)) ||
+        (dot2IsSuccess && dot1.fg.equals(mutedRGBA)),
+    ).toBe(true)
   })
 })

--- a/tests/unit/PickerOverlay.test.tsx
+++ b/tests/unit/PickerOverlay.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
-import { registerEnabledFields, registerDefaultKeys } from "@opentui/keymap/addons"
+import {
+  registerEnabledFields,
+  registerDefaultKeys,
+} from "@opentui/keymap/addons"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"

--- a/tests/unit/VarText.test.tsx
+++ b/tests/unit/VarText.test.tsx
@@ -169,10 +169,7 @@ describe("VarText", () => {
   it("renders variable adjacent to punctuation", async () => {
     const { renderOnce, captureSpans } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
-        <VarText
-          text='{"token":"$bearer"}'
-          env={env({ bearer: "abc123" })}
-        />
+        <VarText text='{"token":"$bearer"}' env={env({ bearer: "abc123" })} />
       </ThemeProvider>,
       { width: 80, height: 5 },
     )

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, mock } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
-import { registerEnabledFields, registerDefaultKeys } from "@opentui/keymap/addons"
+import {
+  registerEnabledFields,
+  registerDefaultKeys,
+} from "@opentui/keymap/addons"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -17,7 +17,9 @@ function theme() {
 describe("splitEnvVars", () => {
   it("returns single plain segment for text without variables", () => {
     const result = splitEnvVars("plain text", env({}))
-    expect(result).toEqual([{ text: "plain text", isVar: false, exists: false }])
+    expect(result).toEqual([
+      { text: "plain text", isVar: false, exists: false },
+    ])
   })
 
   it("returns empty array for empty string", () => {
@@ -80,7 +82,11 @@ describe("splitEnvVars", () => {
   it("does not match $ followed by non-word char", () => {
     const result = splitEnvVars("$var $ stuff", env({ var: "x" }))
     expect(result[0]!).toEqual({ text: "$var", isVar: true, exists: true })
-    expect(result[1]!).toEqual({ text: " $ stuff", isVar: false, exists: false })
+    expect(result[1]!).toEqual({
+      text: " $ stuff",
+      isVar: false,
+      exists: false,
+    })
   })
 
   it("does not match lone $ at end of string", () => {

--- a/tests/unit/syntax.test.ts
+++ b/tests/unit/syntax.test.ts
@@ -83,7 +83,10 @@ describe("highlightJsonTokens", () => {
   })
 
   it("highlights negative numbers and floats", () => {
-    const tokens = highlightJsonTokens('{\n  "a": -3.14,\n  "b": 1e10\n}', opencodeTheme)
+    const tokens = highlightJsonTokens(
+      '{\n  "a": -3.14,\n  "b": 1e10\n}',
+      opencodeTheme,
+    )
     const negToken = tokens.find((t) => t.text === "-3.14")
     const expToken = tokens.find((t) => t.text === "1e10")
     expect(negToken).toBeDefined()
@@ -93,7 +96,10 @@ describe("highlightJsonTokens", () => {
   })
 
   it("handles array values on their own lines", () => {
-    const tokens = highlightJsonTokens('[\n  "a",\n  42,\n  true\n]', opencodeTheme)
+    const tokens = highlightJsonTokens(
+      '[\n  "a",\n  42,\n  true\n]',
+      opencodeTheme,
+    )
     const strToken = tokens.find((t) => t.text === '"a"')
     const numToken = tokens.find((t) => t.text.includes("42"))
     const boolToken = tokens.find((t) => t.text.includes("true"))

--- a/tests/unit/theme-context.test.ts
+++ b/tests/unit/theme-context.test.ts
@@ -58,7 +58,10 @@ describe("theme state machine", () => {
   })
 
   it("navigatePreview up wraps to first theme", () => {
-    const state: ThemeState = { activeIndex: catppuccin, previewIndex: catppuccin }
+    const state: ThemeState = {
+      activeIndex: catppuccin,
+      previewIndex: catppuccin,
+    }
     const next = navigatePreview(state, 1)
     expect(next.previewIndex).toBe(catppuccin + 1)
   })
@@ -70,7 +73,10 @@ describe("theme state machine", () => {
   })
 
   it("commitPreview moves preview to active and clears preview", () => {
-    const state: ThemeState = { activeIndex: opencode, previewIndex: catppuccin }
+    const state: ThemeState = {
+      activeIndex: opencode,
+      previewIndex: catppuccin,
+    }
     const next = commitPreview(state)
     expect(next.activeIndex).toBe(catppuccin)
     expect(next.previewIndex).toBeNull()
@@ -84,7 +90,10 @@ describe("theme state machine", () => {
   })
 
   it("cancelPreview clears preview, keeps active unchanged", () => {
-    const state: ThemeState = { activeIndex: opencode, previewIndex: catppuccin }
+    const state: ThemeState = {
+      activeIndex: opencode,
+      previewIndex: catppuccin,
+    }
     const next = cancelPreview(state)
     expect(next.activeIndex).toBe(opencode)
     expect(next.previewIndex).toBeNull()
@@ -98,7 +107,10 @@ describe("theme state machine", () => {
   })
 
   it("getActiveTheme returns preview theme when picker is open", () => {
-    const state: ThemeState = { activeIndex: opencode, previewIndex: catppuccin }
+    const state: ThemeState = {
+      activeIndex: opencode,
+      previewIndex: catppuccin,
+    }
     expect(getActiveTheme(state).name).toBe("catppuccin")
   })
 

--- a/tests/unit/theme-picker.test.tsx
+++ b/tests/unit/theme-picker.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
-import { registerEnabledFields, registerDefaultKeys } from "@opentui/keymap/addons"
+import {
+  registerEnabledFields,
+  registerDefaultKeys,
+} from "@opentui/keymap/addons"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemePickerOverlay, ThemeProvider } from "../../src/ui/theme"

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -41,7 +41,40 @@ describe("THEMES", () => {
     "zenburn",
   ]
 
-  const nth = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth", "eleventh", "twelfth", "thirteenth", "fourteenth", "fifteenth", "sixteenth", "seventeenth", "eighteenth", "nineteenth", "twentieth", "twenty-first", "twenty-second", "twenty-third", "twenty-fourth", "twenty-fifth", "twenty-sixth", "twenty-seventh", "twenty-eighth", "twenty-ninth", "thirtieth", "thirty-first", "thirty-second"]
+  const nth = [
+    "first",
+    "second",
+    "third",
+    "fourth",
+    "fifth",
+    "sixth",
+    "seventh",
+    "eighth",
+    "ninth",
+    "tenth",
+    "eleventh",
+    "twelfth",
+    "thirteenth",
+    "fourteenth",
+    "fifteenth",
+    "sixteenth",
+    "seventeenth",
+    "eighteenth",
+    "nineteenth",
+    "twentieth",
+    "twenty-first",
+    "twenty-second",
+    "twenty-third",
+    "twenty-fourth",
+    "twenty-fifth",
+    "twenty-sixth",
+    "twenty-seventh",
+    "twenty-eighth",
+    "twenty-ninth",
+    "thirtieth",
+    "thirty-first",
+    "thirty-second",
+  ]
   for (let i = 0; i < expected.length; i++) {
     it(`${nth[i]!} theme is named ${expected[i]}`, () => {
       expect(THEMES[i]!.name).toBe(expected[i])

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -46,25 +46,27 @@ describe("buildDisplayUrl", () => {
     const params: Record<string, KvEntry> = {
       limit: { value: "10", enabled: true },
     }
-    expect(
-      buildDisplayUrl("https://example.com/posts?sort=asc", params),
-    ).toBe("https://example.com/posts?sort=asc&limit=10")
+    expect(buildDisplayUrl("https://example.com/posts?sort=asc", params)).toBe(
+      "https://example.com/posts?sort=asc&limit=10",
+    )
   })
 
   it("strips query string when all params disabled and URL had query", () => {
     const params: Record<string, KvEntry> = {
       page: { value: "1", enabled: false },
     }
-    expect(
-      buildDisplayUrl("https://example.com/posts?page=1", params),
-    ).toBe("https://example.com/posts")
+    expect(buildDisplayUrl("https://example.com/posts?page=1", params)).toBe(
+      "https://example.com/posts",
+    )
   })
 
   it("handles URL with path but no origin (relative-like)", () => {
     const params: Record<string, KvEntry> = {
       filter: { value: "active", enabled: true },
     }
-    expect(buildDisplayUrl("/api/users", params)).toBe("/api/users?filter=active")
+    expect(buildDisplayUrl("/api/users", params)).toBe(
+      "/api/users?filter=active",
+    )
   })
 
   it("returns empty string for empty url", () => {
@@ -103,9 +105,7 @@ describe("buildDisplayUrl", () => {
 
 describe("parseUrlAndParams", () => {
   it("returns base URL and empty params for URL without query", () => {
-    const { baseUrl, params } = parseUrlAndParams(
-      "https://example.com/posts",
-    )
+    const { baseUrl, params } = parseUrlAndParams("https://example.com/posts")
     expect(baseUrl).toBe("https://example.com/posts")
     expect(params).toEqual({})
   })
@@ -162,9 +162,7 @@ describe("parseUrlAndParams", () => {
   })
 
   it("handles URL with empty query string (?)", () => {
-    const { baseUrl, params } = parseUrlAndParams(
-      "https://example.com/posts?",
-    )
+    const { baseUrl, params } = parseUrlAndParams("https://example.com/posts?")
     expect(baseUrl).toBe("https://example.com/posts")
     expect(params).toEqual({})
   })

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -106,13 +106,17 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     await new Promise((r) => setTimeout(r, 30))
 
     const filePath = join(dir, "alpha.env")
-    const before = await readFile(filePath, "utf8").then(() => true).catch(() => false)
+    const before = await readFile(filePath, "utf8")
+      .then(() => true)
+      .catch(() => false)
     expect(before).toBe(true)
 
     await ref.current!.deleteEnv()
     await new Promise((r) => setTimeout(r, 30))
 
-    const after = await readFile(filePath, "utf8").then(() => true).catch(() => false)
+    const after = await readFile(filePath, "utf8")
+      .then(() => true)
+      .catch(() => false)
     expect(after).toBe(false)
   })
 

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -129,17 +129,26 @@ describe("requestEquals", () => {
   })
   it("same followRedirects → true", () => {
     expect(
-      requestEquals(makeReq({ followRedirects: false }), makeReq({ followRedirects: false })),
+      requestEquals(
+        makeReq({ followRedirects: false }),
+        makeReq({ followRedirects: false }),
+      ),
     ).toBe(true)
   })
   it("differing followRedirects → false", () => {
     expect(
-      requestEquals(makeReq({ followRedirects: true }), makeReq({ followRedirects: false })),
+      requestEquals(
+        makeReq({ followRedirects: true }),
+        makeReq({ followRedirects: false }),
+      ),
     ).toBe(false)
   })
   it("same maxRedirects → true", () => {
     expect(
-      requestEquals(makeReq({ maxRedirects: 10 }), makeReq({ maxRedirects: 10 })),
+      requestEquals(
+        makeReq({ maxRedirects: 10 }),
+        makeReq({ maxRedirects: 10 }),
+      ),
     ).toBe(true)
   })
   it("differing maxRedirects → false", () => {
@@ -705,102 +714,206 @@ describe("applyDraft — auth", () => {
   it("setAuthType none -> none (no change)", () => {
     const original = makeReq({ auth: { type: "none" } })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "none" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthType",
+      authType: "none",
+    })
     expect(next.get("r1")!.auth).toEqual({ type: "none" })
   })
 
   it("setAuthType none -> bearer resets token to empty", () => {
     const original = makeReq({ auth: { type: "none" } })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "bearer" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthType",
+      authType: "bearer",
+    })
     expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "" })
   })
 
   it("setAuthType bearer -> basic resets to empty user/pass", () => {
     const original = makeReq({ auth: { type: "bearer", token: "old" } })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "basic" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthType",
+      authType: "basic",
+    })
     expect(next.get("r1")!.auth).toEqual({ type: "basic", user: "", pass: "" })
   })
 
   it("setAuthType basic -> api_key resets to empty with default placement", () => {
     const original = makeReq({ auth: { type: "basic", user: "u", pass: "p" } })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "api_key" })
-    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "", value: "", placement: "header" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthType",
+      authType: "api_key",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "api_key",
+      key: "",
+      value: "",
+      placement: "header",
+    })
   })
 
   it("setAuthField sets bearer token", () => {
     const original = makeReq({ auth: { type: "bearer", token: "old" } })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "bearer", field: "token", value: "new-secret" })
-    expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "new-secret" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthField",
+      authType: "bearer",
+      field: "token",
+      value: "new-secret",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "bearer",
+      token: "new-secret",
+    })
   })
 
   it("setAuthField sets basic user", () => {
-    const original = makeReq({ auth: { type: "basic", user: "old", pass: "p" } })
+    const original = makeReq({
+      auth: { type: "basic", user: "old", pass: "p" },
+    })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "basic", field: "user", value: "admin" })
-    expect(next.get("r1")!.auth).toEqual({ type: "basic", user: "admin", pass: "p" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthField",
+      authType: "basic",
+      field: "user",
+      value: "admin",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "basic",
+      user: "admin",
+      pass: "p",
+    })
   })
 
   it("setAuthField sets basic pass", () => {
-    const original = makeReq({ auth: { type: "basic", user: "u", pass: "old" } })
+    const original = makeReq({
+      auth: { type: "basic", user: "u", pass: "old" },
+    })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "basic", field: "pass", value: "new-pass" })
-    expect(next.get("r1")!.auth).toEqual({ type: "basic", user: "u", pass: "new-pass" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthField",
+      authType: "basic",
+      field: "pass",
+      value: "new-pass",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "basic",
+      user: "u",
+      pass: "new-pass",
+    })
   })
 
   it("setAuthField sets api_key key", () => {
-    const original = makeReq({ auth: { type: "api_key", key: "", value: "", placement: "header" } })
+    const original = makeReq({
+      auth: { type: "api_key", key: "", value: "", placement: "header" },
+    })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "api_key", field: "key", value: "X-API-Key" })
-    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "X-API-Key", value: "", placement: "header" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthField",
+      authType: "api_key",
+      field: "key",
+      value: "X-API-Key",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "api_key",
+      key: "X-API-Key",
+      value: "",
+      placement: "header",
+    })
   })
 
   it("setAuthField sets api_key value", () => {
-    const original = makeReq({ auth: { type: "api_key", key: "k", value: "", placement: "header" } })
+    const original = makeReq({
+      auth: { type: "api_key", key: "k", value: "", placement: "header" },
+    })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "api_key", field: "value", value: "secret" })
-    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "k", value: "secret", placement: "header" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthField",
+      authType: "api_key",
+      field: "value",
+      value: "secret",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "api_key",
+      key: "k",
+      value: "secret",
+      placement: "header",
+    })
   })
 
   it("setApiKeyPlacement toggles placement", () => {
-    const original = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
+    const original = makeReq({
+      auth: { type: "api_key", key: "k", value: "v", placement: "header" },
+    })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setApiKeyPlacement", placement: "query" })
-    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "k", value: "v", placement: "query" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setApiKeyPlacement",
+      placement: "query",
+    })
+    expect(next.get("r1")!.auth).toEqual({
+      type: "api_key",
+      key: "k",
+      value: "v",
+      placement: "query",
+    })
   })
 
   it("setAuthField no-ops when authType doesn't match", () => {
     const original = makeReq({ auth: { type: "bearer", token: "t" } })
     const map = new Map<string, Request>()
-    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "basic", field: "user", value: "x" })
+    const next = applyDraft(map, "r1", original, {
+      kind: "setAuthField",
+      authType: "basic",
+      field: "user",
+      value: "x",
+    })
     expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "t" })
   })
 
   it("revertField auth row 0 reverts entire auth", () => {
     const original = makeReq({ auth: { type: "bearer", token: "orig" } })
-    const map = new Map<string, Request>([["r1", { ...original, auth: { type: "bearer", token: "edited" } }]])
-    const next = applyDraft(map, "r1", original, { kind: "revertField", field: "auth", row: 0 })
+    const map = new Map<string, Request>([
+      ["r1", { ...original, auth: { type: "bearer", token: "edited" } }],
+    ])
+    const next = applyDraft(map, "r1", original, {
+      kind: "revertField",
+      field: "auth",
+      row: 0,
+    })
     expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "orig" })
   })
 })
 
 describe("authEqual — api_key", () => {
   it("same api_key -> true", () => {
-    const a = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
-    const b = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
+    const a = makeReq({
+      auth: { type: "api_key", key: "k", value: "v", placement: "header" },
+    })
+    const b = makeReq({
+      auth: { type: "api_key", key: "k", value: "v", placement: "header" },
+    })
     expect(requestEquals(a, b)).toBe(true)
   })
   it("different api_key key -> false", () => {
-    const a = makeReq({ auth: { type: "api_key", key: "k1", value: "v", placement: "header" } })
-    const b = makeReq({ auth: { type: "api_key", key: "k2", value: "v", placement: "header" } })
+    const a = makeReq({
+      auth: { type: "api_key", key: "k1", value: "v", placement: "header" },
+    })
+    const b = makeReq({
+      auth: { type: "api_key", key: "k2", value: "v", placement: "header" },
+    })
     expect(requestEquals(a, b)).toBe(false)
   })
   it("different api_key placement -> false", () => {
-    const a = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
-    const b = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "query" } })
+    const a = makeReq({
+      auth: { type: "api_key", key: "k", value: "v", placement: "header" },
+    })
+    const b = makeReq({
+      auth: { type: "api_key", key: "k", value: "v", placement: "query" },
+    })
     expect(requestEquals(a, b)).toBe(false)
   })
 })

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -700,3 +700,107 @@ describe("isDirty with originalMap", () => {
     expect(requestEquals(draft, saved)).toBe(true)
   })
 })
+
+describe("applyDraft — auth", () => {
+  it("setAuthType none -> none (no change)", () => {
+    const original = makeReq({ auth: { type: "none" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "none" })
+    expect(next.get("r1")!.auth).toEqual({ type: "none" })
+  })
+
+  it("setAuthType none -> bearer resets token to empty", () => {
+    const original = makeReq({ auth: { type: "none" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "bearer" })
+    expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "" })
+  })
+
+  it("setAuthType bearer -> basic resets to empty user/pass", () => {
+    const original = makeReq({ auth: { type: "bearer", token: "old" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "basic" })
+    expect(next.get("r1")!.auth).toEqual({ type: "basic", user: "", pass: "" })
+  })
+
+  it("setAuthType basic -> api_key resets to empty with default placement", () => {
+    const original = makeReq({ auth: { type: "basic", user: "u", pass: "p" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthType", authType: "api_key" })
+    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "", value: "", placement: "header" })
+  })
+
+  it("setAuthField sets bearer token", () => {
+    const original = makeReq({ auth: { type: "bearer", token: "old" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "bearer", field: "token", value: "new-secret" })
+    expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "new-secret" })
+  })
+
+  it("setAuthField sets basic user", () => {
+    const original = makeReq({ auth: { type: "basic", user: "old", pass: "p" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "basic", field: "user", value: "admin" })
+    expect(next.get("r1")!.auth).toEqual({ type: "basic", user: "admin", pass: "p" })
+  })
+
+  it("setAuthField sets basic pass", () => {
+    const original = makeReq({ auth: { type: "basic", user: "u", pass: "old" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "basic", field: "pass", value: "new-pass" })
+    expect(next.get("r1")!.auth).toEqual({ type: "basic", user: "u", pass: "new-pass" })
+  })
+
+  it("setAuthField sets api_key key", () => {
+    const original = makeReq({ auth: { type: "api_key", key: "", value: "", placement: "header" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "api_key", field: "key", value: "X-API-Key" })
+    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "X-API-Key", value: "", placement: "header" })
+  })
+
+  it("setAuthField sets api_key value", () => {
+    const original = makeReq({ auth: { type: "api_key", key: "k", value: "", placement: "header" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "api_key", field: "value", value: "secret" })
+    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "k", value: "secret", placement: "header" })
+  })
+
+  it("setApiKeyPlacement toggles placement", () => {
+    const original = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setApiKeyPlacement", placement: "query" })
+    expect(next.get("r1")!.auth).toEqual({ type: "api_key", key: "k", value: "v", placement: "query" })
+  })
+
+  it("setAuthField no-ops when authType doesn't match", () => {
+    const original = makeReq({ auth: { type: "bearer", token: "t" } })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, { kind: "setAuthField", authType: "basic", field: "user", value: "x" })
+    expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "t" })
+  })
+
+  it("revertField auth row 0 reverts entire auth", () => {
+    const original = makeReq({ auth: { type: "bearer", token: "orig" } })
+    const map = new Map<string, Request>([["r1", { ...original, auth: { type: "bearer", token: "edited" } }]])
+    const next = applyDraft(map, "r1", original, { kind: "revertField", field: "auth", row: 0 })
+    expect(next.get("r1")!.auth).toEqual({ type: "bearer", token: "orig" })
+  })
+})
+
+describe("authEqual — api_key", () => {
+  it("same api_key -> true", () => {
+    const a = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
+    const b = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
+    expect(requestEquals(a, b)).toBe(true)
+  })
+  it("different api_key key -> false", () => {
+    const a = makeReq({ auth: { type: "api_key", key: "k1", value: "v", placement: "header" } })
+    const b = makeReq({ auth: { type: "api_key", key: "k2", value: "v", placement: "header" } })
+    expect(requestEquals(a, b)).toBe(false)
+  })
+  it("different api_key placement -> false", () => {
+    const a = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "header" } })
+    const b = makeReq({ auth: { type: "api_key", key: "k", value: "v", placement: "query" } })
+    expect(requestEquals(a, b)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds inline auth editing with full api_key support to noodle.

### Changes

- **Schema**: New `api_key` variant in `Auth` union type with `key`, `value`, `placement`
- **Lang**: Parse, serialize, and round-trip for api_key auth (header/query placement)
- **Requests**: Send api_key as custom header or query param; variable substitution in key/value
- **UI**: New `AuthEditor` component replacing static `formatAuth` — inline editing with Select for auth type and placement, textarea for key/value/token, secret masking for bearer tokens and api_key values
- **OpenAPI**: Map `apiKey` security schemes to api_key auth
- **Draft ops**: `setAuthType`, `setAuthField`, `setApiKeyPlacement` with per-type cache for preserving unsaved edits when switching types
- **Edit mode**: Auth field now supports full browse/edit cycle with row navigation

### Tests

895 pass across 52 files. New tests for:
- `useRequestDraft` auth operations (setAuthType, setAuthField, setApiKeyPlacement, revertField, authEqual)
- Lang parse/serialize/round-trip for api_key
- Send header/query api_key injection + variable substitution
- EditMode auth row navigation (bearer=2 rows, basic=3, api_key=4)
- OpenAPI apiKey mapping (header + query)
- formatRequest api_key masking