### PR TITLE
refactor(ui): replace raw collection error with centered empty states

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1060,6 +1060,7 @@ export function AppInner({
                       {expanded !== "response" && (
                         <RequestPane
                           request={draft.draft}
+                          error={error}
                           editState={eb.editState}
                           editKey={eb.editKey}
                           editValue={eb.editValue}
@@ -1091,6 +1092,7 @@ export function AppInner({
                       {expanded !== "response" && (
                         <RequestPane
                           request={draft.draft}
+                          error={error}
                           editState={eb.editState}
                           editKey={eb.editKey}
                           editValue={eb.editValue}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -8,6 +8,7 @@ import type { Auth, Request, Environment } from "../schema"
 import { formatBody } from "./formatRequest"
 import type { EditState, FieldKind } from "./editMode"
 
+import { CenterText } from "./CenterText"
 import { Tabs, type TabDef } from "./Tabs"
 import { useTheme } from "./theme"
 import type { Theme } from "./theme"
@@ -24,6 +25,7 @@ import type { BodyType } from "../schema"
 
 interface Props {
   request: Request | null
+  error?: Error | null
   editState: EditState
   editKey: string
   editValue: string
@@ -49,6 +51,7 @@ const BASE_TAB_DEFS: TabDef[] = [
 
 export function RequestPane({
   request,
+  error,
   editState,
   editKey,
   editValue,
@@ -239,8 +242,38 @@ export function RequestPane({
             </scrollbox>
           </Tabs>
         </>
+      ) : error ? (
+        <box
+          style={{
+            flexGrow: 1,
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            paddingLeft: 4,
+            paddingRight: 4,
+          }}
+        >
+          <CenterText
+            segments={[
+              { text: "No collection found", color: theme.text },
+              { text: " ", color: theme.textMuted },
+              {
+                text: "use --collection <dir> or create the default directory",
+                color: theme.textMuted,
+              },
+            ]}
+          />
+        </box>
       ) : (
-        <text fg={theme.textMuted}>(no request selected)</text>
+        <box
+          style={{
+            flexGrow: 1,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <text fg={theme.textMuted}>empty</text>
+        </box>
       )}
     </box>
   )

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -71,11 +71,25 @@ export function Sidebar({
       titleAlignment="left"
     >
       {loading ? (
-        <text fg={theme.textMuted}>Loading...</text>
-      ) : error ? (
-        <text fg={theme.textMuted}>Error: {error.message}</text>
-      ) : visibleItems.length === 0 ? (
-        <text fg={theme.textMuted}>(empty)</text>
+        <box
+          style={{
+            flexGrow: 1,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <text fg={theme.textMuted}>Loading...</text>
+        </box>
+      ) : error || visibleItems.length === 0 ? (
+        <box
+          style={{
+            flexGrow: 1,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <text fg={theme.textMuted}>empty</text>
+        </box>
       ) : (
         <scrollbox
           ref={scrollRef}

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -22,7 +22,16 @@ const TIPS = [
   "response body auto-formats JSON when detected",
   "create a new request — save with {^S} and type a new name",
   "import an OpenAPI spec with {bun run import <path>}",
+  "import Postman collections with {bun run import <path>}",
   "environment variables let you switch between dev, staging, prod",
+  "clone a request with {^K}",
+  "delete a request with {^W}",
+  "copy the response body with {^B}",
+  "create a new folder with {^Alt+N}",
+  "press {F2} to expand a pane fullscreen",
+  "edit request YAML in your editor with {^Alt+E}",
+  "press {e} to open the environment editor",
+  "recent responses are saved in a timeline per request",
 ]
 
 interface TipPart {

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -73,7 +73,15 @@ export function UrlBar({
       borderColor={focused ? theme.primary : theme.borderSubtle}
     >
       {!displayUrl ? (
-        <text fg={theme.text}>(no request selected)</text>
+        <box
+          style={{
+            flexGrow: 1,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <text fg={theme.textMuted}>no request selected</text>
+        </box>
       ) : (
         <box style={{ flexDirection: "row", gap: 1, paddingX: 1 }}>
           <Badge


### PR DESCRIPTION
### Changes

**Empty state UI — no collection / no request selected**

- **Sidebar**: shows centered `empty` instead of raw `Error: filestore.loadCollection: ...`
- **RequestPane**: shows centered "No collection found" with hint on collection error; centered `empty` when no request selected
- **UrlBar**: shows centered `no request selected` in muted color

**Tips** — added 9 new tips covering clone, delete, copy response, folders, F2 expand, env editor, Postman import, YAML external editor, and timeline.

### Files changed
- `src/ui/Sidebar.tsx` — error branch merged with empty branch, centered
- `src/ui/RequestPane.tsx` — new `error` prop, centered empty/no-collection states
- `src/ui/UrlBar.tsx` — centered empty state with muted color
- `src/ui/AppInner.tsx` — pass `error` to RequestPane
- `src/ui/Tips.tsx` — 9 new tips