### PR TITLE
feat: add copy body keybinding, help overlay, esc to sidebar

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -955,10 +955,7 @@ export function AppInner({
     () => `${displayKey(keybinds.pane_expand)} expand`,
     [keybinds.pane_expand],
   )
-  const copyBodyHint = useMemo(
-    () => `${displayKey(keybinds.response_copy_body)} copy`,
-    [keybinds.response_copy_body],
-  )
+
 
   // ── Render ─────────────────────────────────────────────────────────
   return (
@@ -1069,7 +1066,6 @@ export function AppInner({
                           initialTab={initialResponseTab}
                           onTabChange={onResponseTabChange}
                           expandHint={expandHint}
-                          copyBodyHint={copyBodyHint}
                         />
                       )}
                     </box>
@@ -1101,7 +1097,6 @@ export function AppInner({
                           initialTab={initialResponseTab}
                           onTabChange={onResponseTabChange}
                           expandHint={expandHint}
-                          copyBodyHint={copyBodyHint}
                         />
                       )}
                     </>

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -29,7 +29,6 @@ export function ResponsePane({
   initialTab,
   onTabChange,
   expandHint,
-  copyBodyHint,
 }: {
   state: SendState
   focused?: boolean
@@ -37,7 +36,6 @@ export function ResponsePane({
   initialTab?: "body" | "headers" | "timeline"
   onTabChange?: (tab: "body" | "headers" | "timeline") => void
   expandHint?: string
-  copyBodyHint?: string
 }) {
   const theme = useTheme()
   const focusedRef = useRef(focused)
@@ -127,9 +125,7 @@ export function ResponsePane({
   ) : undefined
 
   const footerLeft = focused ? (
-    <text fg={theme.primary}>
-      {expandHint}{copyBodyHint ? `  ${copyBodyHint}` : ""}
-    </text>
+    <text fg={theme.primary}>{expandHint}</text>
   ) : undefined
 
   const footerRight = isDone ? (

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -89,6 +89,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
           key: displayKey(keybinds.folder_new),
           description: "New folder",
         },
+        {
+          key: displayKey(keybinds.response_copy_body),
+          description: "Copy response body",
+        },
       ],
     },
     {

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -32,7 +32,7 @@ export const Definitions = {
   focus_prev: keybind("shift+tab", "Previous pane", true),
   layout_toggle: keybind("ctrl+l", "Toggle layout (stacked/side-by-side)"),
   pane_expand: keybind("f2", "Expand/collapse focused pane"),
-  response_copy_body: keybind("ctrl+y", "Copy response body"),
+  response_copy_body: keybind("ctrl+alt+c", "Copy response body"),
   request_edit_yaml: keybind("ctrl+alt+e", "Edit request YAML"),
   request_edit_overlay: keybind("ctrl+e", "Edit request"),
   request_edit: keybind("return", "Enter edit-browse (request pane)", true),

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -32,7 +32,7 @@ export const Definitions = {
   focus_prev: keybind("shift+tab", "Previous pane", true),
   layout_toggle: keybind("ctrl+l", "Toggle layout (stacked/side-by-side)"),
   pane_expand: keybind("f2", "Expand/collapse focused pane"),
-  response_copy_body: keybind("ctrl+alt+c", "Copy response body"),
+  response_copy_body: keybind("ctrl+b", "Copy response body"),
   request_edit_yaml: keybind("ctrl+alt+e", "Edit request YAML"),
   request_edit_overlay: keybind("ctrl+e", "Edit request"),
   request_edit: keybind("return", "Enter edit-browse (request pane)", true),

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -219,7 +219,16 @@ export function useAppKeymap(
         run: () => {
           const s = refs.responseStateRef.current
           if (s?.status !== "done") return
-          renderer.copyToClipboardOSC52(s.response.body)
+          const body = s.response.body
+          const tmp = `/tmp/noodle-copy-${Date.now()}`
+          try {
+            Bun.write(tmp, body)
+            Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
+          } catch {
+            renderer.copyToClipboardOSC52(body)
+          } finally {
+            try { Bun.spawnSync(["rm", "-f", tmp]) } catch {}
+          }
           showToast("Response body copied", "success")
         },
       },

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -211,8 +211,6 @@ export function useAppKeymap(
       {
         name: "response.copy-body",
         enabled: () => {
-          const f = keymap.getData("app.focus")
-          if (f !== "response") return false
           const s = refs.responseStateRef.current
           return s?.status === "done"
         },


### PR DESCRIPTION
- Add  to copy response body from any pane
- Move copy body hint from response pane footer to help overlay (F1)
- Use pbcopy for large response bodies (OSC52 limit fix)
-  in base mode focuses sidebar
- Toast border color uses primary theme color