### PR TITLE
refactor(ui): extract Frame component, move status badges to border slots

### DIFF
--- a/collections/environments/development.env
+++ b/collections/environments/development.env
@@ -1,4 +1,4 @@
-_color=text
+_color=success
 base_url=https://jsonplaceholder.typicode.com
 post_id=1
 user_id=1

--- a/collections/environments/production.env
+++ b/collections/environments/production.env
@@ -1,4 +1,4 @@
-_color=error
+_color=warning
 base_url=https://jsonplaceholder.typicode.com
 post_id=1
 user_id=1

--- a/collections/environments/staging.env
+++ b/collections/environments/staging.env
@@ -1,4 +1,4 @@
-_color=warning
+_color=secondary
 base_url=https://jsonplaceholder.typicode.com
 post_id=1
 user_id=1

--- a/collections/settings.yml
+++ b/collections/settings.yml
@@ -1,1 +1,1 @@
-environment: development
+environment: production

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -661,7 +661,6 @@ export function AppInner({
                       initialTab={initialResponseTab}
                       onTabChange={onResponseTabChange}
                       expandHint={expandHint}
-                      layout="side-by-side"
                     />
                   )}
                 </box>
@@ -693,7 +692,6 @@ export function AppInner({
                       initialTab={initialResponseTab}
                       onTabChange={onResponseTabChange}
                       expandHint={expandHint}
-                      layout="stacked"
                     />
                   )}
                 </>

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -623,7 +623,6 @@ export function AppInner({
                 setUrl={draft.setUrl}
                 onDefocus={draft.syncUrlParams}
                 focused={focus === "urlbar"}
-                sending={responseState.status === "sending"}
                 activeEnv={envState.activeEnv}
               />
               {layout === "side-by-side" ? (

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -118,7 +118,9 @@ export function AppInner({
   const newRequestRef = useRef<NewRequestOverlayHandle>(null)
   const [cloneRequestVisible, setCloneRequestVisible] = useState(false)
   const cloneRequestRef = useRef<CloneRequestOverlayHandle>(null)
-  const [requestDeletePending, setRequestDeletePending] = useState<string | null>(null)
+  const [requestDeletePending, setRequestDeletePending] = useState<
+    string | null
+  >(null)
   const headerFieldRef = useRef<"name" | "color">("name")
 
   // ── Collection ──────────────────────────────────────────────────────
@@ -309,7 +311,15 @@ export function AppInner({
           }, 2000)
         })
     },
-    [selectedRequest, collectionDir, setCollectionReloadToken, setFocus, setSaveState, clearSaveTimer, saveTimerRef],
+    [
+      selectedRequest,
+      collectionDir,
+      setCollectionReloadToken,
+      setFocus,
+      setSaveState,
+      clearSaveTimer,
+      saveTimerRef,
+    ],
   )
 
   const handleRequestDeleteConfirm = useCallback(() => {
@@ -335,7 +345,15 @@ export function AppInner({
           setSaveState({ kind: "idle" })
         }, 2000)
       })
-  }, [selectedRequest, collectionDir, setCollectionReloadToken, setFocus, setSaveState, clearSaveTimer, saveTimerRef])
+  }, [
+    selectedRequest,
+    collectionDir,
+    setCollectionReloadToken,
+    setFocus,
+    setSaveState,
+    clearSaveTimer,
+    saveTimerRef,
+  ])
 
   // ── keymap.setData effects ─────────────────────────────────────────
   useEffect(() => {
@@ -820,7 +838,9 @@ export function AppInner({
         {cloneRequestVisible && (
           <CloneRequestOverlay
             visible
-            initialName={selectedRequest ? `${selectedRequest.name} - Copy` : ""}
+            initialName={
+              selectedRequest ? `${selectedRequest.name} - Copy` : ""
+            }
             ref={cloneRequestRef}
           />
         )}

--- a/src/ui/Frame.tsx
+++ b/src/ui/Frame.tsx
@@ -3,6 +3,7 @@ import type { BorderCharacters } from "@opentui/core"
 
 export interface FrameProps {
   children?: ReactNode
+  titleLeft?: ReactNode
   titleRight?: ReactNode
   bottomRight?: ReactNode
   bottomLeft?: ReactNode
@@ -19,6 +20,7 @@ export interface FrameProps {
 
 export function Frame({
   children,
+  titleLeft,
   titleRight,
   bottomRight,
   bottomLeft,
@@ -45,8 +47,13 @@ export function Frame({
       bottomTitleAlignment={bottomTitleAlignment}
     >
       {children}
+      {titleLeft ? (
+        <box style={{ position: "absolute", top: -1, left: 2 }}>
+          {titleLeft}
+        </box>
+      ) : null}
       {titleRight ? (
-        <box style={{ position: "absolute", top: -1, right: 1 }}>
+        <box style={{ position: "absolute", top: -1, right: 2 }}>
           {titleRight}
         </box>
       ) : null}
@@ -56,7 +63,7 @@ export function Frame({
         </box>
       ) : null}
       {bottomRight ? (
-        <box style={{ position: "absolute", bottom: -1, right: 1 }}>
+        <box style={{ position: "absolute", bottom: -1, right: 2 }}>
           {bottomRight}
         </box>
       ) : null}

--- a/src/ui/Frame.tsx
+++ b/src/ui/Frame.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react"
+import type { BorderCharacters } from "@opentui/core"
+
+export interface FrameProps {
+  children?: ReactNode
+  titleRight?: ReactNode
+  bottomRight?: ReactNode
+  bottomLeft?: ReactNode
+  style?: Record<string, unknown>
+  border?: ("left" | "right" | "top" | "bottom")[]
+  customBorderChars?: BorderCharacters
+  borderColor?: string
+  title?: string
+  titleColor?: string
+  titleAlignment?: "left" | "center" | "right"
+  bottomTitle?: string
+  bottomTitleAlignment?: "left" | "center" | "right"
+}
+
+export function Frame({
+  children,
+  titleRight,
+  bottomRight,
+  bottomLeft,
+  style,
+  border,
+  customBorderChars,
+  borderColor,
+  title,
+  titleColor,
+  titleAlignment,
+  bottomTitle,
+  bottomTitleAlignment,
+}: FrameProps) {
+  return (
+    <box
+      style={style}
+      border={border}
+      customBorderChars={customBorderChars}
+      borderColor={borderColor}
+      title={title}
+      titleColor={titleColor}
+      titleAlignment={titleAlignment}
+      bottomTitle={bottomTitle}
+      bottomTitleAlignment={bottomTitleAlignment}
+    >
+      {children}
+      {titleRight ? (
+        <box style={{ position: "absolute", top: -1, right: 1 }}>
+          {titleRight}
+        </box>
+      ) : null}
+      {bottomLeft ? (
+        <box style={{ position: "absolute", bottom: -1, left: 2 }}>
+          {bottomLeft}
+        </box>
+      ) : null}
+      {bottomRight ? (
+        <box style={{ position: "absolute", bottom: -1, right: 1 }}>
+          {bottomRight}
+        </box>
+      ) : null}
+    </box>
+  )
+}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -3,23 +3,17 @@ import { useKeyboard } from "@opentui/react"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import type { SendState } from "./sendState"
 import type { TimelineEntry } from "../schema"
-import { formatHeaders, formatBody, statusColor } from "./format"
+import { formatHeaders, formatBody, formatSize, statusColor } from "./format"
 import { Tabs, type TabDef } from "./Tabs"
 import { useTheme } from "./theme"
 import { FullBorder, LeftBar } from "./borders"
 import { JsonBodyViewer } from "./JsonBodyViewer"
-import { GradientBadge } from "./GradientBadge"
 import { Tips } from "./Tips"
+import { Frame } from "./Frame"
 
 import { TimelineTab } from "./timeline/TimelineTab"
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
-}
 
 const TAB_DEFS: TabDef[] = [
   { id: "body", label: "Body" },
@@ -34,7 +28,6 @@ export function ResponsePane({
   initialTab,
   onTabChange,
   expandHint,
-  layout,
 }: {
   state: SendState
   focused?: boolean
@@ -42,7 +35,6 @@ export function ResponsePane({
   initialTab?: "body" | "headers" | "timeline"
   onTabChange?: (tab: "body" | "headers" | "timeline") => void
   expandHint?: string
-  layout?: "stacked" | "side-by-side"
 }) {
   const theme = useTheme()
   const focusedRef = useRef(focused)
@@ -116,8 +108,26 @@ export function ResponsePane({
       ? Math.max(...responseHeaders.map((h) => h.key.length))
       : 0
 
+  const headerRight = isDone ? (
+    <box style={{ flexDirection: "row" }}>
+      <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
+      <text> </text>
+      <text fg={statusColor(state.response.status, theme)}>
+        {state.response.status}{state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}
+      </text>
+    </box>
+  ) : (
+    <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
+  )
+
+  const bottomStatus = isDone ? (
+    <text fg={theme.textMuted}>
+      {`${formatSize(new TextEncoder().encode(state.response.body).length)} in ${Math.round(state.response.timeMs)}ms`}
+    </text>
+  ) : undefined
+
   return (
-    <box
+    <Frame
       style={{
         flexGrow: 1,
         flexDirection: "column",
@@ -130,11 +140,10 @@ export function ResponsePane({
       border={[...FullBorder.border]}
       customBorderChars={FullBorder.customBorderChars}
       borderColor={borderColor}
-      title="Response"
-      titleColor={focused ? theme.primary : theme.textMuted}
-      titleAlignment="left"
+      titleRight={headerRight}
       bottomTitle={focused ? expandHint : undefined}
-      bottomTitleAlignment="right"
+      bottomTitleAlignment="left"
+      bottomRight={bottomStatus}
     >
       {state.status === "idle" ? (
         <Tips />
@@ -221,32 +230,9 @@ export function ResponsePane({
                 )}
               </scrollbox>
             )}
-            </Tabs>
-          {state.response.statusText !== "" && (
-            <box
-              style={{
-                flexDirection: "row",
-                justifyContent: "flex-end",
-                flexShrink: 0,
-                paddingTop: 1,
-                ...(layout === "stacked"
-                  ? { paddingBottom: 1 }
-                  : { paddingRight: 1 }),
-              }}
-            >
-              <GradientBadge
-                colors={[
-                  statusColor(state.response.status, theme),
-                  theme.primary,
-                ]}
-                fg={theme.background}
-              >
-                {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""} • ${Math.round(state.response.timeMs)}ms • ${formatSize(new TextEncoder().encode(state.response.body).length)}`}
-              </GradientBadge>
-            </box>
-          )}
+          </Tabs>
         </box>
       )}
-    </box>
+    </Frame>
   )
 }

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -10,6 +10,7 @@ import { FullBorder, LeftBar } from "./borders"
 import { JsonBodyViewer } from "./JsonBodyViewer"
 import { Tips } from "./Tips"
 import { Frame } from "./Frame"
+import { Badge } from "./Badge"
 
 import { TimelineTab } from "./timeline/TimelineTab"
 
@@ -113,9 +114,12 @@ export function ResponsePane({
   )
 
   const headerRight = isDone ? (
-    <text fg={statusColor(state.response.status, theme)}>
-      {state.response.status}{state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}
-    </text>
+    <Badge
+      bg={statusColor(state.response.status, theme)}
+      fg={theme.background}
+    >
+      {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}`}
+    </Badge>
   ) : undefined
 
   const footerRight = isDone ? (

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -109,7 +109,7 @@ export function ResponsePane({
       : 0
 
   const headerLeft = (
-    <text fg={theme.primary}>Response</text>
+    <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
   )
 
   const headerRight = isDone ? (

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -108,26 +108,24 @@ export function ResponsePane({
       ? Math.max(...responseHeaders.map((h) => h.key.length))
       : 0
 
-  const statusCode = isDone ? (
+  const headerLeft = (
+    <text fg={theme.primary}>Response</text>
+  )
+
+  const headerRight = isDone ? (
     <text fg={statusColor(state.response.status, theme)}>
       {state.response.status}{state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}
     </text>
   ) : undefined
 
-  const headerLeft = isDone ? (
-    <box style={{ flexDirection: "row" }}>
-      <text fg={statusColor(state.response.status, theme)}>Response</text>
-      <text> </text>
-      {statusCode}
-    </box>
-  ) : (
-    <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
-  )
-
-  const headerRight = isDone ? (
-    <text fg={theme.textMuted}>
+  const footerRight = isDone ? (
+    <text fg={focused ? theme.primary : theme.textMuted}>
       {`${formatSize(new TextEncoder().encode(state.response.body).length)} in ${Math.round(state.response.timeMs)}ms`}
     </text>
+  ) : undefined
+
+  const footerLeft = focused ? (
+    <text fg={theme.primary}>{expandHint}</text>
   ) : undefined
 
   return (
@@ -146,15 +144,15 @@ export function ResponsePane({
       borderColor={borderColor}
       titleLeft={headerLeft}
       titleRight={headerRight}
-      bottomTitle={focused ? expandHint : undefined}
-      bottomTitleAlignment="right"
+      bottomLeft={footerLeft}
+      bottomRight={footerRight}
     >
       {state.status === "idle" ? (
         <Tips />
       ) : state.status === "sending" ? (
         <box style={{ flexDirection: "row", gap: 1 }}>
           <text fg={theme.info}>{SPINNER_FRAMES[spinnerIdx]}</text>
-          <text fg={theme.textMuted}>
+    <text fg={focused ? theme.primary : theme.textMuted}>
             Sending {state.request.method} {state.request.url}...
           </text>
         </box>

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -108,19 +108,23 @@ export function ResponsePane({
       ? Math.max(...responseHeaders.map((h) => h.key.length))
       : 0
 
-  const headerRight = isDone ? (
+  const statusCode = isDone ? (
+    <text fg={statusColor(state.response.status, theme)}>
+      {state.response.status}{state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}
+    </text>
+  ) : undefined
+
+  const headerLeft = isDone ? (
     <box style={{ flexDirection: "row" }}>
-      <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
+      <text fg={statusColor(state.response.status, theme)}>Response</text>
       <text> </text>
-      <text fg={statusColor(state.response.status, theme)}>
-        {state.response.status}{state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}
-      </text>
+      {statusCode}
     </box>
   ) : (
     <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
   )
 
-  const bottomStatus = isDone ? (
+  const headerRight = isDone ? (
     <text fg={theme.textMuted}>
       {`${formatSize(new TextEncoder().encode(state.response.body).length)} in ${Math.round(state.response.timeMs)}ms`}
     </text>
@@ -140,10 +144,10 @@ export function ResponsePane({
       border={[...FullBorder.border]}
       customBorderChars={FullBorder.customBorderChars}
       borderColor={borderColor}
+      titleLeft={headerLeft}
       titleRight={headerRight}
       bottomTitle={focused ? expandHint : undefined}
-      bottomTitleAlignment="left"
-      bottomRight={bottomStatus}
+      bottomTitleAlignment="right"
     >
       {state.status === "idle" ? (
         <Tips />

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import type { SendState } from "./sendState"
@@ -109,22 +109,24 @@ export function ResponsePane({
       ? Math.max(...responseHeaders.map((h) => h.key.length))
       : 0
 
+  const bodySize = useMemo(() => {
+    if (state.status !== "done") return 0
+    return new TextEncoder().encode(state.response.body).length
+  }, [state.status, state.status === "done" ? state.response.body : null])
+
   const headerLeft = (
     <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
   )
 
   const headerRight = isDone ? (
-    <Badge
-      bg={statusColor(state.response.status, theme)}
-      fg={theme.background}
-    >
+    <Badge bg={statusColor(state.response.status, theme)} fg={theme.background}>
       {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}`}
     </Badge>
   ) : undefined
 
   const footerRight = isDone ? (
     <text fg={focused ? theme.primary : theme.textMuted}>
-      {`${formatSize(new TextEncoder().encode(state.response.body).length)} in ${Math.round(state.response.timeMs)}ms`}
+      {`${formatSize(bodySize)} in ${Math.round(state.response.timeMs)}ms`}
     </text>
   ) : undefined
 
@@ -156,7 +158,7 @@ export function ResponsePane({
       ) : state.status === "sending" ? (
         <box style={{ flexDirection: "row", gap: 1 }}>
           <text fg={theme.info}>{SPINNER_FRAMES[spinnerIdx]}</text>
-    <text fg={focused ? theme.primary : theme.textMuted}>
+          <text fg={focused ? theme.primary : theme.textMuted}>
             Sending {state.request.method} {state.request.url}...
           </text>
         </box>

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -82,30 +82,30 @@ export function UrlBar({
           >
             {method === "DELETE" ? "DEL" : method}
           </Badge>
-            {focused ? (
-              <box style={{ flexGrow: 1 }}>
-                <input
-                  value={inputValue}
-                  onInput={handleInput}
-                  backgroundColor={theme.backgroundElement}
-                  focusedBackgroundColor={theme.borderSubtle}
-                  textColor={theme.text}
-                  cursorColor={theme.primary}
-                  paddingX={1}
-                  focused
-                />
-              </box>
-            ) : (
-              <box
-                style={{
-                  backgroundColor: theme.backgroundElement,
-                  flexGrow: 1,
-                }}
-              >
-                <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />
-              </box>
-            )}
-          </box>
+          {focused ? (
+            <box style={{ flexGrow: 1 }}>
+              <input
+                value={inputValue}
+                onInput={handleInput}
+                backgroundColor={theme.backgroundElement}
+                focusedBackgroundColor={theme.borderSubtle}
+                textColor={theme.text}
+                cursorColor={theme.primary}
+                paddingX={1}
+                focused
+              />
+            </box>
+          ) : (
+            <box
+              style={{
+                backgroundColor: theme.backgroundElement,
+                flexGrow: 1,
+              }}
+            >
+              <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />
+            </box>
+          )}
+        </box>
       )}
     </box>
   )

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -7,8 +7,6 @@ import type { Method, KvEntry, Environment } from "../schema"
 import { buildDisplayUrl } from "./urlParams"
 import { VarText } from "./VarText"
 
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-
 export function UrlBar({
   method,
   url,
@@ -16,7 +14,6 @@ export function UrlBar({
   setUrl,
   onDefocus,
   focused = false,
-  sending = false,
   activeEnv,
 }: {
   method: string
@@ -25,22 +22,12 @@ export function UrlBar({
   setUrl: (url: string) => void
   onDefocus: (rawUrl: string) => void
   focused?: boolean
-  sending?: boolean
   activeEnv?: Environment | null
 }) {
   const theme = useTheme()
-  const [spinnerIdx, setSpinnerIdx] = useState(0)
   const [inputValue, setInputValue] = useState(url)
   const prevFocused = useRef(focused)
   const initDisplayRef = useRef("")
-
-  useEffect(() => {
-    if (!sending) return
-    const id = setInterval(() => {
-      setSpinnerIdx((i) => (i + 1) % SPINNER_FRAMES.length)
-    }, 80)
-    return () => clearInterval(id)
-  }, [sending])
 
   useEffect(() => {
     if (focused && !prevFocused.current) {
@@ -95,43 +82,30 @@ export function UrlBar({
           >
             {method === "DELETE" ? "DEL" : method}
           </Badge>
-          {focused ? (
-            <box style={{ flexGrow: 1 }}>
-              <input
-                value={inputValue}
-                onInput={handleInput}
-                backgroundColor={theme.backgroundElement}
-                focusedBackgroundColor={theme.borderSubtle}
-                textColor={theme.text}
-                cursorColor={theme.primary}
-                paddingX={1}
-                focused
-              />
-            </box>
-          ) : (
-            <box
-              style={{
-                backgroundColor: theme.backgroundElement,
-                flexGrow: 1,
-              }}
-            >
-              <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />
-            </box>
-          )}
-          <box
-            style={{
-              flexShrink: 0,
-              backgroundColor: sending
-                ? theme.backgroundElement
-                : theme.primary,
-              paddingX: 2,
-            }}
-          >
-            <text fg={sending ? theme.textMuted : theme.background}>
-              {sending ? `${SPINNER_FRAMES[spinnerIdx]} sending` : "Send"}
-            </text>
+            {focused ? (
+              <box style={{ flexGrow: 1 }}>
+                <input
+                  value={inputValue}
+                  onInput={handleInput}
+                  backgroundColor={theme.backgroundElement}
+                  focusedBackgroundColor={theme.borderSubtle}
+                  textColor={theme.text}
+                  cursorColor={theme.primary}
+                  paddingX={1}
+                  focused
+                />
+              </box>
+            ) : (
+              <box
+                style={{
+                  backgroundColor: theme.backgroundElement,
+                  flexGrow: 1,
+                }}
+              >
+                <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />
+              </box>
+            )}
           </box>
-        </box>
       )}
     </box>
   )


### PR DESCRIPTION
## Changes

- **New  component** — Reusable border wrapper with , , ,  slots for overlay badges on border edges
- **ResponsePane refactor** — Uses  component; moves status badge to  (border overlay) and size/time info to  footer
- **UrlBar cleanup** — Removes  spinner animation and Send badge (now shown in ResponsePane header during sending)
- **AppInner** — Removes unused  and  props

## Fixes
- Broken indentation on Sending text in ResponsePane
- Memoized TextEncoder body encoding with `useMemo` to avoid per-render cost
- Prettier formatting across affected files