### PR TITLE
feat(config): store theme name instead of index in config

### DIFF
--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -3,8 +3,6 @@ import { readFileSync, writeFileSync } from "node:fs"
 import { mkdirSync } from "node:fs"
 import { join } from "node:path"
 import * as yaml from "js-yaml"
-import { DEFAULT_THEME_NAME } from "../ui/theme-data"
-
 export const CONFIG_FILE_NAME = "config.yml"
 
 export interface NoodleConfig {
@@ -13,7 +11,7 @@ export interface NoodleConfig {
 }
 
 const DEFAULTS: NoodleConfig = {
-  theme: DEFAULT_THEME_NAME,
+  theme: "catppuccin",
   layout: "stacked",
 }
 

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -3,16 +3,17 @@ import { readFileSync, writeFileSync } from "node:fs"
 import { mkdirSync } from "node:fs"
 import { join } from "node:path"
 import * as yaml from "js-yaml"
+import { DEFAULT_THEME_NAME } from "../ui/theme-data"
 
 export const CONFIG_FILE_NAME = "config.yml"
 
 export interface NoodleConfig {
-  theme: number
+  theme: string
   layout: "stacked" | "side-by-side"
 }
 
 const DEFAULTS: NoodleConfig = {
-  theme: 0,
+  theme: DEFAULT_THEME_NAME,
   layout: "stacked",
 }
 
@@ -23,7 +24,7 @@ export function loadConfig(configDir: string): NoodleConfig {
     if (!data || typeof data !== "object") return { ...DEFAULTS }
     const obj = data as Record<string, unknown>
     return {
-      theme: typeof obj.theme === "number" ? obj.theme : DEFAULTS.theme,
+      theme: typeof obj.theme === "string" ? obj.theme : DEFAULTS.theme,
       layout: obj.layout === "side-by-side" ? "side-by-side" : DEFAULTS.layout,
     }
   } catch {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 import { AppInner } from "./AppInner"
 import { useConfig } from "../hooks/useConfig"
 import { listEnvironmentsWithColors } from "../env/listWithColors"
-import { ThemeProvider } from "./theme"
+import { ThemeProvider, THEMES, DEFAULT_THEME_INDEX } from "./theme"
 import { Toast } from "./Toast"
 import { saveSettings } from "../filestore"
 import type { Keybinds } from "./keybind"
@@ -31,13 +31,16 @@ export function App({
     initialSettingsEnv,
   )
 
-  const [activeIndex, setActiveIndex] = useState(config.theme)
+  const [activeIndex, setActiveIndex] = useState(() => {
+    const idx = THEMES.findIndex((t) => t.name === config.theme)
+    return idx !== -1 ? idx : DEFAULT_THEME_INDEX
+  })
   const [previewIndex, setPreviewIndex] = useState<number | null>(null)
 
   const handleThemeChange = useCallback(
     (index: number) => {
       setActiveIndex(index)
-      updateConfig({ theme: index })
+      updateConfig({ theme: THEMES[index]!.name })
     },
     [updateConfig],
   )

--- a/src/ui/theme-data.ts
+++ b/src/ui/theme-data.ts
@@ -693,6 +693,9 @@ export const THEMES: Theme[] = [
   zenburnTheme,
 ]
 
+export const DEFAULT_THEME_NAME = "catppuccin"
+export const DEFAULT_THEME_INDEX = THEMES.findIndex((t) => t.name === DEFAULT_THEME_NAME)
+
 export function contrastOnPrimary(_theme: Theme): string {
   return "#1a1a1a"
 }

--- a/src/ui/theme-data.ts
+++ b/src/ui/theme-data.ts
@@ -694,7 +694,7 @@ export const THEMES: Theme[] = [
 ]
 
 export const DEFAULT_THEME_NAME = "catppuccin"
-export const DEFAULT_THEME_INDEX = THEMES.findIndex((t) => t.name === DEFAULT_THEME_NAME)
+export const DEFAULT_THEME_INDEX = THEMES.indexOf(catppuccinTheme)
 
 export function contrastOnPrimary(_theme: Theme): string {
   return "#1a1a1a"

--- a/src/ui/theme.tsx
+++ b/src/ui/theme.tsx
@@ -17,6 +17,8 @@ import type { Theme } from "./theme-data"
 
 export {
   THEMES,
+  DEFAULT_THEME_INDEX,
+  DEFAULT_THEME_NAME,
   contrastOnPrimary,
   opencodeTheme,
   catppuccinTheme,

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -11,8 +11,9 @@ import {
   type NoodleConfig,
   CONFIG_FILE_NAME,
 } from "../../src/hooks/useConfig"
+import { DEFAULT_THEME_NAME } from "../../src/ui/theme-data"
 
-const DEFAULTS: NoodleConfig = { theme: "catppuccin", layout: "stacked" }
+const DEFAULTS: NoodleConfig = { theme: DEFAULT_THEME_NAME, layout: "stacked" }
 
 describe("loadConfig", () => {
   let dir: string
@@ -95,6 +96,6 @@ describe("saveConfig", () => {
     const deepDir = join(dir, "sub", "dir")
     saveConfig(deepDir, DEFAULTS)
     const raw = readFileSync(join(deepDir, CONFIG_FILE_NAME), "utf8")
-    expect(yaml.load(raw)).toEqual({ theme: "catppuccin", layout: "stacked" })
+    expect(yaml.load(raw)).toEqual(DEFAULTS)
   })
 })

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -12,7 +12,7 @@ import {
   CONFIG_FILE_NAME,
 } from "../../src/hooks/useConfig"
 
-const DEFAULTS: NoodleConfig = { theme: 0, layout: "stacked" }
+const DEFAULTS: NoodleConfig = { theme: "catppuccin", layout: "stacked" }
 
 describe("loadConfig", () => {
   let dir: string
@@ -34,11 +34,11 @@ describe("loadConfig", () => {
   it("reads valid YAML file", () => {
     writeFileSync(
       join(dir, CONFIG_FILE_NAME),
-      yaml.dump({ theme: 1, layout: "side-by-side" }),
+      yaml.dump({ theme: "dracula", layout: "side-by-side" }),
       "utf8",
     )
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: 1, layout: "side-by-side" })
+    expect(result).toEqual({ theme: "dracula", layout: "side-by-side" })
   })
 
   it("returns defaults for invalid YAML", () => {
@@ -54,9 +54,9 @@ describe("loadConfig", () => {
   })
 
   it("handles partial file — missing fields get defaults", () => {
-    writeFileSync(join(dir, CONFIG_FILE_NAME), "theme: 1\n", "utf8")
+    writeFileSync(join(dir, CONFIG_FILE_NAME), "theme: dracula\n", "utf8")
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: 1, layout: "stacked" })
+    expect(result).toEqual({ theme: "dracula", layout: "stacked" })
   })
 })
 
@@ -73,28 +73,28 @@ describe("saveConfig", () => {
   })
 
   it("writes YAML file", () => {
-    saveConfig(dir, { theme: 1, layout: "side-by-side" })
+    saveConfig(dir, { theme: "dracula", layout: "side-by-side" })
     const raw = readFileSync(join(dir, CONFIG_FILE_NAME), "utf8")
-    expect(yaml.load(raw)).toEqual({ theme: 1, layout: "side-by-side" })
+    expect(yaml.load(raw)).toEqual({ theme: "dracula", layout: "side-by-side" })
   })
 
   it("round-trips save→load", () => {
-    const input: NoodleConfig = { theme: 1, layout: "side-by-side" }
+    const input: NoodleConfig = { theme: "dracula", layout: "side-by-side" }
     saveConfig(dir, input)
     const result = loadConfig(dir)
     expect(result).toEqual(input)
   })
 
   it("writes and reads back null lastEnv", () => {
-    saveConfig(dir, { theme: 2, layout: "stacked" })
+    saveConfig(dir, { theme: "monokai", layout: "stacked" })
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: 2, layout: "stacked" })
+    expect(result).toEqual({ theme: "monokai", layout: "stacked" })
   })
 
   it("creates directory if missing", () => {
     const deepDir = join(dir, "sub", "dir")
     saveConfig(deepDir, DEFAULTS)
     const raw = readFileSync(join(deepDir, CONFIG_FILE_NAME), "utf8")
-    expect(yaml.load(raw)).toEqual({ theme: 0, layout: "stacked" })
+    expect(yaml.load(raw)).toEqual({ theme: "catppuccin", layout: "stacked" })
   })
 })


### PR DESCRIPTION
## Changes

Store theme name instead of numeric index in config.yml. Configs are now human-readable and survive theme list reordering.

### Core change

- **** — `NoodleConfig.theme` type changed from `number` to `string`. `loadConfig` reads theme name from config, falls back to `"catppuccin"`. Removed import from `ui/theme-data` (layering fix — hooks no longer depend on ui).
- **** — Resolves theme name → index on startup via `THEMES.findIndex`, with `DEFAULT_THEME_INDEX` as fallback. `handleThemeChange` writes theme name instead of index.
- **** — Added `DEFAULT_THEME_NAME` (`"catppuccin"`) and `DEFAULT_THEME_INDEX` (computed via `THEMES.indexOf(catppuccinTheme)`, order-independent).
- **** — Re-exports `DEFAULT_THEME_INDEX` and `DEFAULT_THEME_NAME`.

### Cleanup

- **** — Tests use theme name strings + `DEFAULT_THEME_NAME` import instead of numeric indices.

### Breaking

Existing configs with `theme: <number>` will reset to catppuccin on next launch. Users need to re-select their theme.