### PR TITLE
feat: request folders with inherit auth, folder overrides, and folder pane UI

### DIFF
--- a/collections/auth/basic-auth.yml
+++ b/collections/auth/basic-auth.yml
@@ -6,6 +6,4 @@ followRedirects: true
 maxRedirects: 5
 body_type: none
 auth:
-  type: basic
-  user: user
-  pass: pass
+  type: inherit

--- a/collections/auth/folder.yml
+++ b/collections/auth/folder.yml
@@ -1,0 +1,4 @@
+auth:
+  type: basic
+  user: user
+  pass: pass

--- a/collections/posts/folder.yml
+++ b/collections/posts/folder.yml
@@ -1,0 +1,2 @@
+auth:
+  type: none

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -6,6 +6,7 @@ export interface UseCollectionResult {
   collection: Collection | null
   loading: boolean
   error: Error | null
+  updateCollection: (collection: Collection) => void
 }
 
 export function useCollection(
@@ -41,5 +42,5 @@ export function useCollection(
     }
   }, [dir, reloadToken])
 
-  return { collection, loading, error }
+  return { collection, loading, error, updateCollection: setCollection }
 }

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -80,7 +80,10 @@ function toggleRow(
 
 function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
   if (a === undefined && b === undefined) return true
-  if (a === undefined || b === undefined) return false
+  if (a === undefined || b === undefined) {
+    const defined = a ?? b
+    return defined!.type === "none"
+  }
   if (a.type !== b.type) return false
   if (a.type === "none" && b.type === "none") return true
   if (a.type === "inherit" && b.type === "inherit") return true
@@ -240,13 +243,15 @@ export interface UseFolderDraftResult {
 
 export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
   const [draftMap, setDraftMap] = useState<Map<string, Folder>>(new Map())
-  const [original, setOriginal] = useState<Folder | null>(null)
+  const [originalMap, setOriginalMap] = useState<Map<string, Folder>>(new Map())
 
   useEffect(() => {
     if (!folder) return
-    setOriginal((prev) => {
-      if (prev?.path === folder.path) return prev
-      return folder
+    setOriginalMap((prev) => {
+      if (prev.has(folder.path)) return prev
+      const next = new Map(prev)
+      next.set(folder.path, folder)
+      return next
     })
   }, [folder])
 
@@ -254,11 +259,21 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
 
   const folderDraft = folder ? (draftMap.get(key) ?? folder) : null
 
-  const isDirty = folderDraft && original
-    ? !folderEqual(folderDraft, original)
+  const isDirty = folderDraft
+    ? !folderEqual(folderDraft, originalMap.get(key) ?? folderDraft)
     : false
 
-  const dirtyPaths = useMemo(() => new Set(draftMap.keys()), [draftMap])
+  const dirtyPaths = useMemo(() => {
+    const paths = new Set<string>()
+    for (const [path, draft] of draftMap) {
+      const orig = originalMap.get(path)
+      if (!orig) continue
+      if (!folderEqual(draft, orig)) {
+        paths.add(path)
+      }
+    }
+    return paths
+  }, [draftMap, originalMap])
 
   const dispatch = useCallback(
     (op: FolderDraftOp) => {
@@ -326,7 +341,11 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
   )
   const markSaved = useCallback(() => {
     if (!folderDraft || !folder) return
-    setOriginal({ ...folderDraft })
+    setOriginalMap((prev) => {
+      const next = new Map(prev)
+      next.set(key, { ...folderDraft })
+      return next
+    })
     setDraftMap((prev) => {
       const next = new Map(prev)
       next.delete(key)
@@ -339,7 +358,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       folderDraft,
       isDirty,
       dirtyPaths,
-      originalFolder: original,
+      originalFolder: originalMap.get(key) ?? null,
       setName,
       setSeq,
       setHeaderRow,
@@ -356,7 +375,8 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       folderDraft,
       isDirty,
       dirtyPaths,
-      original,
+      originalMap,
+      key,
       setName,
       setSeq,
       setHeaderRow,

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -1,0 +1,431 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { Auth, Folder, KvEntry } from "../schema"
+
+export type FolderDraftOp =
+  | { kind: "setName"; name: string }
+  | { kind: "setSeq"; seq: number }
+  | { kind: "setHeaderRow"; index: number; key: string; value: string }
+  | { kind: "addHeaderRow"; key: string; value: string }
+  | { kind: "removeHeaderRow"; index: number }
+  | { kind: "toggleHeaderRow"; index: number }
+  | { kind: "setParamRow"; index: number; key: string; value: string }
+  | { kind: "addParamRow"; key: string; value: string }
+  | { kind: "removeParamRow"; index: number }
+  | { kind: "toggleParamRow"; index: number }
+  | { kind: "setAuthType"; authType: Auth["type"] }
+  | { kind: "setAuthField"; authType: string; field: string; value: string }
+  | { kind: "setApiKeyPlacement"; placement: "header" | "query" }
+  | { kind: "revert" }
+  | { kind: "markSaved" }
+
+function sortedEntries(rec: Record<string, KvEntry>): [string, KvEntry][] {
+  return Object.entries(rec)
+}
+
+function replaceRow(
+  rec: Record<string, KvEntry>,
+  index: number,
+  key: string,
+  value: string,
+): Record<string, KvEntry> {
+  const entries = sortedEntries(rec)
+  if (!entries[index]) return rec
+  const out: Record<string, KvEntry> = {}
+  for (let i = 0; i < entries.length; i++) {
+    const [k, entry] = entries[i]!
+    if (i === index) {
+      if (key !== "") out[key] = { value, enabled: entry.enabled }
+    } else if (k !== key) {
+      out[k] = entry
+    }
+  }
+  return out
+}
+
+function addRow(
+  rec: Record<string, KvEntry>,
+  key: string,
+  value: string,
+): Record<string, KvEntry> {
+  if (key === "") return rec
+  return { ...rec, [key]: { value, enabled: true } }
+}
+
+function removeRow(
+  rec: Record<string, KvEntry>,
+  index: number,
+): Record<string, KvEntry> {
+  const entries = sortedEntries(rec)
+  const target = entries[index]
+  if (!target) return rec
+  const out: Record<string, KvEntry> = {}
+  for (const [k, v] of entries) if (k !== target[0]) out[k] = v
+  return out
+}
+
+function toggleRow(
+  rec: Record<string, KvEntry>,
+  index: number,
+): Record<string, KvEntry> {
+  const entries = sortedEntries(rec)
+  const target = entries[index]
+  if (!target) return rec
+  const [k] = target
+  const out: Record<string, KvEntry> = {}
+  for (const [key, v] of entries) {
+    if (key === k) {
+      out[key] = { value: v.value, enabled: !v.enabled }
+    } else {
+      out[key] = v
+    }
+  }
+  return out
+}
+
+function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
+  if (a === undefined && b === undefined) return true
+  if (a === undefined || b === undefined) return false
+  if (a.type !== b.type) return false
+  if (a.type === "none" && b.type === "none") return true
+  if (a.type === "bearer" && b.type === "bearer") return a.token === b.token
+  if (a.type === "basic" && b.type === "basic") {
+    return a.user === b.user && a.pass === b.pass
+  }
+  if (a.type === "api_key" && b.type === "api_key") {
+    return a.key === b.key && a.value === b.value && a.placement === b.placement
+  }
+  return false
+}
+
+function recordsEqual(
+  a: Record<string, KvEntry>,
+  b: Record<string, KvEntry>,
+): boolean {
+  const ae = Object.entries(a).sort(([x], [y]) => (x < y ? -1 : x > y ? 1 : 0))
+  const be = Object.entries(b).sort(([x], [y]) => (x < y ? -1 : x > y ? 1 : 0))
+  if (ae.length !== be.length) return false
+  for (let i = 0; i < ae.length; i++) {
+    if (
+      ae[i]![0] !== be[i]![0] ||
+      ae[i]![1].value !== be[i]![1].value ||
+      ae[i]![1].enabled !== be[i]![1].enabled
+    )
+      return false
+  }
+  return true
+}
+
+function defaultAuth(authType: Auth["type"]): Auth {
+  switch (authType) {
+    case "none":
+      return { type: "none" }
+    case "bearer":
+      return { type: "bearer", token: "" }
+    case "basic":
+      return { type: "basic", user: "", pass: "" }
+    case "api_key":
+      return { type: "api_key", key: "", value: "", placement: "header" }
+  }
+}
+
+export function applyDraftOp(
+  folder: Folder | null,
+  op: FolderDraftOp,
+): Folder | null {
+  if (!folder) return null
+  if (op.kind === "revert") return null
+
+  const draft: Folder = { ...folder }
+
+  switch (op.kind) {
+    case "setName":
+      draft.name = op.name
+      break
+    case "setSeq":
+      draft.seq = op.seq
+      break
+    case "addHeaderRow":
+      draft.overrides = {
+        ...draft.overrides,
+        headers: addRow(draft.overrides?.headers ?? {}, op.key, op.value),
+      }
+      break
+    case "removeHeaderRow":
+      draft.overrides = {
+        ...draft.overrides,
+        headers: removeRow(draft.overrides?.headers ?? {}, op.index),
+      }
+      break
+    case "toggleHeaderRow":
+      draft.overrides = {
+        ...draft.overrides,
+        headers: toggleRow(draft.overrides?.headers ?? {}, op.index),
+      }
+      break
+    case "setHeaderRow": {
+      const { key, value } = op
+      if (key === "") {
+        draft.overrides = {
+          ...draft.overrides,
+          headers: removeRow(draft.overrides?.headers ?? {}, op.index),
+        }
+      } else {
+        draft.overrides = {
+          ...draft.overrides,
+          headers: replaceRow(draft.overrides?.headers ?? {}, op.index, key, value),
+        }
+      }
+      break
+    }
+    case "addParamRow":
+      draft.overrides = {
+        ...draft.overrides,
+        params: addRow(draft.overrides?.params ?? {}, op.key, op.value),
+      }
+      break
+    case "removeParamRow":
+      draft.overrides = {
+        ...draft.overrides,
+        params: removeRow(draft.overrides?.params ?? {}, op.index),
+      }
+      break
+    case "toggleParamRow":
+      draft.overrides = {
+        ...draft.overrides,
+        params: toggleRow(draft.overrides?.params ?? {}, op.index),
+      }
+      break
+    case "setParamRow": {
+      const { key, value } = op
+      if (key === "") {
+        draft.overrides = {
+          ...draft.overrides,
+          params: removeRow(draft.overrides?.params ?? {}, op.index),
+        }
+      } else {
+        draft.overrides = {
+          ...draft.overrides,
+          params: replaceRow(draft.overrides?.params ?? {}, op.index, key, value),
+        }
+      }
+      break
+    }
+    case "setAuthType":
+      draft.overrides = {
+        ...draft.overrides,
+        auth: defaultAuth(op.authType),
+      }
+      break
+    case "setAuthField": {
+      const currentAuth = draft.overrides?.auth
+      if (!currentAuth || currentAuth.type !== op.authType) break
+      if (currentAuth.type === "none") break
+      ;(currentAuth as Record<string, unknown>)[op.field] = op.value
+      break
+    }
+    case "setApiKeyPlacement": {
+      const currentAuth = draft.overrides?.auth
+      if (currentAuth?.type === "api_key") {
+        ;(currentAuth as { placement: "header" | "query" }).placement =
+          op.placement
+      }
+      break
+    }
+    case "markSaved":
+      return folder
+  }
+
+  return draft
+}
+
+export function folderEqual(a: Folder, b: Folder): boolean {
+  if (a.name !== b.name) return false
+  if (a.seq !== b.seq) return false
+  if (
+    !recordsEqual(a.overrides?.headers ?? {}, b.overrides?.headers ?? {})
+  )
+    return false
+  if (
+    !recordsEqual(a.overrides?.params ?? {}, b.overrides?.params ?? {})
+  )
+    return false
+  if (!authEqual(a.overrides?.auth, b.overrides?.auth)) return false
+  return true
+}
+
+export interface UseFolderDraftResult {
+  folderDraft: Folder | null
+  isDirty: boolean
+  originalFolder: Folder | null
+  setName: (name: string) => void
+  setSeq: (seq: number) => void
+  setHeaderRow: (index: number, key: string, value: string) => void
+  addHeaderRow: (key: string, value: string) => void
+  removeHeaderRow: (index: number) => void
+  toggleHeaderRow: (index: number) => void
+  setParamRow: (index: number, key: string, value: string) => void
+  addParamRow: (key: string, value: string) => void
+  removeParamRow: (index: number) => void
+  toggleParamRow: (index: number) => void
+  setAuthType: (authType: Auth["type"]) => void
+  setAuthField: (authType: string, field: string, value: string) => void
+  setApiKeyPlacement: (placement: "header" | "query") => void
+  revertAll: () => void
+  markSaved: () => void
+}
+
+export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
+  const [draftMap, setDraftMap] = useState<Map<string, Folder>>(new Map())
+  const [original, setOriginal] = useState<Folder | null>(null)
+
+  useEffect(() => {
+    if (!folder) return
+    setOriginal((prev) => {
+      if (prev?.path === folder.path) return prev
+      return folder
+    })
+  }, [folder])
+
+  const key = folder?.path ?? ""
+
+  const folderDraft = folder ? (draftMap.get(key) ?? folder) : null
+
+  const isDirty = folderDraft && original
+    ? !folderEqual(folderDraft, original)
+    : false
+
+  const dispatch = useCallback(
+    (op: FolderDraftOp) => {
+      setDraftMap((prev) => {
+        if (!folder) return prev
+        const current = prev.get(key) ?? folder
+        const result = applyDraftOp(current, op)
+        if (result === null) {
+          const next = new Map(prev)
+          next.delete(key)
+          return next
+        }
+        const next = new Map(prev)
+        next.set(key, result)
+        return next
+      })
+    },
+    [folder, key],
+  )
+
+  const setName = useCallback(
+    (name: string) => dispatch({ kind: "setName", name }),
+    [dispatch],
+  )
+  const setSeq = useCallback(
+    (seq: number) => dispatch({ kind: "setSeq", seq }),
+    [dispatch],
+  )
+  const setHeaderRow = useCallback(
+    (index: number, key: string, value: string) =>
+      dispatch({ kind: "setHeaderRow", index, key, value }),
+    [dispatch],
+  )
+  const addHeaderRow = useCallback(
+    (key: string, value: string) =>
+      dispatch({ kind: "addHeaderRow", key, value }),
+    [dispatch],
+  )
+  const removeHeaderRow = useCallback(
+    (index: number) => dispatch({ kind: "removeHeaderRow", index }),
+    [dispatch],
+  )
+  const toggleHeaderRow = useCallback(
+    (index: number) => dispatch({ kind: "toggleHeaderRow", index }),
+    [dispatch],
+  )
+  const setParamRow = useCallback(
+    (index: number, key: string, value: string) =>
+      dispatch({ kind: "setParamRow", index, key, value }),
+    [dispatch],
+  )
+  const addParamRow = useCallback(
+    (key: string, value: string) =>
+      dispatch({ kind: "addParamRow", key, value }),
+    [dispatch],
+  )
+  const removeParamRow = useCallback(
+    (index: number) => dispatch({ kind: "removeParamRow", index }),
+    [dispatch],
+  )
+  const toggleParamRow = useCallback(
+    (index: number) => dispatch({ kind: "toggleParamRow", index }),
+    [dispatch],
+  )
+  const setAuthType = useCallback(
+    (authType: Auth["type"]) =>
+      dispatch({ kind: "setAuthType", authType }),
+    [dispatch],
+  )
+  const setAuthField = useCallback(
+    (authType: string, field: string, value: string) =>
+      dispatch({ kind: "setAuthField", authType, field, value }),
+    [dispatch],
+  )
+  const setApiKeyPlacement = useCallback(
+    (placement: "header" | "query") =>
+      dispatch({ kind: "setApiKeyPlacement", placement }),
+    [dispatch],
+  )
+  const revertAll = useCallback(
+    () => dispatch({ kind: "revert" }),
+    [dispatch],
+  )
+  const markSaved = useCallback(() => {
+    if (!folderDraft || !folder) return
+    setOriginal({ ...folderDraft })
+    setDraftMap((prev) => {
+      const next = new Map(prev)
+      next.delete(key)
+      return next
+    })
+  }, [folderDraft, folder, key])
+
+  return useMemo(
+    () => ({
+      folderDraft,
+      isDirty,
+      originalFolder: original,
+      setName,
+      setSeq,
+      setHeaderRow,
+      addHeaderRow,
+      removeHeaderRow,
+      toggleHeaderRow,
+      setParamRow,
+      addParamRow,
+      removeParamRow,
+      toggleParamRow,
+      setAuthType,
+      setAuthField,
+      setApiKeyPlacement,
+      revertAll,
+      markSaved,
+    }),
+    [
+      folderDraft,
+      isDirty,
+      original,
+      setName,
+      setSeq,
+      setHeaderRow,
+      addHeaderRow,
+      removeHeaderRow,
+      toggleHeaderRow,
+      setParamRow,
+      addParamRow,
+      removeParamRow,
+      toggleParamRow,
+      setAuthType,
+      setAuthField,
+      setApiKeyPlacement,
+      revertAll,
+      markSaved,
+    ],
+  )
+}

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -8,10 +8,6 @@ export type FolderDraftOp =
   | { kind: "addHeaderRow"; key: string; value: string }
   | { kind: "removeHeaderRow"; index: number }
   | { kind: "toggleHeaderRow"; index: number }
-  | { kind: "setParamRow"; index: number; key: string; value: string }
-  | { kind: "addParamRow"; key: string; value: string }
-  | { kind: "removeParamRow"; index: number }
-  | { kind: "toggleParamRow"; index: number }
   | { kind: "setAuthType"; authType: Auth["type"] }
   | { kind: "setAuthField"; authType: string; field: string; value: string }
   | { kind: "setApiKeyPlacement"; placement: "header" | "query" }
@@ -87,6 +83,7 @@ function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
   if (a === undefined || b === undefined) return false
   if (a.type !== b.type) return false
   if (a.type === "none" && b.type === "none") return true
+  if (a.type === "inherit" && b.type === "inherit") return true
   if (a.type === "bearer" && b.type === "bearer") return a.token === b.token
   if (a.type === "basic" && b.type === "basic") {
     return a.user === b.user && a.pass === b.pass
@@ -118,6 +115,8 @@ function recordsEqual(
 function defaultAuth(authType: Auth["type"]): Auth {
   switch (authType) {
     case "none":
+      return { type: "none" }
+    case "inherit":
       return { type: "none" }
     case "bearer":
       return { type: "bearer", token: "" }
@@ -177,39 +176,6 @@ export function applyDraftOp(
       }
       break
     }
-    case "addParamRow":
-      draft.overrides = {
-        ...draft.overrides,
-        params: addRow(draft.overrides?.params ?? {}, op.key, op.value),
-      }
-      break
-    case "removeParamRow":
-      draft.overrides = {
-        ...draft.overrides,
-        params: removeRow(draft.overrides?.params ?? {}, op.index),
-      }
-      break
-    case "toggleParamRow":
-      draft.overrides = {
-        ...draft.overrides,
-        params: toggleRow(draft.overrides?.params ?? {}, op.index),
-      }
-      break
-    case "setParamRow": {
-      const { key, value } = op
-      if (key === "") {
-        draft.overrides = {
-          ...draft.overrides,
-          params: removeRow(draft.overrides?.params ?? {}, op.index),
-        }
-      } else {
-        draft.overrides = {
-          ...draft.overrides,
-          params: replaceRow(draft.overrides?.params ?? {}, op.index, key, value),
-        }
-      }
-      break
-    }
     case "setAuthType":
       draft.overrides = {
         ...draft.overrides,
@@ -250,10 +216,6 @@ export function folderEqual(a: Folder, b: Folder): boolean {
     !recordsEqual(a.overrides?.headers ?? {}, b.overrides?.headers ?? {})
   )
     return false
-  if (
-    !recordsEqual(a.overrides?.params ?? {}, b.overrides?.params ?? {})
-  )
-    return false
   if (!authEqual(a.overrides?.auth, b.overrides?.auth)) return false
   return true
 }
@@ -269,10 +231,6 @@ export interface UseFolderDraftResult {
   addHeaderRow: (key: string, value: string) => void
   removeHeaderRow: (index: number) => void
   toggleHeaderRow: (index: number) => void
-  setParamRow: (index: number, key: string, value: string) => void
-  addParamRow: (key: string, value: string) => void
-  removeParamRow: (index: number) => void
-  toggleParamRow: (index: number) => void
   setAuthType: (authType: Auth["type"]) => void
   setAuthField: (authType: string, field: string, value: string) => void
   setApiKeyPlacement: (placement: "header" | "query") => void
@@ -347,24 +305,6 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
     (index: number) => dispatch({ kind: "toggleHeaderRow", index }),
     [dispatch],
   )
-  const setParamRow = useCallback(
-    (index: number, key: string, value: string) =>
-      dispatch({ kind: "setParamRow", index, key, value }),
-    [dispatch],
-  )
-  const addParamRow = useCallback(
-    (key: string, value: string) =>
-      dispatch({ kind: "addParamRow", key, value }),
-    [dispatch],
-  )
-  const removeParamRow = useCallback(
-    (index: number) => dispatch({ kind: "removeParamRow", index }),
-    [dispatch],
-  )
-  const toggleParamRow = useCallback(
-    (index: number) => dispatch({ kind: "toggleParamRow", index }),
-    [dispatch],
-  )
   const setAuthType = useCallback(
     (authType: Auth["type"]) =>
       dispatch({ kind: "setAuthType", authType }),
@@ -406,10 +346,6 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       addHeaderRow,
       removeHeaderRow,
       toggleHeaderRow,
-      setParamRow,
-      addParamRow,
-      removeParamRow,
-      toggleParamRow,
       setAuthType,
       setAuthField,
       setApiKeyPlacement,
@@ -427,10 +363,6 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       addHeaderRow,
       removeHeaderRow,
       toggleHeaderRow,
-      setParamRow,
-      addParamRow,
-      removeParamRow,
-      toggleParamRow,
       setAuthType,
       setAuthField,
       setApiKeyPlacement,

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -117,7 +117,7 @@ function defaultAuth(authType: Auth["type"]): Auth {
     case "none":
       return { type: "none" }
     case "inherit":
-      return { type: "none" }
+      return { type: "inherit" }
     case "bearer":
       return { type: "bearer", token: "" }
     case "basic":

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -220,14 +220,19 @@ export function applyDraftOp(
       const currentAuth = draft.overrides?.auth
       if (!currentAuth || currentAuth.type !== op.authType) break
       if (currentAuth.type === "none") break
-      ;(currentAuth as Record<string, unknown>)[op.field] = op.value
+      draft.overrides = {
+        ...draft.overrides,
+        auth: { ...currentAuth, [op.field]: op.value },
+      }
       break
     }
     case "setApiKeyPlacement": {
       const currentAuth = draft.overrides?.auth
       if (currentAuth?.type === "api_key") {
-        ;(currentAuth as { placement: "header" | "query" }).placement =
-          op.placement
+        draft.overrides = {
+          ...draft.overrides,
+          auth: { ...currentAuth, placement: op.placement },
+        }
       }
       break
     }

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -261,6 +261,7 @@ export function folderEqual(a: Folder, b: Folder): boolean {
 export interface UseFolderDraftResult {
   folderDraft: Folder | null
   isDirty: boolean
+  dirtyPaths: Set<string>
   originalFolder: Folder | null
   setName: (name: string) => void
   setSeq: (seq: number) => void
@@ -298,6 +299,8 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
   const isDirty = folderDraft && original
     ? !folderEqual(folderDraft, original)
     : false
+
+  const dirtyPaths = useMemo(() => new Set(draftMap.keys()), [draftMap])
 
   const dispatch = useCallback(
     (op: FolderDraftOp) => {
@@ -395,6 +398,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
     () => ({
       folderDraft,
       isDirty,
+      dirtyPaths,
       originalFolder: original,
       setName,
       setSeq,
@@ -415,6 +419,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
     [
       folderDraft,
       isDirty,
+      dirtyPaths,
       original,
       setName,
       setSeq,

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -14,17 +14,13 @@ export type FolderDraftOp =
   | { kind: "revert" }
   | { kind: "markSaved" }
 
-function sortedEntries(rec: Record<string, KvEntry>): [string, KvEntry][] {
-  return Object.entries(rec)
-}
-
 function replaceRow(
   rec: Record<string, KvEntry>,
   index: number,
   key: string,
   value: string,
 ): Record<string, KvEntry> {
-  const entries = sortedEntries(rec)
+  const entries = Object.entries(rec)
   if (!entries[index]) return rec
   const out: Record<string, KvEntry> = {}
   for (let i = 0; i < entries.length; i++) {
@@ -51,7 +47,7 @@ function removeRow(
   rec: Record<string, KvEntry>,
   index: number,
 ): Record<string, KvEntry> {
-  const entries = sortedEntries(rec)
+  const entries = Object.entries(rec)
   const target = entries[index]
   if (!target) return rec
   const out: Record<string, KvEntry> = {}
@@ -63,7 +59,7 @@ function toggleRow(
   rec: Record<string, KvEntry>,
   index: number,
 ): Record<string, KvEntry> {
-  const entries = sortedEntries(rec)
+  const entries = Object.entries(rec)
   const target = entries[index]
   if (!target) return rec
   const [k] = target

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -1,0 +1,444 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { Folder } from "../schema"
+import {
+  initialFolderEditState,
+  enterFolderEditBrowse,
+  exitEditBrowse,
+  moveFolderFieldCursor,
+  moveFolderRowCursor,
+  beginEditing,
+  commitEditing,
+  cancelEditing,
+  toggleSubfield,
+  FOLDER_FIELD_ORDER,
+  type EditState,
+  type FolderRowCount,
+  type FolderFieldKind,
+  type FieldKind,
+} from "../ui/editMode"
+import type { UseFolderDraftResult } from "./useFolderDraft"
+
+const FIELD_ORDER: FolderFieldKind[] = FOLDER_FIELD_ORDER
+
+export type { FolderFieldKind }
+
+export interface UseFolderEditBrowseResult {
+  editState: EditState
+  editValue: string
+  setEditValue: (v: string) => void
+  editKey: string
+  setEditKey: (v: string) => void
+  isActive: boolean
+  activeTab: FieldKind
+  enterBrowse: () => void
+  exitBrowse: () => void
+  browseUp: () => void
+  browseDown: () => void
+  browseLeft: () => void
+  browseRight: () => void
+  enterAndEdit: () => void
+  enterEdit: () => void
+  commitEdit: () => void
+  cancelEdit: () => void
+  browseTab: () => void
+  revertField: () => void
+  revertAll: () => void
+  toggleRow: () => void
+  cycleInactiveTab: (delta: 1 | -1) => void
+}
+
+export interface UseFolderEditBrowseOptions {
+  initialTab?: FieldKind
+  onTabChange?: (tab: FieldKind) => void
+}
+
+function folderRowCount(folder: Folder | null): FolderRowCount {
+  if (!folder) return { meta: 2, headers: 0, params: 0, auth: 1 }
+  let authRows = 1
+  const a = folder.overrides?.auth
+  if (a) {
+    if (a.type === "bearer") authRows = 2
+    else if (a.type === "basic") authRows = 3
+    else if (a.type === "api_key") authRows = 4
+  }
+  return {
+    meta: 2,
+    headers: Object.keys(folder.overrides?.headers ?? {}).length,
+    params: Object.keys(folder.overrides?.params ?? {}).length,
+    auth: authRows,
+  }
+}
+
+function folderCurrentValueFor(
+  folder: Folder | null,
+  field: FolderFieldKind,
+  row: number,
+  addingRow: boolean,
+): string {
+  if (!folder) return ""
+  if (field === "meta") {
+    if (row === 0) return folder.name ?? ""
+    if (row === 1) return String(folder.seq ?? "")
+    return ""
+  }
+  if (field === "auth") {
+    const a = folder.overrides?.auth
+    if (!a || a.type === "none") return ""
+    if (a.type === "bearer") {
+      if (row === 0) return ""
+      if (row === 1) return a.token
+    }
+    if (a.type === "basic") {
+      if (row === 0) return ""
+      if (row === 1) return a.user
+      if (row === 2) return a.pass
+    }
+    if (a.type === "api_key") {
+      if (row === 0) return ""
+      if (row === 1) return a.key
+      if (row === 2) return a.value
+      if (row === 3) return a.placement
+    }
+    return ""
+  }
+  if (field === "headers" || field === "params") {
+    if (addingRow) return ""
+    const rec =
+      field === "headers"
+        ? (folder.overrides?.headers ?? {})
+        : (folder.overrides?.params ?? {})
+    const entries = Object.entries(rec)
+    const entry = entries[row]
+    return entry ? `${entry[0]}: ${entry[1].value}` : ""
+  }
+  return ""
+}
+
+function folderCurrentKeyValueFor(
+  folder: Folder | null,
+  field: FolderFieldKind,
+  row: number,
+  addingRow: boolean,
+): { key: string; value: string } {
+  if (!folder) return { key: "", value: "" }
+  if (addingRow) return { key: "", value: "" }
+  if (field === "headers" || field === "params") {
+    const rec =
+      field === "headers"
+        ? (folder.overrides?.headers ?? {})
+        : (folder.overrides?.params ?? {})
+    const entries = Object.entries(rec)
+    const entry = entries[row]
+    return entry
+      ? { key: entry[0], value: entry[1].value }
+      : { key: "", value: "" }
+  }
+  if (field === "meta") {
+    if (row === 0) return { key: "", value: folder.name ?? "" }
+    if (row === 1) return { key: "", value: String(folder.seq ?? "") }
+    return { key: "", value: "" }
+  }
+  if (field === "auth") {
+    const val = folderCurrentValueFor(folder, field, row, false)
+    return { key: "", value: val }
+  }
+  return { key: "", value: "" }
+}
+
+function cycleField(current: FieldKind, delta: 1 | -1): FieldKind {
+  const idx = FIELD_ORDER.indexOf(current as FolderFieldKind)
+  if (idx === -1) return current
+  const next = (idx + delta + FIELD_ORDER.length) % FIELD_ORDER.length
+  return FIELD_ORDER[next]!
+}
+
+export function useFolderEditBrowse(
+  folder: Folder | null,
+  draftMutators: UseFolderDraftResult,
+  options?: UseFolderEditBrowseOptions,
+): UseFolderEditBrowseResult {
+  const [editState, setEditState] = useState<EditState>(initialFolderEditState())
+  const [editValue, setEditValue] = useState("")
+  const [editKey, setEditKey] = useState("")
+  const [inactiveTab, setInactiveTab] = useState<FieldKind>(
+    options?.initialTab ?? "meta",
+  )
+
+  const draftRef = useRef(folder)
+  draftRef.current = folder
+
+  const editStateRef = useRef(editState)
+  editStateRef.current = editState
+
+  const editValueRef = useRef(editValue)
+  editValueRef.current = editValue
+
+  const editKeyRef = useRef(editKey)
+  editKeyRef.current = editKey
+
+  const onTabChangeRef = useRef(options?.onTabChange)
+  onTabChangeRef.current = options?.onTabChange
+
+  useEffect(() => {
+    setInactiveTab(options?.initialTab ?? "meta")
+  }, [options?.initialTab])
+
+  const isFirstTabChange = useRef(true)
+  useEffect(() => {
+    if (isFirstTabChange.current) {
+      isFirstTabChange.current = false
+      return
+    }
+    onTabChangeRef.current?.(inactiveTab)
+  }, [inactiveTab])
+
+  const activeTab: FieldKind =
+    editState.mode !== "inactive"
+      ? editState.cursor.field
+      : (options?.initialTab ?? inactiveTab)
+
+  const enterBrowse = useCallback(() => {
+    const c = folderRowCount(draftRef.current)
+    const tab = activeTab as FolderFieldKind
+    setEditState((prev) => {
+      if (prev.mode !== "inactive") return prev
+      return enterFolderEditBrowse(prev, c, tab)
+    })
+  }, [activeTab])
+
+  const enterAndEdit = useCallback(() => {
+    const c = folderRowCount(draftRef.current)
+    const currentFolder = draftRef.current
+    const tab = activeTab as FolderFieldKind
+    const state = editStateRef.current
+    if (state.mode !== "inactive") return
+
+    const browsed = enterFolderEditBrowse(state, c, tab)
+    if (browsed.cursor.field === "auth" && browsed.cursor.row === 0) {
+      setEditState(browsed)
+      return
+    }
+    if (browsed.cursor.field === "auth") {
+      const init = folderCurrentValueFor(
+        currentFolder,
+        browsed.cursor.field as FolderFieldKind,
+        browsed.cursor.row,
+        false,
+      )
+      setEditValue(init)
+      setEditState(beginEditing(browsed))
+      return
+    }
+
+    const { field, row, addingRow } = browsed.cursor
+    const kv = folderCurrentKeyValueFor(
+      currentFolder,
+      field as FolderFieldKind,
+      row,
+      addingRow,
+    )
+    setEditKey(kv.key)
+    setEditValue(kv.value)
+    setEditState(beginEditing(browsed))
+  }, [activeTab])
+
+  const exitBrowse = useCallback(() => {
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      return exitEditBrowse(prev)
+    })
+  }, [])
+
+  const browseUp = useCallback(() => {
+    const c = folderRowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      return moveFolderRowCursor(prev, -1, c)
+    })
+  }, [])
+
+  const browseDown = useCallback(() => {
+    const c = folderRowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      return moveFolderRowCursor(prev, +1, c)
+    })
+  }, [])
+
+  const browseLeft = useCallback(() => {
+    const c = folderRowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      const next = moveFolderFieldCursor(prev, -1, c)
+      setInactiveTab(next.cursor.field)
+      return next
+    })
+  }, [])
+
+  const browseRight = useCallback(() => {
+    const c = folderRowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      const next = moveFolderFieldCursor(prev, +1, c)
+      setInactiveTab(next.cursor.field)
+      return next
+    })
+  }, [])
+
+  const enterEdit = useCallback(() => {
+    const state = editStateRef.current
+    if (state.mode !== "browsing") return
+    const { field, row } = state.cursor
+    const currentFolder = draftRef.current
+    if (field === "auth") {
+      if (row === 0) return
+      const init = folderCurrentValueFor(currentFolder, "auth", row, false)
+      setEditValue(init)
+      setEditState((prev) => beginEditing(prev))
+      return
+    }
+    const { addingRow } = state.cursor
+    const kv = folderCurrentKeyValueFor(
+      currentFolder,
+      field as FolderFieldKind,
+      row,
+      addingRow,
+    )
+    setEditKey(kv.key)
+    setEditValue(kv.value)
+    setEditState((prev) => beginEditing(prev))
+  }, [])
+
+  const commitEdit = useCallback(() => {
+    const state = editStateRef.current
+    if (state.mode !== "editing") return
+    const { field, row } = state.cursor
+    const addingRow = state.cursor.addingRow
+    const val = editValueRef.current
+    if (field === "meta") {
+      if (row === 0) draftMutators.setName(val)
+      else if (row === 1) draftMutators.setSeq(Number(val) || 0)
+    } else if (field === "auth") {
+      const currentAuth = draftRef.current?.overrides?.auth
+      if (currentAuth) {
+        if (currentAuth.type === "bearer" && row === 1) {
+          draftMutators.setAuthField("bearer", "token", val)
+        } else if (currentAuth.type === "basic") {
+          if (row === 1) draftMutators.setAuthField("basic", "user", val)
+          else if (row === 2) draftMutators.setAuthField("basic", "pass", val)
+        } else if (currentAuth.type === "api_key") {
+          if (row === 1) draftMutators.setAuthField("api_key", "key", val)
+          else if (row === 2)
+            draftMutators.setAuthField("api_key", "value", val)
+        }
+      }
+    } else if (field === "headers" || field === "params") {
+      const key = editKeyRef.current.trim()
+      const value = editValueRef.current.trim()
+      if (key === "") {
+        if (!addingRow && row >= 0) {
+          if (field === "headers") draftMutators.removeHeaderRow(row)
+          else draftMutators.removeParamRow(row)
+        }
+      } else if (addingRow) {
+        if (field === "headers") draftMutators.addHeaderRow(key, value)
+        else draftMutators.addParamRow(key, value)
+      } else {
+        if (field === "headers")
+          draftMutators.setHeaderRow(row, key, value)
+        else draftMutators.setParamRow(row, key, value)
+      }
+    }
+    setEditState((prev) => commitEditing(prev))
+  }, [draftMutators])
+
+  const cancelEdit = useCallback(() => {
+    setEditKey("")
+    setEditState((prev) => cancelEditing(prev))
+  }, [])
+
+  const browseTab = useCallback(() => {
+    setEditState((prev) => toggleSubfield(prev))
+  }, [])
+
+  const revertFieldHandler = useCallback(() => {
+    const state = editStateRef.current
+    if (state.mode !== "browsing") return
+    const { field, addingRow, row } = state.cursor
+    if (addingRow) return
+    if (field === "auth") {
+      draftMutators.setAuthType("none")
+      return
+    }
+    if (field === "headers") {
+      draftMutators.removeHeaderRow(row)
+    } else if (field === "params") {
+      draftMutators.removeParamRow(row)
+    }
+  }, [draftMutators])
+
+  const revertAllHandler = useCallback(() => {
+    draftMutators.revertAll()
+  }, [draftMutators])
+
+  const toggleRow = useCallback(() => {
+    const state = editStateRef.current
+    if (state.mode !== "browsing") return
+    const { field, addingRow, row } = state.cursor
+    if (addingRow) return
+    if (field === "headers") draftMutators.toggleHeaderRow(row)
+    else if (field === "params") draftMutators.toggleParamRow(row)
+  }, [draftMutators])
+
+  const cycleInactiveTab = useCallback((delta: 1 | -1) => {
+    setInactiveTab((prev) => cycleField(prev, delta))
+  }, [])
+
+  return useMemo(
+    () => ({
+      editState,
+      editValue,
+      setEditValue,
+      editKey,
+      setEditKey,
+      isActive: editState.mode !== "inactive",
+      activeTab,
+      enterBrowse,
+      exitBrowse,
+      browseUp,
+      browseDown,
+      browseLeft,
+      browseRight,
+      enterAndEdit,
+      enterEdit,
+      commitEdit,
+      cancelEdit,
+      browseTab,
+      revertField: revertFieldHandler,
+      revertAll: revertAllHandler,
+      toggleRow,
+      cycleInactiveTab,
+    }),
+    [
+      editState,
+      editValue,
+      editKey,
+      activeTab,
+      enterBrowse,
+      exitBrowse,
+      browseUp,
+      browseDown,
+      browseLeft,
+      browseRight,
+      enterAndEdit,
+      enterEdit,
+      commitEdit,
+      cancelEdit,
+      browseTab,
+      revertFieldHandler,
+      revertAllHandler,
+      toggleRow,
+      cycleInactiveTab,
+    ],
+  )
+}

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -53,7 +53,7 @@ export interface UseFolderEditBrowseOptions {
 }
 
 function folderRowCount(folder: Folder | null): FolderRowCount {
-  if (!folder) return { meta: 1, headers: 0, params: 0, auth: 1 }
+  if (!folder) return { meta: 1, headers: 0, auth: 1 }
   let authRows = 1
   const a = folder.overrides?.auth
   if (a) {
@@ -64,7 +64,7 @@ function folderRowCount(folder: Folder | null): FolderRowCount {
   return {
     meta: 1,
     headers: Object.keys(folder.overrides?.headers ?? {}).length,
-    params: Object.keys(folder.overrides?.params ?? {}).length,
+
     auth: authRows,
   }
 }
@@ -100,12 +100,9 @@ function folderCurrentValueFor(
     }
     return ""
   }
-  if (field === "headers" || field === "params") {
+  if (field === "headers") {
     if (addingRow) return ""
-    const rec =
-      field === "headers"
-        ? (folder.overrides?.headers ?? {})
-        : (folder.overrides?.params ?? {})
+    const rec = folder.overrides?.headers ?? {}
     const entries = Object.entries(rec)
     const entry = entries[row]
     return entry ? `${entry[0]}: ${entry[1].value}` : ""
@@ -121,11 +118,8 @@ function folderCurrentKeyValueFor(
 ): { key: string; value: string } {
   if (!folder) return { key: "", value: "" }
   if (addingRow) return { key: "", value: "" }
-  if (field === "headers" || field === "params") {
-    const rec =
-      field === "headers"
-        ? (folder.overrides?.headers ?? {})
-        : (folder.overrides?.params ?? {})
+  if (field === "headers") {
+    const rec = folder.overrides?.headers ?? {}
     const entries = Object.entries(rec)
     const entry = entries[row]
     return entry
@@ -329,21 +323,17 @@ export function useFolderEditBrowse(
             draftMutators.setAuthField("api_key", "value", val)
         }
       }
-    } else if (field === "headers" || field === "params") {
+    } else if (field === "headers") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()
       if (key === "") {
         if (!addingRow && row >= 0) {
-          if (field === "headers") draftMutators.removeHeaderRow(row)
-          else draftMutators.removeParamRow(row)
+          draftMutators.removeHeaderRow(row)
         }
       } else if (addingRow) {
-        if (field === "headers") draftMutators.addHeaderRow(key, value)
-        else draftMutators.addParamRow(key, value)
+        draftMutators.addHeaderRow(key, value)
       } else {
-        if (field === "headers")
-          draftMutators.setHeaderRow(row, key, value)
-        else draftMutators.setParamRow(row, key, value)
+        draftMutators.setHeaderRow(row, key, value)
       }
     }
     setEditState((prev) => commitEditing(prev))
@@ -369,8 +359,6 @@ export function useFolderEditBrowse(
     }
     if (field === "headers") {
       draftMutators.removeHeaderRow(row)
-    } else if (field === "params") {
-      draftMutators.removeParamRow(row)
     }
   }, [draftMutators])
 
@@ -384,7 +372,6 @@ export function useFolderEditBrowse(
     const { field, addingRow, row } = state.cursor
     if (addingRow) return
     if (field === "headers") draftMutators.toggleHeaderRow(row)
-    else if (field === "params") draftMutators.toggleParamRow(row)
   }, [draftMutators])
 
   const cycleInactiveTab = useCallback((delta: 1 | -1) => {

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -18,8 +18,6 @@ import {
 } from "../ui/editMode"
 import type { UseFolderDraftResult } from "./useFolderDraft"
 
-const FIELD_ORDER: FolderFieldKind[] = FOLDER_FIELD_ORDER
-
 export type { FolderFieldKind }
 
 export interface UseFolderEditBrowseResult {
@@ -138,10 +136,10 @@ function folderCurrentKeyValueFor(
 }
 
 function cycleField(current: FieldKind, delta: 1 | -1): FieldKind {
-  const idx = FIELD_ORDER.indexOf(current as FolderFieldKind)
+  const idx = FOLDER_FIELD_ORDER.indexOf(current as FolderFieldKind)
   if (idx === -1) return current
-  const next = (idx + delta + FIELD_ORDER.length) % FIELD_ORDER.length
-  return FIELD_ORDER[next]!
+  const next = (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
+  return FOLDER_FIELD_ORDER[next]!
 }
 
 export function useFolderEditBrowse(

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -53,7 +53,7 @@ export interface UseFolderEditBrowseOptions {
 }
 
 function folderRowCount(folder: Folder | null): FolderRowCount {
-  if (!folder) return { meta: 2, headers: 0, params: 0, auth: 1 }
+  if (!folder) return { meta: 1, headers: 0, params: 0, auth: 1 }
   let authRows = 1
   const a = folder.overrides?.auth
   if (a) {
@@ -62,7 +62,7 @@ function folderRowCount(folder: Folder | null): FolderRowCount {
     else if (a.type === "api_key") authRows = 4
   }
   return {
-    meta: 2,
+    meta: 1,
     headers: Object.keys(folder.overrides?.headers ?? {}).length,
     params: Object.keys(folder.overrides?.params ?? {}).length,
     auth: authRows,
@@ -78,7 +78,6 @@ function folderCurrentValueFor(
   if (!folder) return ""
   if (field === "meta") {
     if (row === 0) return folder.name ?? ""
-    if (row === 1) return String(folder.seq ?? "")
     return ""
   }
   if (field === "auth") {
@@ -135,7 +134,6 @@ function folderCurrentKeyValueFor(
   }
   if (field === "meta") {
     if (row === 0) return { key: "", value: folder.name ?? "" }
-    if (row === 1) return { key: "", value: String(folder.seq ?? "") }
     return { key: "", value: "" }
   }
   if (field === "auth") {
@@ -316,8 +314,7 @@ export function useFolderEditBrowse(
     const addingRow = state.cursor.addingRow
     const val = editValueRef.current
     if (field === "meta") {
-      if (row === 0) draftMutators.setName(val)
-      else if (row === 1) draftMutators.setSeq(Number(val) || 0)
+      draftMutators.setName(val)
     } else if (field === "auth") {
       const currentAuth = draftRef.current?.overrides?.auth
       if (currentAuth) {

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -27,7 +27,7 @@ export type DraftOp =
   | { kind: "setMaxRedirects"; maxRedirects: number }
   | { kind: "revertField"; field: FieldKind; row?: number }
   | { kind: "revertAll" }
-  | { kind: "setAuthType"; authType: "none" | "bearer" | "basic" | "api_key" }
+  | { kind: "setAuthType"; authType: Auth["type"] }
   | { kind: "setAuthField"; authType: string; field: string; value: string }
   | { kind: "setApiKeyPlacement"; placement: "header" | "query" }
   | { kind: "setBodyType"; bodyType: BodyType }
@@ -376,6 +376,8 @@ export function applyDraft(
         draft.auth = { ...original.auth }
       } else if (op.authType === "none") {
         draft.auth = { type: "none" }
+      } else if (op.authType === "inherit") {
+        draft.auth = { type: "inherit" }
       } else if (op.authType === "bearer") {
         draft.auth = { type: "bearer", token: "" }
       } else if (op.authType === "basic") {
@@ -453,7 +455,7 @@ export interface UseRequestDraftResult {
   setMaxRedirects: (n: number) => void
   revertField: (field: FieldKind, row?: number) => void
   revertAll: () => void
-  setAuthType: (t: "none" | "bearer" | "basic" | "api_key") => void
+  setAuthType: (t: Auth["type"]) => void
   setAuthField: (authType: string, field: string, value: string) => void
   setApiKeyPlacement: (placement: "header" | "query") => void
   setBodyType: (t: BodyType) => void
@@ -558,7 +560,7 @@ export function useRequestDraft(
     [apply],
   )
   const setAuthTypeCb = useCallback(
-    (authType: "none" | "bearer" | "basic" | "api_key") =>
+    (authType: Auth["type"]) =>
       apply({ kind: "setAuthType", authType }),
     [apply],
   )

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -100,6 +100,7 @@ function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
   if (a === undefined || b === undefined) return false
   if (a.type !== b.type) return false
   if (a.type === "none" && b.type === "none") return true
+  if (a.type === "inherit" && b.type === "inherit") return true
   if (a.type === "bearer" && b.type === "bearer") return a.token === b.token
   if (a.type === "basic" && b.type === "basic") {
     return a.user === b.user && a.pass === b.pass

--- a/src/hooks/useResponse.ts
+++ b/src/hooks/useResponse.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { Dispatch, SetStateAction } from "react"
-import type { Environment, Request, Response } from "../schema"
+import type { Collection, Environment, Request, Response } from "../schema"
 import { executor } from "../requests"
 import {
   startSend,
@@ -27,6 +27,8 @@ export function useResponse(
   selectedRequest: Request | null,
   env?: Environment | null,
   onComplete?: (req: Request, result: SendCompleteResult) => void,
+  collection?: Collection,
+  requestPath?: string,
 ): UseResponseResult {
   const [state, setState] = useState<SendState>({ status: "idle" })
   const cacheRef = useRef<Map<string, CachedResult>>(new Map())
@@ -67,10 +69,12 @@ export function useResponse(
         cacheRef,
         abortRef,
         onCompleteRef,
+        collection,
+        requestPath,
       )
       return startSend(prev, req)
     })
-  }, [selectedRequest, env])
+  }, [selectedRequest, env, collection, requestPath])
 
   const cancelSend = useCallback(() => {
     abortRef.current?.abort()
@@ -89,9 +93,11 @@ async function runSend(
   onCompleteRef: React.RefObject<
     ((req: Request, result: SendCompleteResult) => void) | undefined
   >,
+  collection?: Collection,
+  requestPath?: string,
 ): Promise<void> {
   try {
-    const res = await executor.send(req, env, signal)
+    const res = await executor.send(req, env, signal, collection, requestPath)
     cacheRef.current.set(req.id, { status: "done", response: res })
     setState((prev) => finishSend(prev, req, res))
     onCompleteRef.current?.(req, { status: "done", response: res })

--- a/src/lang/folder.ts
+++ b/src/lang/folder.ts
@@ -15,7 +15,6 @@ interface RawFolderMeta {
 interface RawFolder {
   meta?: unknown
   headers?: unknown
-  params?: unknown
   auth?: unknown
   [k: string]: unknown
 }
@@ -56,15 +55,11 @@ export function parseFolder(yamlText: string): {
   let overrides: FolderOverrides | undefined
   if (
     raw.headers !== undefined ||
-    raw.params !== undefined ||
     raw.auth !== undefined
   ) {
     overrides = {}
     if (raw.headers !== undefined) {
       overrides.headers = parseKvMap(raw.headers, "headers", "lang.parseFolder")
-    }
-    if (raw.params !== undefined) {
-      overrides.params = parseKvMap(raw.params, "params", "lang.parseFolder")
     }
     if (raw.auth !== undefined) {
       overrides.auth = parseFolderAuth(raw.auth)
@@ -76,6 +71,7 @@ export function parseFolder(yamlText: string): {
 
 type RawFolderAuth =
   | { type: "none"; [k: string]: unknown }
+  | { type: "inherit"; [k: string]: unknown }
   | { type: "bearer"; token: string; [k: string]: unknown }
   | { type: "basic"; user: string; pass: string; [k: string]: unknown }
   | {
@@ -93,6 +89,7 @@ function parseFolderAuth(value: unknown): Auth {
   }
   const a = value as RawFolderAuth
   if (a.type === "none") return { type: "none" }
+  if (a.type === "inherit") return { type: "inherit" }
   if (a.type === "bearer") {
     if (typeof a.token !== "string")
       throw new Error('lang.parseFolder: auth.bearer requires "token"')
@@ -152,22 +149,12 @@ export function serializeFolder(folder: Folder): string {
         }
       }
     }
-    if (o.params && Object.keys(o.params).length > 0) {
-      out += "params:\n"
-      for (const [k, v] of Object.entries(o.params)) {
-        const key = yamlVal(k)
-        const val = yamlVal(v.value)
-        if (v.enabled) {
-          out += `  ${key}: ${val}\n`
-        } else {
-          out += `  ${key}: { value: ${val}, enabled: false }\n`
-        }
-      }
-    }
     if (o.auth) {
       out += "auth:\n"
       if (o.auth.type === "none") {
         out += "  type: none\n"
+      } else if (o.auth.type === "inherit") {
+        out += "  type: inherit\n"
       } else if (o.auth.type === "bearer") {
         out += "  type: bearer\n"
         out += `  token: ${yamlVal(o.auth.token)}\n`

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -252,6 +252,7 @@ function parseAuth(value: unknown): Auth {
   }
   const a = value as RawAuth
   if (a.type === "none") return { type: "none" }
+  if (a.type === "inherit") return { type: "inherit" }
   if (a.type === "bearer") {
     if (typeof a.token !== "string") {
       throw new Error('lang.parseRequest: auth.bearer requires "token"')
@@ -276,6 +277,6 @@ function parseAuth(value: unknown): Auth {
     return { type: "api_key", key: a.key, value: a.value, placement }
   }
   throw new Error(
-    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|bearer|basic|api_key`,
+    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|inherit|bearer|basic|api_key`,
   )
 }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -77,6 +77,7 @@ export function serializeRequest(req: Request): string {
 
 function authToObj(auth: Auth): Record<string, unknown> {
   if (auth.type === "none") return { type: "none" }
+  if (auth.type === "inherit") return { type: "inherit" }
   if (auth.type === "bearer") return { type: "bearer", token: auth.token }
   if (auth.type === "basic")
     return { type: "basic", user: auth.user, pass: auth.pass }

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,9 +1,15 @@
-import type { Environment, Request, Response } from "../schema"
+import type { Collection, Environment, Request, Response } from "../schema"
 import { send } from "./send"
 import { substitute } from "./substitute"
 
 export interface RequestExecutor {
-  send(req: Request, env?: Environment, signal?: AbortSignal): Promise<Response>
+  send(
+    req: Request,
+    env?: Environment,
+    signal?: AbortSignal,
+    collection?: Collection,
+    requestPath?: string,
+  ): Promise<Response>
 }
 
 export const executor: RequestExecutor = {

--- a/src/requests/mergeFolderOverrides.ts
+++ b/src/requests/mergeFolderOverrides.ts
@@ -1,0 +1,70 @@
+import type { Auth, Collection, Folder, KvEntry, Request } from "../schema"
+import { findFolderByPath } from "../ui/tree"
+
+function mergeKv(
+  base: Record<string, KvEntry>,
+  overrides: Record<string, KvEntry>,
+  requestKeys: Record<string, KvEntry>,
+): Record<string, KvEntry> {
+  const result: Record<string, KvEntry> = { ...base }
+  for (const [key, entry] of Object.entries(overrides)) {
+    if (!(key in requestKeys)) {
+      result[key] = entry
+    }
+  }
+  return result
+}
+
+export function mergeFolderOverrides(
+  request: Request,
+  collection: Collection,
+  requestPath: string,
+): Request {
+  const parts = requestPath.split("/")
+
+  if (parts.length <= 1) return request
+
+  const segments: string[] = []
+  for (let i = 0; i < parts.length - 1; i++) {
+    segments.push(parts.slice(0, i + 1).join("/"))
+  }
+
+  const folders: Folder[] = []
+  for (const seg of segments) {
+    const folder = findFolderByPath(collection.items, seg)
+    if (folder) folders.push(folder)
+  }
+
+  if (folders.length === 0) return request
+
+  let mergedHeaders: Record<string, KvEntry> = {}
+  let mergedParams: Record<string, KvEntry> = {}
+
+  for (const folder of folders) {
+    if (folder.overrides?.headers) {
+      mergedHeaders = mergeKv(mergedHeaders, folder.overrides.headers, request.headers)
+    }
+    if (folder.overrides?.params) {
+      mergedParams = mergeKv(mergedParams, folder.overrides.params, request.params)
+    }
+  }
+
+  let mergedAuth: Auth = { type: "none" }
+  for (const folder of folders) {
+    if (folder.overrides?.auth && folder.overrides.auth.type !== "none") {
+      mergedAuth = folder.overrides.auth
+    }
+  }
+
+  const requestAuth = request.auth ?? { type: "none" }
+  if (requestAuth.type !== "none") {
+    mergedAuth = requestAuth
+  }
+
+  return {
+    ...request,
+    headers: { ...mergedHeaders, ...request.headers },
+    params: { ...mergedParams, ...request.params },
+    auth: mergedAuth,
+  }
+}

--- a/src/requests/mergeFolderOverrides.ts
+++ b/src/requests/mergeFolderOverrides.ts
@@ -38,33 +38,35 @@ export function mergeFolderOverrides(
   if (folders.length === 0) return request
 
   let mergedHeaders: Record<string, KvEntry> = {}
-  let mergedParams: Record<string, KvEntry> = {}
-
   for (const folder of folders) {
     if (folder.overrides?.headers) {
       mergedHeaders = mergeKv(mergedHeaders, folder.overrides.headers, request.headers)
     }
-    if (folder.overrides?.params) {
-      mergedParams = mergeKv(mergedParams, folder.overrides.params, request.params)
-    }
   }
 
-  let mergedAuth: Auth = { type: "none" }
-  for (const folder of folders) {
-    if (folder.overrides?.auth && folder.overrides.auth.type !== "none") {
-      mergedAuth = folder.overrides.auth
-    }
-  }
+  const requestAuth: Auth = request.auth ?? { type: "none" }
 
-  const requestAuth = request.auth ?? { type: "none" }
-  if (requestAuth.type !== "none") {
-    mergedAuth = requestAuth
+  if (requestAuth.type === "inherit") {
+    const reversed = [...folders].reverse()
+    for (const folder of reversed) {
+      if (folder.overrides?.auth && folder.overrides.auth.type !== "none" && folder.overrides.auth.type !== "inherit") {
+        return {
+          ...request,
+          headers: { ...mergedHeaders, ...request.headers },
+          auth: folder.overrides.auth,
+        }
+      }
+    }
+    return {
+      ...request,
+      headers: { ...mergedHeaders, ...request.headers },
+      auth: { type: "none" },
+    }
   }
 
   return {
     ...request,
     headers: { ...mergedHeaders, ...request.headers },
-    params: { ...mergedParams, ...request.params },
-    auth: mergedAuth,
+    auth: requestAuth,
   }
 }

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -16,12 +16,12 @@ export async function send(
   const substituted = env !== undefined ? substitute(merged, env) : merged
 
   const headers: Record<string, string> =
-    substituted === req
-      ? filterKv(req.headers)
+    substituted === merged
+      ? filterKv(merged.headers)
       : (substituted as SubstitutedRequest).headers
   const params: Record<string, string> =
-    substituted === req
-      ? filterKv(req.params)
+    substituted === merged
+      ? filterKv(merged.params)
       : (substituted as SubstitutedRequest).params
 
   let finalUrl: string

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -1,13 +1,19 @@
-import type { Auth, Environment, KvEntry, Request, Response } from "../schema"
+import type { Auth, Collection, Environment, KvEntry, Request, Response } from "../schema"
 import { substitute } from "./substitute"
 import type { SubstitutedRequest } from "./substitute"
+import { mergeFolderOverrides } from "./mergeFolderOverrides"
 
 export async function send(
   req: Request,
   env?: Environment,
   signal?: AbortSignal,
+  collection?: Collection,
+  requestPath?: string,
 ): Promise<Response> {
-  const substituted = env !== undefined ? substitute(req, env) : req
+  const merged =
+    collection && requestPath ? mergeFolderOverrides(req, collection, requestPath) : req
+
+  const substituted = env !== undefined ? substitute(merged, env) : merged
 
   const headers: Record<string, string> =
     substituted === req

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -71,6 +71,7 @@ function substituteAuth(
   resolve: (s: string, field: string) => string,
 ): Auth {
   if (auth.type === "none") return { type: "none" }
+  if (auth.type === "inherit") return { type: "inherit" }
   if (auth.type === "bearer") {
     return { type: "bearer", token: resolve(auth.token, "auth.token") }
   }

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -28,7 +28,6 @@ export interface FolderMeta {
 
 export interface FolderOverrides {
   headers?: Record<string, KvEntry>
-  params?: Record<string, KvEntry>
   auth?: Auth
 }
 
@@ -47,6 +46,7 @@ export type CollectionItem =
 
 export type Auth =
   | { type: "none" }
+  | { type: "inherit" }
   | { type: "bearer"; token: string }
   | { type: "basic"; user: string; pass: string }
   | {

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -824,6 +824,7 @@ export function AppInner({
                   onTabChange={() => {}}
                   onAuthTypeChange={folderDraft.setAuthType}
                   onApiKeyPlacementChange={folderDraft.setApiKeyPlacement}
+                  onSelectOpenChange={setSelectOpen}
                   activeEnv={envState.activeEnv}
                   theme={theme}
                 />

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -619,7 +619,13 @@ export function AppInner({
     state: responseState,
     trySend,
     cancelSend,
-  } = useResponse(draft.draft, envState.activeEnv, onCompleteRef.current)
+  } = useResponse(
+    draft.draft,
+    envState.activeEnv,
+    onCompleteRef.current,
+    collection ?? undefined,
+    draft.draft?.id,
+  )
 
   const envEditor = useEnvironmentEditor({
     environmentsDir,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -9,11 +9,12 @@ import { useCollection } from "../hooks/useCollection"
 import { useTreeNavigation } from "../hooks/useTreeNavigation"
 import { useResponse } from "../hooks/useResponse"
 import type { SendCompleteResult } from "../hooks/useResponse"
-import type { Request as NoodleRequest, Method } from "../schema"
+import type { Folder, Request as NoodleRequest, Method } from "../schema"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
 import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
+import type { InputRenderable } from "@opentui/core"
 import { type Focus } from "./focus"
 import { HelpOverlay } from "./HelpOverlay"
 import { ConfirmOverlay } from "./ConfirmOverlay"
@@ -27,7 +28,7 @@ import {
   CloneRequestOverlay,
   type CloneRequestOverlayHandle,
 } from "./CloneRequestOverlay"
-import { saveRequest, deleteRequest } from "../filestore/save"
+import { saveRequest, deleteRequest, saveFolder } from "../filestore/save"
 import { ThemePickerOverlay, useTheme } from "./theme"
 import { StatusBar } from "./StatusBar"
 import { EnvSidebar } from "./EnvSidebar"
@@ -41,9 +42,13 @@ import { useOverlayIntercepts } from "./useOverlayIntercepts"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
-import { getRequestIds } from "./tree"
+import { getRequestIds, findFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
-import { saveLastRequest, loadExpandedFolders, saveExpandedFolders } from "./tabs/uiState"
+import {
+  saveLastRequest,
+  loadExpandedFolders,
+  saveExpandedFolders,
+} from "./tabs/uiState"
 import { FullBorder } from "./borders"
 import type { FieldKind } from "./editMode"
 import type { ResponseTabKind } from "./tabs/uiState"
@@ -163,6 +168,24 @@ export function AppInner({
   const newRequestFolderRef = useRef(focusedFolderPath)
   newRequestFolderRef.current = focusedFolderPath
 
+  // ── Folder name editing ────────────────────────────────────────────
+  const [folderNameDraft, setFolderNameDraft] = useState(
+    focusedFolderName ?? "",
+  )
+  const folderNameInputRef = useRef<InputRenderable | null>(null)
+  const prevFolderFocus = useRef(false)
+
+  useEffect(() => {
+    setFolderNameDraft(focusedFolderName ?? "")
+  }, [focusedFolderName])
+
+  useEffect(() => {
+    if (focus === "folder" && !prevFolderFocus.current) {
+      folderNameInputRef.current?.focus()
+    }
+    prevFolderFocus.current = focus === "folder"
+  }, [focus])
+
   useEffect(() => {
     setExpanded(null)
   }, [selectedRequest?.id])
@@ -175,9 +198,7 @@ export function AppInner({
       saveLastReqRef.current = true
       return
     }
-    const lastId = focusedFolderPath
-      ? `${focusedFolderPath}/`
-      : selectedId
+    const lastId = focusedFolderPath ? `${focusedFolderPath}/` : selectedId
     if (!lastId) return
     if (saveLastDebounceRef.current) clearTimeout(saveLastDebounceRef.current)
     saveLastDebounceRef.current = setTimeout(() => {
@@ -209,8 +230,7 @@ export function AppInner({
       )
     }, 300)
     return () => {
-      if (expandedDebounceRef.current)
-        clearTimeout(expandedDebounceRef.current)
+      if (expandedDebounceRef.current) clearTimeout(expandedDebounceRef.current)
     }
   }, [expandedFolders, collectionDir])
 
@@ -256,6 +276,57 @@ export function AppInner({
 
   const doSaveRef = useRef(doSave)
   doSaveRef.current = doSave
+
+  // ── Folder name save ───────────────────────────────────────────────
+  const focusedFolderPathRef = useRef(focusedFolderPath)
+  focusedFolderPathRef.current = focusedFolderPath
+  const collectionRef2 = useRef(collection)
+  collectionRef2.current = collection
+  const folderNameDraftRef = useRef(folderNameDraft)
+  folderNameDraftRef.current = folderNameDraft
+  const [folderReloadToken, setFolderReloadToken] = useState(0)
+
+  const folderSaveRef = useRef<() => void>(() => {})
+
+  const handleFolderSave = useCallback(async () => {
+    const path = focusedFolderPathRef.current
+    const col = collectionRef2.current
+    const name = folderNameDraftRef.current.trim()
+    if (!path || !col || !name) return
+    const folder = findFolderByPath(col.items, path)
+    if (!folder) return
+    const updated: Folder = {
+      ...folder,
+      name,
+    }
+    try {
+      await saveFolder(collectionDir, updated)
+      folder.name = name
+      setFolderReloadToken((n) => n + 1)
+      setSaveState({
+        kind: "success",
+        message: `Renamed folder to ${name}`,
+      })
+      clearSaveTimer()
+      saveTimerRef.current = setTimeout(() => {
+        setSaveState({ kind: "idle" })
+      }, 2000)
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e)
+      setSaveState({ kind: "error", message: msg })
+      clearSaveTimer()
+      saveTimerRef.current = setTimeout(() => {
+        setSaveState({ kind: "idle" })
+      }, 2000)
+    }
+  }, [
+    collectionDir,
+    setSaveState,
+    clearSaveTimer,
+    saveTimerRef,
+  ])
+
+  folderSaveRef.current = handleFolderSave
 
   const handleNewRequestConfirm = useCallback(
     (name: string, method: Method, url: string) => {
@@ -318,7 +389,8 @@ export function AppInner({
       const baseId = slugify(newName)
       if (!baseId) return
       const lastSlash = req.id.lastIndexOf("/")
-      const id = lastSlash >= 0 ? `${req.id.slice(0, lastSlash)}/${baseId}` : baseId
+      const id =
+        lastSlash >= 0 ? `${req.id.slice(0, lastSlash)}/${baseId}` : baseId
 
       const cloned: NoodleRequest = {
         ...req,
@@ -617,6 +689,7 @@ export function AppInner({
       savingRef,
       expandedRef,
       folderViewRef,
+      folderSaveRef,
     },
     {
       setFocus,
@@ -749,12 +822,29 @@ export function AppInner({
                   }}
                   border={[...FullBorder.border]}
                   customBorderChars={FullBorder.customBorderChars}
-                  borderColor={focus === "folder" ? theme.primary : theme.borderSubtle}
+                  borderColor={
+                    focus === "folder" ? theme.primary : theme.borderSubtle
+                  }
                   title="Folder"
-                  titleColor={focus === "folder" ? theme.primary : theme.textMuted}
+                  titleColor={
+                    focus === "folder" ? theme.primary : theme.textMuted
+                  }
                   titleAlignment="left"
                 >
-                  <text fg={theme.textMuted}>{focusedFolderName}</text>
+                  <input
+                    ref={folderNameInputRef}
+                    value={folderNameDraft}
+                    placeholder="Folder name"
+                    onInput={setFolderNameDraft}
+                    focused={focus === "folder"}
+                    backgroundColor={theme.backgroundElement}
+                    focusedBackgroundColor={theme.borderSubtle}
+                    textColor={
+                      focus === "folder" ? theme.text : theme.textMuted
+                    }
+                    cursorColor={theme.primary}
+                    style={{ width: 40 }}
+                  />
                 </box>
               ) : (
                 <>

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -180,6 +180,14 @@ export function AppInner({
   const folderEb = useFolderEditBrowse(focusedFolder, folderDraft)
   const folderEbRef = useRef(folderEb)
   folderEbRef.current = folderEb
+
+  const dirtyFolderPaths = useMemo(() => {
+    const s = new Set<string>()
+    if (folderDraft.isDirty && folderDraft.folderDraft) {
+      s.add(folderDraft.folderDraft.path)
+    }
+    return s
+  }, [folderDraft.isDirty, folderDraft.folderDraft])
   const folderDraftRef = useRef(folderDraft)
   folderDraftRef.current = folderDraft
 
@@ -799,6 +807,7 @@ export function AppInner({
               focused={focus === "sidebar"}
               keybinds={keybinds}
               dirtyRequestIds={draft.dirtyRequestIds}
+              dirtyFolderPaths={dirtyFolderPaths}
             />
             <box
               style={{

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -10,14 +10,13 @@ import { useCollection } from "../hooks/useCollection"
 import { useTreeNavigation } from "../hooks/useTreeNavigation"
 import { useResponse } from "../hooks/useResponse"
 import type { SendCompleteResult } from "../hooks/useResponse"
-import type { Folder, Request as NoodleRequest, Method } from "../schema"
+import type { Request as NoodleRequest, Method } from "../schema"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
 import { useFolderDraft } from "../hooks/useFolderDraft"
 import { useFolderEditBrowse } from "../hooks/useFolderEditBrowse"
 import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
-import type { InputRenderable } from "@opentui/core"
 import { type Focus } from "./focus"
 import { HelpOverlay } from "./HelpOverlay"
 import { ConfirmOverlay } from "./ConfirmOverlay"
@@ -52,7 +51,6 @@ import {
   loadExpandedFolders,
   saveExpandedFolders,
 } from "./tabs/uiState"
-import { FullBorder } from "./borders"
 import type { FieldKind } from "./editMode"
 import type { ResponseTabKind } from "./tabs/uiState"
 
@@ -167,6 +165,7 @@ export function AppInner({
     initialLastRequestId,
     initialExpandedFolders ?? undefined,
   )
+  void focusedFolderName
 
   const focusedFolder = useMemo(
     () => (focusedFolderPath ? findFolderByPath(items, focusedFolderPath) : null),

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -44,7 +44,7 @@ import { useOverlayIntercepts } from "./useOverlayIntercepts"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
-import { getRequestIds, findFolderByPath } from "./tree"
+import { getRequestIds, findFolderByPath, updateFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import {
   saveLastRequest,
@@ -136,7 +136,7 @@ export function AppInner({
   const headerFieldRef = useRef<"name" | "color">("name")
 
   // ── Collection ──────────────────────────────────────────────────────
-  const { collection, loading, error } = useCollection(
+  const { collection, loading, error, updateCollection } = useCollection(
     collectionDir,
     collectionReloadToken,
   )
@@ -279,11 +279,14 @@ export function AppInner({
 
   const handleFolderSave = useCallback(async () => {
     const draftFolder = folderDraftRef.current?.folderDraft
-    if (!draftFolder) return
+    if (!draftFolder || !collection) return
     try {
       await saveFolder(collectionDir, draftFolder)
       folderDraftRef.current?.markSaved()
-      setCollectionReloadToken((t) => t + 1)
+      updateCollection({
+        ...collection,
+        items: updateFolderByPath(collection.items, draftFolder.path, draftFolder),
+      })
       setSaveState({ kind: "success", message: `Saved folder ${draftFolder.name}` })
       clearSaveTimer()
       saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
@@ -293,7 +296,7 @@ export function AppInner({
       clearSaveTimer()
       saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
     }
-  }, [collectionDir, setSaveState, setCollectionReloadToken, clearSaveTimer, saveTimerRef])
+  }, [collection, collectionDir, setSaveState, updateCollection, clearSaveTimer, saveTimerRef])
 
   folderSaveRef.current = handleFolderSave
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -157,7 +157,6 @@ export function AppInner({
     visibleItems,
     cursorIndex,
     focusedFolderPath,
-    focusedFolderName,
     expandFolder,
   } = useTreeNavigation(
     items,
@@ -165,7 +164,6 @@ export function AppInner({
     initialLastRequestId,
     initialExpandedFolders ?? undefined,
   )
-  void focusedFolderName
 
   const focusedFolder = useMemo(
     () => (focusedFolderPath ? findFolderByPath(items, focusedFolderPath) : null),
@@ -284,13 +282,8 @@ export function AppInner({
     if (!draftFolder) return
     try {
       await saveFolder(collectionDir, draftFolder)
-      const existing = findFolderByPath(collectionRef.current?.items ?? [], draftFolder.path)
-      if (existing) {
-        existing.name = draftFolder.name
-        existing.seq = draftFolder.seq
-        existing.overrides = draftFolder.overrides
-      }
       folderDraftRef.current?.markSaved()
+      setCollectionReloadToken((t) => t + 1)
       setSaveState({ kind: "success", message: `Saved folder ${draftFolder.name}` })
       clearSaveTimer()
       saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
@@ -300,7 +293,7 @@ export function AppInner({
       clearSaveTimer()
       saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
     }
-  }, [collectionDir, setSaveState, clearSaveTimer, saveTimerRef])
+  }, [collectionDir, setSaveState, setCollectionReloadToken, clearSaveTimer, saveTimerRef])
 
   folderSaveRef.current = handleFolderSave
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -142,7 +142,7 @@ export function AppInner({
   )
   const items = collection?.items ?? []
 
-  const requestIds = getRequestIds(items)
+  const requestIds = useMemo(() => getRequestIds(items), [items])
   const { getTab, setTab } = useUIState(collectionDir, requestIds)
 
   useEffect(() => {
@@ -561,7 +561,7 @@ export function AppInner({
   }, [focus, eb, folderEb])
 
   useEffect(() => {
-    if (focus === "folder" && folderEb.editState.mode === "inactive" && folderEb.isActive === false) {
+    if (focus === "folder" && folderEb.editState.mode === "inactive") {
       folderEb.enterBrowse()
     }
   }, [focus, folderEb])

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -177,7 +177,7 @@ export function AppInner({
 
   // ── Folder draft + edit-browse ────────────────────────────────────
   const folderDraft = useFolderDraft(focusedFolder)
-  const folderEb = useFolderEditBrowse(focusedFolder, folderDraft)
+  const folderEb = useFolderEditBrowse(folderDraft.folderDraft, folderDraft)
   const folderEbRef = useRef(folderEb)
   folderEbRef.current = folderEb
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -181,13 +181,7 @@ export function AppInner({
   const folderEbRef = useRef(folderEb)
   folderEbRef.current = folderEb
 
-  const dirtyFolderPaths = useMemo(() => {
-    const s = new Set<string>()
-    if (folderDraft.isDirty && folderDraft.folderDraft) {
-      s.add(folderDraft.folderDraft.path)
-    }
-    return s
-  }, [folderDraft.isDirty, folderDraft.folderDraft])
+  const dirtyFolderPaths = folderDraft.dirtyPaths
   const folderDraftRef = useRef(folderDraft)
   folderDraftRef.current = folderDraft
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "./Sidebar"
 import { UrlBar } from "./UrlBar"
 import { RequestPane } from "./RequestPane"
 import { ResponsePane } from "./ResponsePane"
+import { FolderPane } from "./FolderPane"
 import { useCollection } from "../hooks/useCollection"
 import { useTreeNavigation } from "../hooks/useTreeNavigation"
 import { useResponse } from "../hooks/useResponse"
@@ -12,6 +13,8 @@ import type { SendCompleteResult } from "../hooks/useResponse"
 import type { Folder, Request as NoodleRequest, Method } from "../schema"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
+import { useFolderDraft } from "../hooks/useFolderDraft"
+import { useFolderEditBrowse } from "../hooks/useFolderEditBrowse"
 import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
 import type { InputRenderable } from "@opentui/core"
@@ -165,26 +168,21 @@ export function AppInner({
     initialExpandedFolders ?? undefined,
   )
 
+  const focusedFolder = useMemo(
+    () => (focusedFolderPath ? findFolderByPath(items, focusedFolderPath) : null),
+    [focusedFolderPath, items],
+  )
+
   const newRequestFolderRef = useRef(focusedFolderPath)
   newRequestFolderRef.current = focusedFolderPath
 
-  // ── Folder name editing ────────────────────────────────────────────
-  const [folderNameDraft, setFolderNameDraft] = useState(
-    focusedFolderName ?? "",
-  )
-  const folderNameInputRef = useRef<InputRenderable | null>(null)
-  const prevFolderFocus = useRef(false)
-
-  useEffect(() => {
-    setFolderNameDraft(focusedFolderName ?? "")
-  }, [focusedFolderName])
-
-  useEffect(() => {
-    if (focus === "folder" && !prevFolderFocus.current) {
-      folderNameInputRef.current?.focus()
-    }
-    prevFolderFocus.current = focus === "folder"
-  }, [focus])
+  // ── Folder draft + edit-browse ────────────────────────────────────
+  const folderDraft = useFolderDraft(focusedFolder)
+  const folderEb = useFolderEditBrowse(focusedFolder, folderDraft)
+  const folderEbRef = useRef(folderEb)
+  folderEbRef.current = folderEb
+  const folderDraftRef = useRef(folderDraft)
+  folderDraftRef.current = folderDraft
 
   useEffect(() => {
     setExpanded(null)
@@ -277,54 +275,31 @@ export function AppInner({
   const doSaveRef = useRef(doSave)
   doSaveRef.current = doSave
 
-  // ── Folder name save ───────────────────────────────────────────────
-  const focusedFolderPathRef = useRef(focusedFolderPath)
-  focusedFolderPathRef.current = focusedFolderPath
-  const collectionRef2 = useRef(collection)
-  collectionRef2.current = collection
-  const folderNameDraftRef = useRef(folderNameDraft)
-  folderNameDraftRef.current = folderNameDraft
-  const [folderReloadToken, setFolderReloadToken] = useState(0)
-
+  // ── Folder save ────────────────────────────────────────────────────
   const folderSaveRef = useRef<() => void>(() => {})
 
   const handleFolderSave = useCallback(async () => {
-    const path = focusedFolderPathRef.current
-    const col = collectionRef2.current
-    const name = folderNameDraftRef.current.trim()
-    if (!path || !col || !name) return
-    const folder = findFolderByPath(col.items, path)
-    if (!folder) return
-    const updated: Folder = {
-      ...folder,
-      name,
-    }
+    const draftFolder = folderDraftRef.current?.folderDraft
+    if (!draftFolder) return
     try {
-      await saveFolder(collectionDir, updated)
-      folder.name = name
-      setFolderReloadToken((n) => n + 1)
-      setSaveState({
-        kind: "success",
-        message: `Renamed folder to ${name}`,
-      })
+      await saveFolder(collectionDir, draftFolder)
+      const existing = findFolderByPath(collectionRef.current?.items ?? [], draftFolder.path)
+      if (existing) {
+        existing.name = draftFolder.name
+        existing.seq = draftFolder.seq
+        existing.overrides = draftFolder.overrides
+      }
+      folderDraftRef.current?.markSaved()
+      setSaveState({ kind: "success", message: `Saved folder ${draftFolder.name}` })
       clearSaveTimer()
-      saveTimerRef.current = setTimeout(() => {
-        setSaveState({ kind: "idle" })
-      }, 2000)
+      saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       setSaveState({ kind: "error", message: msg })
       clearSaveTimer()
-      saveTimerRef.current = setTimeout(() => {
-        setSaveState({ kind: "idle" })
-      }, 2000)
+      saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
     }
-  }, [
-    collectionDir,
-    setSaveState,
-    clearSaveTimer,
-    saveTimerRef,
-  ])
+  }, [collectionDir, setSaveState, clearSaveTimer, saveTimerRef])
 
   folderSaveRef.current = handleFolderSave
 
@@ -560,25 +535,39 @@ export function AppInner({
   }, [view, keymap])
 
   useEffect(() => {
-    const mode =
+    const requestMode =
       eb.editState.mode === "browsing"
         ? "browse"
         : eb.editState.mode === "editing"
           ? "edit"
           : "base"
-    keymap.setData("app.mode", mode)
-  }, [eb.editState.mode, keymap])
+    const folderMode =
+      folderEb.editState.mode === "browsing"
+        ? "browse"
+        : folderEb.editState.mode === "editing"
+          ? "edit"
+          : "base"
+    keymap.setData("app.mode", focus === "folder" ? folderMode : requestMode)
+  }, [eb.editState.mode, folderEb.editState.mode, focus, keymap])
 
   useEffect(() => {
     if (focus !== "request") {
       const state = eb.editState
-      if (state.mode === "editing") {
-        eb.cancelEdit()
-      } else if (state.mode === "browsing") {
-        eb.exitBrowse()
-      }
+      if (state.mode === "editing") eb.cancelEdit()
+      else if (state.mode === "browsing") eb.exitBrowse()
     }
-  }, [focus, eb])
+    if (focus !== "folder") {
+      const state = folderEb.editState
+      if (state.mode === "editing") folderEb.cancelEdit()
+      else if (state.mode === "browsing") folderEb.exitBrowse()
+    }
+  }, [focus, eb, folderEb])
+
+  useEffect(() => {
+    if (focus === "folder" && folderEb.editState.mode === "inactive" && folderEb.isActive === false) {
+      folderEb.enterBrowse()
+    }
+  }, [focus, folderEb])
 
   // ── Environments + response ────────────────────────────────────────
   const envState = useEnvironments(
@@ -675,7 +664,7 @@ export function AppInner({
   selectedIdRef.current = selectedId
 
   const folderViewRef = useRef(false)
-  folderViewRef.current = focusedFolderName !== null
+  folderViewRef.current = focusedFolder !== null
 
   // ── Keymap layers ──────────────────────────────────────────────────
   useAppKeymap(
@@ -696,6 +685,8 @@ export function AppInner({
       expandedRef,
       folderViewRef,
       folderSaveRef,
+      folderEbRef,
+      folderDraftRef,
     },
     {
       setFocus,
@@ -818,40 +809,22 @@ export function AppInner({
                 minHeight: 0,
               }}
             >
-              {focusedFolderName !== null ? (
-                <box
-                  style={{
-                    flexGrow: 1,
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: theme.backgroundPanel,
-                  }}
-                  border={[...FullBorder.border]}
-                  customBorderChars={FullBorder.customBorderChars}
-                  borderColor={
-                    focus === "folder" ? theme.primary : theme.borderSubtle
-                  }
-                  title="Folder"
-                  titleColor={
-                    focus === "folder" ? theme.primary : theme.textMuted
-                  }
-                  titleAlignment="left"
-                >
-                  <input
-                    ref={folderNameInputRef}
-                    value={folderNameDraft}
-                    placeholder="Folder name"
-                    onInput={setFolderNameDraft}
-                    focused={focus === "folder"}
-                    backgroundColor={theme.backgroundElement}
-                    focusedBackgroundColor={theme.borderSubtle}
-                    textColor={
-                      focus === "folder" ? theme.text : theme.textMuted
-                    }
-                    cursorColor={theme.primary}
-                    style={{ width: 40 }}
-                  />
-                </box>
+              {focusedFolder !== null && focus === "folder" ? (
+                <FolderPane
+                  folder={folderDraft.folderDraft}
+                  focused={focus === "folder"}
+                  editState={folderEb.editState}
+                  editKey={folderEb.editKey}
+                  editValue={folderEb.editValue}
+                  setEditKey={folderEb.setEditKey}
+                  setEditValue={folderEb.setEditValue}
+                  activeTab={folderEb.activeTab}
+                  onTabChange={() => {}}
+                  onAuthTypeChange={folderDraft.setAuthType}
+                  onApiKeyPlacementChange={folderDraft.setApiKeyPlacement}
+                  activeEnv={envState.activeEnv}
+                  theme={theme}
+                />
               ) : (
                 <>
                   <UrlBar

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -808,7 +808,7 @@ export function AppInner({
                 minHeight: 0,
               }}
             >
-              {focusedFolder !== null && focus === "folder" ? (
+              {focusedFolder !== null ? (
                 <FolderPane
                   folder={folderDraft.folderDraft}
                   focused={focus === "folder"}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -9,6 +9,7 @@ import { VarText } from "./VarText"
 
 const AUTH_TYPE_ITEMS: SelectItem[] = [
   { id: "none", label: "None" },
+  { id: "inherit", label: "Inherit" },
   { id: "bearer", label: "Bearer Token" },
   { id: "basic", label: "Basic Auth" },
   { id: "api_key", label: "API Key" },
@@ -40,6 +41,9 @@ function maskIfSecret(value: string, isSecret: boolean): string {
 function getAuthRows(auth: Auth | undefined): AuthRows {
   if (!auth || auth.type === "none") {
     return { type: "none", fieldDefs: [] }
+  }
+  if (auth.type === "inherit") {
+    return { type: "inherit", fieldDefs: [] }
   }
   if (auth.type === "bearer") {
     return {
@@ -74,6 +78,7 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
 
 function getFieldValue(auth: Auth, field: string): string {
   if (auth.type === "none") return ""
+  if (auth.type === "inherit") return ""
   if (auth.type === "bearer") return auth.token
   if (auth.type === "basic") {
     if (field === "user") return auth.user
@@ -97,10 +102,11 @@ export interface AuthEditorProps {
   setEditValue: (v: string) => void
   theme: Theme
   activeEnv?: Environment | null
-  onAuthTypeChange: (t: "none" | "bearer" | "basic" | "api_key") => void
+  onAuthTypeChange: (t: Auth["type"]) => void
   onApiKeyPlacementChange: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
   idPrefix?: string
+  showInherit?: boolean
 }
 
 export function AuthEditor({
@@ -115,6 +121,7 @@ export function AuthEditor({
   onApiKeyPlacementChange,
   onSelectOpenChange,
   idPrefix = "auth",
+  showInherit = false,
 }: AuthEditorProps) {
   const textareaRef = useRef<TextareaRenderable | null>(null)
   const [typeSelectOpen, setTypeSelectOpen] = useState(false)
@@ -126,6 +133,9 @@ export function AuthEditor({
   }, [setEditValue])
 
   const { type, fieldDefs } = getAuthRows(auth)
+  const authItems = showInherit
+    ? AUTH_TYPE_ITEMS
+    : AUTH_TYPE_ITEMS.filter((item) => item.id !== "inherit")
 
   const isTypeSelectorActive =
     browseActive &&
@@ -160,11 +170,11 @@ export function AuthEditor({
         }}
       >
         <Select
-          items={AUTH_TYPE_ITEMS}
+          items={authItems}
           value={type}
           onChange={(id) => {
             if (id === type) return
-            onAuthTypeChange(id as "none" | "bearer" | "basic" | "api_key")
+            onAuthTypeChange(id as Auth["type"])
           }}
           focused={isTypeSelectorActive}
           badge={false}

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -90,7 +90,7 @@ function getFieldValue(auth: Auth, field: string): string {
 }
 
 export interface AuthEditorProps {
-  request: { auth?: Auth }
+  auth: Auth
   editState: EditState
   inEdit: boolean
   browseActive: boolean
@@ -100,10 +100,11 @@ export interface AuthEditorProps {
   onAuthTypeChange: (t: "none" | "bearer" | "basic" | "api_key") => void
   onApiKeyPlacementChange: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
+  idPrefix?: string
 }
 
 export function AuthEditor({
-  request,
+  auth,
   editState,
   inEdit,
   browseActive,
@@ -113,6 +114,7 @@ export function AuthEditor({
   onAuthTypeChange,
   onApiKeyPlacementChange,
   onSelectOpenChange,
+  idPrefix = "auth",
 }: AuthEditorProps) {
   const textareaRef = useRef<TextareaRenderable | null>(null)
   const [typeSelectOpen, setTypeSelectOpen] = useState(false)
@@ -123,7 +125,7 @@ export function AuthEditor({
     if (ta) setEditValue(ta.plainText)
   }, [setEditValue])
 
-  const { type, fieldDefs } = getAuthRows(request.auth)
+  const { type, fieldDefs } = getAuthRows(auth)
 
   const isTypeSelectorActive =
     browseActive &&
@@ -149,7 +151,7 @@ export function AuthEditor({
   return (
     <box style={{ flexDirection: "column", gap: 1 }}>
       <box
-        id="auth-field"
+        id={`${idPrefix}-field`}
         style={{
           zIndex: typeSelectOpen ? 1 : undefined,
           backgroundColor: isTypeSelectorActive
@@ -179,9 +181,7 @@ export function AuthEditor({
           inEdit &&
           editState.cursor.field === "auth" &&
           editState.cursor.row === def.row
-        const fieldValue = request.auth
-          ? getFieldValue(request.auth, def.field)
-          : ""
+        const fieldValue = getFieldValue(auth, def.field)
         const displayValue = def.isSecret
           ? maskIfSecret(fieldValue, true)
           : fieldValue
@@ -195,7 +195,7 @@ export function AuthEditor({
             }}
           >
             <box
-              id={`auth-${def.field}`}
+              id={`${idPrefix}-${def.field}`}
               border={[...LeftBar.border]}
               customBorderChars={LeftBar.customBorderChars}
               borderColor={

--- a/src/ui/FolderMetaTab.tsx
+++ b/src/ui/FolderMetaTab.tsx
@@ -8,7 +8,6 @@ import { VarText } from "./VarText"
 
 export interface FolderMetaTabProps {
   name: string
-  seq: number | undefined
   editState: EditState
   editValue: string
   setEditValue: (v: string) => void
@@ -19,7 +18,6 @@ export interface FolderMetaTabProps {
 
 export function FolderMetaTab({
   name,
-  seq,
   editState,
   editValue: _editValue,
   setEditValue,
@@ -27,27 +25,17 @@ export function FolderMetaTab({
   theme,
   activeEnv,
 }: FolderMetaTabProps) {
-  const taRef0 = useRef<TextareaRenderable | null>(null)
-  const taRef1 = useRef<TextareaRenderable | null>(null)
+  const taRef = useRef<TextareaRenderable | null>(null)
 
   const inEdit = editState.mode === "editing"
   const cursorHere = editState.cursor.field === "meta"
   const editingRow = inEdit && cursorHere ? editState.cursor.row : -1
 
-  const cursorRow = editState.cursor.row
-
-  const nameActive = browseActive && cursorHere && cursorRow === 0
-  const seqActive = browseActive && cursorHere && cursorRow === 1
+  const nameActive = browseActive && cursorHere
   const nameEditing = editingRow === 0
-  const seqEditing = editingRow === 1
 
   const handleNameChange = useCallback(() => {
-    const ta = taRef0.current
-    if (ta) setEditValue(ta.plainText)
-  }, [setEditValue])
-
-  const handleSeqChange = useCallback(() => {
-    const ta = taRef1.current
+    const ta = taRef.current
     if (ta) setEditValue(ta.plainText)
   }, [setEditValue])
 
@@ -70,7 +58,7 @@ export function FolderMetaTab({
           <>
             <text fg={theme.textMuted}>Name: </text>
             <textarea
-              ref={taRef0}
+              ref={taRef}
               initialValue={name}
               onContentChange={handleNameChange}
               backgroundColor={theme.backgroundPanel}
@@ -83,42 +71,6 @@ export function FolderMetaTab({
         ) : (
           <VarText
             text={`Name: ${name}`}
-            env={activeEnv ?? null}
-            baseColor={theme.text}
-          />
-        )}
-      </box>
-
-      <box
-        border={[...LeftBar.border]}
-        customBorderChars={LeftBar.customBorderChars}
-        borderColor={
-          seqActive || seqEditing ? theme.primary : theme.borderSubtle
-        }
-        style={{
-          flexDirection: seqEditing ? "row" : undefined,
-          gap: seqEditing ? 1 : undefined,
-          backgroundColor: seqActive ? theme.backgroundElement : undefined,
-          paddingLeft: 1,
-        }}
-      >
-        {seqEditing ? (
-          <>
-            <text fg={theme.textMuted}>Seq: </text>
-            <textarea
-              ref={taRef1}
-              initialValue={seq !== undefined ? String(seq) : ""}
-              onContentChange={handleSeqChange}
-              backgroundColor={theme.backgroundPanel}
-              focusedBackgroundColor={theme.backgroundPanel}
-              textColor={theme.text}
-              cursorColor={theme.primary}
-              focused
-            />
-          </>
-        ) : (
-          <VarText
-            text={`Seq: ${seq !== undefined ? String(seq) : ""}`}
             env={activeEnv ?? null}
             baseColor={theme.text}
           />

--- a/src/ui/FolderMetaTab.tsx
+++ b/src/ui/FolderMetaTab.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useRef } from "react"
+import type { TextareaRenderable } from "@opentui/core"
+import type { Environment } from "../schema"
+import type { EditState } from "./editMode"
+import type { Theme } from "./theme"
+import { LeftBar } from "./borders"
+import { VarText } from "./VarText"
+
+export interface FolderMetaTabProps {
+  name: string
+  seq: number | undefined
+  editState: EditState
+  editValue: string
+  setEditValue: (v: string) => void
+  browseActive: boolean
+  theme: Theme
+  activeEnv?: Environment | null
+}
+
+export function FolderMetaTab({
+  name,
+  seq,
+  editState,
+  editValue: _editValue,
+  setEditValue,
+  browseActive,
+  theme,
+  activeEnv,
+}: FolderMetaTabProps) {
+  const taRef0 = useRef<TextareaRenderable | null>(null)
+  const taRef1 = useRef<TextareaRenderable | null>(null)
+
+  const inEdit = editState.mode === "editing"
+  const cursorHere = editState.cursor.field === "meta"
+  const editingRow = inEdit && cursorHere ? editState.cursor.row : -1
+
+  const cursorRow = editState.cursor.row
+
+  const nameActive = browseActive && cursorHere && cursorRow === 0
+  const seqActive = browseActive && cursorHere && cursorRow === 1
+  const nameEditing = editingRow === 0
+  const seqEditing = editingRow === 1
+
+  const handleNameChange = useCallback(() => {
+    const ta = taRef0.current
+    if (ta) setEditValue(ta.plainText)
+  }, [setEditValue])
+
+  const handleSeqChange = useCallback(() => {
+    const ta = taRef1.current
+    if (ta) setEditValue(ta.plainText)
+  }, [setEditValue])
+
+  return (
+    <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
+      <box
+        border={[...LeftBar.border]}
+        customBorderChars={LeftBar.customBorderChars}
+        borderColor={
+          nameActive || nameEditing ? theme.primary : theme.borderSubtle
+        }
+        style={{
+          flexDirection: nameEditing ? "row" : undefined,
+          gap: nameEditing ? 1 : undefined,
+          backgroundColor: nameActive ? theme.backgroundElement : undefined,
+          paddingLeft: 1,
+        }}
+      >
+        {nameEditing ? (
+          <>
+            <text fg={theme.textMuted}>Name: </text>
+            <textarea
+              ref={taRef0}
+              initialValue={name}
+              onContentChange={handleNameChange}
+              backgroundColor={theme.backgroundPanel}
+              focusedBackgroundColor={theme.backgroundPanel}
+              textColor={theme.text}
+              cursorColor={theme.primary}
+              focused
+            />
+          </>
+        ) : (
+          <VarText
+            text={`Name: ${name}`}
+            env={activeEnv ?? null}
+            baseColor={theme.text}
+          />
+        )}
+      </box>
+
+      <box
+        border={[...LeftBar.border]}
+        customBorderChars={LeftBar.customBorderChars}
+        borderColor={
+          seqActive || seqEditing ? theme.primary : theme.borderSubtle
+        }
+        style={{
+          flexDirection: seqEditing ? "row" : undefined,
+          gap: seqEditing ? 1 : undefined,
+          backgroundColor: seqActive ? theme.backgroundElement : undefined,
+          paddingLeft: 1,
+        }}
+      >
+        {seqEditing ? (
+          <>
+            <text fg={theme.textMuted}>Seq: </text>
+            <textarea
+              ref={taRef1}
+              initialValue={seq !== undefined ? String(seq) : ""}
+              onContentChange={handleSeqChange}
+              backgroundColor={theme.backgroundPanel}
+              focusedBackgroundColor={theme.backgroundPanel}
+              textColor={theme.text}
+              cursorColor={theme.primary}
+              focused
+            />
+          </>
+        ) : (
+          <VarText
+            text={`Seq: ${seq !== undefined ? String(seq) : ""}`}
+            env={activeEnv ?? null}
+            baseColor={theme.text}
+          />
+        )}
+      </box>
+    </box>
+  )
+}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -10,7 +10,6 @@ import { FullBorder } from "./borders"
 const FOLDER_TABS: TabDef[] = [
   { id: "meta", label: "Name & Seq" },
   { id: "headers", label: "Headers" },
-  { id: "params", label: "Params" },
   { id: "auth", label: "Auth" },
 ]
 
@@ -92,21 +91,6 @@ export function FolderPane({
                   kind="headers"
                   entries={Object.entries(
                     folder.overrides?.headers ?? {},
-                  ).map(([key, value], i) => ({ key, value, index: i }))}
-                  editState={editState}
-                  editKey={editKey}
-                  editValue={editValue}
-                  setEditKey={setEditKey}
-                  setEditValue={setEditValue}
-                  theme={theme}
-                  activeEnv={activeEnv}
-                />
-              )}
-              {activeTab === "params" && (
-                <KeyValueSection
-                  kind="params"
-                  entries={Object.entries(
-                    folder.overrides?.params ?? {},
                   ).map(([key, value], i) => ({ key, value, index: i }))}
                   editState={editState}
                   editKey={editKey}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -89,36 +89,46 @@ export function FolderPane({
                 />
               )}
               {activeTab === "headers" && (
-                <KeyValueSection
-                  kind="headers"
-                  entries={Object.entries(
-                    folder.overrides?.headers ?? {},
-                  ).map(([key, value]) => ({ key, value }))}
-                  editState={editState}
-                  editKey={editKey}
-                  editValue={editValue}
-                  setEditKey={setEditKey}
-                  setEditValue={setEditValue}
-                  theme={theme}
-                  activeEnv={activeEnv}
-                />
+                <box style={{ flexDirection: "column", gap: 1 }}>
+                  <text fg={theme.textMuted}>
+                    Headers sent with every request inside this folder.
+                  </text>
+                  <KeyValueSection
+                    kind="headers"
+                    entries={Object.entries(
+                      folder.overrides?.headers ?? {},
+                    ).map(([key, value]) => ({ key, value }))}
+                    editState={editState}
+                    editKey={editKey}
+                    editValue={editValue}
+                    setEditKey={setEditKey}
+                    setEditValue={setEditValue}
+                    theme={theme}
+                    activeEnv={activeEnv}
+                  />
+                </box>
               )}
               {activeTab === "auth" && (
-                <AuthEditor
-                  auth={folder.overrides?.auth ?? { type: "none" }}
-                  editState={editState}
-                  inEdit={inEdit}
-                  browseActive={browseActive}
-                  setEditValue={setEditValue}
-                  theme={theme}
-                  activeEnv={activeEnv}
-                  onAuthTypeChange={onAuthTypeChange ?? (() => {})}
-                  onApiKeyPlacementChange={
-                    onApiKeyPlacementChange ?? (() => {})
-                  }
-                  onSelectOpenChange={onSelectOpenChange}
-                  showInherit={true}
-                />
+                <box style={{ flexDirection: "column", gap: 1 }}>
+                  <text fg={theme.textMuted}>
+                    Auth applied to every request inside this folder.
+                  </text>
+                  <AuthEditor
+                    auth={folder.overrides?.auth ?? { type: "none" }}
+                    editState={editState}
+                    inEdit={inEdit}
+                    browseActive={browseActive}
+                    setEditValue={setEditValue}
+                    theme={theme}
+                    activeEnv={activeEnv}
+                    onAuthTypeChange={onAuthTypeChange ?? (() => {})}
+                    onApiKeyPlacementChange={
+                      onApiKeyPlacementChange ?? (() => {})
+                    }
+                    onSelectOpenChange={onSelectOpenChange}
+                    showInherit={true}
+                  />
+                </box>
               )}
             </scrollbox>
           </Tabs>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -1,0 +1,161 @@
+import type { Folder, Environment, Auth } from "../schema"
+import type { EditState, FolderFieldKind, FieldKind } from "./editMode"
+import { Tabs, type TabDef } from "./Tabs"
+import { FolderMetaTab } from "./FolderMetaTab"
+import { KeyValueSection } from "./KeyValueSection"
+import { AuthEditor } from "./AuthEditor"
+import type { Theme } from "./theme"
+import { FullBorder } from "./borders"
+
+const FOLDER_TABS: TabDef[] = [
+  { id: "meta", label: "Name & Seq" },
+  { id: "headers", label: "Headers" },
+  { id: "params", label: "Params" },
+  { id: "auth", label: "Auth" },
+]
+
+interface FolderPaneProps {
+  folder: Folder | null
+  focused: boolean
+  editState: EditState
+  editKey: string
+  editValue: string
+  setEditKey: (v: string) => void
+  setEditValue: (v: string) => void
+  activeTab: FieldKind
+  onTabChange: (tab: FolderFieldKind) => void
+  onAuthTypeChange: (type: Auth["type"]) => void
+  onApiKeyPlacementChange: (placement: "header" | "query") => void
+  activeEnv: Environment | null
+  theme: Theme
+}
+
+export function FolderPane({
+  folder,
+  focused,
+  editState,
+  editKey,
+  editValue,
+  setEditKey,
+  setEditValue,
+  activeTab,
+  onTabChange: _onTabChange,
+  onAuthTypeChange,
+  onApiKeyPlacementChange,
+  activeEnv,
+  theme,
+}: FolderPaneProps) {
+  const browseActive = editState.mode === "browsing"
+  const inEdit = editState.mode === "editing"
+
+  const headerName = folder?.name ?? "(no folder)"
+  const headerSeq = folder?.seq
+
+  return (
+    <box
+      style={{
+        flexGrow: 1,
+        flexDirection: "column",
+        paddingTop: 0,
+        paddingBottom: 1,
+        paddingLeft: 1,
+        paddingRight: 1,
+        gap: 1,
+        flexBasis: 0,
+        minHeight: 0,
+        backgroundColor: theme.backgroundPanel,
+      }}
+      border={[...FullBorder.border]}
+      customBorderChars={FullBorder.customBorderChars}
+      borderColor={focused ? theme.primary : theme.borderSubtle}
+      title="Folder"
+      titleColor={focused ? theme.primary : theme.textMuted}
+      titleAlignment="left"
+    >
+      {folder ? (
+        <>
+          <box
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              paddingLeft: 1,
+              paddingRight: 1,
+            }}
+          >
+            <text fg={theme.text}>Name: {headerName}</text>
+            {headerSeq !== undefined && (
+              <text fg={theme.textMuted}>Seq: {headerSeq}</text>
+            )}
+          </box>
+
+          <Tabs tabs={FOLDER_TABS} activeId={activeTab}>
+            <scrollbox
+              scrollY
+              style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
+            >
+              {activeTab === "meta" && (
+                <FolderMetaTab
+                  name={folder.name}
+                  seq={folder.seq}
+                  editState={editState}
+                  editValue={editValue}
+                  setEditValue={setEditValue}
+                  browseActive={browseActive}
+                  theme={theme}
+                  activeEnv={activeEnv}
+                />
+              )}
+              {activeTab === "headers" && (
+                <KeyValueSection
+                  kind="headers"
+                  entries={Object.entries(
+                    folder.overrides?.headers ?? {},
+                  ).map(([key, value], i) => ({ key, value, index: i }))}
+                  editState={editState}
+                  editKey={editKey}
+                  editValue={editValue}
+                  setEditKey={setEditKey}
+                  setEditValue={setEditValue}
+                  theme={theme}
+                  activeEnv={activeEnv}
+                />
+              )}
+              {activeTab === "params" && (
+                <KeyValueSection
+                  kind="params"
+                  entries={Object.entries(
+                    folder.overrides?.params ?? {},
+                  ).map(([key, value], i) => ({ key, value, index: i }))}
+                  editState={editState}
+                  editKey={editKey}
+                  editValue={editValue}
+                  setEditKey={setEditKey}
+                  setEditValue={setEditValue}
+                  theme={theme}
+                  activeEnv={activeEnv}
+                />
+              )}
+              {activeTab === "auth" && (
+                <AuthEditor
+                  auth={folder.overrides?.auth ?? { type: "none" }}
+                  editState={editState}
+                  inEdit={inEdit}
+                  browseActive={browseActive}
+                  setEditValue={setEditValue}
+                  theme={theme}
+                  activeEnv={activeEnv}
+                  onAuthTypeChange={onAuthTypeChange ?? (() => {})}
+                  onApiKeyPlacementChange={
+                    onApiKeyPlacementChange ?? (() => {})
+                  }
+                />
+              )}
+            </scrollbox>
+          </Tabs>
+        </>
+      ) : (
+        <text fg={theme.textMuted}>(no folder selected)</text>
+      )}
+    </box>
+  )
+}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -93,7 +93,7 @@ export function FolderPane({
                   kind="headers"
                   entries={Object.entries(
                     folder.overrides?.headers ?? {},
-                  ).map(([key, value], i) => ({ key, value, index: i }))}
+                  ).map(([key, value]) => ({ key, value }))}
                   editState={editState}
                   editKey={editKey}
                   editValue={editValue}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -117,6 +117,7 @@ export function FolderPane({
                     onApiKeyPlacementChange ?? (() => {})
                   }
                   onSelectOpenChange={onSelectOpenChange}
+                  showInherit={true}
                 />
               )}
             </scrollbox>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -25,6 +25,7 @@ interface FolderPaneProps {
   onTabChange: (tab: FolderFieldKind) => void
   onAuthTypeChange: (type: Auth["type"]) => void
   onApiKeyPlacementChange: (placement: "header" | "query") => void
+  onSelectOpenChange?: (open: boolean) => void
   activeEnv: Environment | null
   theme: Theme
 }
@@ -41,6 +42,7 @@ export function FolderPane({
   onTabChange: _onTabChange,
   onAuthTypeChange,
   onApiKeyPlacementChange,
+  onSelectOpenChange,
   activeEnv,
   theme,
 }: FolderPaneProps) {
@@ -114,6 +116,7 @@ export function FolderPane({
                   onApiKeyPlacementChange={
                     onApiKeyPlacementChange ?? (() => {})
                   }
+                  onSelectOpenChange={onSelectOpenChange}
                 />
               )}
             </scrollbox>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -48,9 +48,6 @@ export function FolderPane({
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
 
-  const headerName = folder?.name ?? "(no folder)"
-  const headerSeq = folder?.seq
-
   return (
     <box
       style={{
@@ -74,20 +71,6 @@ export function FolderPane({
     >
       {folder ? (
         <>
-          <box
-            style={{
-              flexDirection: "row",
-              justifyContent: "space-between",
-              paddingLeft: 1,
-              paddingRight: 1,
-            }}
-          >
-            <text fg={theme.text}>Name: {headerName}</text>
-            {headerSeq !== undefined && (
-              <text fg={theme.textMuted}>Seq: {headerSeq}</text>
-            )}
-          </box>
-
           <Tabs tabs={FOLDER_TABS} activeId={activeTab}>
             <scrollbox
               scrollY

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -79,7 +79,6 @@ export function FolderPane({
               {activeTab === "meta" && (
                 <FolderMetaTab
                   name={folder.name}
-                  seq={folder.seq}
                   editState={editState}
                   editValue={editValue}
                   setEditValue={setEditValue}

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -1,4 +1,4 @@
-import type { Request, Environment } from "../schema"
+import type { KvEntry, Environment } from "../schema"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { Checkbox } from "./Checkbox"
@@ -6,31 +6,28 @@ import { varSummaryColor } from "./envHighlight"
 
 export interface KeyValueSectionProps {
   kind: "headers" | "params"
-  request: Request
+  entries: Array<{ key: string; value: KvEntry; index: number }>
   editState: EditState
   editKey: string
   editValue: string
   setEditKey: (v: string) => void
   setEditValue: (v: string) => void
-  browseActive: boolean
   theme: Theme
   activeEnv?: Environment | null
 }
 
 export function KeyValueSection({
   kind,
-  request,
+  entries,
   editState,
   editKey,
   editValue,
   setEditKey,
   setEditValue,
-  browseActive,
   theme,
   activeEnv,
 }: KeyValueSectionProps) {
-  const rec = kind === "headers" ? request.headers : request.params
-  const rows = Object.entries(rec)
+  const rows = entries
 
   const panelNum = parseInt(theme.backgroundPanel.slice(1), 16)
   const elemNum = parseInt(theme.backgroundElement.slice(1), 16)
@@ -79,14 +76,15 @@ export function KeyValueSection({
         </box>
       ) : (
         <>
-          {rows.map(([k, entry], i) => {
+          {rows.map((entry, i) => {
+            const kv = entry.value
             const isEditingThisRow = editingRow === i
             const cursorOnThisRow =
-              browseActive &&
+              editState.mode === "browsing" &&
               cursorHere &&
               !editState.cursor.addingRow &&
               editState.cursor.row === i
-            const dimmed = (inEdit && !isEditingThisRow) || !entry.enabled
+            const dimmed = (inEdit && !isEditingThisRow) || !kv.enabled
 
             return (
               <box
@@ -103,9 +101,9 @@ export function KeyValueSection({
                         : undefined,
                 }}
               >
-                <Checkbox checked={entry.enabled} theme={theme} />
+                <Checkbox checked={kv.enabled} theme={theme} />
                 <input
-                  value={isEditingThisRow ? editKey : k}
+                  value={isEditingThisRow ? editKey : entry.key}
                   placeholder="Key"
                   onInput={isEditingThisRow ? setEditKey : undefined}
                   focused={
@@ -119,7 +117,7 @@ export function KeyValueSection({
                     isEditingThisRow
                       ? theme.text
                       : varSummaryColor(
-                          k,
+                          entry.key,
                           activeEnv ?? null,
                           theme,
                           dimmed ? theme.textMuted : theme.text,
@@ -129,7 +127,7 @@ export function KeyValueSection({
                   style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
                 />
                 <input
-                  value={isEditingThisRow ? editValue : entry.value}
+                  value={isEditingThisRow ? editValue : kv.value}
                   placeholder="Value"
                   onInput={isEditingThisRow ? setEditValue : undefined}
                   focused={
@@ -143,7 +141,7 @@ export function KeyValueSection({
                     isEditingThisRow
                       ? theme.text
                       : varSummaryColor(
-                          entry.value,
+                          kv.value,
                           activeEnv ?? null,
                           theme,
                           dimmed

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -6,7 +6,7 @@ import { varSummaryColor } from "./envHighlight"
 
 export interface KeyValueSectionProps {
   kind: "headers" | "params"
-  entries: Array<{ key: string; value: KvEntry; index: number }>
+  entries: Array<{ key: string; value: KvEntry }>
   editState: EditState
   editKey: string
   editValue: string

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -4,7 +4,7 @@ import type {
   LineNumberRenderable,
 } from "@opentui/core"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import type { Request, Environment } from "../schema"
+import type { Auth, Request, Environment } from "../schema"
 import { formatBody } from "./formatRequest"
 import type { EditState, FieldKind } from "./editMode"
 
@@ -32,7 +32,7 @@ interface Props {
   focused?: boolean
   activeTab: FieldKind
   activeEnv?: Environment | null
-  onAuthTypeChange?: (t: "none" | "bearer" | "basic" | "api_key") => void
+  onAuthTypeChange?: (t: Auth["type"]) => void
   onApiKeyPlacementChange?: (placement: "header" | "query") => void
   onBodyTypeChange?: (t: BodyType) => void
   onSelectOpenChange?: (open: boolean) => void
@@ -222,6 +222,7 @@ export function RequestPane({
                     onApiKeyPlacementChange ?? (() => {})
                   }
                   onSelectOpenChange={handleSelectOpenChange}
+                  showInherit={true}
                 />
               )}
               {activeTab === "settings" && (

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -166,7 +166,7 @@ export function RequestPane({
                 <KeyValueSection
                   kind="headers"
                   entries={Object.entries(request?.headers ?? {}).map(
-                    ([key, value], i) => ({ key, value, index: i }),
+                    ([key, value]) => ({ key, value }),
                   )}
                   editState={editState}
                   editKey={editKey}
@@ -181,7 +181,7 @@ export function RequestPane({
                 <KeyValueSection
                   kind="params"
                   entries={Object.entries(request?.params ?? {}).map(
-                    ([key, value], i) => ({ key, value, index: i }),
+                    ([key, value]) => ({ key, value }),
                   )}
                   editState={editState}
                   editKey={editKey}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -165,13 +165,14 @@ export function RequestPane({
               {activeTab === "headers" && (
                 <KeyValueSection
                   kind="headers"
-                  request={request}
+                  entries={Object.entries(request?.headers ?? {}).map(
+                    ([key, value], i) => ({ key, value, index: i }),
+                  )}
                   editState={editState}
                   editKey={editKey}
                   editValue={editValue}
                   setEditKey={setEditKey}
                   setEditValue={setEditValue}
-                  browseActive={browseActive}
                   theme={theme}
                   activeEnv={activeEnv}
                 />
@@ -179,13 +180,14 @@ export function RequestPane({
               {activeTab === "params" && (
                 <KeyValueSection
                   kind="params"
-                  request={request}
+                  entries={Object.entries(request?.params ?? {}).map(
+                    ([key, value], i) => ({ key, value, index: i }),
+                  )}
                   editState={editState}
                   editKey={editKey}
                   editValue={editValue}
                   setEditKey={setEditKey}
                   setEditValue={setEditValue}
-                  browseActive={browseActive}
                   theme={theme}
                   activeEnv={activeEnv}
                 />

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -210,7 +210,7 @@ export function RequestPane({
               )}
               {activeTab === "auth" && (
                 <AuthEditor
-                  request={request}
+                  auth={request?.auth ?? { type: "none" }}
                   editState={editState}
                   inEdit={inEdit}
                   browseActive={browseActive}

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -26,6 +26,7 @@ export function Sidebar({
   focused = false,
   keybinds: _keybinds,
   dirtyRequestIds,
+  dirtyFolderPaths,
 }: {
   items: CollectionItem[]
   loading: boolean
@@ -37,6 +38,7 @@ export function Sidebar({
   focused?: boolean
   keybinds?: Keybinds
   dirtyRequestIds?: Set<string>
+  dirtyFolderPaths?: Set<string>
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -93,6 +95,7 @@ export function Sidebar({
                   ? "\u25BE"
                   : "\u25B8"
                 : "\u00A0"
+              const isFolderDirty = dirtyFolderPaths?.has(node.id)
               return (
                 <box
                   key={node.id}
@@ -110,6 +113,7 @@ export function Sidebar({
                 >
                   <text fg={theme.textMuted}>{chevron} </text>
                   <text fg={theme.textMuted}>{truncName(node.name, 20)}</text>
+                  {isFolderDirty && <text fg={theme.warning}> \u25CF</text>}
                 </box>
               )
             }

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -151,7 +151,9 @@ export function Sidebar({
                     {truncName(node.name, 20)}
                   </text>
                 </box>
-                {isDirty && <text fg={theme.warning}>\u25CF</text>}
+                {isDirty && (
+                  <text fg={theme.warning}>{`\u25CF`}</text>
+                )}
               </box>
             )
           })}

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -102,6 +102,7 @@ export function Sidebar({
                   id={`so-${node.id}`}
                   style={{
                     flexDirection: "row",
+                    justifyContent: "space-between",
                     paddingLeft: node.depth * 2,
                     backgroundColor: isCursor
                       ? theme.backgroundElement
@@ -111,9 +112,15 @@ export function Sidebar({
                   customBorderChars={LeftBar.customBorderChars}
                   borderColor={isCursor ? theme.primary : theme.backgroundPanel}
                 >
-                  <text fg={theme.textMuted}>{chevron} </text>
-                  <text fg={theme.textMuted}>{truncName(node.name, 20)}</text>
-                  {isFolderDirty && <text fg={theme.warning}> \u25CF</text>}
+                  <box style={{ flexDirection: "row" }}>
+                    <text fg={theme.textMuted}>{chevron} </text>
+                    <text fg={theme.textMuted} wrapMode="none">
+                      {truncName(node.name, 20)}
+                    </text>
+                  </box>
+                  {isFolderDirty && (
+                    <text fg={theme.warning}>{`\u25CF`}</text>
+                  )}
                 </box>
               )
             }

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,4 +1,4 @@
-export type FieldKind = "headers" | "params" | "body" | "auth" | "settings"
+export type FieldKind = "headers" | "params" | "body" | "auth" | "settings" | "meta"
 export type Mode = "inactive" | "browsing" | "editing"
 
 export interface FieldCursor {
@@ -22,6 +22,13 @@ export interface SectionRowCount {
   settings: number
 }
 
+export interface FolderRowCount {
+  meta: number
+  headers: number
+  params: number
+  auth: number
+}
+
 export const FIELD_ORDER: FieldKind[] = [
   "headers",
   "params",
@@ -30,10 +37,25 @@ export const FIELD_ORDER: FieldKind[] = [
   "settings",
 ]
 
+export const FOLDER_FIELD_ORDER: FieldKind[] = [
+  "meta",
+  "headers",
+  "params",
+  "auth",
+]
+
 export function initialEditState(): EditState {
   return {
     mode: "inactive",
     cursor: { field: "headers", row: -1, addingRow: false },
+    editingRow: -1,
+  }
+}
+
+export function initialFolderEditState(): EditState {
+  return {
+    mode: "inactive",
+    cursor: { field: "meta", row: -1, addingRow: false },
     editingRow: -1,
   }
 }
@@ -57,6 +79,24 @@ export function enterEditBrowse(
   }
 }
 
+export function enterFolderEditBrowse(
+  prev: EditState,
+  counts: FolderRowCount = {
+    meta: 0,
+    headers: 0,
+    params: 0,
+    auth: 0,
+  },
+  startField: FieldKind = "meta",
+): EditState {
+  if (prev.mode !== "inactive") return prev
+  return {
+    mode: "browsing",
+    cursor: folderCursorForField(startField, counts),
+    editingRow: -1,
+  }
+}
+
 export function exitEditBrowse(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   return { ...prev, mode: "inactive" }
@@ -64,6 +104,10 @@ export function exitEditBrowse(prev: EditState): EditState {
 
 function fieldIndex(field: FieldKind): number {
   return FIELD_ORDER.indexOf(field)
+}
+
+export function folderFieldIndex(field: FieldKind): number {
+  return FOLDER_FIELD_ORDER.indexOf(field)
 }
 
 function cursorForField(
@@ -85,10 +129,26 @@ function cursorForField(
   return { field, row: 0, addingRow: false }
 }
 
+export function folderCursorForField(
+  field: FieldKind,
+  counts: FolderRowCount,
+): FieldCursor {
+  switch (field) {
+    case "meta":
+    case "auth":
+      return { field, row: 0, addingRow: false }
+  }
+  const count = field === "headers" ? counts.headers : counts.params
+  if (count === 0) {
+    return { field, row: -1, addingRow: true }
+  }
+  return { field, row: 0, addingRow: false }
+}
+
 export function toggleSubfield(prev: EditState): EditState {
   if (prev.mode !== "editing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "params" && field !== "body") return prev
+  if (field !== "headers" && field !== "params" && field !== "body" && field !== "meta") return prev
   const current = prev.cursor.subfield ?? "key"
   const next: "key" | "value" = current === "key" ? "value" : "key"
   return {
@@ -109,6 +169,21 @@ export function moveFieldCursor(
   return {
     ...prev,
     cursor: cursorForField(nextField, counts),
+  }
+}
+
+export function moveFolderFieldCursor(
+  prev: EditState,
+  delta: 1 | -1,
+  counts: FolderRowCount,
+): EditState {
+  if (prev.mode !== "browsing") return prev
+  const idx = folderFieldIndex(prev.cursor.field)
+  const nextIdx = (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
+  const nextField = FOLDER_FIELD_ORDER[nextIdx]!
+  return {
+    ...prev,
+    cursor: folderCursorForField(nextField, counts),
   }
 }
 
@@ -194,11 +269,55 @@ export function moveRowCursor(
   return { ...prev, cursor: { field, row: next, addingRow: false } }
 }
 
+export function moveFolderRowCursor(
+  prev: EditState,
+  delta: 1 | -1,
+  counts: FolderRowCount,
+): EditState {
+  if (prev.mode !== "browsing") return prev
+  const { field } = prev.cursor
+  if (field !== "meta" && field !== "headers" && field !== "params" && field !== "auth") return prev
+
+  let count = 0
+  if (field === "meta") count = counts.meta
+  else if (field === "headers") count = counts.headers
+  else if (field === "params") count = counts.params
+  else if (field === "auth") count = counts.auth
+
+  if (count === 0) return prev
+
+  if (prev.cursor.addingRow) {
+    return {
+      ...prev,
+      cursor: { field, row: delta > 0 ? 0 : count - 1, addingRow: false },
+    }
+  }
+
+  const row = prev.cursor.row
+  const next = row + delta
+
+  if (field === "meta" || field === "auth") {
+    if (next < 0)
+      return { ...prev, cursor: { field, row: 0, addingRow: false } }
+    if (next > count - 1)
+      return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
+    return { ...prev, cursor: { field, row: next, addingRow: false } }
+  }
+
+  if (next < 0) {
+    return { ...prev, cursor: { field, row: -1, addingRow: true } }
+  }
+  if (next > count - 1) {
+    return { ...prev, cursor: { field, row: -1, addingRow: true } }
+  }
+  return { ...prev, cursor: { field, row: next, addingRow: false } }
+}
+
 export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
-    prev.cursor.field === "headers" || prev.cursor.field === "params"
+    prev.cursor.field === "headers" || prev.cursor.field === "params" || prev.cursor.field === "meta"
       ? "key"
       : prev.cursor.field === "body"
         ? "key"

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -135,12 +135,13 @@ export function folderCursorForField(
     case "meta":
     case "auth":
       return { field, row: 0, addingRow: false }
+    case "headers": {
+      if (counts.headers === 0) {
+        return { field, row: -1, addingRow: true }
+      }
+      return { field, row: 0, addingRow: false }
+    }
   }
-  const count = counts.headers
-  if (count === 0) {
-    return { field, row: -1, addingRow: true }
-  }
-  return { field, row: 0, addingRow: false }
 }
 
 export function toggleSubfield(prev: EditState): EditState {

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,5 +1,5 @@
 export type FieldKind = "headers" | "params" | "body" | "auth" | "settings" | "meta"
-export type FolderFieldKind = "meta" | "headers" | "params" | "auth"
+export type FolderFieldKind = "meta" | "headers" | "auth"
 export type Mode = "inactive" | "browsing" | "editing"
 
 export interface FieldCursor {
@@ -26,7 +26,6 @@ export interface SectionRowCount {
 export interface FolderRowCount {
   meta: number
   headers: number
-  params: number
   auth: number
 }
 
@@ -41,7 +40,6 @@ export const FIELD_ORDER: FieldKind[] = [
 export const FOLDER_FIELD_ORDER: FolderFieldKind[] = [
   "meta",
   "headers",
-  "params",
   "auth",
 ]
 
@@ -85,7 +83,6 @@ export function enterFolderEditBrowse(
   counts: FolderRowCount = {
     meta: 0,
     headers: 0,
-    params: 0,
     auth: 0,
   },
   startField: FolderFieldKind = "meta",
@@ -139,7 +136,7 @@ export function folderCursorForField(
     case "auth":
       return { field, row: 0, addingRow: false }
   }
-  const count = field === "headers" ? counts.headers : counts.params
+  const count = counts.headers
   if (count === 0) {
     return { field, row: -1, addingRow: true }
   }
@@ -149,7 +146,7 @@ export function folderCursorForField(
 export function toggleSubfield(prev: EditState): EditState {
   if (prev.mode !== "editing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "params" && field !== "body" && field !== "meta") return prev
+  if (field !== "headers" && field !== "body" && field !== "meta") return prev
   const current = prev.cursor.subfield ?? "key"
   const next: "key" | "value" = current === "key" ? "value" : "key"
   return {
@@ -277,12 +274,11 @@ export function moveFolderRowCursor(
 ): EditState {
   if (prev.mode !== "browsing") return prev
   const { field } = prev.cursor
-  if (field !== "meta" && field !== "headers" && field !== "params" && field !== "auth") return prev
+  if (field !== "meta" && field !== "headers" && field !== "auth") return prev
 
   let count = 0
   if (field === "meta") count = counts.meta
   else if (field === "headers") count = counts.headers
-  else if (field === "params") count = counts.params
   else if (field === "auth") count = counts.auth
 
   if (count === 0) return prev
@@ -318,7 +314,7 @@ export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
-    prev.cursor.field === "headers" || prev.cursor.field === "params" || prev.cursor.field === "meta"
+    prev.cursor.field === "headers" || prev.cursor.field === "meta"
       ? "key"
       : prev.cursor.field === "body"
         ? "key"

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -147,7 +147,7 @@ export function folderCursorForField(
 export function toggleSubfield(prev: EditState): EditState {
   if (prev.mode !== "editing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "body" && field !== "meta") return prev
+  if (field !== "headers" && field !== "params" && field !== "body" && field !== "meta") return prev
   const current = prev.cursor.subfield ?? "key"
   const next: "key" | "value" = current === "key" ? "value" : "key"
   return {
@@ -315,7 +315,7 @@ export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
-    prev.cursor.field === "headers" || prev.cursor.field === "meta"
+    prev.cursor.field === "headers" || prev.cursor.field === "params" || prev.cursor.field === "meta"
       ? "key"
       : prev.cursor.field === "body"
         ? "key"

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,4 +1,5 @@
 export type FieldKind = "headers" | "params" | "body" | "auth" | "settings" | "meta"
+export type FolderFieldKind = "meta" | "headers" | "params" | "auth"
 export type Mode = "inactive" | "browsing" | "editing"
 
 export interface FieldCursor {
@@ -37,7 +38,7 @@ export const FIELD_ORDER: FieldKind[] = [
   "settings",
 ]
 
-export const FOLDER_FIELD_ORDER: FieldKind[] = [
+export const FOLDER_FIELD_ORDER: FolderFieldKind[] = [
   "meta",
   "headers",
   "params",
@@ -87,7 +88,7 @@ export function enterFolderEditBrowse(
     params: 0,
     auth: 0,
   },
-  startField: FieldKind = "meta",
+  startField: FolderFieldKind = "meta",
 ): EditState {
   if (prev.mode !== "inactive") return prev
   return {
@@ -106,7 +107,7 @@ function fieldIndex(field: FieldKind): number {
   return FIELD_ORDER.indexOf(field)
 }
 
-export function folderFieldIndex(field: FieldKind): number {
+export function folderFieldIndex(field: FolderFieldKind): number {
   return FOLDER_FIELD_ORDER.indexOf(field)
 }
 
@@ -130,7 +131,7 @@ function cursorForField(
 }
 
 export function folderCursorForField(
-  field: FieldKind,
+  field: FolderFieldKind,
   counts: FolderRowCount,
 ): FieldCursor {
   switch (field) {
@@ -178,7 +179,7 @@ export function moveFolderFieldCursor(
   counts: FolderRowCount,
 ): EditState {
   if (prev.mode !== "browsing") return prev
-  const idx = folderFieldIndex(prev.cursor.field)
+  const idx = folderFieldIndex(prev.cursor.field as FolderFieldKind)
   const nextIdx = (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
   const nextField = FOLDER_FIELD_ORDER[nextIdx]!
   return {

--- a/src/ui/focus.ts
+++ b/src/ui/focus.ts
@@ -84,6 +84,9 @@ export function hintForFocus(
     // editing
     return "[Enter] commit · [Esc] cancel"
   }
+  if (focus === "folder") {
+    return "[^S] save name · [Tab] next"
+  }
   // response
   return "[↑/↓/PgUp/PgDn] scroll · [Tab] next"
 }

--- a/src/ui/focus.ts
+++ b/src/ui/focus.ts
@@ -85,7 +85,13 @@ export function hintForFocus(
     return "[Enter] commit · [Esc] cancel"
   }
   if (focus === "folder") {
-    return "[^S] save name · [Tab] next"
+    if (mode === "browsing") {
+      return "[↑/↓] navigate · [←/→] tabs · [Enter] edit · [Esc] back · [^S] save · [^R] revert all"
+    }
+    if (mode === "editing") {
+      return "[Enter] commit · [Esc] cancel"
+    }
+    return "[^S] save · [Tab] next"
   }
   // response
   return "[↑/↓/PgUp/PgDn] scroll · [Tab] next"

--- a/src/ui/tree.ts
+++ b/src/ui/tree.ts
@@ -1,5 +1,27 @@
 import type { CollectionItem, Folder, Request } from "../schema"
 
+export function updateFolderByPath(
+  items: CollectionItem[],
+  path: string,
+  folder: Folder,
+): CollectionItem[] {
+  return items.map((item) => {
+    if (item.type === "folder") {
+      if (item.data.path === path) {
+        return { type: "folder", data: { ...folder } }
+      }
+      return {
+        type: "folder",
+        data: {
+          ...item.data,
+          children: updateFolderByPath(item.data.children, path, folder),
+        },
+      }
+    }
+    return item
+  })
+}
+
 export function findFolderByPath(
   items: CollectionItem[],
   path: string,

--- a/src/ui/tree.ts
+++ b/src/ui/tree.ts
@@ -1,4 +1,18 @@
-import type { CollectionItem, Request } from "../schema"
+import type { CollectionItem, Folder, Request } from "../schema"
+
+export function findFolderByPath(
+  items: CollectionItem[],
+  path: string,
+): Folder | null {
+  for (const item of items) {
+    if (item.type === "folder") {
+      if (item.data.path === path) return item.data
+      const found = findFolderByPath(item.data.children, path)
+      if (found) return found
+    }
+  }
+  return null
+}
 
 export function findRequestById(
   items: CollectionItem[],

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -25,6 +25,7 @@ export interface UseAppKeymapRefs {
   savingRef: RefObject<boolean>
   expandedRef: RefObject<"request" | "response" | null>
   folderViewRef: RefObject<boolean>
+  folderSaveRef: RefObject<() => void>
 }
 
 export interface UseAppKeymapSetters {
@@ -206,6 +207,7 @@ export function useAppKeymap(
   useBindings(() => ({
     enabled: () =>
       keymap.getData("app.mode") === "base" &&
+      keymap.getData("app.focus") !== "folder" &&
       keymap.getData("app.overlay") === "none" &&
       keymap.getData("app.view") !== "env-editor",
     commands: [
@@ -376,6 +378,21 @@ export function useAppKeymap(
       { key: keybinds.request_save, cmd: "browse.save" },
       { key: keybinds.browse_toggle_form_type, cmd: "browse.toggle-form-type" },
     ],
+  }))
+
+  // ── Keymap: Folder Focus Layer ────────────────────────────────────
+  useBindings(() => ({
+    enabled: () =>
+      keymap.getData("app.focus") === "folder" &&
+      keymap.getData("app.overlay") === "none" &&
+      keymap.getData("app.view") !== "env-editor",
+    commands: [
+      {
+        name: "folder.save",
+        run: () => refs.folderSaveRef.current(),
+      },
+    ],
+    bindings: [{ key: keybinds.request_save, cmd: "folder.save" }],
   }))
 
   // ── Keymap: Edit Layer ─────────────────────────────────────────────

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -335,6 +335,7 @@ export function useAppKeymap(
   useBindings(() => ({
     enabled: () =>
       keymap.getData("app.mode") === "browse" &&
+      keymap.getData("app.focus") !== "folder" &&
       keymap.getData("app.overlay") === "none" &&
       keymap.getData("app.view") !== "env-editor",
     commands: [
@@ -456,6 +457,7 @@ export function useAppKeymap(
   useBindings(() => ({
     enabled: () =>
       keymap.getData("app.mode") === "edit" &&
+      keymap.getData("app.focus") !== "folder" &&
       keymap.getData("app.overlay") === "none" &&
       keymap.getData("app.view") !== "env-editor",
     commands: [

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -385,6 +385,37 @@ export function useAppKeymap(
     ],
   }))
 
+  // ── Keymap: Folder Init Layer (base mode, folder focused) ──────
+  useBindings(() => ({
+    enabled: () =>
+      keymap.getData("app.mode") === "base" &&
+      keymap.getData("app.focus") === "folder" &&
+      keymap.getData("app.overlay") === "none" &&
+      keymap.getData("app.view") !== "env-editor",
+    commands: [
+      {
+        name: "folder.edit-enter",
+        run: () => {
+          refs.folderEbRef.current?.enterBrowse()
+          setters.setFocus("folder")
+        },
+      },
+      {
+        name: "folder.tab-prev",
+        run: () => refs.folderEbRef.current?.cycleInactiveTab(-1),
+      },
+      {
+        name: "folder.tab-next",
+        run: () => refs.folderEbRef.current?.cycleInactiveTab(1),
+      },
+    ],
+    bindings: [
+      { key: "return", cmd: "folder.edit-enter" },
+      { key: "left", cmd: "folder.tab-prev" },
+      { key: "right", cmd: "folder.tab-next" },
+    ],
+  }))
+
   // ── Keymap: Folder Focus Layer (always when folder is focused) ───
   useBindings(() => ({
     enabled: () =>

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -5,6 +5,8 @@ import { cycleFocus, toggleExpand, type Focus } from "./focus"
 import type { Keybinds } from "./keybind"
 import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
+import type { UseFolderEditBrowseResult } from "../hooks/useFolderEditBrowse"
+import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
 import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
 import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
 import type { Collection } from "../schema"
@@ -13,6 +15,8 @@ import { findRequestById } from "./tree"
 export interface UseAppKeymapRefs {
   ebRef: RefObject<UseEditBrowseResult>
   draftRef: RefObject<UseRequestDraftResult>
+  folderEbRef: RefObject<UseFolderEditBrowseResult>
+  folderDraftRef: RefObject<UseFolderDraftResult>
   envStateRef: RefObject<UseEnvironmentsResult>
   envEditorRef: RefObject<UseEnvironmentEditorResult>
   collectionRef: RefObject<Collection | null>
@@ -380,7 +384,7 @@ export function useAppKeymap(
     ],
   }))
 
-  // ── Keymap: Folder Focus Layer ────────────────────────────────────
+  // ── Keymap: Folder Focus Layer (always when folder is focused) ───
   useBindings(() => ({
     enabled: () =>
       keymap.getData("app.focus") === "folder" &&
@@ -393,6 +397,59 @@ export function useAppKeymap(
       },
     ],
     bindings: [{ key: keybinds.request_save, cmd: "folder.save" }],
+  }))
+
+  // ── Keymap: Folder Browse Layer ──────────────────────────────────
+  useBindings(() => ({
+    enabled: () =>
+      keymap.getData("app.focus") === "folder" &&
+      keymap.getData("app.mode") === "browse" &&
+      keymap.getData("app.overlay") === "none" &&
+      keymap.getData("app.view") !== "env-editor",
+    commands: [
+      { name: "folder-browse.up", run: () => refs.folderEbRef.current?.browseUp() },
+      { name: "folder-browse.down", run: () => refs.folderEbRef.current?.browseDown() },
+      { name: "folder-browse.left", run: () => refs.folderEbRef.current?.browseLeft() },
+      { name: "folder-browse.right", run: () => refs.folderEbRef.current?.browseRight() },
+      { name: "folder-browse.enter", run: () => refs.folderEbRef.current?.enterEdit() },
+      { name: "folder-browse.escape", run: () => {
+        refs.folderEbRef.current?.exitBrowse()
+        setters.setFocus("sidebar")
+      }},
+      { name: "folder-browse.toggle", run: () => refs.folderEbRef.current?.toggleRow() },
+      { name: "folder-browse.revert-field", run: () => refs.folderEbRef.current?.revertField() },
+      { name: "folder-browse.revert-all", run: () => refs.folderEbRef.current?.revertAll() },
+    ],
+    bindings: [
+      { key: "up", cmd: "folder-browse.up" },
+      { key: "down", cmd: "folder-browse.down" },
+      { key: "left", cmd: "folder-browse.left" },
+      { key: "right", cmd: "folder-browse.right" },
+      { key: "return", cmd: "folder-browse.enter" },
+      { key: "escape", cmd: "folder-browse.escape" },
+      { key: "space", cmd: "folder-browse.toggle" },
+      { key: keybinds.browse_delete, cmd: "folder-browse.revert-field" },
+      { key: keybinds.browse_revert_all, cmd: "folder-browse.revert-all" },
+    ],
+  }))
+
+  // ── Keymap: Folder Edit Layer ────────────────────────────────────
+  useBindings(() => ({
+    enabled: () =>
+      keymap.getData("app.focus") === "folder" &&
+      keymap.getData("app.mode") === "edit" &&
+      keymap.getData("app.overlay") === "none" &&
+      keymap.getData("app.view") !== "env-editor",
+    commands: [
+      { name: "folder-edit.commit", run: () => refs.folderEbRef.current?.commitEdit() },
+      { name: "folder-edit.cancel", run: () => refs.folderEbRef.current?.cancelEdit() },
+      { name: "folder-edit.tab", run: () => refs.folderEbRef.current?.browseTab() },
+    ],
+    bindings: [
+      { key: "return", cmd: "folder-edit.commit" },
+      { key: "escape", cmd: "folder-edit.cancel" },
+      { key: "tab", cmd: "folder-edit.tab" },
+    ],
   }))
 
   // ── Keymap: Edit Layer ─────────────────────────────────────────────

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -327,6 +327,21 @@ describe("filestore.saveFolder — path validation", () => {
     const content = await readFile(join(dir, "my-folder", "folder.yml"), "utf8")
     expect(content).toContain("name: My Folder")
   })
+
+  it("overwrites folder.yml with new name on rename", async () => {
+    const folderPath = "rename-test"
+    await saveFolder(dir, makeFolder({ path: folderPath, name: "Old Name" }))
+    const before = await readFile(join(dir, folderPath, "folder.yml"), "utf8")
+    expect(before).toContain("name: Old Name")
+
+    await saveFolder(
+      dir,
+      makeFolder({ path: folderPath, name: "New Name" }),
+    )
+    const after = await readFile(join(dir, folderPath, "folder.yml"), "utf8")
+    expect(after).toContain("name: New Name")
+    expect(after).not.toContain("Old Name")
+  })
 })
 
 describe("filestore.deleteFolder — path validation", () => {

--- a/tests/folder-lang.test.ts
+++ b/tests/folder-lang.test.ts
@@ -151,4 +151,26 @@ describe("lang.serializeFolder", () => {
     const reparsed = lang.parseFolder(serialized)
     expect(reparsed.overrides?.auth).toEqual({ type: "none" })
   })
+
+  it("serializes folder renamed from dirname to custom name", () => {
+    const result = lang.serializeFolder({
+      id: "auth",
+      name: "Authentication",
+      path: "auth",
+      children: [],
+    })
+    expect(result).toContain("meta:")
+    expect(result).toContain("name: Authentication")
+  })
+
+  it("round-trips folder rename: serialize with new name -> parse gets meta.name", () => {
+    const serialized = lang.serializeFolder({
+      id: "posts",
+      name: "Blog Posts",
+      path: "posts",
+      children: [],
+    })
+    const parsed = lang.parseFolder(serialized)
+    expect(parsed.meta?.name).toBe("Blog Posts")
+  })
 })

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -160,7 +160,7 @@ describe("lang.parseRequest — strictness", () => {
   it("throws on invalid auth.type", () => {
     const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: oauth\n`
     expect(() => lang.parseRequest("x", yaml)).toThrow(
-      'lang.parseRequest: invalid auth.type "oauth", expected none|bearer|basic',
+      'lang.parseRequest: invalid auth.type "oauth", expected none|inherit|bearer|basic|api_key',
     )
   })
 

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { findRequestById, findFolderByPath, flattenRequests, visibleNodes } from "../src/ui/tree"
-import type { CollectionItem, Folder, Request } from "../src/schema"
+import type { CollectionItem } from "../src/schema"
 
 function req(id: string, name?: string): CollectionItem {
   return {

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { findRequestById, findFolderByPath, updateFolderByPath, flattenRequests, visibleNodes } from "../src/ui/tree"
-import type { CollectionItem, Folder } from "../src/schema"
+import type { CollectionItem } from "../src/schema"
 
 function req(id: string, name?: string): CollectionItem {
   return {

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
-import { findRequestById, findFolderByPath, flattenRequests, visibleNodes } from "../src/ui/tree"
-import type { CollectionItem } from "../src/schema"
+import { findRequestById, findFolderByPath, updateFolderByPath, flattenRequests, visibleNodes } from "../src/ui/tree"
+import type { CollectionItem, Folder } from "../src/schema"
 
 function req(id: string, name?: string): CollectionItem {
   return {
@@ -90,6 +90,51 @@ describe("findFolderByPath", () => {
 
   it("returns null when path matches a request not a folder", () => {
     expect(findFolderByPath(nestedItems, "root")).toBeNull()
+  })
+})
+
+describe("updateFolderByPath", () => {
+  it("updates folder name in flat list", () => {
+    const updated = updateFolderByPath(nestedItems, "auth", {
+      id: "auth",
+      name: "Renamed",
+      path: "auth",
+      children: [],
+    })
+    const folder = findFolderByPath(updated, "auth")
+    expect(folder?.name).toBe("Renamed")
+  })
+
+  it("updates nested folder", () => {
+    const updated = updateFolderByPath(nestedItems, "users/admins", {
+      id: "admins",
+      name: "Super Admins",
+      path: "users/admins",
+      children: [],
+    })
+    const folder = findFolderByPath(updated, "users/admins")
+    expect(folder?.name).toBe("Super Admins")
+  })
+
+  it("preserves other folders unchanged", () => {
+    const updated = updateFolderByPath(nestedItems, "auth", {
+      id: "auth",
+      name: "Renamed",
+      path: "auth",
+      children: [],
+    })
+    const users = findFolderByPath(updated, "users")
+    expect(users?.name).toBe("Users")
+  })
+
+  it("returns same items when path not found", () => {
+    const updated = updateFolderByPath(nestedItems, "nope", {
+      id: "nope",
+      name: "?",
+      path: "nope",
+      children: [],
+    })
+    expect(updated).toEqual(nestedItems)
   })
 })
 

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { findRequestById, flattenRequests, visibleNodes } from "../src/ui/tree"
+import { findRequestById, findFolderByPath, flattenRequests, visibleNodes } from "../src/ui/tree"
 import type { CollectionItem, Folder, Request } from "../src/schema"
 
 function req(id: string, name?: string): CollectionItem {
@@ -64,6 +64,32 @@ describe("findRequestById", () => {
     const result = findRequestById(nestedItems, "users/admins/root")
     expect(result).not.toBeNull()
     expect(result!.id).toBe("users/admins/root")
+  })
+})
+
+describe("findFolderByPath", () => {
+  it("finds folder in flat list", () => {
+    const items: CollectionItem[] = [
+      folder("auth", [req("auth/login")], "Auth"),
+    ]
+    const result = findFolderByPath(items, "auth")
+    expect(result).not.toBeNull()
+    expect(result!.path).toBe("auth")
+    expect(result!.name).toBe("Auth")
+  })
+
+  it("returns null for missing path", () => {
+    expect(findFolderByPath(nestedItems, "nope")).toBeNull()
+  })
+
+  it("finds nested folder", () => {
+    const result = findFolderByPath(nestedItems, "users/admins")
+    expect(result).not.toBeNull()
+    expect(result!.path).toBe("users/admins")
+  })
+
+  it("returns null when path matches a request not a folder", () => {
+    expect(findFolderByPath(nestedItems, "root")).toBeNull()
   })
 })
 

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "bun:test"
+import { applyDraftOp, folderEqual } from "../../src/hooks/useFolderDraft"
+import type { Folder } from "../../src/schema"
+
+function makeFolder(overrides?: Partial<Folder>): Folder {
+  return {
+    id: "test",
+    name: "Test",
+    path: "test",
+    children: [],
+    ...overrides,
+  }
+}
+
+describe("applyDraftOp", () => {
+  it("setName changes folder name", () => {
+    const f = makeFolder({ name: "Old" })
+    const r = applyDraftOp(f, { kind: "setName", name: "New" })
+    expect(r?.name).toBe("New")
+  })
+
+  it("setSeq changes seq", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "setSeq", seq: 5 })
+    expect(r?.seq).toBe(5)
+  })
+
+  it("addHeaderRow adds to empty overrides", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, {
+      kind: "addHeaderRow",
+      key: "Authorization",
+      value: "Bearer x",
+    })
+    expect(r?.overrides?.headers?.["Authorization"]).toEqual({
+      value: "Bearer x",
+      enabled: true,
+    })
+  })
+
+  it("addHeaderRow adds to existing headers", () => {
+    const f = makeFolder({
+      overrides: {
+        headers: { "X-1": { value: "v1", enabled: true } },
+      },
+    })
+    const r = applyDraftOp(f, {
+      kind: "addHeaderRow",
+      key: "X-2",
+      value: "v2",
+    })
+    expect(Object.keys(r?.overrides?.headers ?? {})).toHaveLength(2)
+  })
+
+  it("removeHeaderRow deletes row by index", () => {
+    const f = makeFolder({
+      overrides: {
+        headers: {
+          "X-1": { value: "v1", enabled: true },
+          "X-2": { value: "v2", enabled: true },
+        },
+      },
+    })
+    const r = applyDraftOp(f, { kind: "removeHeaderRow", index: 0 })
+    expect(Object.keys(r?.overrides?.headers ?? {})).toEqual(["X-2"])
+  })
+
+  it("toggleHeaderRow toggles enabled", () => {
+    const f = makeFolder({
+      overrides: {
+        headers: { "X-1": { value: "v1", enabled: true } },
+      },
+    })
+    const r = applyDraftOp(f, { kind: "toggleHeaderRow", index: 0 })
+    expect(r?.overrides?.headers?.["X-1"]?.enabled).toBe(false)
+  })
+
+  it("setAuthType sets auth to bearer", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "setAuthType", authType: "bearer" })
+    expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "" })
+  })
+
+  it("setAuthField updates token for bearer", () => {
+    const f = makeFolder({
+      overrides: { auth: { type: "bearer", token: "" } },
+    })
+    const r = applyDraftOp(f, {
+      kind: "setAuthField",
+      authType: "bearer",
+      field: "token",
+      value: "tok123",
+    })
+    expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "tok123" })
+  })
+
+  it("setApiKeyPlacement changes placement", () => {
+    const f = makeFolder({
+      overrides: {
+        auth: { type: "api_key", key: "k", value: "v", placement: "header" },
+      },
+    })
+    const r = applyDraftOp(f, { kind: "setApiKeyPlacement", placement: "query" })
+    expect(r?.overrides?.auth).toEqual({
+      type: "api_key", key: "k", value: "v", placement: "query",
+    })
+  })
+
+  it("setHeaderRow updates key and value preserving enabled", () => {
+    const f = makeFolder({
+      overrides: {
+        headers: { "X-Old": { value: "old", enabled: false } },
+      },
+    })
+    const r = applyDraftOp(f, { kind: "setHeaderRow", index: 0, key: "X-New", value: "new" })
+    expect(Object.keys(r?.overrides?.headers ?? {})).toEqual(["X-New"])
+    expect(r?.overrides?.headers?.["X-New"]).toEqual({ value: "new", enabled: false })
+  })
+
+  it("addParamRow adds to empty params", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "addParamRow", key: "page", value: "1" })
+    expect(r?.overrides?.params?.["page"]).toEqual({ value: "1", enabled: true })
+  })
+
+  it("removeParamRow deletes by index", () => {
+    const f = makeFolder({
+      overrides: { params: { p1: { value: "v1", enabled: true }, p2: { value: "v2", enabled: true } } },
+    })
+    const r = applyDraftOp(f, { kind: "removeParamRow", index: 1 })
+    expect(Object.keys(r?.overrides?.params ?? {})).toEqual(["p1"])
+  })
+
+  it("toggleParamRow toggles enabled", () => {
+    const f = makeFolder({
+      overrides: { params: { p1: { value: "v1", enabled: true } } },
+    })
+    const r = applyDraftOp(f, { kind: "toggleParamRow", index: 0 })
+    expect(r?.overrides?.params?.["p1"]?.enabled).toBe(false)
+  })
+
+  it("setParamRow updates key and value preserving enabled", () => {
+    const f = makeFolder({
+      overrides: { params: { "old-key": { value: "old", enabled: true } } },
+    })
+    const r = applyDraftOp(f, { kind: "setParamRow", index: 0, key: "new-key", value: "new" })
+    expect(Object.keys(r?.overrides?.params ?? {})).toEqual(["new-key"])
+    expect(r?.overrides?.params?.["new-key"]).toEqual({ value: "new", enabled: true })
+  })
+
+  it("revert signals return to original (null)", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "revert" })
+    expect(r).toBeNull()
+  })
+
+  it("returns null for null folder input", () => {
+    expect(applyDraftOp(null, { kind: "setName", name: "x" })).toBeNull()
+  })
+
+  it("setAuthField is no-op when auth type mismatch", () => {
+    const f = makeFolder({
+      overrides: { auth: { type: "bearer", token: "tok" } },
+    })
+    const r = applyDraftOp(f, { kind: "setAuthField", authType: "basic", field: "user", value: "u" })
+    expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "tok" })
+  })
+
+  it("setApiKeyPlacement is no-op when auth is not api_key", () => {
+    const f = makeFolder({
+      overrides: { auth: { type: "bearer", token: "tok" } },
+    })
+    const r = applyDraftOp(f, { kind: "setApiKeyPlacement", placement: "query" })
+    expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "tok" })
+  })
+
+  it("markSaved is identity", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "markSaved" })
+    expect(r).toBe(f)
+  })
+})
+
+describe("folderEqual", () => {
+  it("returns true for identical folders", () => {
+    expect(folderEqual(makeFolder(), makeFolder())).toBe(true)
+  })
+
+  it("returns false for different names", () => {
+    expect(folderEqual(makeFolder({ name: "A" }), makeFolder({ name: "B" }))).toBe(false)
+  })
+
+  it("returns false for different seq", () => {
+    expect(folderEqual(makeFolder({ seq: 1 }), makeFolder({ seq: 2 }))).toBe(false)
+  })
+
+  it("returns false for different headers", () => {
+    const a = makeFolder({
+      overrides: { headers: { "X-1": { value: "v1", enabled: true } } },
+    })
+    const b = makeFolder()
+    expect(folderEqual(a, b)).toBe(false)
+  })
+
+  it("returns false for different params", () => {
+    const a = makeFolder({
+      overrides: { params: { p1: { value: "v1", enabled: true } } },
+    })
+    const b = makeFolder()
+    expect(folderEqual(a, b)).toBe(false)
+  })
+
+  it("returns false for different auth", () => {
+    const a = makeFolder({
+      overrides: { auth: { type: "bearer", token: "tok" } },
+    })
+    const b = makeFolder()
+    expect(folderEqual(a, b)).toBe(false)
+  })
+
+  it("returns true for both undefined auth", () => {
+    expect(folderEqual(makeFolder(), makeFolder())).toBe(true)
+  })
+})

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -81,6 +81,18 @@ describe("applyDraftOp", () => {
     expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "" })
   })
 
+  it("setAuthType sets auth to none", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "setAuthType", authType: "none" })
+    expect(r?.overrides?.auth).toEqual({ type: "none" })
+  })
+
+  it("setAuthType sets auth to inherit", () => {
+    const f = makeFolder()
+    const r = applyDraftOp(f, { kind: "setAuthType", authType: "inherit" })
+    expect(r?.overrides?.auth).toEqual({ type: "inherit" })
+  })
+
   it("setAuthField updates token for bearer", () => {
     const f = makeFolder({
       overrides: { auth: { type: "bearer", token: "" } },

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -195,4 +195,12 @@ describe("folderEqual", () => {
   it("returns true for both undefined auth", () => {
     expect(folderEqual(makeFolder(), makeFolder())).toBe(true)
   })
+
+  it("returns true when one folder has none auth and other has no overrides", () => {
+    const a = makeFolder({
+      overrides: { auth: { type: "none" } },
+    })
+    const b = makeFolder()
+    expect(folderEqual(a, b)).toBe(true)
+  })
 })

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -117,37 +117,6 @@ describe("applyDraftOp", () => {
     expect(r?.overrides?.headers?.["X-New"]).toEqual({ value: "new", enabled: false })
   })
 
-  it("addParamRow adds to empty params", () => {
-    const f = makeFolder()
-    const r = applyDraftOp(f, { kind: "addParamRow", key: "page", value: "1" })
-    expect(r?.overrides?.params?.["page"]).toEqual({ value: "1", enabled: true })
-  })
-
-  it("removeParamRow deletes by index", () => {
-    const f = makeFolder({
-      overrides: { params: { p1: { value: "v1", enabled: true }, p2: { value: "v2", enabled: true } } },
-    })
-    const r = applyDraftOp(f, { kind: "removeParamRow", index: 1 })
-    expect(Object.keys(r?.overrides?.params ?? {})).toEqual(["p1"])
-  })
-
-  it("toggleParamRow toggles enabled", () => {
-    const f = makeFolder({
-      overrides: { params: { p1: { value: "v1", enabled: true } } },
-    })
-    const r = applyDraftOp(f, { kind: "toggleParamRow", index: 0 })
-    expect(r?.overrides?.params?.["p1"]?.enabled).toBe(false)
-  })
-
-  it("setParamRow updates key and value preserving enabled", () => {
-    const f = makeFolder({
-      overrides: { params: { "old-key": { value: "old", enabled: true } } },
-    })
-    const r = applyDraftOp(f, { kind: "setParamRow", index: 0, key: "new-key", value: "new" })
-    expect(Object.keys(r?.overrides?.params ?? {})).toEqual(["new-key"])
-    expect(r?.overrides?.params?.["new-key"]).toEqual({ value: "new", enabled: true })
-  })
-
   it("revert signals return to original (null)", () => {
     const f = makeFolder()
     const r = applyDraftOp(f, { kind: "revert" })
@@ -202,13 +171,6 @@ describe("folderEqual", () => {
     expect(folderEqual(a, b)).toBe(false)
   })
 
-  it("returns false for different params", () => {
-    const a = makeFolder({
-      overrides: { params: { p1: { value: "v1", enabled: true } } },
-    })
-    const b = makeFolder()
-    expect(folderEqual(a, b)).toBe(false)
-  })
 
   it("returns false for different auth", () => {
     const a = makeFolder({

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -49,14 +49,12 @@ function folderEditing(
 const defaultCounts: FolderRowCount = {
   meta: 3,
   headers: 3,
-  params: 3,
   auth: 3,
 }
 
 const emptyCounts: FolderRowCount = {
   meta: 0,
   headers: 0,
-  params: 0,
   auth: 0,
 }
 
@@ -73,7 +71,7 @@ describe("initialFolderEditState", () => {
 
 describe("FOLDER_FIELD_ORDER", () => {
   it("has correct order", () => {
-    expect(FOLDER_FIELD_ORDER).toEqual(["meta", "headers", "params", "auth"])
+    expect(FOLDER_FIELD_ORDER).toEqual(["meta", "headers", "auth"])
   })
 })
 
@@ -81,8 +79,7 @@ describe("folderFieldIndex", () => {
   it("maps field to index based on FOLDER_FIELD_ORDER", () => {
     expect(folderFieldIndex("meta")).toBe(0)
     expect(folderFieldIndex("headers")).toBe(1)
-    expect(folderFieldIndex("params")).toBe(2)
-    expect(folderFieldIndex("auth")).toBe(3)
+    expect(folderFieldIndex("auth")).toBe(2)
   })
 
   it("returns -1 for unknown field", () => {
@@ -111,10 +108,7 @@ describe("folderCursorForField", () => {
     expect(c).toEqual({ field: "headers", row: 0, addingRow: false })
   })
 
-  it("non-empty params returns row 0, addingRow false", () => {
-    const c = folderCursorForField("params", defaultCounts)
-    expect(c).toEqual({ field: "params", row: 0, addingRow: false })
-  })
+
 })
 
 describe("enterFolderEditBrowse", () => {
@@ -130,10 +124,10 @@ describe("enterFolderEditBrowse", () => {
     const result = enterFolderEditBrowse(
       folderInactive(),
       defaultCounts,
-      "params",
+      "auth",
     )
     expect(result.mode).toBe("browsing")
-    expect(result.cursor.field).toBe("params")
+    expect(result.cursor.field).toBe("auth")
     expect(result.cursor.row).toBe(0)
   })
 
@@ -171,27 +165,23 @@ describe("exitEditBrowse", () => {
 })
 
 describe("moveFolderFieldCursor", () => {
-  it("+1 walks meta → headers → params → auth → meta", () => {
+  it("+1 walks meta → headers → auth → meta", () => {
     const counts = emptyCounts
     const atMeta = enterFolderEditBrowse(folderInactive(), counts, "meta")
     const atHeaders = moveFolderFieldCursor(atMeta, 1, counts)
     expect(atHeaders.cursor.field).toBe("headers")
-    const atParams = moveFolderFieldCursor(atHeaders, 1, counts)
-    expect(atParams.cursor.field).toBe("params")
-    const atAuth = moveFolderFieldCursor(atParams, 1, counts)
+    const atAuth = moveFolderFieldCursor(atHeaders, 1, counts)
     expect(atAuth.cursor.field).toBe("auth")
     const backToMeta = moveFolderFieldCursor(atAuth, 1, counts)
     expect(backToMeta.cursor.field).toBe("meta")
   })
 
-  it("-1 walks meta → auth → params → headers → meta", () => {
+  it("-1 walks meta → auth → headers → meta", () => {
     const counts = emptyCounts
     const atMeta = enterFolderEditBrowse(folderInactive(), counts, "meta")
     const atAuth = moveFolderFieldCursor(atMeta, -1, counts)
     expect(atAuth.cursor.field).toBe("auth")
-    const atParams = moveFolderFieldCursor(atAuth, -1, counts)
-    expect(atParams.cursor.field).toBe("params")
-    const atHeaders = moveFolderFieldCursor(atParams, -1, counts)
+    const atHeaders = moveFolderFieldCursor(atAuth, -1, counts)
     expect(atHeaders.cursor.field).toBe("headers")
     const backToMeta = moveFolderFieldCursor(atHeaders, -1, counts)
     expect(backToMeta.cursor.field).toBe("meta")
@@ -206,21 +196,21 @@ describe("moveFolderFieldCursor", () => {
 
 describe("moveFolderRowCursor", () => {
   it("meta rows clamp: 0 → clamped at 0", () => {
-    const counts: FolderRowCount = { meta: 1, headers: 0, params: 0, auth: 0 }
+    const counts: FolderRowCount = { meta: 1, headers: 0, auth: 0 }
     const browsing = folderBrowsing("meta", 0)
     const step = moveFolderRowCursor(browsing, 1, counts)
     expect(step.cursor.row).toBe(0)
   })
 
   it("auth rows clamp", () => {
-    const counts: FolderRowCount = { meta: 0, headers: 0, params: 0, auth: 2 }
+    const counts: FolderRowCount = { meta: 0, headers: 0, auth: 2 }
     const browsing = folderBrowsing("auth", 1)
     const stepDown = moveFolderRowCursor(browsing, 1, counts)
     expect(stepDown.cursor.row).toBe(1)
   })
 
   it("headers addingRow wrap: 0 → 1 → [+] → 0 → 1", () => {
-    const counts: FolderRowCount = { meta: 0, headers: 2, params: 0, auth: 0 }
+    const counts: FolderRowCount = { meta: 0, headers: 2, auth: 0 }
     const at0 = folderBrowsing("headers", 0)
     const at1 = moveFolderRowCursor(at0, 1, counts)
     expect(at1.cursor.row).toBe(1)
@@ -235,18 +225,9 @@ describe("moveFolderRowCursor", () => {
     expect(backTo1.cursor.row).toBe(1)
   })
 
-  it("params addingRow wrap similar to headers", () => {
-    const counts: FolderRowCount = { meta: 0, headers: 0, params: 1, auth: 0 }
-    const browsing = folderBrowsing("params", 0)
-    const atPlus = moveFolderRowCursor(browsing, 1, counts)
-    expect(atPlus.cursor.addingRow).toBe(true)
-    const backTo0 = moveFolderRowCursor(atPlus, 1, counts)
-    expect(backTo0.cursor.row).toBe(0)
-    expect(backTo0.cursor.addingRow).toBe(false)
-  })
 
   it("headers backward wrap: [+] → last row, 0 → [+]", () => {
-    const counts: FolderRowCount = { meta: 0, headers: 3, params: 0, auth: 0 }
+    const counts: FolderRowCount = { meta: 0, headers: 3, auth: 0 }
     const at0 = folderBrowsing("headers", 0)
     const toPlus = moveFolderRowCursor(at0, -1, counts)
     expect(toPlus.cursor.addingRow).toBe(true)

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -205,13 +205,11 @@ describe("moveFolderFieldCursor", () => {
 })
 
 describe("moveFolderRowCursor", () => {
-  it("meta rows clamp: 0 → 1 → clamped at count-1", () => {
-    const counts: FolderRowCount = { meta: 2, headers: 0, params: 0, auth: 0 }
+  it("meta rows clamp: 0 → clamped at 0", () => {
+    const counts: FolderRowCount = { meta: 1, headers: 0, params: 0, auth: 0 }
     const browsing = folderBrowsing("meta", 0)
-    const step1 = moveFolderRowCursor(browsing, 1, counts)
-    expect(step1.cursor.row).toBe(1)
-    const step2 = moveFolderRowCursor(step1, 1, counts)
-    expect(step2.cursor.row).toBe(1)
+    const step = moveFolderRowCursor(browsing, 1, counts)
+    expect(step.cursor.row).toBe(0)
   })
 
   it("auth rows clamp", () => {

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -14,7 +14,7 @@ import {
   folderCursorForField,
   type EditState,
   type FolderRowCount,
-  type FieldKind,
+  type FolderFieldKind,
 } from "../../src/ui/editMode"
 
 function folderInactive(): EditState {
@@ -22,7 +22,7 @@ function folderInactive(): EditState {
 }
 
 function folderBrowsing(
-  field: FieldKind = "meta",
+  field: FolderFieldKind = "meta",
   row = 0,
   addingRow = false,
 ): EditState {
@@ -34,7 +34,7 @@ function folderBrowsing(
 }
 
 function folderEditing(
-  field: FieldKind = "meta",
+  field: FolderFieldKind = "meta",
   row = 0,
   subfield: "key" | "value" = "key",
   editingRow = 0,
@@ -86,7 +86,7 @@ describe("folderFieldIndex", () => {
   })
 
   it("returns -1 for unknown field", () => {
-    expect(folderFieldIndex("body" as FieldKind)).toBe(-1)
+    expect(folderFieldIndex("body" as FolderFieldKind)).toBe(-1)
   })
 })
 
@@ -109,6 +109,11 @@ describe("folderCursorForField", () => {
   it("non-empty headers returns row 0, addingRow false", () => {
     const c = folderCursorForField("headers", defaultCounts)
     expect(c).toEqual({ field: "headers", row: 0, addingRow: false })
+  })
+
+  it("non-empty params returns row 0, addingRow false", () => {
+    const c = folderCursorForField("params", defaultCounts)
+    expect(c).toEqual({ field: "params", row: 0, addingRow: false })
   })
 })
 
@@ -240,6 +245,17 @@ describe("moveFolderRowCursor", () => {
     const backTo0 = moveFolderRowCursor(atPlus, 1, counts)
     expect(backTo0.cursor.row).toBe(0)
     expect(backTo0.cursor.addingRow).toBe(false)
+  })
+
+  it("headers backward wrap: [+] → last row, 0 → [+]", () => {
+    const counts: FolderRowCount = { meta: 0, headers: 3, params: 0, auth: 0 }
+    const at0 = folderBrowsing("headers", 0)
+    const toPlus = moveFolderRowCursor(at0, -1, counts)
+    expect(toPlus.cursor.addingRow).toBe(true)
+    expect(toPlus.cursor.row).toBe(-1)
+    const toLast = moveFolderRowCursor(toPlus, -1, counts)
+    expect(toLast.cursor.row).toBe(counts.headers - 1)
+    expect(toLast.cursor.addingRow).toBe(false)
   })
 
   it("empty section is no-op", () => {

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from "bun:test"
+import {
+  initialFolderEditState,
+  enterFolderEditBrowse,
+  exitEditBrowse,
+  moveFolderFieldCursor,
+  moveFolderRowCursor,
+  beginEditing,
+  commitEditing,
+  cancelEditing,
+  toggleSubfield,
+  FOLDER_FIELD_ORDER,
+  folderFieldIndex,
+  folderCursorForField,
+  type EditState,
+  type FolderRowCount,
+  type FieldKind,
+} from "../../src/ui/editMode"
+
+function folderInactive(): EditState {
+  return initialFolderEditState()
+}
+
+function folderBrowsing(
+  field: FieldKind = "meta",
+  row = 0,
+  addingRow = false,
+): EditState {
+  return {
+    mode: "browsing",
+    cursor: { field, row, addingRow },
+    editingRow: -1,
+  }
+}
+
+function folderEditing(
+  field: FieldKind = "meta",
+  row = 0,
+  subfield: "key" | "value" = "key",
+  editingRow = 0,
+): EditState {
+  return {
+    mode: "editing",
+    cursor: { field, row, addingRow: false, subfield },
+    editingRow,
+  }
+}
+
+const defaultCounts: FolderRowCount = {
+  meta: 3,
+  headers: 3,
+  params: 3,
+  auth: 3,
+}
+
+const emptyCounts: FolderRowCount = {
+  meta: 0,
+  headers: 0,
+  params: 0,
+  auth: 0,
+}
+
+describe("initialFolderEditState", () => {
+  it("starts inactive with meta cursor", () => {
+    const state = initialFolderEditState()
+    expect(state.mode).toBe("inactive")
+    expect(state.cursor.field).toBe("meta")
+    expect(state.cursor.row).toBe(-1)
+    expect(state.cursor.addingRow).toBe(false)
+    expect(state.editingRow).toBe(-1)
+  })
+})
+
+describe("FOLDER_FIELD_ORDER", () => {
+  it("has correct order", () => {
+    expect(FOLDER_FIELD_ORDER).toEqual(["meta", "headers", "params", "auth"])
+  })
+})
+
+describe("folderFieldIndex", () => {
+  it("maps field to index based on FOLDER_FIELD_ORDER", () => {
+    expect(folderFieldIndex("meta")).toBe(0)
+    expect(folderFieldIndex("headers")).toBe(1)
+    expect(folderFieldIndex("params")).toBe(2)
+    expect(folderFieldIndex("auth")).toBe(3)
+  })
+
+  it("returns -1 for unknown field", () => {
+    expect(folderFieldIndex("body" as FieldKind)).toBe(-1)
+  })
+})
+
+describe("folderCursorForField", () => {
+  it("meta returns row 0, addingRow false", () => {
+    const c = folderCursorForField("meta", emptyCounts)
+    expect(c).toEqual({ field: "meta", row: 0, addingRow: false })
+  })
+
+  it("auth returns row 0, addingRow false", () => {
+    const c = folderCursorForField("auth", emptyCounts)
+    expect(c).toEqual({ field: "auth", row: 0, addingRow: false })
+  })
+
+  it("empty headers returns addingRow true, row -1", () => {
+    const c = folderCursorForField("headers", emptyCounts)
+    expect(c).toEqual({ field: "headers", row: -1, addingRow: true })
+  })
+
+  it("non-empty headers returns row 0, addingRow false", () => {
+    const c = folderCursorForField("headers", defaultCounts)
+    expect(c).toEqual({ field: "headers", row: 0, addingRow: false })
+  })
+})
+
+describe("enterFolderEditBrowse", () => {
+  it("inactive → browsing at meta", () => {
+    const result = enterFolderEditBrowse(folderInactive(), emptyCounts)
+    expect(result.mode).toBe("browsing")
+    expect(result.cursor.field).toBe("meta")
+    expect(result.cursor.row).toBe(0)
+    expect(result.editingRow).toBe(-1)
+  })
+
+  it("inactive → browsing at explicit start field", () => {
+    const result = enterFolderEditBrowse(
+      folderInactive(),
+      defaultCounts,
+      "params",
+    )
+    expect(result.mode).toBe("browsing")
+    expect(result.cursor.field).toBe("params")
+    expect(result.cursor.row).toBe(0)
+  })
+
+  it("no-op from browsing", () => {
+    const browsing = folderBrowsing()
+    const result = enterFolderEditBrowse(browsing, defaultCounts)
+    expect(result).toBe(browsing)
+  })
+
+  it("no-op from editing", () => {
+    const editing = folderEditing()
+    const result = enterFolderEditBrowse(editing, defaultCounts)
+    expect(result).toBe(editing)
+  })
+})
+
+describe("exitEditBrowse", () => {
+  it("browsing → inactive", () => {
+    const result = exitEditBrowse(folderBrowsing())
+    expect(result.mode).toBe("inactive")
+    expect(result.cursor.field).toBe("meta")
+  })
+
+  it("no-op from editing", () => {
+    const editing = folderEditing()
+    const result = exitEditBrowse(editing)
+    expect(result).toBe(editing)
+  })
+
+  it("no-op from inactive", () => {
+    const inactive = folderInactive()
+    const result = exitEditBrowse(inactive)
+    expect(result).toBe(inactive)
+  })
+})
+
+describe("moveFolderFieldCursor", () => {
+  it("+1 walks meta → headers → params → auth → meta", () => {
+    const counts = emptyCounts
+    const atMeta = enterFolderEditBrowse(folderInactive(), counts, "meta")
+    const atHeaders = moveFolderFieldCursor(atMeta, 1, counts)
+    expect(atHeaders.cursor.field).toBe("headers")
+    const atParams = moveFolderFieldCursor(atHeaders, 1, counts)
+    expect(atParams.cursor.field).toBe("params")
+    const atAuth = moveFolderFieldCursor(atParams, 1, counts)
+    expect(atAuth.cursor.field).toBe("auth")
+    const backToMeta = moveFolderFieldCursor(atAuth, 1, counts)
+    expect(backToMeta.cursor.field).toBe("meta")
+  })
+
+  it("-1 walks meta → auth → params → headers → meta", () => {
+    const counts = emptyCounts
+    const atMeta = enterFolderEditBrowse(folderInactive(), counts, "meta")
+    const atAuth = moveFolderFieldCursor(atMeta, -1, counts)
+    expect(atAuth.cursor.field).toBe("auth")
+    const atParams = moveFolderFieldCursor(atAuth, -1, counts)
+    expect(atParams.cursor.field).toBe("params")
+    const atHeaders = moveFolderFieldCursor(atParams, -1, counts)
+    expect(atHeaders.cursor.field).toBe("headers")
+    const backToMeta = moveFolderFieldCursor(atHeaders, -1, counts)
+    expect(backToMeta.cursor.field).toBe("meta")
+  })
+
+  it("no-op when editing", () => {
+    const editing = folderEditing()
+    const result = moveFolderFieldCursor(editing, 1, emptyCounts)
+    expect(result).toBe(editing)
+  })
+})
+
+describe("moveFolderRowCursor", () => {
+  it("meta rows clamp: 0 → 1 → clamped at count-1", () => {
+    const counts: FolderRowCount = { meta: 2, headers: 0, params: 0, auth: 0 }
+    const browsing = folderBrowsing("meta", 0)
+    const step1 = moveFolderRowCursor(browsing, 1, counts)
+    expect(step1.cursor.row).toBe(1)
+    const step2 = moveFolderRowCursor(step1, 1, counts)
+    expect(step2.cursor.row).toBe(1)
+  })
+
+  it("auth rows clamp", () => {
+    const counts: FolderRowCount = { meta: 0, headers: 0, params: 0, auth: 2 }
+    const browsing = folderBrowsing("auth", 1)
+    const stepDown = moveFolderRowCursor(browsing, 1, counts)
+    expect(stepDown.cursor.row).toBe(1)
+  })
+
+  it("headers addingRow wrap: 0 → 1 → [+] → 0 → 1", () => {
+    const counts: FolderRowCount = { meta: 0, headers: 2, params: 0, auth: 0 }
+    const at0 = folderBrowsing("headers", 0)
+    const at1 = moveFolderRowCursor(at0, 1, counts)
+    expect(at1.cursor.row).toBe(1)
+    expect(at1.cursor.addingRow).toBe(false)
+    const atPlus = moveFolderRowCursor(at1, 1, counts)
+    expect(atPlus.cursor.row).toBe(-1)
+    expect(atPlus.cursor.addingRow).toBe(true)
+    const backTo0 = moveFolderRowCursor(atPlus, 1, counts)
+    expect(backTo0.cursor.row).toBe(0)
+    expect(backTo0.cursor.addingRow).toBe(false)
+    const backTo1 = moveFolderRowCursor(backTo0, 1, counts)
+    expect(backTo1.cursor.row).toBe(1)
+  })
+
+  it("params addingRow wrap similar to headers", () => {
+    const counts: FolderRowCount = { meta: 0, headers: 0, params: 1, auth: 0 }
+    const browsing = folderBrowsing("params", 0)
+    const atPlus = moveFolderRowCursor(browsing, 1, counts)
+    expect(atPlus.cursor.addingRow).toBe(true)
+    const backTo0 = moveFolderRowCursor(atPlus, 1, counts)
+    expect(backTo0.cursor.row).toBe(0)
+    expect(backTo0.cursor.addingRow).toBe(false)
+  })
+
+  it("empty section is no-op", () => {
+    const browsing = folderBrowsing("headers", 0)
+    const result = moveFolderRowCursor(browsing, 1, emptyCounts)
+    expect(result).toBe(browsing)
+  })
+
+  it("no-op when editing", () => {
+    const editing = folderEditing()
+    const result = moveFolderRowCursor(editing, 1, defaultCounts)
+    expect(result).toBe(editing)
+  })
+})
+
+describe("beginEditing for meta", () => {
+  it("sets subfield to 'key' for meta", () => {
+    const browsing = folderBrowsing("meta", 0)
+    const result = beginEditing(browsing)
+    expect(result.mode).toBe("editing")
+    expect(result.cursor.subfield).toBe("key")
+    expect(result.editingRow).toBe(0)
+  })
+})
+
+describe("toggleSubfield for meta", () => {
+  it("toggles key → value for meta", () => {
+    const editing = folderEditing("meta", 0, "key", 0)
+    const toggled = toggleSubfield(editing)
+    expect(toggled.cursor.subfield).toBe("value")
+    const toggledBack = toggleSubfield(toggled)
+    expect(toggledBack.cursor.subfield).toBe("key")
+  })
+})
+
+describe("commitEditing", () => {
+  it("editing → browsing, editingRow reset to -1", () => {
+    const editing = folderEditing("meta", 0, "key", 0)
+    const result = commitEditing(editing)
+    expect(result.mode).toBe("browsing")
+    expect(result.editingRow).toBe(-1)
+  })
+
+  it("no-op when not editing", () => {
+    const browsing = folderBrowsing()
+    const result = commitEditing(browsing)
+    expect(result).toBe(browsing)
+  })
+
+  it("clears subfield after commit", () => {
+    const editing = folderEditing("meta", 0, "key", 0)
+    const result = commitEditing(editing)
+    expect(result.cursor.subfield).toBeUndefined()
+  })
+})
+
+describe("cancelEditing", () => {
+  it("editing → browsing, editingRow reset to -1, cursor preserved", () => {
+    const editing = folderEditing("meta", 0, "key", 0)
+    const result = cancelEditing(editing)
+    expect(result.mode).toBe("browsing")
+    expect(result.editingRow).toBe(-1)
+    expect(result.cursor.field).toBe("meta")
+    expect(result.cursor.row).toBe(0)
+  })
+
+  it("no-op when not editing", () => {
+    const browsing = folderBrowsing()
+    const result = cancelEditing(browsing)
+    expect(result).toBe(browsing)
+  })
+
+  it("clears subfield after cancel", () => {
+    const editing = folderEditing("meta", 0, "key", 0)
+    const result = cancelEditing(editing)
+    expect(result.cursor.subfield).toBeUndefined()
+  })
+})

--- a/tests/unit/hintForFocus.test.ts
+++ b/tests/unit/hintForFocus.test.ts
@@ -77,6 +77,40 @@ describe("hintForFocus — sidebar is mode-independent", () => {
   })
 })
 
+describe("hintForFocus — folder browsing", () => {
+  it("shows navigate, tabs, edit, Esc, save, revert all", () => {
+    const hint = hintForFocus("folder", "browsing")
+    expect(hint).toContain("↑")
+    expect(hint).toContain("↓")
+    expect(hint).toContain("←")
+    expect(hint).toContain("→")
+    expect(hint).toContain("tabs")
+    expect(hint).toContain("Enter")
+    expect(hint).toContain("edit")
+    expect(hint).toContain("Esc")
+    expect(hint).toContain("save")
+    expect(hint).toContain("revert")
+  })
+})
+
+describe("hintForFocus — folder editing", () => {
+  it("shows commit and cancel", () => {
+    const hint = hintForFocus("folder", "editing")
+    expect(hint).toContain("commit")
+    expect(hint).toContain("cancel")
+  })
+})
+
+describe("hintForFocus — folder inactive", () => {
+  it("shows save and Tab", () => {
+    const hint = hintForFocus("folder", "inactive")
+    expect(hint).toContain("save")
+    expect(hint).toContain("Tab")
+    expect(hint).not.toContain("edit")
+    expect(hint).not.toContain("revert")
+  })
+})
+
 describe("hintForFocus — response is mode-independent", () => {
   it("same hint for all modes when response focused", () => {
     const a = hintForFocus("response", "inactive")

--- a/tests/unit/mergeFolderOverrides.test.ts
+++ b/tests/unit/mergeFolderOverrides.test.ts
@@ -46,6 +46,13 @@ describe("mergeFolderOverrides", () => {
     expect(result.headers).toEqual(req.headers)
   })
 
+  it("returns request unchanged when path has no folders", () => {
+    const req = makeRequest()
+    const col: Collection = { id: "c", name: "C", items: [] }
+    const result = mergeFolderOverrides(req, col, "plain-req")
+    expect(result).toBe(req)
+  })
+
   it("merges folder headers into request", () => {
     const folder = makeFolder("auth", {
       headers: { "X-Folder": { value: "fv", enabled: true } },
@@ -79,61 +86,16 @@ describe("mergeFolderOverrides", () => {
     expect(result.headers["X-Common"]?.value).toBe("request")
   })
 
-  it("merges folder params", () => {
-    const folder = makeFolder("api", {
-      params: { limit: { value: "50", enabled: true } },
-    })
-    const req = makeRequest()
-    const col: Collection = {
-      id: "c",
-      name: "C",
-      items: [{ type: "folder", data: folder }],
-    }
-    const result = mergeFolderOverrides(req, col, "api/users")
-    expect(result.params["limit"]).toEqual({ value: "50", enabled: true })
-  })
-
-  it("applies folder auth when request auth is none", () => {
-    const folder = makeFolder("auth", {
-      auth: { type: "bearer", token: "tok123" },
-    })
-    const req = makeRequest({ auth: { type: "none" } })
-    const col: Collection = {
-      id: "c",
-      name: "C",
-      items: [{ type: "folder", data: folder }],
-    }
-    const result = mergeFolderOverrides(req, col, "auth/login")
-    expect(result.auth).toEqual({ type: "bearer", token: "tok123" })
-  })
-
-  it("request auth overrides folder auth", () => {
-    const folder = makeFolder("auth", {
-      auth: { type: "bearer", token: "folder-tok" },
-    })
-    const req = makeRequest({
-      auth: { type: "basic", user: "u", pass: "p" },
-    })
-    const col: Collection = {
-      id: "c",
-      name: "C",
-      items: [{ type: "folder", data: folder }],
-    }
-    const result = mergeFolderOverrides(req, col, "auth/login")
-    expect(result.auth).toEqual({ type: "basic", user: "u", pass: "p" })
-  })
-
-  it("nested folders merge in path order (parent->child)", () => {
+  it("nested folders merge headers in parent->child order", () => {
     const child = makeFolder("auth/bearer", {
       headers: { "X-Child": { value: "cv", enabled: true } },
-      auth: { type: "bearer", token: "child-tok" },
     })
     const parent = makeFolderData(
       "auth",
       { headers: { "X-Parent": { value: "pv", enabled: true } } },
       [{ type: "folder", data: child }],
     )
-    const req = makeRequest({ auth: { type: "none" } })
+    const req = makeRequest()
     const col: Collection = {
       id: "c",
       name: "C",
@@ -142,18 +104,6 @@ describe("mergeFolderOverrides", () => {
     const result = mergeFolderOverrides(req, col, "auth/bearer/login")
     expect(result.headers["X-Parent"]?.value).toBe("pv")
     expect(result.headers["X-Child"]?.value).toBe("cv")
-    expect(result.auth).toEqual({ type: "bearer", token: "child-tok" })
-  })
-
-  it("returns request unchanged when path has no folders", () => {
-    const req = makeRequest()
-    const col: Collection = {
-      id: "c",
-      name: "C",
-      items: [],
-    }
-    const result = mergeFolderOverrides(req, col, "plain-req")
-    expect(result).toBe(req)
   })
 
   it("child folder headers don't override request on conflict", () => {
@@ -179,7 +129,85 @@ describe("mergeFolderOverrides", () => {
     expect(result.headers["Accept"]?.value).toBe("application/json")
   })
 
-  it("innermost non-none folder auth wins", () => {
+  it("request auth overrides folder auth", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "bearer", token: "folder-tok" },
+    })
+    const req = makeRequest({
+      auth: { type: "basic", user: "u", pass: "p" },
+    })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "basic", user: "u", pass: "p" })
+  })
+
+  it("none request auth means no auth — does NOT look up folder", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "bearer", token: "tok123" },
+    })
+    const req = makeRequest({ auth: { type: "none" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "none" })
+  })
+
+  it("undefined request auth means no auth — does NOT look up folder", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "bearer", token: "tok123" },
+    })
+    const req = makeRequest()
+    req.auth = undefined
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "none" })
+  })
+
+  it("inherit request auth uses folder auth when available", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "bearer", token: "tok123" },
+    })
+    const req = makeRequest({ auth: { type: "inherit" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "bearer", token: "tok123" })
+  })
+
+  it("inherit falls back to none when no folder has auth", () => {
+    const folder = makeFolder("empty", { headers: {} })
+    const req = makeRequest({ auth: { type: "inherit" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "empty/login")
+    expect(result.auth).toEqual({ type: "none" })
+  })
+
+  it("inherit falls back to none when no folders exist", () => {
+    const req = makeRequest({ auth: { type: "inherit" } })
+    const col: Collection = { id: "c", name: "C", items: [] }
+    const result = mergeFolderOverrides(req, col, "foo")
+    expect(result).toBe(req)
+  })
+
+  it("inherit walks child→parent, picks deepest non-none folder auth", () => {
     const child = makeFolder("api/v2", {
       auth: { type: "bearer", token: "child-tok" },
     })
@@ -188,7 +216,7 @@ describe("mergeFolderOverrides", () => {
       { auth: { type: "basic", user: "parent", pass: "pw" } },
       [{ type: "folder", data: child }],
     )
-    const req = makeRequest({ auth: { type: "none" } })
+    const req = makeRequest({ auth: { type: "inherit" } })
     const col: Collection = {
       id: "c",
       name: "C",
@@ -196,5 +224,57 @@ describe("mergeFolderOverrides", () => {
     }
     const result = mergeFolderOverrides(req, col, "api/v2/endpoint")
     expect(result.auth).toEqual({ type: "bearer", token: "child-tok" })
+  })
+
+  it("inherit skips parent with none, picks child with bearer", () => {
+    const child = makeFolder("api/v2", {
+      auth: { type: "bearer", token: "tok" },
+    })
+    const parent = makeFolderData(
+      "api",
+      { auth: { type: "none" } },
+      [{ type: "folder", data: child }],
+    )
+    const req = makeRequest({ auth: { type: "inherit" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: parent }],
+    }
+    const result = mergeFolderOverrides(req, col, "api/v2/endpoint")
+    expect(result.auth).toEqual({ type: "bearer", token: "tok" })
+  })
+
+  it("inherit picks parent auth when child is none", () => {
+    const child = makeFolder("api/v2", {
+      auth: { type: "none" },
+    })
+    const parent = makeFolderData(
+      "api",
+      { auth: { type: "basic", user: "admin", pass: "pw" } },
+      [{ type: "folder", data: child }],
+    )
+    const req = makeRequest({ auth: { type: "inherit" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: parent }],
+    }
+    const result = mergeFolderOverrides(req, col, "api/v2/endpoint")
+    expect(result.auth).toEqual({ type: "basic", user: "admin", pass: "pw" })
+  })
+
+  it("inherit skips folder auth marked as inherit", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "inherit" },
+    })
+    const req = makeRequest({ auth: { type: "inherit" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "none" })
   })
 })

--- a/tests/unit/mergeFolderOverrides.test.ts
+++ b/tests/unit/mergeFolderOverrides.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "bun:test"
+import { mergeFolderOverrides } from "../../src/requests/mergeFolderOverrides"
+import type { Collection, Folder, Request } from "../../src/schema"
+
+function makeRequest(overrides?: Partial<Request>): Request {
+  return {
+    id: "test",
+    name: "Test",
+    method: "GET",
+    url: "https://example.com",
+    headers: {},
+    params: {},
+    auth: { type: "none" },
+    bodyType: "none",
+    body: "",
+    timeout: 0,
+    followRedirects: true,
+    maxRedirects: 5,
+    ...overrides,
+  }
+}
+
+function makeFolderData(
+  path: string,
+  overrides?: Folder["overrides"],
+  children?: Folder["children"],
+): Folder {
+  return {
+    id: path.split("/").pop()!,
+    name: path.split("/").pop()!,
+    path,
+    children: children ?? [],
+    overrides,
+  }
+}
+
+function makeFolder(path: string, overrides?: Folder["overrides"]): Folder {
+  return makeFolderData(path, overrides)
+}
+
+describe("mergeFolderOverrides", () => {
+  it("returns unchanged request when no folder exists", () => {
+    const req = makeRequest()
+    const col: Collection = { id: "c", name: "C", items: [] }
+    const result = mergeFolderOverrides(req, col, "test")
+    expect(result.headers).toEqual(req.headers)
+  })
+
+  it("merges folder headers into request", () => {
+    const folder = makeFolder("auth", {
+      headers: { "X-Folder": { value: "fv", enabled: true } },
+    })
+    const req = makeRequest({
+      headers: { "X-Req": { value: "rv", enabled: true } },
+    })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.headers["X-Folder"]).toEqual({ value: "fv", enabled: true })
+    expect(result.headers["X-Req"]).toEqual({ value: "rv", enabled: true })
+  })
+
+  it("request headers override folder headers on conflict", () => {
+    const folder = makeFolder("auth", {
+      headers: { "X-Common": { value: "folder", enabled: true } },
+    })
+    const req = makeRequest({
+      headers: { "X-Common": { value: "request", enabled: true } },
+    })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.headers["X-Common"]?.value).toBe("request")
+  })
+
+  it("merges folder params", () => {
+    const folder = makeFolder("api", {
+      params: { limit: { value: "50", enabled: true } },
+    })
+    const req = makeRequest()
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "api/users")
+    expect(result.params["limit"]).toEqual({ value: "50", enabled: true })
+  })
+
+  it("applies folder auth when request auth is none", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "bearer", token: "tok123" },
+    })
+    const req = makeRequest({ auth: { type: "none" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "bearer", token: "tok123" })
+  })
+
+  it("request auth overrides folder auth", () => {
+    const folder = makeFolder("auth", {
+      auth: { type: "bearer", token: "folder-tok" },
+    })
+    const req = makeRequest({
+      auth: { type: "basic", user: "u", pass: "p" },
+    })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: folder }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/login")
+    expect(result.auth).toEqual({ type: "basic", user: "u", pass: "p" })
+  })
+
+  it("nested folders merge in path order (parent->child)", () => {
+    const child = makeFolder("auth/bearer", {
+      headers: { "X-Child": { value: "cv", enabled: true } },
+      auth: { type: "bearer", token: "child-tok" },
+    })
+    const parent = makeFolderData(
+      "auth",
+      { headers: { "X-Parent": { value: "pv", enabled: true } } },
+      [{ type: "folder", data: child }],
+    )
+    const req = makeRequest({ auth: { type: "none" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: parent }],
+    }
+    const result = mergeFolderOverrides(req, col, "auth/bearer/login")
+    expect(result.headers["X-Parent"]?.value).toBe("pv")
+    expect(result.headers["X-Child"]?.value).toBe("cv")
+    expect(result.auth).toEqual({ type: "bearer", token: "child-tok" })
+  })
+
+  it("returns request unchanged when path has no folders", () => {
+    const req = makeRequest()
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [],
+    }
+    const result = mergeFolderOverrides(req, col, "plain-req")
+    expect(result).toBe(req)
+  })
+
+  it("child folder headers don't override request on conflict", () => {
+    const child = makeFolder("api/v2", {
+      headers: { Accept: { value: "text/plain", enabled: true } },
+    })
+    const parent = makeFolderData(
+      "api",
+      { headers: { Accept: { value: "text/csv", enabled: true } } },
+      [{ type: "folder", data: child }],
+    )
+    const req = makeRequest({
+      headers: {
+        Accept: { value: "application/json", enabled: true },
+      },
+    })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: parent }],
+    }
+    const result = mergeFolderOverrides(req, col, "api/v2/endpoint")
+    expect(result.headers["Accept"]?.value).toBe("application/json")
+  })
+
+  it("innermost non-none folder auth wins", () => {
+    const child = makeFolder("api/v2", {
+      auth: { type: "bearer", token: "child-tok" },
+    })
+    const parent = makeFolderData(
+      "api",
+      { auth: { type: "basic", user: "parent", pass: "pw" } },
+      [{ type: "folder", data: child }],
+    )
+    const req = makeRequest({ auth: { type: "none" } })
+    const col: Collection = {
+      id: "c",
+      name: "C",
+      items: [{ type: "folder", data: parent }],
+    }
+    const result = mergeFolderOverrides(req, col, "api/v2/endpoint")
+    expect(result.auth).toEqual({ type: "bearer", token: "child-tok" })
+  })
+})


### PR DESCRIPTION
## Summary

Adds folder-level configuration for HTTP collections — folders can now define shared headers, auth overrides, and metadata that cascade down to contained requests.

## Changes

- **Schema:** Add `inherit` auth type, remove `params` from folder overrides
- **Lang layer:** Parse/serialize `inherit` auth in requests and folders
- **Merge logic:** `mergeFolderOverrides` — folders merge headers (request wins on conflict), auth supports `inherit` (walks deepest→shallowest)
- **Send pipeline:** Folder overrides applied before env substitution
- **AuthEditor:** Generalized to accept standalone `auth` prop; shows `inherit` option for requests and folders
- **KeyValueSection:** Generalized to accept `entries` prop (not tied to request object)
- **Draft hooks:** `useFolderDraft` + `useFolderEditBrowse` for mutable editing with dirty tracking
- **FolderPane:** Full folder editor with Meta, Headers, Auth tabs; dirty indicators in sidebar
- **Keybind layers:** Browse/edit keymaps for folder focus mode

## Bugs fixed during review

- Headers/params sent as `[object Object]` when folder overrides apply without active env (send.ts)
- Collection state mutation bypassing React re-render on folder save
- Dead code cleanup (`sortedEntries`, `FIELD_ORDER`, `.index` on entries)
- Redundant `isActive` check in auto-enter-browse effect