### PR TITLE
feat(undo): add global undo-all (Ctrl+Z) to revert all unsaved drafts

### DIFF
--- a/.agents/skills/noodle-dev/architecture.md
+++ b/.agents/skills/noodle-dev/architecture.md
@@ -233,7 +233,7 @@ createMain(main) — citty argparse
 | `useResponse` | `src/hooks/useResponse.ts` | `SendState` — `{status, response, error}` |
 | `useEnvironments` | `src/hooks/useEnvironments.ts` | `{activeIndex, activeEnv, names}` |
 | `useEnvironmentEditor` | `src/hooks/useEnvironmentEditor.ts` | Full env CRUD state for editor pane |
-| `useConfig` | `src/hooks/useConfig.ts` | `{theme, layout}` persisted to `~/.config/noodle/config.yml` |
+| `useConfig` | `src/hooks/useConfig.ts` | `{theme, layout, confirm_undo_all}` persisted to `~/.config/noodle/config.yml` |
 | `useTimeline` | `src/hooks/useTimeline.ts` | `TimelineEntry[]` per-request response history |
 
 ## Keymap layer architecture

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -8,11 +8,13 @@ export const CONFIG_FILE_NAME = "config.yml"
 export interface NoodleConfig {
   theme: string
   layout: "stacked" | "side-by-side"
+  confirm_undo_all: boolean
 }
 
 const DEFAULTS: NoodleConfig = {
   theme: "catppuccin",
   layout: "stacked",
+  confirm_undo_all: true,
 }
 
 export function loadConfig(configDir: string): NoodleConfig {
@@ -24,6 +26,10 @@ export function loadConfig(configDir: string): NoodleConfig {
     return {
       theme: typeof obj.theme === "string" ? obj.theme : DEFAULTS.theme,
       layout: obj.layout === "side-by-side" ? "side-by-side" : DEFAULTS.layout,
+      confirm_undo_all:
+        typeof obj.confirm_undo_all === "boolean"
+          ? obj.confirm_undo_all
+          : DEFAULTS.confirm_undo_all,
     }
   } catch {
     return { ...DEFAULTS }
@@ -35,6 +41,7 @@ export function saveConfig(configDir: string, config: NoodleConfig): void {
   const data = {
     theme: config.theme,
     layout: config.layout,
+    confirm_undo_all: config.confirm_undo_all,
   }
   writeFileSync(join(configDir, CONFIG_FILE_NAME), yaml.dump(data), "utf8")
 }

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -452,6 +452,9 @@ export function useEnvironmentEditor({
   )
 
   const revertDraft = useCallback(() => {
+    draftRef.current = null
+    originalRef.current = null
+    selectedEnvNameRef.current = null
     setDraft(null)
     setOriginal(null)
     setSelectedEnvName(null)

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -58,6 +58,7 @@ export interface UseEnvironmentEditorResult {
   save: () => Promise<void>
   deleteEnv: () => Promise<void>
   cloneEnv: (targetName: string) => Promise<void>
+  revertDraft: () => void
 }
 
 function envToVarRows(
@@ -450,6 +451,15 @@ export function useEnvironmentEditor({
     [environmentsDir, localNames, loadEnv],
   )
 
+  const revertDraft = useCallback(() => {
+    setDraft(null)
+    setOriginal(null)
+    setSelectedEnvName(null)
+    setSelectedRowIndex(-1)
+    setEditingField(null)
+    setError(null)
+  }, [])
+
   const dirty = dirtyChanged(
     original,
     draft?.name ?? "",
@@ -483,5 +493,6 @@ export function useEnvironmentEditor({
     save,
     deleteEnv: deleteEnvAction,
     cloneEnv: cloneEnvAction,
+    revertDraft,
   }
 }

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -238,6 +238,7 @@ export interface UseFolderDraftResult {
   setApiKeyPlacement: (placement: "header" | "query") => void
   revertAll: () => void
   markSaved: () => void
+  revertAllFolders: () => void
 }
 
 export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
@@ -347,6 +348,9 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       return next
     })
   }, [folderDraft, folder, key])
+  const revertAllFolders = useCallback(() => {
+    setDraftMap(new Map())
+  }, [])
 
   return useMemo(
     () => ({
@@ -365,6 +369,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       setApiKeyPlacement,
       revertAll,
       markSaved,
+      revertAllFolders,
     }),
     [
       folderDraft,
@@ -383,6 +388,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       setApiKeyPlacement,
       revertAll,
       markSaved,
+      revertAllFolders,
     ],
   )
 }

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -609,6 +609,8 @@ export function useRequestDraft(
   const revertAll = useCallback(() => apply({ kind: "revertAll" }), [apply])
 
   const revertAllRequests = useCallback(() => {
+    authTypeCache.clear()
+    bodyCache.clear()
     setMap(new Map())
   }, [])
 

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -471,6 +471,7 @@ export interface UseRequestDraftResult {
   toggleFormRow: (index: number) => void
   setFilePath: (path: string) => void
   markSaved: () => void
+  revertAllRequests: () => void
 }
 
 export function useRequestDraft(
@@ -607,6 +608,10 @@ export function useRequestDraft(
   )
   const revertAll = useCallback(() => apply({ kind: "revertAll" }), [apply])
 
+  const revertAllRequests = useCallback(() => {
+    setMap(new Map())
+  }, [])
+
   const mapRef = useRef(map)
   mapRef.current = map
 
@@ -666,6 +671,7 @@ export function useRequestDraft(
       toggleParamRow,
       revertField,
       revertAll,
+      revertAllRequests,
       setAuthType: setAuthTypeCb,
       setAuthField: setAuthFieldCb,
       setApiKeyPlacement: setApiKeyPlacementCb,
@@ -697,6 +703,7 @@ export function useRequestDraft(
       toggleParamRow,
       revertField,
       revertAll,
+      revertAllRequests,
       setAuthTypeCb,
       setAuthFieldCb,
       setApiKeyPlacementCb,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -98,6 +98,7 @@ export function App({
         keybinds={keybinds}
         initialLastRequestId={lastRequestId}
         initialLayout={config.layout}
+        confirmUndoAll={config.confirm_undo_all}
         onLayoutChange={handleLayoutChange}
         onEnvChange={handleEnvChange}
         onEnvListChanged={handleEnvListChanged}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -77,6 +77,7 @@ export function AppInner({
   onThemeChange,
   keybinds,
   initialLayout,
+  confirmUndoAll,
   onLayoutChange,
   onEnvChange,
   onEnvListChanged,
@@ -94,6 +95,7 @@ export function AppInner({
   onThemeChange: (index: number) => void
   keybinds: Keybinds
   initialLayout: "stacked" | "side-by-side"
+  confirmUndoAll: boolean
   onLayoutChange: (layout: "stacked" | "side-by-side") => void
   onEnvChange: (name: string | null) => void
   onEnvListChanged: () => Promise<void>
@@ -148,6 +150,7 @@ export function AppInner({
     null,
   )
   const folderDeletePathRef = useRef<string | null>(null)
+  const [undoAllPending, setUndoAllPending] = useState(false)
   const [initialExpandedFolders, setInitialExpandedFolders] =
     useState<Set<string> | null>(null)
   const headerFieldRef = useRef<"name" | "color">("name")
@@ -694,7 +697,9 @@ export function AppInner({
         ? "theme"
         : saveState.kind === "confirming"
           ? "confirm"
-          : yamlEditor.visible
+          : undoAllPending
+            ? "undo-all"
+            : yamlEditor.visible
             ? "yaml-editor"
             : newRequestVisible
               ? "new-request"
@@ -721,6 +726,7 @@ export function AppInner({
     newFolderVisible,
     folderDeletePending,
     requestDeletePending,
+    undoAllPending,
     keymap,
   ])
 
@@ -905,10 +911,12 @@ export function AppInner({
       setRequestDeletePending,
       setNewFolderVisible,
       setFolderDeletePending,
+      setUndoAllPending,
       onLayoutChange,
       setExpanded,
     },
     collectionDir,
+    confirmUndoAll,
   )
 
   // ── Overlay intercepts ────────────────────────────────────────────
@@ -959,6 +967,10 @@ export function AppInner({
     folderDeletePending,
     setFolderDeletePending,
     onFolderDeleteConfirm: handleFolderDeleteConfirm,
+    undoAllPending,
+    setUndoAllPending,
+    draftRef,
+    folderDraftRef,
   })
 
   // ── Derived values for render ─────────────────────────────────────
@@ -1198,6 +1210,13 @@ export function AppInner({
             visible
             message={`Delete environment "${envDeletePending}"?`}
             selectedIndex={deleteConfirmSelection}
+          />
+        )}
+        {undoAllPending && (
+          <ConfirmOverlay
+            visible
+            message="Discard all unsaved changes? (y/n)"
+            selectedIndex={confirmSelection}
           />
         )}
         {previewIndex !== null && (

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -700,20 +700,20 @@ export function AppInner({
           : undoAllPending
             ? "undo-all"
             : yamlEditor.visible
-            ? "yaml-editor"
-            : newRequestVisible
-              ? "new-request"
-              : editRequestVisible
-                ? "edit-request"
-                : cloneRequestVisible
-                  ? "clone-request"
-                  : newFolderVisible
-                    ? "new-folder"
-                    : folderDeletePending !== null
-                      ? "delete-folder"
-                      : requestDeletePending !== null
-                        ? "request-delete"
-                        : "none"
+              ? "yaml-editor"
+              : newRequestVisible
+                ? "new-request"
+                : editRequestVisible
+                  ? "edit-request"
+                  : cloneRequestVisible
+                    ? "clone-request"
+                    : newFolderVisible
+                      ? "new-folder"
+                      : folderDeletePending !== null
+                        ? "delete-folder"
+                        : requestDeletePending !== null
+                          ? "request-delete"
+                          : "none"
     keymap.setData("app.overlay", overlay)
   }, [
     helpVisible,

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -104,6 +104,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
           key: displayKey(keybinds.theme_picker),
           description: "Open theme picker",
         },
+        {
+          key: displayKey(keybinds.global_undo_all),
+          description: "Undo all unsaved changes",
+        },
       ],
     },
     {

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -27,6 +27,7 @@ export const Definitions = {
   theme_picker: keybind("ctrl+t", "Open theme picker"),
   browse_delete: keybind("ctrl+d", "Revert field"),
   browse_revert_all: keybind("ctrl+r", "Revert all fields"),
+  global_undo_all: keybind("ctrl+z", "Undo all unsaved changes"),
 
   focus_next: keybind("tab", "Next pane", true),
   focus_prev: keybind("shift+tab", "Previous pane", true),
@@ -81,6 +82,7 @@ export const CommandMap = {
   browse_escape: "browse.escape",
   browse_delete: "browse.delete",
   browse_revert_all: "browse.revert-all",
+  global_undo_all: "global.undo-all",
   browse_toggle_form_type: "browse.toggle-form-type",
   edit_commit: "edit.commit",
   edit_cancel: "edit.cancel",

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -102,9 +102,7 @@ export interface UseAppKeymapSetters {
   setFolderDeletePending: (
     s: string | null | ((prev: string | null) => string | null),
   ) => void
-  setUndoAllPending: (
-    v: boolean | ((prev: boolean) => boolean),
-  ) => void
+  setUndoAllPending: (v: boolean | ((prev: boolean) => boolean)) => void
 }
 
 export function useAppKeymap(

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -241,7 +241,8 @@ export function useAppKeymap(
         name: "global.undo-all",
         enabled: () => {
           const mode = keymap.getData("app.mode") as string
-          return mode !== "edit"
+          const overlay = keymap.getData("app.overlay") as string
+          return mode !== "edit" && overlay === "none"
         },
         run: () => {
           const d = refs.draftRef.current

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -102,6 +102,9 @@ export interface UseAppKeymapSetters {
   setFolderDeletePending: (
     s: string | null | ((prev: string | null) => string | null),
   ) => void
+  setUndoAllPending: (
+    v: boolean | ((prev: boolean) => boolean),
+  ) => void
 }
 
 export function useAppKeymap(
@@ -109,6 +112,7 @@ export function useAppKeymap(
   refs: UseAppKeymapRefs,
   setters: UseAppKeymapSetters,
   collectionDir: string,
+  confirmUndoAll: boolean,
 ): void {
   const keymap = useKeymap()
   const renderer = useRenderer()
@@ -235,6 +239,28 @@ export function useAppKeymap(
           showToast("Response body copied", "success")
         },
       },
+      {
+        name: "global.undo-all",
+        enabled: () => {
+          const mode = keymap.getData("app.mode") as string
+          return mode !== "edit"
+        },
+        run: () => {
+          const d = refs.draftRef.current
+          const fd = refs.folderDraftRef.current
+          const ee = refs.envEditorRef.current
+          const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
+          if (!hasDirty) return
+
+          if (confirmUndoAll) {
+            setters.setUndoAllPending(true)
+          } else {
+            d.revertAllRequests()
+            fd.revertAllFolders()
+            ee?.revertDraft()
+          }
+        },
+      },
     ],
     bindings: [
       { key: "tab", cmd: "focus.next" },
@@ -244,6 +270,7 @@ export function useAppKeymap(
       { key: keybinds.request_edit_yaml, cmd: "request.edit-yaml" },
       { key: keybinds.pane_expand, cmd: "request.expand-toggle" },
       { key: keybinds.response_copy_body, cmd: "response.copy-body" },
+      { key: keybinds.global_undo_all, cmd: "global.undo-all" },
     ],
   }))
 

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -8,6 +8,8 @@ import type { EnvHeaderPaneHandle } from "./EnvHeaderPane"
 import type { NewRequestOverlayHandle } from "./NewRequestOverlay"
 import type { CloneRequestOverlayHandle } from "./CloneRequestOverlay"
 import type { NewFolderOverlayHandle } from "./NewFolderOverlay"
+import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
+import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
 
 export function useOverlayIntercepts(opts: {
   cancelSendRef: RefObject<() => void>
@@ -63,6 +65,10 @@ export function useOverlayIntercepts(opts: {
   folderDeletePending: string | null
   setFolderDeletePending: (s: string | null) => void
   onFolderDeleteConfirm: () => void
+  undoAllPending: boolean
+  setUndoAllPending: (v: boolean) => void
+  draftRef: RefObject<UseRequestDraftResult>
+  folderDraftRef: RefObject<UseFolderDraftResult>
 }): void {
   const keymap = useKeymap()
   const {
@@ -110,6 +116,10 @@ export function useOverlayIntercepts(opts: {
     folderDeletePending,
     setFolderDeletePending,
     onFolderDeleteConfirm,
+    undoAllPending,
+    setUndoAllPending,
+    draftRef,
+    folderDraftRef,
   } = opts
 
   // ── Cancel send on ESC ──────────────────────────────────────────────
@@ -472,6 +482,38 @@ export function useOverlayIntercepts(opts: {
     onFolderDeleteConfirm,
     setFolderDeletePending,
     keymap,
+  ])
+
+  // ── Overlay: Undo All ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!undoAllPending) return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        const name = ctx.event.name
+        if (name === "y") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          draftRef.current.revertAllRequests()
+          folderDraftRef.current.revertAllFolders()
+          envEditorRef.current?.revertDraft()
+          setUndoAllPending(false)
+        } else if (name === "n" || name === "escape") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          setUndoAllPending(false)
+        }
+      },
+      { priority: 100 },
+    )
+    return dispose
+  }, [
+    undoAllPending,
+    keymap,
+    setUndoAllPending,
+    draftRef,
+    folderDraftRef,
+    envEditorRef,
   ])
 
   // ── Overlay: New Folder ───────────────────────────────────────────

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -261,6 +261,46 @@ describe("keymap dispatch", () => {
     cleanup()
   })
 
+  it("global.undo-all dispatches ctrl+z in base mode with no overlay", () => {
+    const { keymap, host, cleanup } = setup()
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () => {
+        const mode = keymap.getData("app.mode") as string
+        const overlay = keymap.getData("app.overlay") as string
+        return mode !== "edit" && overlay === "none"
+      },
+      commands: [
+        {
+          name: "global.undo-all",
+          run: () => {
+            called = true
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+z", cmd: "global.undo-all" }],
+    })
+
+    host.press("z", { ctrl: true })
+    expect(called).toBe(true)
+
+    // Does not dispatch in edit mode
+    called = false
+    keymap.setData("app.mode", "edit")
+    host.press("z", { ctrl: true })
+    expect(called).toBe(false)
+
+    // Does not dispatch when overlay is active
+    called = false
+    keymap.setData("app.mode", "base")
+    keymap.setData("app.overlay", "theme")
+    host.press("z", { ctrl: true })
+    expect(called).toBe(false)
+
+    cleanup()
+  })
+
   it("browse layer does not dispatch when overlay is active", () => {
     const { keymap, host, cleanup } = setup()
     keymap.setData("app.mode", "browse")

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -83,7 +83,11 @@ describe("loadConfig", () => {
   })
 
   it("confirm_undo_all: false round-trips through save/load", () => {
-    saveConfig(dir, { theme: "dracula", layout: "stacked", confirm_undo_all: false })
+    saveConfig(dir, {
+      theme: "dracula",
+      layout: "stacked",
+      confirm_undo_all: false,
+    })
     const result = loadConfig(dir)
     expect(result.confirm_undo_all).toBe(false)
   })
@@ -133,7 +137,11 @@ describe("saveConfig", () => {
       confirm_undo_all: true,
     })
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: "monokai", layout: "stacked", confirm_undo_all: true })
+    expect(result).toEqual({
+      theme: "monokai",
+      layout: "stacked",
+      confirm_undo_all: true,
+    })
   })
 
   it("creates directory if missing", () => {

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -13,7 +13,11 @@ import {
 } from "../../src/hooks/useConfig"
 import { DEFAULT_THEME_NAME } from "../../src/ui/theme-data"
 
-const DEFAULTS: NoodleConfig = { theme: DEFAULT_THEME_NAME, layout: "stacked" }
+const DEFAULTS: NoodleConfig = {
+  theme: DEFAULT_THEME_NAME,
+  layout: "stacked",
+  confirm_undo_all: true,
+}
 
 describe("loadConfig", () => {
   let dir: string
@@ -39,7 +43,11 @@ describe("loadConfig", () => {
       "utf8",
     )
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: "dracula", layout: "side-by-side" })
+    expect(result).toEqual({
+      theme: "dracula",
+      layout: "side-by-side",
+      confirm_undo_all: true,
+    })
   })
 
   it("returns defaults for invalid YAML", () => {
@@ -57,7 +65,27 @@ describe("loadConfig", () => {
   it("handles partial file — missing fields get defaults", () => {
     writeFileSync(join(dir, CONFIG_FILE_NAME), "theme: dracula\n", "utf8")
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: "dracula", layout: "stacked" })
+    expect(result).toEqual({
+      theme: "dracula",
+      layout: "stacked",
+      confirm_undo_all: true,
+    })
+  })
+
+  it("confirm_undo_all defaults to true when missing from file", () => {
+    writeFileSync(
+      join(dir, CONFIG_FILE_NAME),
+      yaml.dump({ theme: "dracula", layout: "stacked" }),
+      "utf8",
+    )
+    const result = loadConfig(dir)
+    expect(result.confirm_undo_all).toBe(true)
+  })
+
+  it("confirm_undo_all: false round-trips through save/load", () => {
+    saveConfig(dir, { theme: "dracula", layout: "stacked", confirm_undo_all: false })
+    const result = loadConfig(dir)
+    expect(result.confirm_undo_all).toBe(false)
   })
 })
 
@@ -74,22 +102,38 @@ describe("saveConfig", () => {
   })
 
   it("writes YAML file", () => {
-    saveConfig(dir, { theme: "dracula", layout: "side-by-side" })
+    saveConfig(dir, {
+      theme: "dracula",
+      layout: "side-by-side",
+      confirm_undo_all: true,
+    })
     const raw = readFileSync(join(dir, CONFIG_FILE_NAME), "utf8")
-    expect(yaml.load(raw)).toEqual({ theme: "dracula", layout: "side-by-side" })
+    expect(yaml.load(raw)).toEqual({
+      theme: "dracula",
+      layout: "side-by-side",
+      confirm_undo_all: true,
+    })
   })
 
   it("round-trips save→load", () => {
-    const input: NoodleConfig = { theme: "dracula", layout: "side-by-side" }
+    const input: NoodleConfig = {
+      theme: "dracula",
+      layout: "side-by-side",
+      confirm_undo_all: true,
+    }
     saveConfig(dir, input)
     const result = loadConfig(dir)
-    expect(result).toEqual(input)
+    expect(result).toEqual({ ...input, confirm_undo_all: true })
   })
 
   it("writes and reads back null lastEnv", () => {
-    saveConfig(dir, { theme: "monokai", layout: "stacked" })
+    saveConfig(dir, {
+      theme: "monokai",
+      layout: "stacked",
+      confirm_undo_all: true,
+    })
     const result = loadConfig(dir)
-    expect(result).toEqual({ theme: "monokai", layout: "stacked" })
+    expect(result).toEqual({ theme: "monokai", layout: "stacked", confirm_undo_all: true })
   })
 
   it("creates directory if missing", () => {


### PR DESCRIPTION
## Summary

Adds **Ctrl+Z** (global undo-all) that reverts all unsaved changes across requests, folders, and environments in one action. Configurable via `confirm_undo_all` in `config.yml` (default `true` — asks `y/n` before reverting).

## Changes

### Config
- `src/hooks/useConfig.ts` — Added `confirm_undo_all: boolean` field, defaults to `true`, loads/saves with existing config

### Keybinding
- `src/ui/keybind.ts` — Defined `global_undo_all` (`ctrl+z`), mapped to `global.undo-all` command
- `src/ui/useAppKeymap.ts` — Always-on layer command `global.undo-all`, gated on `mode !== "edit"` and `overlay === "none"`. Checks dirty state across request/folder/env drafts. Triggers confirm overlay or direct revert based on config.

### Draft revert methods
- `src/hooks/useRequestDraft.ts` — `revertAllRequests()` clears draft map + auth/body caches
- `src/hooks/useFolderDraft.ts` — `revertAllFolders()` clears folder draft map
- `src/hooks/useEnvironmentEditor.ts` — `revertDraft()` resets env editor state + refs

### Overlay
- `src/ui/useOverlayIntercepts.ts` — Undo-all confirm overlay intercept (`y` to confirm, `n`/esc to cancel)
- `src/ui/AppInner.tsx` — `undoAllPending` state, overlay detection priority, `ConfirmOverlay` render

### UI wiring
- `src/ui/App.tsx` — Passes `confirmUndoAll` config prop to `AppInner`
- `src/ui/helpTexts.ts` — Added undo-all to help overlay

### Tests
- `tests/integration/keymap.test.ts` — Integration test for `global.undo-all` keymap dispatch (base mode, disabled in edit, disabled with overlay)
- `tests/unit/useConfig.test.ts` — Tests for `confirm_undo_all` default, partial file, round-trip with false

### Bug fixes (review feedback)
- Clear stale `draftRef`/ `originalRef`/ `selectedEnvNameRef` in `revertDraft` to prevent `save()` from reading stale data
- Clear `authTypeCache` and `bodyCache` in `revertAllRequests` to prevent stale form-data/auth from leaking into future edits

## Testing
- ✅ 1252 tests pass (0 fail)
- ✅ Lint clean
- ✅ Typecheck clean
- ✅ Prettier clean