### PR TITLE
fix(requests): bodyType always overrides Content-Type header

### DIFF
--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -139,15 +139,13 @@ export async function bodyForSend(
 ): Promise<BodyInit | undefined> {
   if (req.bodyType === "none") return undefined
 
-  const hasContentType = headers.has("content-type")
-
   if (req.bodyType === "json" && req.body !== undefined) {
-    if (!hasContentType) headers.set("content-type", "application/json")
+    headers.set("content-type", "application/json")
     return req.body
   }
 
   if (req.bodyType === "urlencoded" && req.formData) {
-    if (!hasContentType) headers.set("content-type", "application/x-www-form-urlencoded")
+    headers.set("content-type", "application/x-www-form-urlencoded")
     const params = new URLSearchParams()
     for (const entry of req.formData) {
       if (entry.enabled) params.append(entry.name, entry.value)
@@ -156,6 +154,7 @@ export async function bodyForSend(
   }
 
   if (req.bodyType === "multipart" && req.formData) {
+    headers.delete("content-type")
     const fd = new FormData()
     for (const entry of req.formData) {
       if (!entry.enabled) continue
@@ -176,7 +175,7 @@ export async function bodyForSend(
       if (!(await Bun.file(req.filePath).exists())) {
         throw new Error(`file not found: ${req.filePath}`)
       }
-      if (!hasContentType) headers.set("content-type", "application/octet-stream")
+      headers.set("content-type", "application/octet-stream")
       return Bun.file(req.filePath) as unknown as BodyInit
     }
     return undefined

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -182,6 +182,62 @@ describe("bodyForSend — bodyType routing", () => {
     const result = await bodyForSend({ bodyType: "binary" }, h)
     expect(result).toBeUndefined()
   })
+
+  it("sets content-type even when user already set one (json)", async () => {
+    const h = new Headers({ "content-type": "text/plain" })
+    const result = await bodyForSend(
+      { bodyType: "json", body: '{"key":"val"}' },
+      h,
+    )
+    expect(result).toBe('{"key":"val"}')
+    expect(h.get("content-type")).toBe("application/json")
+  })
+
+  it("sets content-type even when user already set one (urlencoded)", async () => {
+    const h = new Headers({ "content-type": "application/json" })
+    const result = await bodyForSend(
+      {
+        bodyType: "urlencoded",
+        formData: [{ name: "q", value: "hello", enabled: true, type: "text" }],
+      },
+      h,
+    )
+    expect(result).toBe("q=hello")
+    expect(h.get("content-type")).toBe("application/x-www-form-urlencoded")
+  })
+
+  it("sets content-type even when user already set one (binary)", async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs")
+    const { join } = await import("node:path")
+    const dir = mkdtempSync("/tmp/noodle-test-")
+    const filePath = join(dir, "data.bin")
+    writeFileSync(filePath, "binary content")
+
+    try {
+      const h = new Headers({ "content-type": "application/json" })
+      const result = await bodyForSend(
+        { bodyType: "binary", filePath },
+        h,
+      )
+      expect(result).toBeDefined()
+      expect(h.get("content-type")).toBe("application/octet-stream")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("deletes user-set content-type for multipart", async () => {
+    const h = new Headers({ "content-type": "application/json" })
+    const result = await bodyForSend(
+      {
+        bodyType: "multipart",
+        formData: [{ name: "field", value: "val", enabled: true, type: "text" }],
+      },
+      h,
+    )
+    expect(result).toBeDefined()
+    expect(h.get("content-type")).toBeNull()
+  })
 })
 
 describe("bodyForSend — file validation", () => {


### PR DESCRIPTION
## Summary
- Remove `hasContentType` guard in `bodyForSend()`
- `bodyType` now always sets/overrides `Content-Type` header (json, urlencoded, binary) or deletes it (multipart)
- Fixes two edge cases: multipart + explicit Content-Type breaks boundary, and bodyType/Content-Type mismatch
- 4 new tests covering override behavior for all bodyTypes

## Test Plan
- `bun test` — 898/898 pass
- `bun run lint` — clean
- `bun run typecheck` — clean