### PR TITLE
feat: folder activity tab

### DIFF
--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -10,12 +10,7 @@ import type {
   Request,
 } from "../schema"
 
-const SKIP_DIRS = new Set([
-  ".noodle",
-  ".timeline",
-  ".git",
-  "node_modules",
-])
+const SKIP_DIRS = new Set([".noodle", ".timeline", ".git", "node_modules"])
 
 async function walk(
   absDir: string,
@@ -37,7 +32,11 @@ async function walk(
     const msg = e instanceof Error ? e.message : String(e)
     throw new Error(`filestore.loadCollection: ${msg}`, { cause: e })
   }
-  if (root !== undefined && resolved !== root && !resolved.startsWith(root + "/")) {
+  if (
+    root !== undefined &&
+    resolved !== root &&
+    !resolved.startsWith(root + "/")
+  ) {
     return []
   }
   if (visited.has(resolved)) return []

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -231,7 +231,6 @@ export function useEditBrowse(
       : (options?.initialTab ?? inactiveTab)
 
   const enterBrowse = useCallback(() => {
-    if (activeTab === "activity") return
     const c = rowCount(draftRef.current)
     const tab = activeTab
     setEditState((prev) => {

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -231,6 +231,7 @@ export function useEditBrowse(
       : (options?.initialTab ?? inactiveTab)
 
   const enterBrowse = useCallback(() => {
+    if (activeTab === "activity") return
     const c = rowCount(draftRef.current)
     const tab = activeTab
     setEditState((prev) => {
@@ -240,6 +241,7 @@ export function useEditBrowse(
   }, [activeTab])
 
   const enterAndEdit = useCallback(() => {
+    if (activeTab === "activity") return
     const c = rowCount(draftRef.current)
     const currentDraft = draftRef.current
     const tab = activeTab

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -170,7 +170,12 @@ export function applyDraftOp(
       } else {
         draft.overrides = {
           ...draft.overrides,
-          headers: replaceRow(draft.overrides?.headers ?? {}, op.index, key, value),
+          headers: replaceRow(
+            draft.overrides?.headers ?? {},
+            op.index,
+            key,
+            value,
+          ),
         }
       }
       break
@@ -211,9 +216,7 @@ export function applyDraftOp(
 export function folderEqual(a: Folder, b: Folder): boolean {
   if (a.name !== b.name) return false
   if (a.seq !== b.seq) return false
-  if (
-    !recordsEqual(a.overrides?.headers ?? {}, b.overrides?.headers ?? {})
-  )
+  if (!recordsEqual(a.overrides?.headers ?? {}, b.overrides?.headers ?? {}))
     return false
   if (!authEqual(a.overrides?.auth, b.overrides?.auth)) return false
   return true
@@ -317,8 +320,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
     [dispatch],
   )
   const setAuthType = useCallback(
-    (authType: Auth["type"]) =>
-      dispatch({ kind: "setAuthType", authType }),
+    (authType: Auth["type"]) => dispatch({ kind: "setAuthType", authType }),
     [dispatch],
   )
   const setAuthField = useCallback(
@@ -331,10 +333,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       dispatch({ kind: "setApiKeyPlacement", placement }),
     [dispatch],
   )
-  const revertAll = useCallback(
-    () => dispatch({ kind: "revert" }),
-    [dispatch],
-  )
+  const revertAll = useCallback(() => dispatch({ kind: "revert" }), [dispatch])
   const markSaved = useCallback(() => {
     if (!folderDraft || !folder) return
     setOriginalMap((prev) => {

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -74,6 +74,7 @@ function folderCurrentValueFor(
   addingRow: boolean,
 ): string {
   if (!folder) return ""
+  if (field === "activity") return ""
   if (field === "meta") {
     if (row === 0) return folder.name ?? ""
     return ""
@@ -115,6 +116,7 @@ function folderCurrentKeyValueFor(
   addingRow: boolean,
 ): { key: string; value: string } {
   if (!folder) return { key: "", value: "" }
+  if (field === "activity") return { key: "", value: "" }
   if (addingRow) return { key: "", value: "" }
   if (field === "headers") {
     const rec = folder.overrides?.headers ?? {}
@@ -188,6 +190,7 @@ export function useFolderEditBrowse(
       : (options?.initialTab ?? inactiveTab)
 
   const enterBrowse = useCallback(() => {
+    if (activeTab === "activity") return
     const c = folderRowCount(draftRef.current)
     const tab = activeTab as FolderFieldKind
     setEditState((prev) => {
@@ -197,6 +200,7 @@ export function useFolderEditBrowse(
   }, [activeTab])
 
   const enterAndEdit = useCallback(() => {
+    if (activeTab === "activity") return
     const c = folderRowCount(draftRef.current)
     const currentFolder = draftRef.current
     const tab = activeTab as FolderFieldKind

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -156,7 +156,7 @@ export function useFolderEditBrowse(
   const [editValue, setEditValue] = useState("")
   const [editKey, setEditKey] = useState("")
   const [inactiveTab, setInactiveTab] = useState<FieldKind>(
-    options?.initialTab ?? "meta",
+    options?.initialTab ?? "activity",
   )
 
   const draftRef = useRef(folder)

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -175,7 +175,7 @@ export function useFolderEditBrowse(
   onTabChangeRef.current = options?.onTabChange
 
   useEffect(() => {
-    setInactiveTab(options?.initialTab ?? "meta")
+    setInactiveTab(options?.initialTab ?? "activity")
   }, [options?.initialTab])
 
   const isFirstTabChange = useRef(true)

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -193,7 +193,6 @@ export function useFolderEditBrowse(
       : (options?.initialTab ?? inactiveTab)
 
   const enterBrowse = useCallback(() => {
-    if (activeTab === "activity") return
     const c = folderRowCount(draftRef.current)
     const tab = activeTab as FolderFieldKind
     setEditState((prev) => {
@@ -203,7 +202,6 @@ export function useFolderEditBrowse(
   }, [activeTab])
 
   const enterAndEdit = useCallback(() => {
-    if (activeTab === "activity") return
     const c = folderRowCount(draftRef.current)
     const currentFolder = draftRef.current
     const tab = activeTab as FolderFieldKind

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -140,7 +140,8 @@ function folderCurrentKeyValueFor(
 function cycleField(current: FieldKind, delta: 1 | -1): FieldKind {
   const idx = FOLDER_FIELD_ORDER.indexOf(current as FolderFieldKind)
   if (idx === -1) return current
-  const next = (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
+  const next =
+    (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
   return FOLDER_FIELD_ORDER[next]!
 }
 
@@ -149,7 +150,9 @@ export function useFolderEditBrowse(
   draftMutators: UseFolderDraftResult,
   options?: UseFolderEditBrowseOptions,
 ): UseFolderEditBrowseResult {
-  const [editState, setEditState] = useState<EditState>(initialFolderEditState())
+  const [editState, setEditState] = useState<EditState>(
+    initialFolderEditState(),
+  )
   const [editValue, setEditValue] = useState("")
   const [editKey, setEditKey] = useState("")
   const [inactiveTab, setInactiveTab] = useState<FieldKind>(

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -156,7 +156,7 @@ export function useFolderEditBrowse(
   const [editValue, setEditValue] = useState("")
   const [editKey, setEditKey] = useState("")
   const [inactiveTab, setInactiveTab] = useState<FieldKind>(
-    options?.initialTab ?? "activity",
+    options?.initialTab ?? "meta",
   )
 
   const draftRef = useRef(folder)
@@ -175,7 +175,7 @@ export function useFolderEditBrowse(
   onTabChangeRef.current = options?.onTabChange
 
   useEffect(() => {
-    setInactiveTab(options?.initialTab ?? "activity")
+    setInactiveTab(options?.initialTab ?? "meta")
   }, [options?.initialTab])
 
   const isFirstTabChange = useRef(true)

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -561,8 +561,7 @@ export function useRequestDraft(
     [apply],
   )
   const setAuthTypeCb = useCallback(
-    (authType: Auth["type"]) =>
-      apply({ kind: "setAuthType", authType }),
+    (authType: Auth["type"]) => apply({ kind: "setAuthType", authType }),
     [apply],
   )
   const setAuthFieldCb = useCallback(

--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -34,7 +34,11 @@ export function useTreeNavigation(
 
   const expandedInitDone = useRef(false)
   useEffect(() => {
-    if (!expandedInitDone.current && initialExpanded && initialExpanded.size > 0) {
+    if (
+      !expandedInitDone.current &&
+      initialExpanded &&
+      initialExpanded.size > 0
+    ) {
       setExpanded(new Set(initialExpanded))
       expandedInitDone.current = true
     }
@@ -103,7 +107,10 @@ export function useTreeNavigation(
         const found = findRequestById(items, initialSelectedId)
         if (found) targetId = initialSelectedId
       }
-      if (!targetId && !(initialSelectedId && initialSelectedId.endsWith("/"))) {
+      if (
+        !targetId &&
+        !(initialSelectedId && initialSelectedId.endsWith("/"))
+      ) {
         targetId = flatReqs[0].id
       }
       if (targetId && targetId !== selectedId) {

--- a/src/lang/folder.ts
+++ b/src/lang/folder.ts
@@ -1,10 +1,5 @@
 import yaml from "js-yaml"
-import type {
-  Auth,
-  Folder,
-  FolderMeta,
-  FolderOverrides,
-} from "../schema"
+import type { Auth, Folder, FolderMeta, FolderOverrides } from "../schema"
 import { parseKvMap } from "./parse"
 
 interface RawFolderMeta {
@@ -53,10 +48,7 @@ export function parseFolder(yamlText: string): {
   }
 
   let overrides: FolderOverrides | undefined
-  if (
-    raw.headers !== undefined ||
-    raw.auth !== undefined
-  ) {
+  if (raw.headers !== undefined || raw.auth !== undefined) {
     overrides = {}
     if (raw.headers !== undefined) {
       overrides.headers = parseKvMap(raw.headers, "headers", "lang.parseFolder")
@@ -107,7 +99,11 @@ function parseFolderAuth(value: unknown): Auth {
         'lang.parseFolder: auth.api_key requires "key" and "value"',
       )
     }
-    if (a.placement !== undefined && a.placement !== "header" && a.placement !== "query") {
+    if (
+      a.placement !== undefined &&
+      a.placement !== "header" &&
+      a.placement !== "query"
+    ) {
       throw new Error(
         `lang.parseFolder: auth.api_key placement must be "header" or "query", got "${String(a.placement)}"`,
       )

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -1,5 +1,12 @@
 import yaml from "js-yaml"
-import type { Auth, BodyType, FormEntry, KvEntry, Method, Request } from "../schema"
+import type {
+  Auth,
+  BodyType,
+  FormEntry,
+  KvEntry,
+  Method,
+  Request,
+} from "../schema"
 
 const METHODS: readonly Method[] = [
   "GET",
@@ -230,9 +237,7 @@ export function parseKvMap(
     } else if (typeof v === "object" && v !== null && !Array.isArray(v)) {
       const obj = v as Record<string, unknown>
       if (typeof obj.value !== "string") {
-        throw new Error(
-          `${prefix}: ${field}.${k} must have string "value"`,
-        )
+        throw new Error(`${prefix}: ${field}.${k} must have string "value"`)
       }
       const enabled = obj.enabled === undefined ? true : Boolean(obj.enabled)
       out[k] = { value: obj.value, enabled }

--- a/src/requests/mergeFolderOverrides.ts
+++ b/src/requests/mergeFolderOverrides.ts
@@ -40,7 +40,11 @@ export function mergeFolderOverrides(
   let mergedHeaders: Record<string, KvEntry> = {}
   for (const folder of folders) {
     if (folder.overrides?.headers) {
-      mergedHeaders = mergeKv(mergedHeaders, folder.overrides.headers, request.headers)
+      mergedHeaders = mergeKv(
+        mergedHeaders,
+        folder.overrides.headers,
+        request.headers,
+      )
     }
   }
 
@@ -49,7 +53,11 @@ export function mergeFolderOverrides(
   if (requestAuth.type === "inherit") {
     const reversed = [...folders].reverse()
     for (const folder of reversed) {
-      if (folder.overrides?.auth && folder.overrides.auth.type !== "none" && folder.overrides.auth.type !== "inherit") {
+      if (
+        folder.overrides?.auth &&
+        folder.overrides.auth.type !== "none" &&
+        folder.overrides.auth.type !== "inherit"
+      ) {
         return {
           ...request,
           headers: { ...mergedHeaders, ...request.headers },

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -1,4 +1,11 @@
-import type { Auth, Collection, Environment, KvEntry, Request, Response } from "../schema"
+import type {
+  Auth,
+  Collection,
+  Environment,
+  KvEntry,
+  Request,
+  Response,
+} from "../schema"
 import { substitute } from "./substitute"
 import type { SubstitutedRequest } from "./substitute"
 import { mergeFolderOverrides } from "./mergeFolderOverrides"
@@ -11,7 +18,9 @@ export async function send(
   requestPath?: string,
 ): Promise<Response> {
   const merged =
-    collection && requestPath ? mergeFolderOverrides(req, collection, requestPath) : req
+    collection && requestPath
+      ? mergeFolderOverrides(req, collection, requestPath)
+      : req
 
   const substituted = env !== undefined ? substitute(merged, env) : merged
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1002,7 +1002,6 @@ export function AppInner({
                   setEditKey={folderEb.setEditKey}
                   setEditValue={folderEb.setEditValue}
                   activeTab={folderEb.activeTab}
-                  onTabChange={() => {}}
                   onAuthTypeChange={folderDraft.setAuthType}
                   onApiKeyPlacementChange={folderDraft.setApiKeyPlacement}
                   onSelectOpenChange={setSelectOpen}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -967,6 +967,7 @@ export function AppInner({
             >
               {focusedFolder !== null ? (
                 <FolderPane
+                  collectionDir={collectionDir}
                   folder={folderDraft.folderDraft}
                   focused={focus === "folder"}
                   editState={folderEb.editState}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -35,7 +35,12 @@ import {
   NewFolderOverlay,
   type NewFolderOverlayHandle,
 } from "./NewFolderOverlay"
-import { saveRequest, deleteRequest, saveFolder, deleteFolder } from "../filestore/save"
+import {
+  saveRequest,
+  deleteRequest,
+  saveFolder,
+  deleteFolder,
+} from "../filestore/save"
 import { ThemePickerOverlay, useTheme } from "./theme"
 import { StatusBar } from "./StatusBar"
 import { EnvSidebar } from "./EnvSidebar"
@@ -138,9 +143,9 @@ export function AppInner({
   >(null)
   const [newFolderVisible, setNewFolderVisible] = useState(false)
   const newFolderRef = useRef<NewFolderOverlayHandle>(null)
-  const [folderDeletePending, setFolderDeletePending] = useState<
-    string | null
-  >(null)
+  const [folderDeletePending, setFolderDeletePending] = useState<string | null>(
+    null,
+  )
   const folderDeletePathRef = useRef<string | null>(null)
   const [initialExpandedFolders, setInitialExpandedFolders] =
     useState<Set<string> | null>(null)
@@ -179,7 +184,8 @@ export function AppInner({
   )
 
   const focusedFolder = useMemo(
-    () => (focusedFolderPath ? findFolderByPath(items, focusedFolderPath) : null),
+    () =>
+      focusedFolderPath ? findFolderByPath(items, focusedFolderPath) : null,
     [focusedFolderPath, items],
   )
 
@@ -321,18 +327,38 @@ export function AppInner({
       folderDraftRef.current?.markSaved()
       updateCollection({
         ...collection,
-        items: updateFolderByPath(collection.items, draftFolder.path, draftFolder),
+        items: updateFolderByPath(
+          collection.items,
+          draftFolder.path,
+          draftFolder,
+        ),
       })
-      setSaveState({ kind: "success", message: `Saved folder ${draftFolder.name}` })
+      setSaveState({
+        kind: "success",
+        message: `Saved folder ${draftFolder.name}`,
+      })
       clearSaveTimer()
-      saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
+      saveTimerRef.current = setTimeout(
+        () => setSaveState({ kind: "idle" }),
+        2000,
+      )
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       setSaveState({ kind: "error", message: msg })
       clearSaveTimer()
-      saveTimerRef.current = setTimeout(() => setSaveState({ kind: "idle" }), 2000)
+      saveTimerRef.current = setTimeout(
+        () => setSaveState({ kind: "idle" }),
+        2000,
+      )
     }
-  }, [collection, collectionDir, setSaveState, updateCollection, clearSaveTimer, saveTimerRef])
+  }, [
+    collection,
+    collectionDir,
+    setSaveState,
+    updateCollection,
+    clearSaveTimer,
+    saveTimerRef,
+  ])
 
   folderSaveRef.current = handleFolderSave
 
@@ -649,15 +675,15 @@ export function AppInner({
               ? "new-request"
               : editRequestVisible
                 ? "edit-request"
-            : cloneRequestVisible
-              ? "clone-request"
-              : newFolderVisible
-                ? "new-folder"
-                : folderDeletePending !== null
-                  ? "delete-folder"
-                : requestDeletePending !== null
-                  ? "request-delete"
-                  : "none"
+                : cloneRequestVisible
+                  ? "clone-request"
+                  : newFolderVisible
+                    ? "new-folder"
+                    : folderDeletePending !== null
+                      ? "delete-folder"
+                      : requestDeletePending !== null
+                        ? "request-delete"
+                        : "none"
     keymap.setData("app.overlay", overlay)
   }, [
     helpVisible,

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -2,18 +2,6 @@ import { methodColor } from "./formatRequest"
 import type { Theme } from "./theme"
 import type { FolderActivityStats } from "./useFolderActivity"
 
-function relativeTime(ts: number): string {
-  const diff = Date.now() - ts
-  const sec = Math.floor(diff / 1000)
-  if (sec < 5) return "now"
-  if (sec < 60) return `${sec}s`
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}h`
-  return `${Math.floor(hr / 24)}d`
-}
-
 function pct(v: number): string {
   return `${Math.round(v * 100)}%`
 }
@@ -139,7 +127,9 @@ export function FolderActivityTab({
               fg={r.avgTimeMs !== null ? theme.text : theme.textMuted}
               wrapMode="none"
             >
-              {r.avgTimeMs !== null ? ms(r.avgTimeMs).padEnd(8) : "\u2014".padEnd(8)}
+              {r.avgTimeMs !== null
+                ? ms(r.avgTimeMs).padEnd(8)
+                : "\u2014".padEnd(8)}
             </text>
             <text fg={theme.textMuted} wrapMode="none">
               {r.callCount > 0 ? `${r.callCount}c` : "\u2014"}

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -1,6 +1,11 @@
+import { useMemo } from "react"
 import { methodColor } from "./formatRequest"
 import type { Theme } from "./theme"
 import type { FolderActivityStats } from "./useFolderActivity"
+
+function shortMethod(m: string): string {
+  return m === "DELETE" ? "DEL" : m
+}
 
 function pct(v: number): string {
   return `${Math.round(v * 100)}%`
@@ -57,13 +62,44 @@ export function FolderActivityTab({
     )
   }
 
+  const widths = useMemo(() => {
+    const method = Math.max(
+      ...stats.requests.map((r) => shortMethod(r.method).length),
+      "Method".length,
+    ) + 1
+    const name = Math.min(
+      Math.max(...stats.requests.map((r) => r.name.length), "Name".length),
+      20,
+    )
+    const ok = Math.max(
+      ...stats.requests.map((r) =>
+        r.successRate !== null ? pct(r.successRate).length : 1,
+      ),
+      "OK%".length,
+    )
+    const avg = Math.max(
+      ...stats.requests.map((r) =>
+        r.avgTimeMs !== null ? ms(r.avgTimeMs).length : 1,
+      ),
+      "Avg".length,
+    )
+    const last = Math.max(
+      ...stats.requests.map((r) => {
+        const lastSent = r.lastSent !== null ? relativeTime(r.lastSent) : "\u2014"
+        const calls = r.callCount > 0 ? `${r.callCount}c \u00B7 ` : ""
+        return `${calls}${lastSent}`.length
+      }),
+      "Last".length,
+    )
+    return { method, name, ok, avg, last }
+  }, [stats])
+
   return (
     <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
       <box
         style={{
           flexDirection: "row",
           justifyContent: "space-between",
-          paddingBottom: 1,
         }}
         border={["bottom"]}
         borderColor={theme.borderSubtle}
@@ -86,29 +122,38 @@ export function FolderActivityTab({
         </text>
       </box>
 
-      <box
-        style={{ flexDirection: "row", paddingBottom: 0 }}
+      <box style={{ flexDirection: "row", justifyContent: "space-between", paddingBottom: 0 }}
         border={["bottom"]}
         borderColor={theme.borderSubtle}
       >
-        <text fg={theme.textMuted} wrapMode="none">
-          {"Method".padEnd(7)}
+        <text fg={theme.textMuted} wrapMode="none"
+          style={{ flexShrink: 0, minWidth: widths.method }}
+        >
+          {"Method".padEnd(widths.method)}
         </text>
-        <text fg={theme.textMuted} wrapMode="none">
-          {"Name".padEnd(14)}
+        <text fg={theme.textMuted} wrapMode="none"
+          style={{ flexShrink: 1, minWidth: widths.name }}
+        >
+          {"Name".padEnd(widths.name)}
         </text>
-        <text fg={theme.textMuted} wrapMode="none">
-          {"OK%".padEnd(6)}
+        <text fg={theme.textMuted} wrapMode="none"
+          style={{ flexShrink: 0, minWidth: widths.ok }}
+        >
+          {"OK%".padStart(widths.ok)}
         </text>
-        <text fg={theme.textMuted} wrapMode="none">
-          {"Avg".padEnd(7)}
+        <text fg={theme.textMuted} wrapMode="none"
+          style={{ flexShrink: 0, minWidth: widths.avg }}
+        >
+          {"Avg".padStart(widths.avg)}
         </text>
-        <text fg={theme.textMuted} wrapMode="none">
-          Last
+        <text fg={theme.textMuted} wrapMode="none"
+          style={{ flexShrink: 0, minWidth: widths.last }}
+        >
+          {"Last".padEnd(widths.last)}
         </text>
       </box>
 
-      {stats.requests.map((r) => {
+      {stats.requests.map((r, _i) => {
         const statusColor =
           r.successRate === null
             ? theme.textMuted
@@ -123,39 +168,50 @@ export function FolderActivityTab({
         const callsText =
           r.callCount > 0 ? `${r.callCount}c \u00B7 ` : ""
 
+        const method = shortMethod(r.method).padEnd(widths.method)
+        const name = nameColumn(r.name, widths.name).padEnd(widths.name)
+        const okPct = r.successRate !== null
+          ? pct(r.successRate).padStart(widths.ok)
+          : "\u2014".padStart(widths.ok)
+        const avgTime = r.avgTimeMs !== null
+          ? ms(r.avgTimeMs).padStart(widths.avg)
+          : "\u2014".padStart(widths.avg)
+        const last = `${callsText}${lastSentText}`
+
         return (
-          <box key={r.id} style={{ flexDirection: "row" }}>
-            <text fg={methodColor(r.method, theme)} wrapMode="none">
-              {r.method === "DELETE" ? "DEL" : r.method.padEnd(7).slice(0, 7)}
-            </text>
-            <text
-              fg={r.callCount > 0 ? theme.text : theme.textMuted}
+          <box key={r.id}
+            style={{ flexDirection: "row", justifyContent: "space-between" }}
+          >
+            <text fg={methodColor(r.method, theme)}
               wrapMode="none"
+              style={{ flexShrink: 0, minWidth: widths.method }}
             >
-              {nameColumn(r.name, 12)}
-              {"  "}
+              {method}
             </text>
-            <text fg={statusColor} wrapMode="none">
-              {r.successRate !== null
-                ? pct(r.successRate).padEnd(6)
-                : "\u2014".padEnd(6)}
-            </text>
-            <text
-              fg={r.avgTimeMs !== null ? theme.text : theme.textMuted}
+            <text fg={r.callCount > 0 ? theme.text : theme.textMuted}
               wrapMode="none"
+              style={{ flexShrink: 1, minWidth: widths.name }}
             >
-              {r.avgTimeMs !== null
-                ? ms(r.avgTimeMs).padEnd(7)
-                : "\u2014".padEnd(7)}
+              {name}
             </text>
-            <box style={{ flexDirection: "row" }}>
-              <text fg={theme.textMuted} wrapMode="none">
-                {callsText}
-              </text>
-              <text fg={r.lastSent !== null ? theme.text : theme.textMuted}>
-                {lastSentText}
-              </text>
-            </box>
+            <text fg={statusColor}
+              wrapMode="none"
+              style={{ flexShrink: 0, minWidth: widths.ok }}
+            >
+              {okPct}
+            </text>
+            <text fg={r.avgTimeMs !== null ? theme.text : theme.textMuted}
+              wrapMode="none"
+              style={{ flexShrink: 0, minWidth: widths.avg }}
+            >
+              {avgTime}
+            </text>
+            <text fg={theme.textMuted}
+              wrapMode="none"
+              style={{ flexShrink: 0, minWidth: widths.last }}
+            >
+              {last}
+            </text>
           </box>
         )
       })}

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -1,0 +1,152 @@
+import { methodColor } from "./formatRequest"
+import type { Theme } from "./theme"
+import type { FolderActivityStats } from "./useFolderActivity"
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts
+  const sec = Math.floor(diff / 1000)
+  if (sec < 5) return "now"
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h`
+  return `${Math.floor(hr / 24)}d`
+}
+
+function pct(v: number): string {
+  return `${Math.round(v * 100)}%`
+}
+
+function ms(v: number): string {
+  if (v < 1000) return `${v}ms`
+  return `${(v / 1000).toFixed(1)}s`
+}
+
+function nameColumn(name: string, max: number): string {
+  if (name.length <= max) return name
+  return name.slice(0, max - 1) + "\u2026"
+}
+
+export function FolderActivityTab({
+  stats,
+  loading,
+  theme,
+}: {
+  stats: FolderActivityStats | null
+  loading: boolean
+  theme: Theme
+}) {
+  if (loading) {
+    return <text fg={theme.textMuted}>Loading...</text>
+  }
+
+  if (!stats) {
+    return <text fg={theme.textMuted}>No activity data.</text>
+  }
+
+  if (stats.requests.length === 0) {
+    return <text fg={theme.textMuted}>No requests in this folder.</text>
+  }
+
+  if (stats.summary.totalCalls === 0) {
+    return (
+      <text fg={theme.textMuted}>
+        No activity yet. Send requests to see stats.
+      </text>
+    )
+  }
+
+  return (
+    <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingBottom: 1,
+        }}
+        border={["bottom"]}
+        borderColor={theme.borderSubtle}
+      >
+        <text fg={theme.textMuted}>
+          {stats.summary.overallSuccessRate !== null
+            ? pct(stats.summary.overallSuccessRate)
+            : "\u2014"}{" "}
+          success
+        </text>
+        <text fg={theme.textMuted}>
+          {stats.summary.overallAvgTime !== null
+            ? ms(stats.summary.overallAvgTime)
+            : "\u2014"}{" "}
+          avg
+        </text>
+        <text fg={theme.textMuted}>
+          {stats.summary.totalCalls} call
+          {stats.summary.totalCalls !== 1 ? "s" : ""}
+        </text>
+      </box>
+
+      <box
+        style={{ flexDirection: "row", paddingBottom: 0 }}
+        border={["bottom"]}
+        borderColor={theme.borderSubtle}
+      >
+        <text fg={theme.textMuted} wrapMode="none">
+          {"Method".padEnd(7)}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">
+          {"Name".padEnd(18)}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">
+          {"OK%".padEnd(6)}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">
+          {"Avg".padEnd(8)}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">
+          Calls
+        </text>
+      </box>
+
+      {stats.requests.map((r) => {
+        const statusColor =
+          r.successRate === null
+            ? theme.textMuted
+            : r.successRate >= 0.9
+              ? theme.success
+              : r.successRate >= 0.5
+                ? theme.warning
+                : theme.error
+
+        return (
+          <box key={r.id} style={{ flexDirection: "row" }}>
+            <text fg={methodColor(r.method, theme)} wrapMode="none">
+              {r.method === "DELETE" ? "DEL" : r.method.padEnd(7).slice(0, 7)}
+            </text>
+            <text
+              fg={r.callCount > 0 ? theme.text : theme.textMuted}
+              wrapMode="none"
+            >
+              {nameColumn(r.name, 16)}
+              {"  "}
+            </text>
+            <text fg={statusColor} wrapMode="none">
+              {r.successRate !== null
+                ? pct(r.successRate).padEnd(6)
+                : "\u2014".padEnd(6)}
+            </text>
+            <text
+              fg={r.avgTimeMs !== null ? theme.text : theme.textMuted}
+              wrapMode="none"
+            >
+              {r.avgTimeMs !== null ? ms(r.avgTimeMs).padEnd(8) : "\u2014".padEnd(8)}
+            </text>
+            <text fg={theme.textMuted} wrapMode="none">
+              {r.callCount > 0 ? `${r.callCount}c` : "\u2014"}
+            </text>
+          </box>
+        )
+      })}
+    </box>
+  )
+}

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -148,12 +148,14 @@ export function FolderActivityTab({
                 ? ms(r.avgTimeMs).padEnd(7)
                 : "\u2014".padEnd(7)}
             </text>
-            <text fg={theme.textMuted} wrapMode="none">
-              {callsText}
+            <box style={{ flexDirection: "row" }}>
+              <text fg={theme.textMuted} wrapMode="none">
+                {callsText}
+              </text>
               <text fg={r.lastSent !== null ? theme.text : theme.textMuted}>
                 {lastSentText}
               </text>
-            </text>
+            </box>
           </box>
         )
       })}

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -96,31 +96,9 @@ export function FolderActivityTab({
 
   return (
     <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
-      <box
-        style={{
-          flexDirection: "row",
-          justifyContent: "space-between",
-        }}
-        border={["bottom"]}
-        borderColor={theme.borderSubtle}
-      >
-        <text fg={theme.textMuted}>
-          {stats.summary.overallSuccessRate !== null
-            ? pct(stats.summary.overallSuccessRate)
-            : "\u2014"}{" "}
-          success
-        </text>
-        <text fg={theme.textMuted}>
-          {stats.summary.overallAvgTime !== null
-            ? ms(stats.summary.overallAvgTime)
-            : "\u2014"}{" "}
-          avg
-        </text>
-        <text fg={theme.textMuted}>
-          {stats.summary.totalCalls} call
-          {stats.summary.totalCalls !== 1 ? "s" : ""}
-        </text>
-      </box>
+      <text fg={theme.textMuted}>
+        Activity stats for requests inside this folder.
+      </text>
 
       <box style={{ flexDirection: "row", justifyContent: "space-between", paddingBottom: 0 }}
         border={["bottom"]}

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react"
 import { methodColor } from "./formatRequest"
 import type { Theme } from "./theme"
 import type { FolderActivityStats } from "./useFolderActivity"
@@ -62,7 +61,7 @@ export function FolderActivityTab({
     )
   }
 
-  const widths = useMemo(() => {
+  const widths = (() => {
     const method = Math.max(
       ...stats.requests.map((r) => shortMethod(r.method).length),
       "Method".length,
@@ -92,7 +91,7 @@ export function FolderActivityTab({
       "Last".length,
     )
     return { method, name, ok, avg, last }
-  }, [stats])
+  })()
 
   return (
     <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -11,6 +11,18 @@ function ms(v: number): string {
   return `${(v / 1000).toFixed(1)}s`
 }
 
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts
+  const sec = Math.floor(diff / 1000)
+  if (sec < 5) return "now"
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h`
+  return `${Math.floor(hr / 24)}d`
+}
+
 function nameColumn(name: string, max: number): string {
   if (name.length <= max) return name
   return name.slice(0, max - 1) + "\u2026"
@@ -83,16 +95,16 @@ export function FolderActivityTab({
           {"Method".padEnd(7)}
         </text>
         <text fg={theme.textMuted} wrapMode="none">
-          {"Name".padEnd(18)}
+          {"Name".padEnd(14)}
         </text>
         <text fg={theme.textMuted} wrapMode="none">
           {"OK%".padEnd(6)}
         </text>
         <text fg={theme.textMuted} wrapMode="none">
-          {"Avg".padEnd(8)}
+          {"Avg".padEnd(7)}
         </text>
         <text fg={theme.textMuted} wrapMode="none">
-          Calls
+          Last
         </text>
       </box>
 
@@ -106,6 +118,11 @@ export function FolderActivityTab({
                 ? theme.warning
                 : theme.error
 
+        const lastSentText =
+          r.lastSent !== null ? relativeTime(r.lastSent) : "\u2014"
+        const callsText =
+          r.callCount > 0 ? `${r.callCount}c \u00B7 ` : ""
+
         return (
           <box key={r.id} style={{ flexDirection: "row" }}>
             <text fg={methodColor(r.method, theme)} wrapMode="none">
@@ -115,7 +132,7 @@ export function FolderActivityTab({
               fg={r.callCount > 0 ? theme.text : theme.textMuted}
               wrapMode="none"
             >
-              {nameColumn(r.name, 16)}
+              {nameColumn(r.name, 12)}
               {"  "}
             </text>
             <text fg={statusColor} wrapMode="none">
@@ -128,11 +145,14 @@ export function FolderActivityTab({
               wrapMode="none"
             >
               {r.avgTimeMs !== null
-                ? ms(r.avgTimeMs).padEnd(8)
-                : "\u2014".padEnd(8)}
+                ? ms(r.avgTimeMs).padEnd(7)
+                : "\u2014".padEnd(7)}
             </text>
             <text fg={theme.textMuted} wrapMode="none">
-              {r.callCount > 0 ? `${r.callCount}c` : "\u2014"}
+              {callsText}
+              <text fg={r.lastSent !== null ? theme.text : theme.textMuted}>
+                {lastSentText}
+              </text>
             </text>
           </box>
         )

--- a/src/ui/FolderActivityTab.tsx
+++ b/src/ui/FolderActivityTab.tsx
@@ -53,7 +53,7 @@ export function FolderActivityTab({
     return <text fg={theme.textMuted}>No requests in this folder.</text>
   }
 
-  if (stats.summary.totalCalls === 0) {
+  if (stats.requests.every((r) => r.callCount === 0)) {
     return (
       <text fg={theme.textMuted}>
         No activity yet. Send requests to see stats.

--- a/src/ui/FolderMetaTab.tsx
+++ b/src/ui/FolderMetaTab.tsx
@@ -41,6 +41,9 @@ export function FolderMetaTab({
 
   return (
     <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
+      <text fg={theme.textMuted}>
+        Edit folder metadata.
+      </text>
       <box
         border={[...LeftBar.border]}
         customBorderChars={LeftBar.customBorderChars}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import type { Folder, Environment, Auth } from "../schema"
-import type { EditState, FolderFieldKind, FieldKind } from "./editMode"
+import type { EditState, FieldKind } from "./editMode"
 import { Tabs } from "./Tabs"
 import { FolderMetaTab } from "./FolderMetaTab"
 import { FolderActivityTab } from "./FolderActivityTab"
@@ -20,7 +20,6 @@ interface FolderPaneProps {
   setEditKey: (v: string) => void
   setEditValue: (v: string) => void
   activeTab: FieldKind
-  onTabChange: (tab: FolderFieldKind) => void
   onAuthTypeChange: (type: Auth["type"]) => void
   onApiKeyPlacementChange: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
@@ -38,7 +37,6 @@ export function FolderPane({
   setEditKey,
   setEditValue,
   activeTab,
-  onTabChange: _onTabChange,
   onAuthTypeChange,
   onApiKeyPlacementChange,
   onSelectOpenChange,

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -63,9 +63,9 @@ export function FolderPane({
         { id: "auth", label: "Auth" },
       ]
     }
-    const hasHeaders = Object.values(
-      folder.overrides?.headers ?? {},
-    ).some((e) => e.enabled)
+    const hasHeaders = Object.values(folder.overrides?.headers ?? {}).some(
+      (e) => e.enabled,
+    )
     const hasAuth =
       folder.overrides?.auth?.type !== undefined &&
       folder.overrides.auth.type !== "none" &&

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -3,12 +3,15 @@ import type { Folder, Environment, Auth } from "../schema"
 import type { EditState, FolderFieldKind, FieldKind } from "./editMode"
 import { Tabs } from "./Tabs"
 import { FolderMetaTab } from "./FolderMetaTab"
+import { FolderActivityTab } from "./FolderActivityTab"
+import { useFolderActivity } from "./useFolderActivity"
 import { KeyValueSection } from "./KeyValueSection"
 import { AuthEditor } from "./AuthEditor"
 import type { Theme } from "./theme"
 import { FullBorder } from "./borders"
 
 interface FolderPaneProps {
+  collectionDir: string
   folder: Folder | null
   focused: boolean
   editState: EditState
@@ -26,6 +29,7 @@ interface FolderPaneProps {
 }
 
 export function FolderPane({
+  collectionDir,
   folder,
   focused,
   editState,
@@ -44,10 +48,17 @@ export function FolderPane({
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
 
+  const { stats: activityStats, loading: activityLoading } = useFolderActivity(
+    collectionDir,
+    folder,
+    activeTab === "activity",
+  )
+
   const tabs = useMemo(() => {
     if (!folder) {
       return [
-        { id: "meta", label: "Name & Seq" },
+        { id: "activity", label: "Activity" },
+        { id: "meta", label: "General" },
         { id: "headers", label: "Headers" },
         { id: "auth", label: "Auth" },
       ]
@@ -60,7 +71,8 @@ export function FolderPane({
       folder.overrides.auth.type !== "none" &&
       folder.overrides.auth.type !== "inherit"
     return [
-      { id: "meta", label: "Name & Seq" },
+      { id: "activity", label: "Activity" },
+      { id: "meta", label: "General" },
       { id: "headers", label: hasHeaders ? "Headers \u2022" : "Headers" },
       { id: "auth", label: hasAuth ? "Auth \u2022" : "Auth" },
     ]
@@ -94,6 +106,13 @@ export function FolderPane({
               scrollY
               style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
             >
+              {activeTab === "activity" && (
+                <FolderActivityTab
+                  stats={activityStats}
+                  loading={activityLoading}
+                  theme={theme}
+                />
+              )}
               {activeTab === "meta" && (
                 <FolderMetaTab
                   name={folder.name}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -125,7 +125,7 @@ export function FolderPane({
                 />
               )}
               {activeTab === "headers" && (
-                <box style={{ flexDirection: "column", gap: 1 }}>
+                <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
                   <text fg={theme.textMuted}>
                     Headers sent with every request inside this folder.
                   </text>
@@ -145,7 +145,7 @@ export function FolderPane({
                 </box>
               )}
               {activeTab === "auth" && (
-                <box style={{ flexDirection: "column", gap: 1 }}>
+                <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
                   <text fg={theme.textMuted}>
                     Auth applied to every request inside this folder.
                   </text>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -57,10 +57,10 @@ export function FolderPane({
   const tabs = useMemo(() => {
     if (!folder) {
       return [
-        { id: "activity", label: "Activity" },
         { id: "meta", label: "General" },
         { id: "headers", label: "Headers" },
         { id: "auth", label: "Auth" },
+        { id: "activity", label: "Activity" },
       ]
     }
     const hasHeaders = Object.values(folder.overrides?.headers ?? {}).some(
@@ -71,10 +71,10 @@ export function FolderPane({
       folder.overrides.auth.type !== "none" &&
       folder.overrides.auth.type !== "inherit"
     return [
-      { id: "activity", label: "Activity" },
       { id: "meta", label: "General" },
       { id: "headers", label: hasHeaders ? "Headers \u2022" : "Headers" },
       { id: "auth", label: hasAuth ? "Auth \u2022" : "Auth" },
+      { id: "activity", label: "Activity" },
     ]
   }, [folder])
 

--- a/src/ui/NewRequestOverlay.tsx
+++ b/src/ui/NewRequestOverlay.tsx
@@ -14,7 +14,12 @@ import type { Method } from "../schema"
 export interface NewRequestOverlayHandle {
   cycleFocus: (direction: 1 | -1) => void
   commitField: () => void
-  confirm: () => { name: string; method: Method; url: string; folderPath?: string } | null
+  confirm: () => {
+    name: string
+    method: Method
+    url: string
+    folderPath?: string
+  } | null
   getFocus: () => "folder" | "name" | "method" | "url"
 }
 
@@ -50,7 +55,15 @@ export const NewRequestOverlay = forwardRef<
   NewRequestOverlayHandle,
   NewRequestOverlayProps
 >(function NewRequestOverlay(
-  { visible, mode, initialName, initialMethod, initialUrl, folderPaths, initialFolderPath },
+  {
+    visible,
+    mode,
+    initialName,
+    initialMethod,
+    initialUrl,
+    folderPaths,
+    initialFolderPath,
+  },
   ref,
 ) {
   const theme = useTheme()
@@ -61,7 +74,7 @@ export const NewRequestOverlay = forwardRef<
   const [url, setUrl] = useState("")
   const [folderPath, setFolderPath] = useState("")
   const [focus, setFocus] = useState<"folder" | "name" | "method" | "url">(
-    showFolder ? "folder" : "name"
+    showFolder ? "folder" : "name",
   )
   const [errorText, setErrorText] = useState<string | null>(null)
   const [folderSelectOpen, setFolderSelectOpen] = useState(false)
@@ -119,7 +132,15 @@ export const NewRequestOverlay = forwardRef<
       setFocus(showFolder ? "folder" : "name")
       setErrorText(null)
     }
-  }, [visible, isEdit, initialName, initialMethod, initialUrl, initialFolderPath, showFolder])
+  }, [
+    visible,
+    isEdit,
+    initialName,
+    initialMethod,
+    initialUrl,
+    initialFolderPath,
+    showFolder,
+  ])
 
   // Auto-focus based on focus state
   useEffect(() => {

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -46,9 +46,7 @@ export function Sidebar({
   useEffect(() => {
     if (cursorIndex >= 0 && visibleItems.length > 0) {
       const idx = Math.min(cursorIndex, visibleItems.length - 1)
-      scrollRef.current?.scrollChildIntoView(
-        `so-${visibleItems[idx].id}`,
-      )
+      scrollRef.current?.scrollChildIntoView(`so-${visibleItems[idx].id}`)
     }
   }, [cursorIndex, visibleItems])
 
@@ -90,9 +88,7 @@ export function Sidebar({
           {visibleItems.map((node, i) => {
             const isCursor = i === cursorIndex
             if (node.type === "folder") {
-              const chevron = node.expanded
-                ? "\u25BE"
-                : "\u25B8"
+              const chevron = node.expanded ? "\u25BE" : "\u25B8"
               const isFolderDirty = dirtyFolderPaths?.has(node.id)
               return (
                 <box
@@ -116,9 +112,7 @@ export function Sidebar({
                       {truncName(node.name, 20)}
                     </text>
                   </box>
-                  {isFolderDirty && (
-                    <text fg={theme.warning}>{`\u25CF`}</text>
-                  )}
+                  {isFolderDirty && <text fg={theme.warning}>{`\u25CF`}</text>}
                 </box>
               )
             }
@@ -149,9 +143,7 @@ export function Sidebar({
                     {truncName(node.name, 20)}
                   </text>
                 </box>
-                {isDirty && (
-                  <text fg={theme.warning}>{`\u25CF`}</text>
-                )}
+                {isDirty && <text fg={theme.warning}>{`\u25CF`}</text>}
               </box>
             )
           })}

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -45,10 +45,10 @@ export const FIELD_ORDER: FieldKind[] = [
 ]
 
 export const FOLDER_FIELD_ORDER: FolderFieldKind[] = [
-  "activity",
   "meta",
   "headers",
   "auth",
+  "activity",
 ]
 
 export function initialEditState(): EditState {
@@ -62,7 +62,7 @@ export function initialEditState(): EditState {
 export function initialFolderEditState(): EditState {
   return {
     mode: "inactive",
-    cursor: { field: "activity", row: -1, addingRow: false },
+    cursor: { field: "meta", row: -1, addingRow: false },
     editingRow: -1,
   }
 }
@@ -93,7 +93,7 @@ export function enterFolderEditBrowse(
     headers: 0,
     auth: 0,
   },
-  startField: FolderFieldKind = "activity",
+  startField: FolderFieldKind = "meta",
 ): EditState {
   if (prev.mode !== "inactive") return prev
   return {

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,4 +1,11 @@
-export type FieldKind = "headers" | "params" | "body" | "auth" | "settings" | "meta" | "activity"
+export type FieldKind =
+  | "headers"
+  | "params"
+  | "body"
+  | "auth"
+  | "settings"
+  | "meta"
+  | "activity"
 export type FolderFieldKind = "activity" | "meta" | "headers" | "auth"
 export type Mode = "inactive" | "browsing" | "editing"
 
@@ -152,7 +159,13 @@ export function folderCursorForField(
 export function toggleSubfield(prev: EditState): EditState {
   if (prev.mode !== "editing") return prev
   const { field } = prev.cursor
-  if (field !== "headers" && field !== "params" && field !== "body" && field !== "meta") return prev
+  if (
+    field !== "headers" &&
+    field !== "params" &&
+    field !== "body" &&
+    field !== "meta"
+  )
+    return prev
   const current = prev.cursor.subfield ?? "key"
   const next: "key" | "value" = current === "key" ? "value" : "key"
   return {
@@ -183,7 +196,8 @@ export function moveFolderFieldCursor(
 ): EditState {
   if (prev.mode !== "browsing") return prev
   const idx = folderFieldIndex(prev.cursor.field as FolderFieldKind)
-  const nextIdx = (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
+  const nextIdx =
+    (idx + delta + FOLDER_FIELD_ORDER.length) % FOLDER_FIELD_ORDER.length
   const nextField = FOLDER_FIELD_ORDER[nextIdx]!
   return {
     ...prev,
@@ -320,7 +334,9 @@ export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
-    prev.cursor.field === "headers" || prev.cursor.field === "params" || prev.cursor.field === "meta"
+    prev.cursor.field === "headers" ||
+    prev.cursor.field === "params" ||
+    prev.cursor.field === "meta"
       ? "key"
       : prev.cursor.field === "body"
         ? "key"

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -62,7 +62,7 @@ export function initialEditState(): EditState {
 export function initialFolderEditState(): EditState {
   return {
     mode: "inactive",
-    cursor: { field: "meta", row: -1, addingRow: false },
+    cursor: { field: "activity", row: -1, addingRow: false },
     editingRow: -1,
   }
 }
@@ -93,7 +93,7 @@ export function enterFolderEditBrowse(
     headers: 0,
     auth: 0,
   },
-  startField: FolderFieldKind = "meta",
+  startField: FolderFieldKind = "activity",
 ): EditState {
   if (prev.mode !== "inactive") return prev
   return {

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,5 +1,5 @@
-export type FieldKind = "headers" | "params" | "body" | "auth" | "settings" | "meta"
-export type FolderFieldKind = "meta" | "headers" | "auth"
+export type FieldKind = "headers" | "params" | "body" | "auth" | "settings" | "meta" | "activity"
+export type FolderFieldKind = "activity" | "meta" | "headers" | "auth"
 export type Mode = "inactive" | "browsing" | "editing"
 
 export interface FieldCursor {
@@ -38,6 +38,7 @@ export const FIELD_ORDER: FieldKind[] = [
 ]
 
 export const FOLDER_FIELD_ORDER: FolderFieldKind[] = [
+  "activity",
   "meta",
   "headers",
   "auth",
@@ -119,6 +120,8 @@ function cursorForField(
       return { field, row: 0, addingRow: false }
     case "settings":
       return { field, row: 0, addingRow: false }
+    case "activity":
+      return { field, row: 0, addingRow: false }
   }
   const count = field === "headers" ? counts.headers : counts.params
   if (count === 0) {
@@ -135,6 +138,8 @@ export function folderCursorForField(
     case "meta":
     case "auth":
       return { field, row: 0, addingRow: false }
+    case "activity":
+      return { field: "activity", row: 0, addingRow: false }
     case "headers": {
       if (counts.headers === 0) {
         return { field, row: -1, addingRow: true }

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -332,6 +332,7 @@ export function moveFolderRowCursor(
 
 export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
+  if (prev.cursor.field === "activity") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
   const subfield: "key" | "value" | undefined =
     prev.cursor.field === "headers" ||

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -495,18 +495,45 @@ export function useAppKeymap(
       keymap.getData("app.overlay") === "none" &&
       keymap.getData("app.view") !== "env-editor",
     commands: [
-      { name: "folder-browse.up", run: () => refs.folderEbRef.current?.browseUp() },
-      { name: "folder-browse.down", run: () => refs.folderEbRef.current?.browseDown() },
-      { name: "folder-browse.left", run: () => refs.folderEbRef.current?.browseLeft() },
-      { name: "folder-browse.right", run: () => refs.folderEbRef.current?.browseRight() },
-      { name: "folder-browse.enter", run: () => refs.folderEbRef.current?.enterEdit() },
-      { name: "folder-browse.escape", run: () => {
-        refs.folderEbRef.current?.exitBrowse()
-        setters.setFocus("sidebar")
-      }},
-      { name: "folder-browse.toggle", run: () => refs.folderEbRef.current?.toggleRow() },
-      { name: "folder-browse.revert-field", run: () => refs.folderEbRef.current?.revertField() },
-      { name: "folder-browse.revert-all", run: () => refs.folderEbRef.current?.revertAll() },
+      {
+        name: "folder-browse.up",
+        run: () => refs.folderEbRef.current?.browseUp(),
+      },
+      {
+        name: "folder-browse.down",
+        run: () => refs.folderEbRef.current?.browseDown(),
+      },
+      {
+        name: "folder-browse.left",
+        run: () => refs.folderEbRef.current?.browseLeft(),
+      },
+      {
+        name: "folder-browse.right",
+        run: () => refs.folderEbRef.current?.browseRight(),
+      },
+      {
+        name: "folder-browse.enter",
+        run: () => refs.folderEbRef.current?.enterEdit(),
+      },
+      {
+        name: "folder-browse.escape",
+        run: () => {
+          refs.folderEbRef.current?.exitBrowse()
+          setters.setFocus("sidebar")
+        },
+      },
+      {
+        name: "folder-browse.toggle",
+        run: () => refs.folderEbRef.current?.toggleRow(),
+      },
+      {
+        name: "folder-browse.revert-field",
+        run: () => refs.folderEbRef.current?.revertField(),
+      },
+      {
+        name: "folder-browse.revert-all",
+        run: () => refs.folderEbRef.current?.revertAll(),
+      },
     ],
     bindings: [
       { key: "up", cmd: "folder-browse.up" },
@@ -529,9 +556,18 @@ export function useAppKeymap(
       keymap.getData("app.overlay") === "none" &&
       keymap.getData("app.view") !== "env-editor",
     commands: [
-      { name: "folder-edit.commit", run: () => refs.folderEbRef.current?.commitEdit() },
-      { name: "folder-edit.cancel", run: () => refs.folderEbRef.current?.cancelEdit() },
-      { name: "folder-edit.tab", run: () => refs.folderEbRef.current?.browseTab() },
+      {
+        name: "folder-edit.commit",
+        run: () => refs.folderEbRef.current?.commitEdit(),
+      },
+      {
+        name: "folder-edit.cancel",
+        run: () => refs.folderEbRef.current?.cancelEdit(),
+      },
+      {
+        name: "folder-edit.tab",
+        run: () => refs.folderEbRef.current?.browseTab(),
+      },
     ],
     bindings: [
       { key: "return", cmd: "folder-edit.commit" },

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -94,8 +94,11 @@ export function useFolderActivity(
   const loadedRef = useRef(false)
   const lastDirRef = useRef("")
   const lastPathRef = useRef("")
+  const loadIdRef = useRef(0)
 
   const compute = useCallback(async () => {
+    const loadId = ++loadIdRef.current
+
     if (!folder) {
       setStats(null)
       return
@@ -114,18 +117,25 @@ export function useFolderActivity(
       return
     }
 
+    if (loadId !== loadIdRef.current) return
+
     setLoading(true)
     try {
       const timelines = new Map<string, TimelineEntry[]>()
       for (const req of childRequests) {
         const entries = await loadTimeline(collectionDir, req.id)
         timelines.set(req.id, entries)
+        if (loadId !== loadIdRef.current) return
       }
+      if (loadId !== loadIdRef.current) return
       setStats(computeFolderActivity(childRequests, timelines))
     } catch {
+      if (loadId !== loadIdRef.current) return
       setStats(null)
     } finally {
-      setLoading(false)
+      if (loadId === loadIdRef.current) {
+        setLoading(false)
+      }
     }
   }, [collectionDir, folder])
 

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -39,10 +39,8 @@ export function computeFolderActivity(
     const avgTimeMs =
       successEntries.length > 0
         ? Math.round(
-            successEntries.reduce(
-              (s, e) => s + (e.response?.timeMs ?? 0),
-              0,
-            ) / successEntries.length,
+            successEntries.reduce((s, e) => s + (e.response?.timeMs ?? 0), 0) /
+              successEntries.length,
           )
         : null
     const lastSent = entries.length > 0 ? entries[0]!.timestamp : null
@@ -61,7 +59,9 @@ export function computeFolderActivity(
   const totalCalls = requests.reduce((s, r) => s + r.callCount, 0)
 
   const allEntries = requests.flatMap((r) => timelines.get(r.id) ?? [])
-  const allSuccessCount = allEntries.filter((e) => e.response !== undefined).length
+  const allSuccessCount = allEntries.filter(
+    (e) => e.response !== undefined,
+  ).length
   const overallSuccessRate =
     totalCalls > 0 ? allSuccessCount / totalCalls : null
 

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -14,11 +14,6 @@ export interface RequestActivityStats {
 
 export interface FolderActivityStats {
   requests: RequestActivityStats[]
-  summary: {
-    totalCalls: number
-    overallSuccessRate: number | null
-    overallAvgTime: number | null
-  }
 }
 
 interface ChildRequest {
@@ -56,32 +51,7 @@ export function computeFolderActivity(
     }
   })
 
-  const totalCalls = requests.reduce((s, r) => s + r.callCount, 0)
-
-  const allEntries = requests.flatMap((r) => timelines.get(r.id) ?? [])
-  const allSuccessCount = allEntries.filter(
-    (e) => e.response !== undefined,
-  ).length
-  const overallSuccessRate =
-    totalCalls > 0 ? allSuccessCount / totalCalls : null
-
-  const allTimes = allEntries
-    .filter((e) => e.response !== undefined)
-    .map((e) => e.response!.timeMs)
-
-  const overallAvgTime =
-    allTimes.length > 0
-      ? Math.round(allTimes.reduce((s, t) => s + t, 0) / allTimes.length)
-      : null
-
-  return {
-    requests,
-    summary: {
-      totalCalls,
-      overallSuccessRate,
-      overallAvgTime,
-    },
-  }
+  return { requests }
 }
 
 export function useFolderActivity(

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -1,4 +1,6 @@
-import type { TimelineEntry, Method } from "../schema"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { TimelineEntry, Method, Folder } from "../schema"
+import { loadTimeline } from "../filestore"
 
 export interface RequestActivityStats {
   id: string
@@ -80,4 +82,69 @@ export function computeFolderActivity(
       overallAvgTime,
     },
   }
+}
+
+export function useFolderActivity(
+  collectionDir: string,
+  folder: Folder | null,
+  active: boolean,
+): { stats: FolderActivityStats | null; loading: boolean } {
+  const [stats, setStats] = useState<FolderActivityStats | null>(null)
+  const [loading, setLoading] = useState(false)
+  const loadedRef = useRef(false)
+  const lastDirRef = useRef("")
+  const lastPathRef = useRef("")
+
+  const compute = useCallback(async () => {
+    if (!folder) {
+      setStats(null)
+      return
+    }
+
+    const childRequests = folder.children
+      .filter((c) => c.type === "request")
+      .map((c) => ({
+        id: c.data.id,
+        name: c.data.name,
+        method: c.data.method,
+      }))
+
+    if (childRequests.length === 0) {
+      setStats(computeFolderActivity([], new Map()))
+      return
+    }
+
+    setLoading(true)
+    try {
+      const timelines = new Map<string, TimelineEntry[]>()
+      for (const req of childRequests) {
+        const entries = await loadTimeline(collectionDir, req.id)
+        timelines.set(req.id, entries)
+      }
+      setStats(computeFolderActivity(childRequests, timelines))
+    } catch {
+      setStats(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [collectionDir, folder])
+
+  useEffect(() => {
+    const path = folder?.path ?? ""
+    if (collectionDir !== lastDirRef.current || path !== lastPathRef.current) {
+      lastDirRef.current = collectionDir
+      lastPathRef.current = path
+      loadedRef.current = false
+      setStats(null)
+    }
+  }, [collectionDir, folder])
+
+  useEffect(() => {
+    if (active && !loadedRef.current && folder) {
+      loadedRef.current = true
+      compute()
+    }
+  }, [active, folder, compute])
+
+  return { stats, loading }
 }

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -91,13 +91,14 @@ export function useFolderActivity(
 
     setLoading(true)
     try {
-      const timelines = new Map<string, TimelineEntry[]>()
-      for (const req of childRequests) {
-        const entries = await loadTimeline(collectionDir, req.id)
-        timelines.set(req.id, entries)
-        if (loadId !== loadIdRef.current) return
-      }
+      const entriesList = await Promise.all(
+        childRequests.map((req) => loadTimeline(collectionDir, req.id)),
+      )
       if (loadId !== loadIdRef.current) return
+      const timelines = new Map<string, TimelineEntry[]>()
+      for (let i = 0; i < childRequests.length; i++) {
+        timelines.set(childRequests[i]!.id, entriesList[i]!)
+      }
       setStats(computeFolderActivity(childRequests, timelines))
     } catch {
       if (loadId !== loadIdRef.current) return

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -1,0 +1,88 @@
+import type { TimelineEntry, Method } from "../schema"
+
+export interface RequestActivityStats {
+  id: string
+  name: string
+  method: Method
+  successRate: number | null
+  avgTimeMs: number | null
+  callCount: number
+  lastSent: number | null
+}
+
+export interface FolderActivityStats {
+  requests: RequestActivityStats[]
+  summary: {
+    totalCalls: number
+    overallSuccessRate: number | null
+    overallAvgTime: number | null
+  }
+}
+
+interface ChildRequest {
+  id: string
+  name: string
+  method: Method
+}
+
+export function computeFolderActivity(
+  childRequests: ChildRequest[],
+  timelines: Map<string, TimelineEntry[]>,
+): FolderActivityStats {
+  const requests: RequestActivityStats[] = childRequests.map((req) => {
+    const entries = timelines.get(req.id) ?? []
+    const successEntries = entries.filter((e) => e.response !== undefined)
+    const callCount = entries.length
+    const successRate = callCount > 0 ? successEntries.length / callCount : null
+    const avgTimeMs =
+      successEntries.length > 0
+        ? Math.round(
+            successEntries.reduce(
+              (s, e) => s + (e.response?.timeMs ?? 0),
+              0,
+            ) / successEntries.length,
+          )
+        : null
+    const lastSent = entries.length > 0 ? entries[0]!.timestamp : null
+
+    return {
+      id: req.id,
+      name: req.name,
+      method: req.method,
+      successRate,
+      avgTimeMs,
+      callCount,
+      lastSent,
+    }
+  })
+
+  const totalCalls = requests.reduce((s, r) => s + r.callCount, 0)
+  const allSuccessEntries =
+    totalCalls > 0
+      ? requests.reduce((s, r) => {
+          const count =
+            r.successRate !== null ? r.successRate * r.callCount : 0
+          return s + count
+        }, 0) / totalCalls
+      : null
+  const allTimes = requests.flatMap((r) => {
+    const entries = timelines.get(r.id) ?? []
+    return entries
+      .filter((e) => e.response !== undefined)
+      .map((e) => e.response!.timeMs)
+  })
+
+  const overallAvgTime =
+    allTimes.length > 0
+      ? Math.round(allTimes.reduce((s, t) => s + t, 0) / allTimes.length)
+      : null
+
+  return {
+    requests,
+    summary: {
+      totalCalls,
+      overallSuccessRate: allSuccessEntries,
+      overallAvgTime,
+    },
+  }
+}

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -57,20 +57,15 @@ export function computeFolderActivity(
   })
 
   const totalCalls = requests.reduce((s, r) => s + r.callCount, 0)
-  const allSuccessEntries =
-    totalCalls > 0
-      ? requests.reduce((s, r) => {
-          const count =
-            r.successRate !== null ? r.successRate * r.callCount : 0
-          return s + count
-        }, 0) / totalCalls
-      : null
-  const allTimes = requests.flatMap((r) => {
-    const entries = timelines.get(r.id) ?? []
-    return entries
-      .filter((e) => e.response !== undefined)
-      .map((e) => e.response!.timeMs)
-  })
+
+  const allEntries = requests.flatMap((r) => timelines.get(r.id) ?? [])
+  const allSuccessCount = allEntries.filter((e) => e.response !== undefined).length
+  const overallSuccessRate =
+    totalCalls > 0 ? allSuccessCount / totalCalls : null
+
+  const allTimes = allEntries
+    .filter((e) => e.response !== undefined)
+    .map((e) => e.response!.timeMs)
 
   const overallAvgTime =
     allTimes.length > 0
@@ -81,7 +76,7 @@ export function computeFolderActivity(
     requests,
     summary: {
       totalCalls,
-      overallSuccessRate: allSuccessEntries,
+      overallSuccessRate,
       overallAvgTime,
     },
   }

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -342,7 +342,10 @@ export function useOverlayIntercepts(opts: {
             e.stopPropagation()
             const result = handle.confirm()
             if (result) onEditRequestConfirm(result)
-          } else if (handle.getFocus() === "method" || handle.getFocus() === "folder") {
+          } else if (
+            handle.getFocus() === "method" ||
+            handle.getFocus() === "folder"
+          ) {
             return
           } else {
             e.preventDefault()

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, symlink } from "node:fs/promises"
+import {
+  mkdtemp,
+  rm,
+  mkdir,
+  writeFile,
+  readFile,
+  readdir,
+  symlink,
+} from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
-import { filestore, loadSettings, saveSettings, saveFolder, deleteFolder } from "../src/filestore"
+import {
+  filestore,
+  loadSettings,
+  saveSettings,
+  saveFolder,
+  deleteFolder,
+} from "../src/filestore"
 import type { Folder, Request, Collection } from "../src/schema"
 
 function reqs(col: Collection): Request[] {
@@ -334,10 +348,7 @@ describe("filestore.saveFolder — path validation", () => {
     const before = await readFile(join(dir, folderPath, "folder.yml"), "utf8")
     expect(before).toContain("name: Old Name")
 
-    await saveFolder(
-      dir,
-      makeFolder({ path: folderPath, name: "New Name" }),
-    )
+    await saveFolder(dir, makeFolder({ path: folderPath, name: "New Name" }))
     const after = await readFile(join(dir, folderPath, "folder.yml"), "utf8")
     expect(after).toContain("name: New Name")
     expect(after).not.toContain("Old Name")
@@ -365,22 +376,48 @@ describe("filestore.deleteFolder — path validation", () => {
 
   it("deletes folder directory", async () => {
     await mkdir(join(dir, "to-delete"))
-    await writeFile(join(dir, "to-delete", "folder.yml"), "meta:\n  name: Bye\n", "utf8")
+    await writeFile(
+      join(dir, "to-delete", "folder.yml"),
+      "meta:\n  name: Bye\n",
+      "utf8",
+    )
     await deleteFolder(dir, "to-delete")
-    await expect(readFile(join(dir, "to-delete", "folder.yml"), "utf8")).rejects.toThrow()
+    await expect(
+      readFile(join(dir, "to-delete", "folder.yml"), "utf8"),
+    ).rejects.toThrow()
   })
 
   it("deletes folder with nested requests and subfolders", async () => {
     await mkdir(join(dir, "nested", "sub"), { recursive: true })
-    await writeFile(join(dir, "nested", "folder.yml"), "meta:\n  name: Nested\n", "utf8")
-    await writeFile(join(dir, "nested", "get-user.yml"), "method: GET\nurl: /user\n", "utf8")
-    await writeFile(join(dir, "nested", "sub", "folder.yml"), "meta:\n  name: Sub\n", "utf8")
-    await writeFile(join(dir, "nested", "sub", "delete.yml"), "method: DELETE\nurl: /user\n", "utf8")
+    await writeFile(
+      join(dir, "nested", "folder.yml"),
+      "meta:\n  name: Nested\n",
+      "utf8",
+    )
+    await writeFile(
+      join(dir, "nested", "get-user.yml"),
+      "method: GET\nurl: /user\n",
+      "utf8",
+    )
+    await writeFile(
+      join(dir, "nested", "sub", "folder.yml"),
+      "meta:\n  name: Sub\n",
+      "utf8",
+    )
+    await writeFile(
+      join(dir, "nested", "sub", "delete.yml"),
+      "method: DELETE\nurl: /user\n",
+      "utf8",
+    )
 
     await deleteFolder(dir, "nested")
 
-    await expect(readFile(join(dir, "nested", "folder.yml"), "utf8")).rejects.toThrow()
-    await expect(readFile(join(dir, "nested", "sub", "delete.yml"), "utf8")).rejects.toThrow()
+    await expect(
+      readFile(join(dir, "nested", "folder.yml"), "utf8"),
+    ).rejects.toThrow()
+    await expect(
+      readFile(join(dir, "nested", "sub", "delete.yml"), "utf8"),
+    ).rejects.toThrow()
     await expect(readdir(join(dir, "nested"))).rejects.toThrow()
   })
 })
@@ -501,8 +538,15 @@ describe("filestore — nested folders", () => {
 describe("filestore — symlink handling", () => {
   it("skips symlink pointing outside collection root", async () => {
     await mkdir(join(dir, "outside-collection"))
-    await writeFile(join(dir, "outside-collection", "x.yml"), yamlTmpl(makeReq({ name: "Outside" })))
-    await symlink(join(dir, "outside-collection"), join(dir, "outside-link"), "dir")
+    await writeFile(
+      join(dir, "outside-collection", "x.yml"),
+      yamlTmpl(makeReq({ name: "Outside" })),
+    )
+    await symlink(
+      join(dir, "outside-collection"),
+      join(dir, "outside-link"),
+      "dir",
+    )
 
     const col = await filestore.loadCollection(dir)
     const folderNames = col.items
@@ -513,7 +557,10 @@ describe("filestore — symlink handling", () => {
 
   it("follows symlink pointing to sibling directory inside collection", async () => {
     await mkdir(join(dir, "real-folder"))
-    await writeFile(join(dir, "real-folder", "inside.yml"), yamlTmpl(makeReq({ name: "Inside", id: "real-folder/inside" })))
+    await writeFile(
+      join(dir, "real-folder", "inside.yml"),
+      yamlTmpl(makeReq({ name: "Inside", id: "real-folder/inside" })),
+    )
     await symlink(join(dir, "real-folder"), join(dir, "link-to-real"), "dir")
 
     const col = await filestore.loadCollection(dir)
@@ -525,22 +572,39 @@ describe("filestore — symlink handling", () => {
 
   it("detects symlink cycles and skips duplicate", async () => {
     await mkdir(join(dir, "cycle-a"))
-    await writeFile(join(dir, "cycle-a", "a.yml"), yamlTmpl(makeReq({ name: "A", id: "cycle-a/a" })))
-    await symlink(join(dir, "cycle-a"), join(dir, "cycle-a", "link-to-self"), "dir")
+    await writeFile(
+      join(dir, "cycle-a", "a.yml"),
+      yamlTmpl(makeReq({ name: "A", id: "cycle-a/a" })),
+    )
+    await symlink(
+      join(dir, "cycle-a"),
+      join(dir, "cycle-a", "link-to-self"),
+      "dir",
+    )
 
     const col = await filestore.loadCollection(dir)
     // Should load without infinite loop
-    expect(col.items.some((i) => i.type === "folder" && i.data.name === "cycle-a")).toBe(true)
+    expect(
+      col.items.some((i) => i.type === "folder" && i.data.name === "cycle-a"),
+    ).toBe(true)
   })
 
   it("loads collection under path with symlinked parent components", async () => {
-    await writeFile(join(dir, "root.yml"), yamlTmpl(makeReq({ id: "root", name: "Root" })))
+    await writeFile(
+      join(dir, "root.yml"),
+      yamlTmpl(makeReq({ id: "root", name: "Root" })),
+    )
     await mkdir(join(dir, "sub"))
-    await writeFile(join(dir, "sub", "nested.yml"), yamlTmpl(makeReq({ id: "sub/nested", name: "Nested" })))
+    await writeFile(
+      join(dir, "sub", "nested.yml"),
+      yamlTmpl(makeReq({ id: "sub/nested", name: "Nested" })),
+    )
 
     const col = await filestore.loadCollection(dir)
     expect(col.items).toHaveLength(2)
-    expect(col.items.some((i) => i.type === "request" && i.data.id === "root")).toBe(true)
+    expect(
+      col.items.some((i) => i.type === "request" && i.data.id === "root"),
+    ).toBe(true)
     expect(col.items.some((i) => i.type === "folder")).toBe(true)
   })
 })

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -177,9 +177,7 @@ describe("visibleNodes", () => {
 
   it("shows collapsed folder as single node", () => {
     const result = visibleNodes(nestedItems, new Set())
-    const folderIds = result
-      .filter((n) => n.type === "folder")
-      .map((n) => n.id)
+    const folderIds = result.filter((n) => n.type === "folder").map((n) => n.id)
     expect(folderIds).toEqual(["auth", "users"])
     expect(result).toHaveLength(3) // auth, root, users
   })
@@ -226,7 +224,9 @@ describe("deriveRequestParentFolder", () => {
   it("derives parent folder from selectedId when no focused folder", () => {
     expect(deriveRequestParentFolder(null, "users/list")).toBe("users")
     expect(deriveRequestParentFolder(null, "auth/login")).toBe("auth")
-    expect(deriveRequestParentFolder(null, "users/admins/root")).toBe("users/admins")
+    expect(deriveRequestParentFolder(null, "users/admins/root")).toBe(
+      "users/admins",
+    )
   })
 
   it("returns null for root request and no focused folder", () => {
@@ -242,9 +242,7 @@ describe("getFolderPaths", () => {
   })
 
   it("returns root + single folder", () => {
-    const items: CollectionItem[] = [
-      folder("api", [], "API Requests"),
-    ]
+    const items: CollectionItem[] = [folder("api", [], "API Requests")]
     const paths = getFolderPaths(items)
     expect(paths).toEqual([
       { path: "", name: "(root)" },
@@ -269,10 +267,14 @@ describe("getFolderPaths", () => {
 
   it("returns flat list even with nested items", () => {
     const items: CollectionItem[] = [
-      folder("auth", [
-        req("auth/login"),
-        folder("auth/oauth", [req("auth/oauth/github")], "OAuth"),
-      ], "Auth"),
+      folder(
+        "auth",
+        [
+          req("auth/login"),
+          folder("auth/oauth", [req("auth/oauth/github")], "OAuth"),
+        ],
+        "Auth",
+      ),
       req("root-request"),
       folder("users", [req("users/list")], "Users"),
     ]

--- a/tests/unit/folder-activity.test.ts
+++ b/tests/unit/folder-activity.test.ts
@@ -43,7 +43,7 @@ function makeTimeline(
 }
 
 describe("computeFolderActivity", () => {
-  it("returns empty requests array and zero summary for empty timeline map", () => {
+  it("returns zeroed per-request stats for empty timeline map", () => {
     const result = computeFolderActivity(
       [{ id: "user/list", name: "List Users", method: "GET" }],
       new Map(),
@@ -53,9 +53,6 @@ describe("computeFolderActivity", () => {
     expect(result.requests[0]!.successRate).toBeNull()
     expect(result.requests[0]!.avgTimeMs).toBeNull()
     expect(result.requests[0]!.lastSent).toBeNull()
-    expect(result.summary.totalCalls).toBe(0)
-    expect(result.summary.overallSuccessRate).toBeNull()
-    expect(result.summary.overallAvgTime).toBeNull()
   })
 
   it("computes per-request stats from timeline entries", () => {
@@ -87,30 +84,6 @@ describe("computeFolderActivity", () => {
     expect(result.requests[0]!.avgTimeMs).toBeNull()
   })
 
-  it("computes summary across multiple requests", () => {
-    const timeline = new Map<string, TimelineEntry[]>()
-    timeline.set("user/list", [
-      makeEntry({
-        response: { ...makeEntry().response!, timeMs: 100, status: 200 },
-      }),
-      makeEntry({
-        response: { ...makeEntry().response!, timeMs: 300, status: 200 },
-      }),
-    ])
-    timeline.set("user/create", [
-      makeEntry({ error: { message: "err" }, response: undefined }),
-    ])
-    const result = computeFolderActivity(
-      [
-        { id: "user/list", name: "List Users", method: "GET" },
-        { id: "user/create", name: "Create User", method: "POST" },
-      ],
-      timeline,
-    )
-    expect(result.summary.totalCalls).toBe(3)
-    expect(result.summary.overallSuccessRate).toBe(2 / 3)
-  })
-
   it("handles partial data (some requests have no timeline)", () => {
     const timeline = makeTimeline("user/list", [
       { response: { ...makeEntry().response!, timeMs: 100, status: 200 } },
@@ -124,12 +97,10 @@ describe("computeFolderActivity", () => {
     )
     expect(result.requests[1]!.callCount).toBe(0)
     expect(result.requests[1]!.successRate).toBeNull()
-    expect(result.summary.totalCalls).toBe(1)
   })
 
   it("returns empty when no requests in folder", () => {
     const result = computeFolderActivity([], new Map())
     expect(result.requests).toHaveLength(0)
-    expect(result.summary.totalCalls).toBe(0)
   })
 })

--- a/tests/unit/folder-activity.test.ts
+++ b/tests/unit/folder-activity.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "bun:test"
+import { computeFolderActivity } from "../../src/ui/useFolderActivity"
+import type { TimelineEntry, Method } from "../../src/schema"
+
+function makeEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+  return {
+    timestamp: Date.now() - 60_000,
+    request: {
+      id: "user/list",
+      name: "List Users",
+      method: "GET" as Method,
+      url: "https://api.example.com/users",
+      headers: {},
+      params: {},
+    },
+    response: {
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: "{}",
+      timeMs: 120,
+      size: 100,
+    },
+    ...overrides,
+  } as TimelineEntry
+}
+
+function makeTimeline(
+  requestId: string,
+  entries: Partial<TimelineEntry>[],
+): Map<string, TimelineEntry[]> {
+  const map = new Map<string, TimelineEntry[]>()
+  map.set(
+    requestId,
+    entries.map((e) =>
+      makeEntry({
+        ...e,
+        request: { ...makeEntry().request, id: requestId },
+      }),
+    ),
+  )
+  return map
+}
+
+describe("computeFolderActivity", () => {
+  it("returns empty requests array and zero summary for empty timeline map", () => {
+    const result = computeFolderActivity(
+      [{ id: "user/list", name: "List Users", method: "GET" }],
+      new Map(),
+    )
+    expect(result.requests).toHaveLength(1)
+    expect(result.requests[0]!.callCount).toBe(0)
+    expect(result.requests[0]!.successRate).toBeNull()
+    expect(result.requests[0]!.avgTimeMs).toBeNull()
+    expect(result.requests[0]!.lastSent).toBeNull()
+    expect(result.summary.totalCalls).toBe(0)
+    expect(result.summary.overallSuccessRate).toBeNull()
+    expect(result.summary.overallAvgTime).toBeNull()
+  })
+
+  it("computes per-request stats from timeline entries", () => {
+    const timeline = makeTimeline("user/list", [
+      { response: { ...makeEntry().response!, timeMs: 100, status: 200 } },
+      { response: { ...makeEntry().response!, timeMs: 200, status: 200 } },
+    ])
+    const result = computeFolderActivity(
+      [{ id: "user/list", name: "List Users", method: "GET" }],
+      timeline,
+    )
+    const req = result.requests[0]!
+    expect(req.callCount).toBe(2)
+    expect(req.successRate).toBe(1)
+    expect(req.avgTimeMs).toBe(150)
+    expect(req.lastSent).toBe(timeline.get("user/list")![0]!.timestamp)
+  })
+
+  it("handles error entries (0% success)", () => {
+    const timeline = makeTimeline("user/create", [
+      { error: { message: "timeout" }, response: undefined },
+    ])
+    const result = computeFolderActivity(
+      [{ id: "user/create", name: "Create User", method: "POST" }],
+      timeline,
+    )
+    expect(result.requests[0]!.successRate).toBe(0)
+    expect(result.requests[0]!.callCount).toBe(1)
+    expect(result.requests[0]!.avgTimeMs).toBeNull()
+  })
+
+  it("computes summary across multiple requests", () => {
+    const timeline = new Map<string, TimelineEntry[]>()
+    timeline.set("user/list", [
+      makeEntry({
+        response: { ...makeEntry().response!, timeMs: 100, status: 200 },
+      }),
+      makeEntry({
+        response: { ...makeEntry().response!, timeMs: 300, status: 200 },
+      }),
+    ])
+    timeline.set("user/create", [
+      makeEntry({ error: { message: "err" }, response: undefined }),
+    ])
+    const result = computeFolderActivity(
+      [
+        { id: "user/list", name: "List Users", method: "GET" },
+        { id: "user/create", name: "Create User", method: "POST" },
+      ],
+      timeline,
+    )
+    expect(result.summary.totalCalls).toBe(3)
+    expect(result.summary.overallSuccessRate).toBe(2 / 3)
+  })
+
+  it("handles partial data (some requests have no timeline)", () => {
+    const timeline = makeTimeline("user/list", [
+      { response: { ...makeEntry().response!, timeMs: 100, status: 200 } },
+    ])
+    const result = computeFolderActivity(
+      [
+        { id: "user/list", name: "List Users", method: "GET" },
+        { id: "user/delete", name: "Delete User", method: "DELETE" },
+      ],
+      timeline,
+    )
+    expect(result.requests[1]!.callCount).toBe(0)
+    expect(result.requests[1]!.successRate).toBeNull()
+    expect(result.summary.totalCalls).toBe(1)
+  })
+
+  it("returns empty when no requests in folder", () => {
+    const result = computeFolderActivity([], new Map())
+    expect(result.requests).toHaveLength(0)
+    expect(result.summary.totalCalls).toBe(0)
+  })
+})

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -112,9 +112,15 @@ describe("applyDraftOp", () => {
         auth: { type: "api_key", key: "k", value: "v", placement: "header" },
       },
     })
-    const r = applyDraftOp(f, { kind: "setApiKeyPlacement", placement: "query" })
+    const r = applyDraftOp(f, {
+      kind: "setApiKeyPlacement",
+      placement: "query",
+    })
     expect(r?.overrides?.auth).toEqual({
-      type: "api_key", key: "k", value: "v", placement: "query",
+      type: "api_key",
+      key: "k",
+      value: "v",
+      placement: "query",
     })
   })
 
@@ -124,9 +130,17 @@ describe("applyDraftOp", () => {
         headers: { "X-Old": { value: "old", enabled: false } },
       },
     })
-    const r = applyDraftOp(f, { kind: "setHeaderRow", index: 0, key: "X-New", value: "new" })
+    const r = applyDraftOp(f, {
+      kind: "setHeaderRow",
+      index: 0,
+      key: "X-New",
+      value: "new",
+    })
     expect(Object.keys(r?.overrides?.headers ?? {})).toEqual(["X-New"])
-    expect(r?.overrides?.headers?.["X-New"]).toEqual({ value: "new", enabled: false })
+    expect(r?.overrides?.headers?.["X-New"]).toEqual({
+      value: "new",
+      enabled: false,
+    })
   })
 
   it("revert signals return to original (null)", () => {
@@ -143,7 +157,12 @@ describe("applyDraftOp", () => {
     const f = makeFolder({
       overrides: { auth: { type: "bearer", token: "tok" } },
     })
-    const r = applyDraftOp(f, { kind: "setAuthField", authType: "basic", field: "user", value: "u" })
+    const r = applyDraftOp(f, {
+      kind: "setAuthField",
+      authType: "basic",
+      field: "user",
+      value: "u",
+    })
     expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "tok" })
   })
 
@@ -151,7 +170,10 @@ describe("applyDraftOp", () => {
     const f = makeFolder({
       overrides: { auth: { type: "bearer", token: "tok" } },
     })
-    const r = applyDraftOp(f, { kind: "setApiKeyPlacement", placement: "query" })
+    const r = applyDraftOp(f, {
+      kind: "setApiKeyPlacement",
+      placement: "query",
+    })
     expect(r?.overrides?.auth).toEqual({ type: "bearer", token: "tok" })
   })
 
@@ -168,11 +190,15 @@ describe("folderEqual", () => {
   })
 
   it("returns false for different names", () => {
-    expect(folderEqual(makeFolder({ name: "A" }), makeFolder({ name: "B" }))).toBe(false)
+    expect(
+      folderEqual(makeFolder({ name: "A" }), makeFolder({ name: "B" })),
+    ).toBe(false)
   })
 
   it("returns false for different seq", () => {
-    expect(folderEqual(makeFolder({ seq: 1 }), makeFolder({ seq: 2 }))).toBe(false)
+    expect(folderEqual(makeFolder({ seq: 1 }), makeFolder({ seq: 2 }))).toBe(
+      false,
+    )
   })
 
   it("returns false for different headers", () => {
@@ -182,7 +208,6 @@ describe("folderEqual", () => {
     const b = makeFolder()
     expect(folderEqual(a, b)).toBe(false)
   })
-
 
   it("returns false for different auth", () => {
     const a = makeFolder({

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -71,15 +71,16 @@ describe("initialFolderEditState", () => {
 
 describe("FOLDER_FIELD_ORDER", () => {
   it("has correct order", () => {
-    expect(FOLDER_FIELD_ORDER).toEqual(["meta", "headers", "auth"])
+    expect(FOLDER_FIELD_ORDER).toEqual(["activity", "meta", "headers", "auth"])
   })
 })
 
 describe("folderFieldIndex", () => {
   it("maps field to index based on FOLDER_FIELD_ORDER", () => {
-    expect(folderFieldIndex("meta")).toBe(0)
-    expect(folderFieldIndex("headers")).toBe(1)
-    expect(folderFieldIndex("auth")).toBe(2)
+    expect(folderFieldIndex("activity")).toBe(0)
+    expect(folderFieldIndex("meta")).toBe(1)
+    expect(folderFieldIndex("headers")).toBe(2)
+    expect(folderFieldIndex("auth")).toBe(3)
   })
 
   it("returns -1 for unknown field", () => {
@@ -165,21 +166,25 @@ describe("exitEditBrowse", () => {
 })
 
 describe("moveFolderFieldCursor", () => {
-  it("+1 walks meta → headers → auth → meta", () => {
+  it("+1 walks activity → meta → headers → auth → activity", () => {
     const counts = emptyCounts
-    const atMeta = enterFolderEditBrowse(folderInactive(), counts, "meta")
+    const atActivity = enterFolderEditBrowse(folderInactive(), counts, "activity")
+    const atMeta = moveFolderFieldCursor(atActivity, 1, counts)
+    expect(atMeta.cursor.field).toBe("meta")
     const atHeaders = moveFolderFieldCursor(atMeta, 1, counts)
     expect(atHeaders.cursor.field).toBe("headers")
     const atAuth = moveFolderFieldCursor(atHeaders, 1, counts)
     expect(atAuth.cursor.field).toBe("auth")
-    const backToMeta = moveFolderFieldCursor(atAuth, 1, counts)
-    expect(backToMeta.cursor.field).toBe("meta")
+    const backToActivity = moveFolderFieldCursor(atAuth, 1, counts)
+    expect(backToActivity.cursor.field).toBe("activity")
   })
 
-  it("-1 walks meta → auth → headers → meta", () => {
+  it("-1 walks meta → activity → auth → headers → meta", () => {
     const counts = emptyCounts
     const atMeta = enterFolderEditBrowse(folderInactive(), counts, "meta")
-    const atAuth = moveFolderFieldCursor(atMeta, -1, counts)
+    const atActivity = moveFolderFieldCursor(atMeta, -1, counts)
+    expect(atActivity.cursor.field).toBe("activity")
+    const atAuth = moveFolderFieldCursor(atActivity, -1, counts)
     expect(atAuth.cursor.field).toBe("auth")
     const atHeaders = moveFolderFieldCursor(atAuth, -1, counts)
     expect(atHeaders.cursor.field).toBe("headers")

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -59,10 +59,10 @@ const emptyCounts: FolderRowCount = {
 }
 
 describe("initialFolderEditState", () => {
-  it("starts inactive with meta cursor", () => {
+  it("starts inactive with activity cursor", () => {
     const state = initialFolderEditState()
     expect(state.mode).toBe("inactive")
-    expect(state.cursor.field).toBe("meta")
+    expect(state.cursor.field).toBe("activity")
     expect(state.cursor.row).toBe(-1)
     expect(state.cursor.addingRow).toBe(false)
     expect(state.editingRow).toBe(-1)
@@ -111,10 +111,10 @@ describe("folderCursorForField", () => {
 })
 
 describe("enterFolderEditBrowse", () => {
-  it("inactive → browsing at meta", () => {
+  it("inactive → browsing at activity", () => {
     const result = enterFolderEditBrowse(folderInactive(), emptyCounts)
     expect(result.mode).toBe("browsing")
-    expect(result.cursor.field).toBe("meta")
+    expect(result.cursor.field).toBe("activity")
     expect(result.cursor.row).toBe(0)
     expect(result.editingRow).toBe(-1)
   })

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -108,8 +108,6 @@ describe("folderCursorForField", () => {
     const c = folderCursorForField("headers", defaultCounts)
     expect(c).toEqual({ field: "headers", row: 0, addingRow: false })
   })
-
-
 })
 
 describe("enterFolderEditBrowse", () => {
@@ -168,7 +166,11 @@ describe("exitEditBrowse", () => {
 describe("moveFolderFieldCursor", () => {
   it("+1 walks activity → meta → headers → auth → activity", () => {
     const counts = emptyCounts
-    const atActivity = enterFolderEditBrowse(folderInactive(), counts, "activity")
+    const atActivity = enterFolderEditBrowse(
+      folderInactive(),
+      counts,
+      "activity",
+    )
     const atMeta = moveFolderFieldCursor(atActivity, 1, counts)
     expect(atMeta.cursor.field).toBe("meta")
     const atHeaders = moveFolderFieldCursor(atMeta, 1, counts)
@@ -229,7 +231,6 @@ describe("moveFolderRowCursor", () => {
     const backTo1 = moveFolderRowCursor(backTo0, 1, counts)
     expect(backTo1.cursor.row).toBe(1)
   })
-
 
   it("headers backward wrap: [+] → last row, 0 → [+]", () => {
     const counts: FolderRowCount = { meta: 0, headers: 3, auth: 0 }

--- a/tests/unit/folder-editMode.test.ts
+++ b/tests/unit/folder-editMode.test.ts
@@ -59,10 +59,10 @@ const emptyCounts: FolderRowCount = {
 }
 
 describe("initialFolderEditState", () => {
-  it("starts inactive with activity cursor", () => {
+  it("starts inactive with meta cursor", () => {
     const state = initialFolderEditState()
     expect(state.mode).toBe("inactive")
-    expect(state.cursor.field).toBe("activity")
+    expect(state.cursor.field).toBe("meta")
     expect(state.cursor.row).toBe(-1)
     expect(state.cursor.addingRow).toBe(false)
     expect(state.editingRow).toBe(-1)
@@ -71,16 +71,16 @@ describe("initialFolderEditState", () => {
 
 describe("FOLDER_FIELD_ORDER", () => {
   it("has correct order", () => {
-    expect(FOLDER_FIELD_ORDER).toEqual(["activity", "meta", "headers", "auth"])
+    expect(FOLDER_FIELD_ORDER).toEqual(["meta", "headers", "auth", "activity"])
   })
 })
 
 describe("folderFieldIndex", () => {
   it("maps field to index based on FOLDER_FIELD_ORDER", () => {
-    expect(folderFieldIndex("activity")).toBe(0)
-    expect(folderFieldIndex("meta")).toBe(1)
-    expect(folderFieldIndex("headers")).toBe(2)
-    expect(folderFieldIndex("auth")).toBe(3)
+    expect(folderFieldIndex("activity")).toBe(3)
+    expect(folderFieldIndex("meta")).toBe(0)
+    expect(folderFieldIndex("headers")).toBe(1)
+    expect(folderFieldIndex("auth")).toBe(2)
   })
 
   it("returns -1 for unknown field", () => {
@@ -111,10 +111,10 @@ describe("folderCursorForField", () => {
 })
 
 describe("enterFolderEditBrowse", () => {
-  it("inactive → browsing at activity", () => {
+  it("inactive → browsing at meta by default", () => {
     const result = enterFolderEditBrowse(folderInactive(), emptyCounts)
     expect(result.mode).toBe("browsing")
-    expect(result.cursor.field).toBe("activity")
+    expect(result.cursor.field).toBe("meta")
     expect(result.cursor.row).toBe(0)
     expect(result.editingRow).toBe(-1)
   })

--- a/tests/unit/mergeFolderOverrides.test.ts
+++ b/tests/unit/mergeFolderOverrides.test.ts
@@ -230,11 +230,9 @@ describe("mergeFolderOverrides", () => {
     const child = makeFolder("api/v2", {
       auth: { type: "bearer", token: "tok" },
     })
-    const parent = makeFolderData(
-      "api",
-      { auth: { type: "none" } },
-      [{ type: "folder", data: child }],
-    )
+    const parent = makeFolderData("api", { auth: { type: "none" } }, [
+      { type: "folder", data: child },
+    ])
     const req = makeRequest({ auth: { type: "inherit" } })
     const col: Collection = {
       id: "c",

--- a/tests/unit/useTreeNavigation.test.tsx
+++ b/tests/unit/useTreeNavigation.test.tsx
@@ -42,13 +42,14 @@ interface Props {
   ) => void
 }
 
-function Harness({ initialSelectedId, initialItems, afterMount }: Props): ReactNode {
+function Harness({
+  initialSelectedId,
+  initialItems,
+  afterMount,
+}: Props): ReactNode {
   const [items, setItems] = useState(initialItems)
-  const { selectedId, setSelectedId, expandFolder, cursorIndex } = useTreeNavigation(
-    items,
-    () => true,
-    initialSelectedId,
-  )
+  const { selectedId, setSelectedId, expandFolder, cursorIndex } =
+    useTreeNavigation(items, () => true, initialSelectedId)
 
   useEffect(() => {
     afterMount?.(setSelectedId, setItems, expandFolder)
@@ -72,9 +73,7 @@ describe("useTreeNavigation", () => {
     const { keymap, cleanup } = setupKeymap()
     keyCleanup = cleanup
     return testRender(
-      <KeymapProvider keymap={keymap}>
-        {element}
-      </KeymapProvider>,
+      <KeymapProvider keymap={keymap}>{element}</KeymapProvider>,
       { width: 80, height: 10 },
     )
   }
@@ -115,10 +114,7 @@ describe("useTreeNavigation", () => {
     const items = [fld("users", [])]
 
     const { renderOnce, captureCharFrame } = await render(
-      <Harness
-        initialSelectedId="users/"
-        initialItems={items}
-      />,
+      <Harness initialSelectedId="users/" initialItems={items} />,
     )
 
     await renderOnce()
@@ -134,10 +130,7 @@ describe("useTreeNavigation", () => {
     const items = [fld("users", [req("users/list")])]
 
     const { renderOnce, captureCharFrame } = await render(
-      <Harness
-        initialSelectedId="users/list"
-        initialItems={items}
-      />,
+      <Harness initialSelectedId="users/list" initialItems={items} />,
     )
 
     await renderOnce()


### PR DESCRIPTION
Adds an Activity tab to folder panes showing per-request stats (success rate, avg time, call count, last sent) loaded from timeline files.

### Changes

- New `FolderActivityTab` component displaying a table of per-request activity stats
- New `useFolderActivity` hook with lazy loading from disk-backed timeline files
- New `computeFolderActivity` pure function with unit tests
- Activity tab integrated into folder browse/edit navigation cycle with editing guard
- Timelines loaded in parallel (`Promise.all`)
- Generation-counter abort pattern to prevent stale async results on folder switch
- Removed unused `summary` computation and dead `onTabChange` prop
- Column widths computed at render time to prevent alignment drift from `relativeTime`