### PR TITLE
fix(useTreeNavigation): preserve selectedId when initialSelectedId is a folder path

### DIFF
--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -93,18 +93,20 @@ export function useTreeNavigation(
   useEffect(() => {
     if (flatReqs.length > 0) {
       initialCursorSet.current = false
-      if (initialSelectedId && initialSelectedId.endsWith("/")) return
+
       let targetId: string | null = null
       if (selectedId) {
         const found = findRequestById(items, selectedId)
         if (found) targetId = selectedId
       }
-      if (!targetId && initialSelectedId) {
+      if (!targetId && initialSelectedId && !initialSelectedId.endsWith("/")) {
         const found = findRequestById(items, initialSelectedId)
         if (found) targetId = initialSelectedId
       }
-      if (!targetId) targetId = flatReqs[0].id
-      if (targetId !== selectedId) {
+      if (!targetId && !(initialSelectedId && initialSelectedId.endsWith("/"))) {
+        targetId = flatReqs[0].id
+      }
+      if (targetId && targetId !== selectedId) {
         setSelectedIdState(targetId)
         const parts = targetId.split("/")
         if (parts.length > 1) {
@@ -133,7 +135,6 @@ export function useTreeNavigation(
     if (vis.length === 0) return
 
     if (!initialSetupDone.current) {
-      initialSetupDone.current = true
       if (initialSelectedId && initialSelectedId.endsWith("/")) {
         const folderPath = initialSelectedId.slice(0, -1)
         const idx = vis.findIndex(
@@ -142,9 +143,11 @@ export function useTreeNavigation(
         if (idx >= 0) {
           setCursorIndex(idx)
           initialCursorSet.current = true
+          initialSetupDone.current = true
           return
         }
       }
+      initialSetupDone.current = true
     }
 
     if (!selectedId) return

--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -158,7 +158,7 @@ export function useTreeNavigation(
       setCursorIndex(idx)
       initialCursorSet.current = true
     }
-  })
+  }, [selectedId, vis])
 
   useKeyboard((key) => {
     if (!enabled()) return

--- a/tests/unit/useTreeNavigation.test.tsx
+++ b/tests/unit/useTreeNavigation.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { useEffect, useState, type ReactNode } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { setupKeymap } from "./_helpers"
+import { useTreeNavigation } from "../../src/hooks/useTreeNavigation"
+import type { CollectionItem } from "../../src/schema"
+
+function req(id: string): CollectionItem {
+  return {
+    type: "request" as const,
+    data: {
+      id,
+      name: id,
+      method: "GET",
+      url: "https://example.com",
+      headers: {},
+      params: {},
+      timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
+      auth: { type: "none" as const },
+    },
+  }
+}
+
+function fld(path: string, children: CollectionItem[]): CollectionItem {
+  const id = path.split("/").pop()!
+  return {
+    type: "folder" as const,
+    data: { id, name: id, path, children },
+  }
+}
+
+interface Props {
+  initialSelectedId?: string
+  initialItems: CollectionItem[]
+  afterMount?: (
+    setSelectedId: (id: string) => void,
+    setItems: (items: CollectionItem[]) => void,
+    expandFolder: (path: string) => void,
+  ) => void
+}
+
+function Harness({ initialSelectedId, initialItems, afterMount }: Props): ReactNode {
+  const [items, setItems] = useState(initialItems)
+  const { selectedId, setSelectedId, expandFolder, cursorIndex } = useTreeNavigation(
+    items,
+    () => true,
+    initialSelectedId,
+  )
+
+  useEffect(() => {
+    afterMount?.(setSelectedId, setItems, expandFolder)
+  }, [])
+
+  return <text>{`s:${selectedId ?? ""}|c:${cursorIndex}`}</text>
+}
+
+describe("useTreeNavigation", () => {
+  let keyCleanup: (() => void) | undefined
+
+  beforeEach(() => {
+    keyCleanup = undefined
+  })
+
+  afterEach(() => {
+    keyCleanup?.()
+  })
+
+  function render(element: ReactNode) {
+    const { keymap, cleanup } = setupKeymap()
+    keyCleanup = cleanup
+    return testRender(
+      <KeymapProvider keymap={keymap}>
+        {element}
+      </KeymapProvider>,
+      { width: 80, height: 10 },
+    )
+  }
+
+  it("selects new request when initialSelectedId is a folder path", async () => {
+    const items1 = [fld("users", [])]
+    const items2 = [fld("users", [req("users/list")])]
+
+    const { renderOnce, captureCharFrame } = await render(
+      <Harness
+        initialSelectedId="users/"
+        initialItems={items1}
+        afterMount={(setSelectedId, setItems, expandFolder) => {
+          setTimeout(() => {
+            expandFolder("users")
+            setSelectedId("users/list")
+            setItems(items2)
+          }, 5)
+        }}
+      />,
+    )
+
+    await renderOnce()
+    await renderOnce()
+
+    // Wait for the create flow to complete
+    await new Promise((r) => setTimeout(r, 30))
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    // selectedId should be "users/list" (not null) and cursor should
+    // point to the request (not the folder)
+    expect(frame).toContain("s:users/list")
+    expect(frame).toContain("c:1")
+  })
+
+  it("keeps folder cursor when initialSelectedId is a folder and no request selected", async () => {
+    const items = [fld("users", [])]
+
+    const { renderOnce, captureCharFrame } = await render(
+      <Harness
+        initialSelectedId="users/"
+        initialItems={items}
+      />,
+    )
+
+    await renderOnce()
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    // No request selected, cursor should be at folder index (0)
+    expect(frame).toContain("s:")
+    expect(frame).toContain("c:0")
+  })
+
+  it("selects request from initialSelectedId when it names a request", async () => {
+    const items = [fld("users", [req("users/list")])]
+
+    const { renderOnce, captureCharFrame } = await render(
+      <Harness
+        initialSelectedId="users/list"
+        initialItems={items}
+      />,
+    )
+
+    await renderOnce()
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame).toContain("s:users/list")
+    expect(frame).toContain("c:1")
+  })
+})


### PR DESCRIPTION
Orphaned commits from merged `refactor/ui-ux` branch. Two fixes:

1. **selectedId cleared on folder-path initialSelectedId** — early return skipped `selectedId` state check after create/clone request
2. **Missing dependency array** — added `[selectedId, vis]` to cursor sync effect

3 new tests in `tests/unit/useTreeNavigation.test.tsx`.

1105 pass, 0 fail, lint + typecheck clean.