### PR TITLE
UI/UX refactor: expand hint position, toast notifications, help overlay cleanup

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -83,8 +83,28 @@ try {
 
 const keybinds = parseOverrides(keybindsConfig)
 
-const renderer = await createCliRenderer({ exitOnCtrlC: true })
+const renderer = await createCliRenderer({ exitOnCtrlC: false })
 const keymap = createNoodleKeymap(renderer)
+
+renderer.on("selection", (selection) => {
+  const text = selection.getSelectedText()
+  if (text) renderer.copyToClipboardOSC52(text)
+})
+
+renderer.keyInput.on("keypress", (key) => {
+  if (key.ctrl && key.name === "c") {
+    const editor = renderer.currentFocusedEditor
+    const selectedText =
+      editor?.hasSelection() ? editor.getSelectedText() :
+      renderer.hasSelection ? renderer.getSelection()?.getSelectedText() : null
+    if (selectedText) {
+      renderer.copyToClipboardOSC52(selectedText)
+      renderer.clearSelection()
+      return
+    }
+    renderer.destroy()
+  }
+})
 
 createRoot(renderer).render(
   <KeymapProvider keymap={keymap}>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -9,6 +9,7 @@ import { loadSettings } from "../filestore"
 import { loadLastRequest } from "../ui/tabs/uiState"
 import { createNoodleKeymap } from "../hooks/useKeymap"
 import { parseOverrides } from "../ui/keybind"
+import { showToast } from "../ui/Toast"
 import { join } from "node:path"
 import * as yaml from "js-yaml"
 import { readFileSync } from "node:fs"
@@ -88,7 +89,10 @@ const keymap = createNoodleKeymap(renderer)
 
 renderer.on("selection", (selection) => {
   const text = selection.getSelectedText()
-  if (text) renderer.copyToClipboardOSC52(text)
+  if (text) {
+    renderer.copyToClipboardOSC52(text)
+    showToast("Copied to clipboard", "info")
+  }
 })
 
 renderer.keyInput.on("keypress", (key) => {
@@ -100,6 +104,7 @@ renderer.keyInput.on("keypress", (key) => {
     if (selectedText) {
       renderer.copyToClipboardOSC52(selectedText)
       renderer.clearSelection()
+      showToast("Copied to clipboard", "info")
       return
     }
     renderer.destroy()

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,6 +3,7 @@ import { AppInner } from "./AppInner"
 import { useConfig } from "../hooks/useConfig"
 import { listEnvironmentsWithColors } from "../env/listWithColors"
 import { ThemeProvider } from "./theme"
+import { Toast } from "./Toast"
 import { saveSettings } from "../filestore"
 import type { Keybinds } from "./keybind"
 
@@ -80,6 +81,7 @@ export function App({
 
   return (
     <ThemeProvider activeIndex={activeIndex} previewIndex={previewIndex}>
+      <Toast />
       <AppInner
         collectionDir={collectionDir}
         environmentsDir={environmentsDir}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -43,6 +43,7 @@ import {
 } from "../filestore/save"
 import { ThemePickerOverlay, useTheme } from "./theme"
 import { StatusBar } from "./StatusBar"
+import { showToast } from "./Toast"
 import { EnvSidebar } from "./EnvSidebar"
 import { EnvHeaderPane, type EnvHeaderPaneHandle } from "./EnvHeaderPane"
 import { EnvEditorPane } from "./EnvEditorPane"
@@ -316,6 +317,12 @@ export function AppInner({
   const doSaveRef = useRef(doSave)
   doSaveRef.current = doSave
 
+  useEffect(() => {
+    if (saveState.kind === "success" || saveState.kind === "error") {
+      showToast(saveState.message, saveState.kind)
+    }
+  }, [saveState])
+
   // ── Folder save ────────────────────────────────────────────────────
   const folderSaveRef = useRef<() => void>(() => {})
 
@@ -335,7 +342,7 @@ export function AppInner({
       })
       setSaveState({
         kind: "success",
-        message: `Saved folder ${draftFolder.name}`,
+        message: `Successfully saved folder ${draftFolder.name}`,
       })
       clearSaveTimer()
       saveTimerRef.current = setTimeout(
@@ -391,7 +398,7 @@ export function AppInner({
           setSelectedId(id)
           setNewRequestVisible(false)
           setFocus("sidebar")
-          setSaveState({ kind: "success", message: `Created ${name}` })
+          setSaveState({ kind: "success", message: `Successfully created ${name}` })
           clearSaveTimer()
           saveTimerRef.current = setTimeout(() => {
             setSaveState({ kind: "idle" })
@@ -442,7 +449,7 @@ export function AppInner({
           setSelectedId(id)
           const lastSlash = id.lastIndexOf("/")
           if (lastSlash >= 0) expandFolder(id.slice(0, lastSlash))
-          setSaveState({ kind: "success", message: `Cloned ${newName}` })
+          setSaveState({ kind: "success", message: `Successfully created ${newName}` })
           clearSaveTimer()
           saveTimerRef.current = setTimeout(() => {
             setSaveState({ kind: "idle" })
@@ -490,7 +497,7 @@ export function AppInner({
           setCollectionReloadToken((n) => n + 1)
           setNewFolderVisible(false)
           setFocus("sidebar")
-          setSaveState({ kind: "success", message: `Created folder ${name}` })
+          setSaveState({ kind: "success", message: `Successfully created folder ${name}` })
           clearSaveTimer()
           saveTimerRef.current = setTimeout(() => {
             setSaveState({ kind: "idle" })
@@ -525,7 +532,7 @@ export function AppInner({
         setCollectionReloadToken((n) => n + 1)
         setFolderDeletePending(null)
         setFocus("sidebar")
-        setSaveState({ kind: "success", message: `Deleted folder ${path}` })
+        setSaveState({ kind: "success", message: `Successfully deleted folder ${path}` })
         clearSaveTimer()
         saveTimerRef.current = setTimeout(() => {
           setSaveState({ kind: "idle" })
@@ -594,7 +601,7 @@ export function AppInner({
           setEditRequestVisible(false)
           setFocus("sidebar")
           if (newFolder) expandFolder(newFolder)
-          setSaveState({ kind: "success", message: `Saved ${name}` })
+          setSaveState({ kind: "success", message: `Successfully edited ${name}` })
           clearSaveTimer()
           saveTimerRef.current = setTimeout(() => {
             setSaveState({ kind: "idle" })
@@ -630,7 +637,7 @@ export function AppInner({
         setCollectionReloadToken((n) => n + 1)
         setRequestDeletePending(null)
         setFocus("sidebar")
-        setSaveState({ kind: "success", message: `Deleted ${req.name}` })
+        setSaveState({ kind: "success", message: `Successfully deleted ${req.name}` })
         clearSaveTimer()
         saveTimerRef.current = setTimeout(() => {
           setSaveState({ kind: "idle" })
@@ -1194,7 +1201,7 @@ export function AppInner({
               setFocus(yamlEditor.returnFocus)
               setSaveState({
                 kind: "success",
-                message: `Saved ${yamlEditor.filePath.split("/").pop() ?? ""}`,
+                message: `Successfully edited ${yamlEditor.filePath.split("/").pop() ?? ""}`,
               })
               clearSaveTimer()
               saveTimerRef.current = setTimeout(() => {

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -15,6 +15,7 @@ export function Badge({
         backgroundColor: bg,
         paddingLeft: 1,
         paddingRight: 1,
+        flexShrink: 0,
       }}
     >
       <text fg={fg}>{children}</text>

--- a/src/ui/CloneRequestOverlay.tsx
+++ b/src/ui/CloneRequestOverlay.tsx
@@ -56,7 +56,7 @@ export const CloneRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>Clone Request</text>
+        <text fg={theme.text}>Clone Request</text>
         <text fg={theme.textMuted}>esc</text>
       </box>
 
@@ -90,10 +90,10 @@ export const CloneRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>^S</text>
+        <text fg={theme.text}>^S</text>
         <text fg={theme.textMuted}>save</text>
         <text fg={theme.textMuted}> · </text>
-        <text fg={theme.primary}>esc</text>
+        <text fg={theme.text}>esc</text>
         <text fg={theme.textMuted}>close</text>
       </box>
     </Overlay>

--- a/src/ui/ConfirmOverlay.tsx
+++ b/src/ui/ConfirmOverlay.tsx
@@ -24,7 +24,7 @@ export function ConfirmOverlay({
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>Confirm</text>
+        <text fg={theme.text}>Confirm</text>
         <text fg={theme.textMuted}>esc</text>
       </box>
       <box style={{ paddingX: 2, paddingBottom: 1 }}>
@@ -38,10 +38,10 @@ export function ConfirmOverlay({
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>y</text>
+        <text fg={theme.text}>y</text>
         <text fg={theme.textMuted}>confirm</text>
         <text fg={theme.textMuted}> · </text>
-        <text fg={theme.primary}>n</text>
+        <text fg={theme.text}>n</text>
         <text fg={theme.textMuted}>cancel</text>
       </box>
     </Overlay>

--- a/src/ui/HelpOverlay.tsx
+++ b/src/ui/HelpOverlay.tsx
@@ -2,6 +2,7 @@ import { getHelpSections } from "./helpTexts"
 import { useTheme } from "./theme"
 import { Overlay } from "./Overlay"
 import type { Keybinds } from "./keybind"
+import { TextAttributes } from "@opentui/core"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useRef } from "react"
 
@@ -46,7 +47,7 @@ export function HelpOverlay({
           {sections.map((section) => (
             <box key={section.title} style={{ flexDirection: "column" }}>
               <box paddingLeft={4} paddingRight={4}>
-                <text fg={theme.text}>{section.title}</text>
+                <text fg={theme.text} attributes={TextAttributes.BOLD}>{section.title}</text>
               </box>
               {section.keys.map((k, i) => (
                 <box
@@ -55,7 +56,7 @@ export function HelpOverlay({
                   paddingRight={4}
                   style={{ flexDirection: "row" }}
                 >
-                  <text fg={theme.primary}>{k.key.padEnd(11)}</text>
+                  <text fg={theme.text}>{k.key.padEnd(11)}</text>
                   <text fg={theme.textMuted}>{k.description}</text>
                 </box>
               ))}

--- a/src/ui/NewFolderOverlay.tsx
+++ b/src/ui/NewFolderOverlay.tsx
@@ -55,7 +55,7 @@ export const NewFolderOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>New Folder</text>
+        <text fg={theme.text}>New Folder</text>
         <text fg={theme.textMuted}>esc</text>
       </box>
 

--- a/src/ui/NewRequestOverlay.tsx
+++ b/src/ui/NewRequestOverlay.tsx
@@ -159,7 +159,7 @@ export const NewRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>
+        <text fg={theme.text}>
           {isEdit ? "Edit Request" : "New Request"}
         </text>
         <text fg={theme.textMuted}>esc</text>
@@ -246,10 +246,10 @@ export const NewRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>^S</text>
+        <text fg={theme.text}>^S</text>
         <text fg={theme.textMuted}>save</text>
         <text fg={theme.textMuted}> · </text>
-        <text fg={theme.primary}>esc</text>
+        <text fg={theme.text}>esc</text>
         <text fg={theme.textMuted}>close</text>
       </box>
     </Overlay>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -152,7 +152,7 @@ export function RequestPane({
       titleColor={focused ? theme.primary : theme.textMuted}
       titleAlignment="left"
       bottomTitle={focused ? expandHint : undefined}
-      bottomTitleAlignment="right"
+      bottomTitleAlignment="left"
     >
       {request ? (
         <>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -142,13 +142,6 @@ export function StatusBar(input: {
           theme.info)
         : theme.info
 
-  const saveFlash =
-    sk === "success"
-      ? `✓ ${input.saveState.message}`
-      : sk === "error"
-        ? `✗ ${input.saveState.message}`
-        : null
-
   const isEnvEditor = input.view === "env-editor"
   const envEditorSegments = [
     { key: "Esc", word: "back" },
@@ -170,11 +163,7 @@ export function StatusBar(input: {
       }}
     >
       <box style={{ flexDirection: "row" }}>
-        {saveFlash ? (
-          <Badge bg={theme.primary} fg={theme.background}>
-            {saveFlash}
-          </Badge>
-        ) : isEnvEditor ? (
+        {isEnvEditor ? (
           <Badge bg={theme.backgroundElement} fg={theme.info}>
             {input.envStats || "Env Editor"}
           </Badge>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -175,7 +175,7 @@ export function StatusBar(input: {
         {(isEnvEditor ? envEditorSegments : rightSegments).map((seg, i) => (
           <box key={i} style={{ flexDirection: "row" }}>
             {i > 0 ? <text fg={theme.textMuted}> · </text> : null}
-            <text fg={theme.primary}>{seg.key}</text>
+            <text fg={theme.text}>{seg.key}</text>
             <text fg={theme.textMuted}> {seg.word}</text>
           </box>
         ))}

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -35,6 +35,7 @@ export function Tabs({
               key={tab.id}
               style={{
                 flexDirection: "column",
+                flexShrink: 0,
               }}
             >
               <box style={{ paddingLeft: 1, paddingRight: 2 }}>

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -60,7 +60,7 @@ export function Tips() {
   )
   const parts = parseTip(tip)
   const segments = [
-    { text: "● Tip", color: theme.accent },
+    { text: "● Tip", color: theme.primary },
     ...parts.map((p) => ({
       text: p.text,
       color: p.isKey ? theme.text : theme.textMuted,

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -60,10 +60,10 @@ export function Tips() {
   )
   const parts = parseTip(tip)
   const segments = [
-    { text: "● Tip", color: theme.secondary },
+    { text: "● Tip", color: theme.accent },
     ...parts.map((p) => ({
       text: p.text,
-      color: p.isKey ? theme.primary : theme.textMuted,
+      color: p.isKey ? theme.text : theme.textMuted,
     })),
   ]
 

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from "react"
+import { useTheme } from "./theme"
+import { PaneBorder } from "./borders"
+
+type ToastVariant = "info" | "success" | "warning" | "error"
+
+let showToastFn: ((message: string, variant?: ToastVariant) => void) | null = null
+
+export function showToast(message: string, variant?: ToastVariant) {
+  showToastFn?.(message, variant)
+}
+
+export function Toast() {
+  const theme = useTheme()
+  const [state, setState] = useState<{
+    message: string
+    variant: ToastVariant
+  } | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    showToastFn = (message: string, variant?: ToastVariant) => {
+      setState({ message, variant: variant ?? "info" })
+      clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => setState(null), 5000)
+    }
+    return () => {
+      showToastFn = null
+    }
+  }, [])
+
+  if (!state) return null
+
+  return (
+    <box
+      position="absolute"
+      top={2}
+      right={2}
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      backgroundColor={theme.backgroundPanel}
+      border={[...PaneBorder.border]}
+      customBorderChars={PaneBorder.customBorderChars}
+      borderColor={theme[state.variant]}
+    >
+      <text fg={theme.text}>{state.message}</text>
+    </box>
+  )
+}

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -100,6 +100,7 @@ export function UrlBar({
               style={{
                 backgroundColor: theme.backgroundElement,
                 flexGrow: 1,
+                overflow: "hidden",
               }}
             >
               <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />

--- a/src/ui/VarText.tsx
+++ b/src/ui/VarText.tsx
@@ -17,7 +17,7 @@ export function VarText({
   const defaultColor = baseColor ?? theme.text
 
   return (
-    <box style={{ flexDirection: "row", gap: 0 }}>
+    <box style={{ flexDirection: "row", gap: 0, flexShrink: 1, minWidth: 0, overflow: "hidden" }}>
       {segments.map((seg, i) => (
         <text
           key={i}
@@ -28,6 +28,7 @@ export function VarText({
                 : theme.error
               : defaultColor
           }
+          wrapMode="none"
         >
           {seg.text}
         </text>

--- a/src/ui/YamlEditorOverlay.tsx
+++ b/src/ui/YamlEditorOverlay.tsx
@@ -131,7 +131,7 @@ export function YamlEditorOverlay({
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>{requestName}.yml</text>
+        <text fg={theme.text}>{requestName}.yml</text>
         <text fg={theme.textMuted}>esc</text>
       </box>
       {readError ? (
@@ -194,10 +194,10 @@ export function YamlEditorOverlay({
             gap: 1,
           }}
         >
-          <text fg={theme.primary}>^S</text>
+          <text fg={theme.text}>^S</text>
           <text fg={theme.textMuted}>save</text>
           <text fg={theme.textMuted}> · </text>
-          <text fg={theme.primary}>esc</text>
+          <text fg={theme.text}>esc</text>
           <text fg={theme.textMuted}>close</text>
         </box>
       </box>

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -27,7 +27,7 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
       ],
     },
     {
-      title: "Environments",
+      title: "Request Editing",
       keys: [
         {
           key: displayKey(keybinds.request_edit_overlay),

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -20,10 +20,6 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
         { key: "↑/↓", description: "Move cursor (browse) · request" },
         { key: keybinds.focus_next, description: "Next pane" },
         { key: keybinds.focus_prev, description: "Previous pane" },
-        {
-          key: keybinds.request_edit,
-          description: "Enter request edit-browse · request pane",
-        },
       ],
     },
     {
@@ -38,11 +34,6 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
           description: "Edit request YAML",
         },
         {
-          key: keybinds.browse_enter,
-          description: "Edit focused field · request browse",
-        },
-        { key: keybinds.edit_commit, description: "Commit edit" },
-        {
           key: keybinds.browse_escape,
           description: "Cancel edit / exit browse",
         },
@@ -54,6 +45,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
         {
           key: displayKey(keybinds.browse_revert_all),
           description: "Revert all fields",
+        },
+        {
+          key: displayKey(keybinds.browse_toggle_form_type),
+          description: "Toggle form entry type",
         },
       ],
     },
@@ -89,6 +84,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
         {
           key: displayKey(keybinds.pane_expand),
           description: "Expand/collapse focused pane",
+        },
+        {
+          key: displayKey(keybinds.folder_new),
+          description: "New folder",
         },
       ],
     },

--- a/src/ui/useSaveFile.ts
+++ b/src/ui/useSaveFile.ts
@@ -54,7 +54,7 @@ export function useSaveFile(
         clearSaveTimer()
         setSaveState({
           kind: "success",
-          message: `Saved ${requestId}.yml`,
+          message: `Successfully edited ${requestId}`,
         })
         saveTimerRef.current = setTimeout(() => {
           setSaveState({ kind: "idle" })

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -44,16 +44,16 @@ describe("getHelpSections", () => {
     expect(keys).toContain("shift+tab")
   })
 
-  it("REQUEST EDITING section shows return, escape, ^d, space, ^r, ^e", () => {
+  it("REQUEST EDITING section shows escape, ^d, space, ^r, ^e, ^t", () => {
     const sections = getHelpSections(defaults)
     const edit = sections.find((s) => s.title === "Request Editing")!
     const keys = edit.keys.map((k) => k.key)
-    expect(keys).toContain("return")
     expect(keys).toContain("escape")
     expect(keys).toContain("^d")
     expect(keys).toContain("space")
     expect(keys).toContain("^r")
     expect(keys).toContain("^e")
+    expect(keys).toContain("^t")
   })
 
   it("ACTIONS section shows ^return, ^s, ^n, ^k, ^w, ^p, ^l", () => {
@@ -75,13 +75,6 @@ describe("getHelpSections", () => {
     const keys = sys.keys.map((k) => k.key)
     expect(keys).toContain("^c")
     expect(keys).toContain("f1")
-  })
-
-  it("NAVIGATION section contains return for edit-enter", () => {
-    const sections = getHelpSections(defaults)
-    const nav = sections.find((s) => s.title === "Navigation")!
-    const keys = nav.keys.map((k) => k.key)
-    expect(keys).toContain("return")
   })
 
   it("reflects custom keybinds", () => {

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -10,10 +10,10 @@ describe("getHelpSections", () => {
     expect(sections).toHaveLength(5)
   })
 
-  it("section titles are NAVIGATION, ENVIRONMENTS, ACTIONS, SYSTEM, ENV EDITOR", () => {
+  it("section titles are NAVIGATION, REQUEST EDITING, ACTIONS, SYSTEM, ENV EDITOR", () => {
     const sections = getHelpSections(defaults)
     expect(sections[0]!.title).toBe("Navigation")
-    expect(sections[1]!.title).toBe("Environments")
+    expect(sections[1]!.title).toBe("Request Editing")
     expect(sections[2]!.title).toBe("Actions")
     expect(sections[3]!.title).toBe("System")
     expect(sections[4]!.title).toBe("Env Editor")
@@ -44,10 +44,10 @@ describe("getHelpSections", () => {
     expect(keys).toContain("shift+tab")
   })
 
-  it("ENVIRONMENTS section shows return, escape, ^d, space, ^r, ^e", () => {
+  it("REQUEST EDITING section shows return, escape, ^d, space, ^r, ^e", () => {
     const sections = getHelpSections(defaults)
-    const env = sections.find((s) => s.title === "Environments")!
-    const keys = env.keys.map((k) => k.key)
+    const edit = sections.find((s) => s.title === "Request Editing")!
+    const keys = edit.keys.map((k) => k.key)
     expect(keys).toContain("return")
     expect(keys).toContain("escape")
     expect(keys).toContain("^d")


### PR DESCRIPTION
Moves expand hint to bottom-left on request pane, replaces save flash with toast notifications, adds copy toast, cleans up help overlay, and applies style consistency pass.