### PR TITLE
feat(ui): add command palette (Ctrl+P)

### DIFF
--- a/.agents/skills/noodle-dev/architecture.md
+++ b/.agents/skills/noodle-dev/architecture.md
@@ -176,7 +176,8 @@ App (src/ui/App.tsx)
       │   │   └── KeyValueSection / JsonBodyViewer / AuthEditor / FormEditor / Select / Checkbox
       │   └── ResponsePane     ← Tabs: body/headers/timeline
       ├── [overlays]
-      │   ├── HelpOverlay, ThemePickerOverlay, YamlEditorOverlay
+      │   ├── PickerOverlay (generic base), ThemePickerOverlay (uses PickerOverlay)
+      │   ├── HelpOverlay, YamlEditorOverlay
       │   ├── NewRequestOverlay, CloneRequestOverlay, NewFolderOverlay
       │   └── ConfirmOverlay
       └── StatusBar

--- a/.agents/skills/noodle-dev/recipes.md
+++ b/.agents/skills/noodle-dev/recipes.md
@@ -55,13 +55,19 @@ Each recipe follows: **Locate → Follow → Implement → Test → Verify**
 ## Add a new overlay
 
 **Locate:**
-- Existing overlays: `src/ui/NewRequestOverlay.tsx`, `src/ui/ThemePickerOverlay.tsx`, `src/ui/YamlEditorOverlay.tsx`, `src/ui/ConfirmOverlay.tsx`
+- Existing overlays: `src/ui/PickerOverlay.tsx` (generic base), `src/ui/ThemePickerOverlay.tsx` (uses PickerOverlay), `src/ui/YamlEditorOverlay.tsx`, `src/ui/ConfirmOverlay.tsx`
 - `src/ui/AppInner.tsx` — overlay rendering gated on `overlay` state
 - `src/ui/useAppKeymap.ts` — overlay keymap layers (Close/Cancel)
 
-**Follow:** Overlays use `Modal` from OpenTUI, typically have a title, content area, and action buttons. State is managed via a `useState` in `AppInner.tsx` or a dedicated hook.
+**Follow:** For picker-style overlays (search + filter + list + selection), reuse `PickerOverlay<T>` with render props. Others use `Modal` from OpenTUI directly. State is managed via a `useState` in `AppInner.tsx` or a dedicated hook.
 
-**Implement:**
+**Implement (picker-style):**
+1. Define item type and use `PickerOverlay<T>` with `keyExtractor`, `filter`, `renderItem` props
+2. Wire `onSelect`, `onClose`, `onHighlightChange` to parent state
+3. Add render branch in `AppInner.tsx` gated on your state
+4. Add keybinding — typically in Always-On Layer for global keys, or focus-specific layer
+
+**Implement (modal):**
 1. Create component in `src/ui/YourOverlay.tsx`
 2. Add overlay type name to any overlay state tracking (e.g., `app.overlay` keymap data)
 3. Add render branch in `AppInner.tsx` when your overlay is active

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ tests/integration/ # Integration tests
 All except `fixed` keys can be overridden in YAML:
 ```yaml
 request_send: ctrl+enter
-env_cycle: ctrl+shift+p
+env_cycle: ctrl+u
 ```
 
 ### Global (always active, gated on `!helpVisible`)
@@ -109,7 +109,8 @@ env_cycle: ctrl+shift+p
 | `Ctrl+N` | New request |
 | `Ctrl+K` | Clone request |
 | `Ctrl+W` | Delete request |
-| `Ctrl+P` | Cycle environment |
+| `Ctrl+U` | Cycle environment |
+| `Ctrl+P` | Open command palette |
 | `Ctrl+L` | Toggle layout (stacked / side-by-side) |
 | `F2` | Expand/collapse focused pane |
 | `F1` | Toggle help overlay |

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -36,6 +36,10 @@ import {
   type NewFolderOverlayHandle,
 } from "./NewFolderOverlay"
 import {
+  CommandPaletteOverlay,
+  type CommandItem,
+} from "./CommandPaletteOverlay"
+import {
   saveRequest,
   deleteRequest,
   saveFolder,
@@ -48,6 +52,7 @@ import { EnvSidebar } from "./EnvSidebar"
 import { EnvHeaderPane, type EnvHeaderPaneHandle } from "./EnvHeaderPane"
 import { EnvEditorPane } from "./EnvEditorPane"
 
+import { join } from "node:path"
 import { type Keybinds, displayKey } from "./keybind"
 import { useSaveFile } from "./useSaveFile"
 import { useAppKeymap } from "./useAppKeymap"
@@ -55,7 +60,12 @@ import { useOverlayIntercepts } from "./useOverlayIntercepts"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
-import { getRequestIds, findFolderByPath, updateFolderByPath } from "./tree"
+import {
+  findRequestById,
+  getRequestIds,
+  findFolderByPath,
+  updateFolderByPath,
+} from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import {
   saveLastRequest,
@@ -692,31 +702,34 @@ export function AppInner({
   }, [focus, keymap])
 
   useEffect(() => {
-    const overlay = helpVisible
-      ? "help"
-      : previewIndex !== null
-        ? "theme"
-        : saveState.kind === "confirming"
-          ? "confirm"
-          : undoAllPending
-            ? "undo-all"
-            : yamlEditor.visible
-              ? "yaml-editor"
-              : newRequestVisible
-                ? "new-request"
-                : editRequestVisible
-                  ? "edit-request"
-                  : cloneRequestVisible
-                    ? "clone-request"
-                    : newFolderVisible
-                      ? "new-folder"
-                      : folderDeletePending !== null
-                        ? "delete-folder"
-                        : requestDeletePending !== null
-                          ? "request-delete"
-                          : "none"
+    const overlay = commandPaletteVisible
+      ? "command-palette"
+      : helpVisible
+        ? "help"
+        : previewIndex !== null
+          ? "theme"
+          : saveState.kind === "confirming"
+            ? "confirm"
+            : undoAllPending
+              ? "undo-all"
+              : yamlEditor.visible
+                ? "yaml-editor"
+                : newRequestVisible
+                  ? "new-request"
+                  : editRequestVisible
+                    ? "edit-request"
+                    : cloneRequestVisible
+                      ? "clone-request"
+                      : newFolderVisible
+                        ? "new-folder"
+                        : folderDeletePending !== null
+                          ? "delete-folder"
+                          : requestDeletePending !== null
+                            ? "request-delete"
+                            : "none"
     keymap.setData("app.overlay", overlay)
   }, [
+    commandPaletteVisible,
     helpVisible,
     previewIndex,
     saveState.kind,
@@ -988,6 +1001,241 @@ export function AppInner({
     [keybinds.pane_expand],
   )
 
+  const commandPaletteCommands = useMemo<CommandItem[]>(
+    () => [
+      {
+        id: "request.send",
+        label: "Send Request",
+        section: "Actions",
+        keybinding: displayKey(keybinds.request_send),
+        run: () => trySendRef.current?.(),
+      },
+      {
+        id: "request.save",
+        label: "Save Request",
+        section: "Actions",
+        keybinding: displayKey(keybinds.request_save),
+        run: () => {
+          const d = draftRef.current
+          if (!savingRef.current && d.draft && d.isDirty) {
+            doSaveRef.current()
+          }
+        },
+      },
+      {
+        id: "env.cycle",
+        label: "Cycle Environment",
+        section: "Actions",
+        keybinding: displayKey(keybinds.env_cycle),
+        run: () => envStateRef.current.cycle(1),
+      },
+      {
+        id: "response.copy-body",
+        label: "Copy Response Body",
+        section: "Actions",
+        keybinding: displayKey(keybinds.response_copy_body),
+        run: () => {
+          const s = responseStateRef.current
+          if (s?.status !== "done") return
+          const body = s.response.body
+          let copied = false
+          const tmp = `/tmp/noodle-copy-${Date.now()}`
+          try {
+            Bun.write(tmp, body)
+            Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
+            copied = true
+          } catch {
+            // fallback failed — toast shows error
+          } finally {
+            try {
+              Bun.spawnSync(["rm", "-f", tmp])
+            } catch {
+              // cleanup is best-effort; ignore failures
+            }
+          }
+          showToast(
+            copied ? "Response body copied" : "Failed to copy response body",
+            copied ? "success" : "error",
+          )
+        },
+      },
+      {
+        id: "layout.toggle",
+        label: "Toggle Layout",
+        section: "View",
+        keybinding: displayKey(keybinds.layout_toggle),
+        run: () =>
+          setLayout((prev: "stacked" | "side-by-side") => {
+            const next = prev === "stacked" ? "side-by-side" : "stacked"
+            onLayoutChange(next)
+            return next
+          }),
+      },
+      {
+        id: "pane.expand",
+        label: "Expand/Collapse Pane",
+        section: "View",
+        keybinding: displayKey(keybinds.pane_expand),
+        run: () => {
+          const f = keymap.getData("app.focus") as "request" | "response"
+          if (f !== "request" && f !== "response") return
+          setExpanded((prev: "request" | "response" | null) =>
+            prev === f ? null : f,
+          )
+        },
+      },
+      {
+        id: "app.help",
+        label: "Toggle Help",
+        section: "View",
+        keybinding: displayKey(keybinds.help_toggle),
+        run: () => setHelpVisible((prev: boolean) => !prev),
+      },
+      {
+        id: "request.new",
+        label: "New Request",
+        section: "Create",
+        keybinding: displayKey(keybinds.request_new),
+        run: () => setNewRequestVisible(true),
+      },
+      {
+        id: "folder.new",
+        label: "New Folder",
+        section: "Create",
+        keybinding: displayKey(keybinds.folder_new),
+        run: () => setNewFolderVisible(true),
+      },
+      {
+        id: "request.clone",
+        label: "Clone Request",
+        section: "Create",
+        keybinding: displayKey(keybinds.request_clone),
+        run: () => {
+          const sid = selectedIdRef.current
+          if (!sid) return
+          const col = collectionRef.current
+          if (!col) return
+          const req = findRequestById(col.items, sid)
+          if (!req) return
+          setCloneRequestVisible(true)
+        },
+      },
+      {
+        id: "request.edit-overlay",
+        label: "Edit Request Metadata",
+        section: "Edit",
+        keybinding: displayKey(keybinds.request_edit_overlay),
+        run: () => {
+          if (focusedFolderPathRef.current) return
+          const sid = selectedIdRef.current
+          if (!sid) return
+          setEditRequestVisible(true)
+        },
+      },
+      {
+        id: "request.edit-yaml",
+        label: "Edit Request YAML",
+        section: "Edit",
+        keybinding: displayKey(keybinds.request_edit_yaml),
+        run: () => {
+          if (focusedFolderPathRef.current) return
+          const sid = selectedIdRef.current
+          if (!sid || !collectionDir) return
+          const col = collectionRef.current
+          if (!col) return
+          const r = findRequestById(col.items, sid)
+          if (!r) return
+          const filePath = join(collectionDir, `${sid}.yml`)
+          setYamlEditor({
+            visible: true,
+            filePath,
+            requestName: r.name,
+            returnFocus: focusRef.current,
+          })
+        },
+      },
+      {
+        id: "request.delete",
+        label: "Delete Request",
+        section: "Delete",
+        keybinding: displayKey(keybinds.request_delete),
+        run: () => {
+          const folderPath = focusedFolderPathRef.current
+          const folderName = focusedFolderNameRef.current
+          if (folderPath && folderName) {
+            folderDeletePathRef.current = folderPath
+            setFolderDeletePending(folderName)
+            return
+          }
+          const sid = selectedIdRef.current
+          if (!sid) return
+          const col = collectionRef.current
+          if (!col) return
+          const req = findRequestById(col.items, sid)
+          if (!req) return
+          setRequestDeletePending(req.name)
+        },
+      },
+      {
+        id: "env.editor-open",
+        label: "Open Environment Editor",
+        section: "Workspace",
+        keybinding: displayKey(keybinds.env_editor),
+        run: () => {
+          const name = envStateRef.current.activeEnv?.name
+          envEditorRef.current.openEditor(name)
+          setView("env-editor")
+          setFocus("env-sidebar")
+        },
+      },
+      {
+        id: "app.theme",
+        label: "Open Theme Picker",
+        section: "Workspace",
+        keybinding: displayKey(keybinds.theme_picker),
+        run: () => setPreviewIndexProp(activeIndexRef.current),
+      },
+      {
+        id: "global.undo-all",
+        label: "Undo All Unsaved Changes",
+        section: "System",
+        keybinding: displayKey(keybinds.global_undo_all),
+        run: () => {
+          const d = draftRef.current
+          const fd = folderDraftRef.current
+          const ee = envEditorRef.current
+          const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
+          if (!hasDirty) return
+          if (confirmUndoAll) {
+            setUndoAllPending(true)
+          } else {
+            d.revertAllRequests()
+            fd.revertAllFolders()
+            ee?.revertDraft()
+          }
+        },
+      },
+    ],
+    [
+      keybinds,
+      setLayout,
+      onLayoutChange,
+      setHelpVisible,
+      setNewRequestVisible,
+      setNewFolderVisible,
+      setCloneRequestVisible,
+      setEditRequestVisible,
+      setYamlEditor,
+      setRequestDeletePending,
+      setView,
+      setFocus,
+      setUndoAllPending,
+      setExpanded,
+      collectionDir,
+      confirmUndoAll,
+    ],
+  )
+
   // ── Render ─────────────────────────────────────────────────────────
   return (
     <box
@@ -1219,6 +1467,13 @@ export function AppInner({
             visible
             message="Discard all unsaved changes? (y/n)"
             selectedIndex={confirmSelection}
+          />
+        )}
+        {commandPaletteVisible && (
+          <CommandPaletteOverlay
+            visible
+            commands={commandPaletteCommands}
+            onClose={() => setCommandPaletteVisible(false)}
           />
         )}
         {previewIndex !== null && (

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -151,6 +151,7 @@ export function AppInner({
   )
   const folderDeletePathRef = useRef<string | null>(null)
   const [undoAllPending, setUndoAllPending] = useState(false)
+  const [commandPaletteVisible, setCommandPaletteVisible] = useState(false)
   const [initialExpandedFolders, setInitialExpandedFolders] =
     useState<Set<string> | null>(null)
   const headerFieldRef = useRef<"name" | "color">("name")
@@ -912,6 +913,7 @@ export function AppInner({
       setNewFolderVisible,
       setFolderDeletePending,
       setUndoAllPending,
+      setCommandPaletteVisible,
       onLayoutChange,
       setExpanded,
     },

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -35,10 +35,8 @@ import {
   NewFolderOverlay,
   type NewFolderOverlayHandle,
 } from "./NewFolderOverlay"
-import {
-  CommandPaletteOverlay,
-  type CommandItem,
-} from "./CommandPaletteOverlay"
+import { CommandPaletteOverlay } from "./CommandPaletteOverlay"
+import { buildCommandPaletteCommands } from "./commands"
 import {
   saveRequest,
   deleteRequest,
@@ -52,7 +50,6 @@ import { EnvSidebar } from "./EnvSidebar"
 import { EnvHeaderPane, type EnvHeaderPaneHandle } from "./EnvHeaderPane"
 import { EnvEditorPane } from "./EnvEditorPane"
 
-import { join } from "node:path"
 import { type Keybinds, displayKey } from "./keybind"
 import { useSaveFile } from "./useSaveFile"
 import { useAppKeymap } from "./useAppKeymap"
@@ -60,12 +57,7 @@ import { useOverlayIntercepts } from "./useOverlayIntercepts"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
-import {
-  findRequestById,
-  getRequestIds,
-  findFolderByPath,
-  updateFolderByPath,
-} from "./tree"
+import { getRequestIds, findFolderByPath, updateFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import {
   saveLastRequest,
@@ -1001,239 +993,45 @@ export function AppInner({
     [keybinds.pane_expand],
   )
 
-  const commandPaletteCommands = useMemo<CommandItem[]>(
-    () => [
-      {
-        id: "request.send",
-        label: "Send Request",
-        section: "Actions",
-        keybinding: displayKey(keybinds.request_send),
-        run: () => trySendRef.current?.(),
-      },
-      {
-        id: "request.save",
-        label: "Save Request",
-        section: "Actions",
-        keybinding: displayKey(keybinds.request_save),
-        run: () => {
-          const d = draftRef.current
-          if (!savingRef.current && d.draft && d.isDirty) {
-            doSaveRef.current()
-          }
-        },
-      },
-      {
-        id: "env.cycle",
-        label: "Cycle Environment",
-        section: "Actions",
-        keybinding: displayKey(keybinds.env_cycle),
-        run: () => envStateRef.current.cycle(1),
-      },
-      {
-        id: "response.copy-body",
-        label: "Copy Response Body",
-        section: "Actions",
-        keybinding: displayKey(keybinds.response_copy_body),
-        run: () => {
-          const s = responseStateRef.current
-          if (s?.status !== "done") return
-          const body = s.response.body
-          let copied = false
-          const tmp = `/tmp/noodle-copy-${Date.now()}`
-          try {
-            Bun.write(tmp, body)
-            Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
-            copied = true
-          } catch {
-            // fallback failed — toast shows error
-          } finally {
-            try {
-              Bun.spawnSync(["rm", "-f", tmp])
-            } catch {
-              // cleanup is best-effort; ignore failures
-            }
-          }
-          showToast(
-            copied ? "Response body copied" : "Failed to copy response body",
-            copied ? "success" : "error",
-          )
-        },
-      },
-      {
-        id: "layout.toggle",
-        label: "Toggle Layout",
-        section: "View",
-        keybinding: displayKey(keybinds.layout_toggle),
-        run: () =>
-          setLayout((prev: "stacked" | "side-by-side") => {
-            const next = prev === "stacked" ? "side-by-side" : "stacked"
-            onLayoutChange(next)
-            return next
-          }),
-      },
-      {
-        id: "pane.expand",
-        label: "Expand/Collapse Pane",
-        section: "View",
-        keybinding: displayKey(keybinds.pane_expand),
-        run: () => {
-          const f = keymap.getData("app.focus") as "request" | "response"
-          if (f !== "request" && f !== "response") return
-          setExpanded((prev: "request" | "response" | null) =>
-            prev === f ? null : f,
-          )
-        },
-      },
-      {
-        id: "app.help",
-        label: "Toggle Help",
-        section: "View",
-        keybinding: displayKey(keybinds.help_toggle),
-        run: () => setHelpVisible((prev: boolean) => !prev),
-      },
-      {
-        id: "request.new",
-        label: "New Request",
-        section: "Create",
-        keybinding: displayKey(keybinds.request_new),
-        run: () => setNewRequestVisible(true),
-      },
-      {
-        id: "folder.new",
-        label: "New Folder",
-        section: "Create",
-        keybinding: displayKey(keybinds.folder_new),
-        run: () => setNewFolderVisible(true),
-      },
-      {
-        id: "request.clone",
-        label: "Clone Request",
-        section: "Create",
-        keybinding: displayKey(keybinds.request_clone),
-        run: () => {
-          const sid = selectedIdRef.current
-          if (!sid) return
-          const col = collectionRef.current
-          if (!col) return
-          const req = findRequestById(col.items, sid)
-          if (!req) return
-          setCloneRequestVisible(true)
-        },
-      },
-      {
-        id: "request.edit-overlay",
-        label: "Edit Request Metadata",
-        section: "Edit",
-        keybinding: displayKey(keybinds.request_edit_overlay),
-        run: () => {
-          if (focusedFolderPathRef.current) return
-          const sid = selectedIdRef.current
-          if (!sid) return
-          setEditRequestVisible(true)
-        },
-      },
-      {
-        id: "request.edit-yaml",
-        label: "Edit Request YAML",
-        section: "Edit",
-        keybinding: displayKey(keybinds.request_edit_yaml),
-        run: () => {
-          if (focusedFolderPathRef.current) return
-          const sid = selectedIdRef.current
-          if (!sid || !collectionDir) return
-          const col = collectionRef.current
-          if (!col) return
-          const r = findRequestById(col.items, sid)
-          if (!r) return
-          const filePath = join(collectionDir, `${sid}.yml`)
-          setYamlEditor({
-            visible: true,
-            filePath,
-            requestName: r.name,
-            returnFocus: focusRef.current,
-          })
-        },
-      },
-      {
-        id: "request.delete",
-        label: "Delete Request",
-        section: "Delete",
-        keybinding: displayKey(keybinds.request_delete),
-        run: () => {
-          const folderPath = focusedFolderPathRef.current
-          const folderName = focusedFolderNameRef.current
-          if (folderPath && folderName) {
-            folderDeletePathRef.current = folderPath
-            setFolderDeletePending(folderName)
-            return
-          }
-          const sid = selectedIdRef.current
-          if (!sid) return
-          const col = collectionRef.current
-          if (!col) return
-          const req = findRequestById(col.items, sid)
-          if (!req) return
-          setRequestDeletePending(req.name)
-        },
-      },
-      {
-        id: "env.editor-open",
-        label: "Open Environment Editor",
-        section: "Workspace",
-        keybinding: displayKey(keybinds.env_editor),
-        run: () => {
-          const name = envStateRef.current.activeEnv?.name
-          envEditorRef.current.openEditor(name)
-          setView("env-editor")
-          setFocus("env-sidebar")
-        },
-      },
-      {
-        id: "app.theme",
-        label: "Open Theme Picker",
-        section: "Workspace",
-        keybinding: displayKey(keybinds.theme_picker),
-        run: () => setPreviewIndexProp(activeIndexRef.current),
-      },
-      {
-        id: "global.undo-all",
-        label: "Undo All Unsaved Changes",
-        section: "System",
-        keybinding: displayKey(keybinds.global_undo_all),
-        run: () => {
-          const d = draftRef.current
-          const fd = folderDraftRef.current
-          const ee = envEditorRef.current
-          const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
-          if (!hasDirty) return
-          if (confirmUndoAll) {
-            setUndoAllPending(true)
-          } else {
-            d.revertAllRequests()
-            fd.revertAllFolders()
-            ee?.revertDraft()
-          }
-        },
-      },
-    ],
-    [
-      keybinds,
-      setLayout,
-      onLayoutChange,
-      setHelpVisible,
-      setNewRequestVisible,
-      setNewFolderVisible,
-      setCloneRequestVisible,
-      setEditRequestVisible,
-      setYamlEditor,
-      setRequestDeletePending,
-      setView,
-      setFocus,
-      setUndoAllPending,
-      setExpanded,
-      collectionDir,
-      confirmUndoAll,
-    ],
+  const commandPaletteCommands = useMemo(
+    () =>
+      buildCommandPaletteCommands({
+        keybinds,
+        collectionDir,
+        confirmUndoAll,
+        trySendRef,
+        draftRef,
+        folderDraftRef,
+        envStateRef,
+        envEditorRef,
+        collectionRef,
+        selectedIdRef,
+        focusRef,
+        responseStateRef,
+        activeIndexRef,
+        savingRef,
+        doSaveRef,
+        focusedFolderPathRef,
+        focusedFolderNameRef,
+        folderDeletePathRef,
+        getKeymapFocus: () => keymap.getData("app.focus") as string,
+        setLayout,
+        onLayoutChange,
+        setHelpVisible,
+        setNewRequestVisible,
+        setNewFolderVisible,
+        setCloneRequestVisible,
+        setEditRequestVisible,
+        setRequestDeletePending,
+        setFolderDeletePending,
+        setYamlEditor,
+        setView,
+        setFocus,
+        setUndoAllPending,
+        setExpanded,
+        setPreviewIndexProp,
+      }),
+    [keybinds, collectionDir, confirmUndoAll, onLayoutChange],
   )
 
   // ── Render ─────────────────────────────────────────────────────────

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -53,6 +53,7 @@ import { EnvEditorPane } from "./EnvEditorPane"
 import { type Keybinds, displayKey } from "./keybind"
 import { useSaveFile } from "./useSaveFile"
 import { useAppKeymap } from "./useAppKeymap"
+import { useRenderer } from "./RendererContext"
 import { useOverlayIntercepts } from "./useOverlayIntercepts"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
@@ -993,12 +994,15 @@ export function AppInner({
     [keybinds.pane_expand],
   )
 
+  const renderer = useRenderer()
+
   const commandPaletteCommands = useMemo(
     () =>
       buildCommandPaletteCommands({
         keybinds,
         collectionDir,
         confirmUndoAll,
+        renderer,
         trySendRef,
         draftRef,
         folderDraftRef,

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -111,7 +111,7 @@ export function CommandPaletteOverlay({
       // Header at start of list — handle wrap
       if (idx === 0) {
         const last = [...visible].reverse().find(isNavigable)
-        if (highlightedId === after?.id && last) {
+        if ((highlightedId === after?.id || highlightedId === null) && last) {
           // Was on first command, pressed up — wrap to last
           setHighlightedId(last.id)
           return

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -53,45 +53,6 @@ function buildDisplayItems(commands: CommandItem[]): PaletteItem[] {
   return items
 }
 
-function filterDisplayItems(
-  items: PaletteItem[],
-  commands: CommandItem[],
-  query: string,
-): PaletteItem[] {
-  if (!query) return items
-  return items.filter((item) => {
-    if (item.type === "command") {
-      return item.label.toLowerCase().includes(query.toLowerCase())
-    }
-    if (item.type === "header") {
-      return commands.some(
-        (c) =>
-          c.section === item.section &&
-          c.label.toLowerCase().includes(query.toLowerCase()),
-      )
-    }
-    // spacer: only visible if both adjacent sections have visible commands
-    const idx = items.indexOf(item)
-    const prevHeader = items
-      .slice(0, idx)
-      .reverse()
-      .find((i) => i.type === "header")
-    const nextHeader = items.slice(idx + 1).find((i) => i.type === "header")
-    if (!prevHeader || !nextHeader) return true
-    const prevVisible = commands.some(
-      (c) =>
-        c.section === prevHeader.section &&
-        c.label.toLowerCase().includes(query.toLowerCase()),
-    )
-    const nextVisible = commands.some(
-      (c) =>
-        c.section === nextHeader.section &&
-        c.label.toLowerCase().includes(query.toLowerCase()),
-    )
-    return prevVisible && nextVisible
-  })
-}
-
 export function CommandPaletteOverlay({
   visible,
   commands,
@@ -127,7 +88,7 @@ export function CommandPaletteOverlay({
             c.label.toLowerCase().includes(query.toLowerCase()),
         )
       }
-      // spacer: only if both adjacent sections are visible
+      // spacer: only if both adjacent sections have matching commands
       const idx = displayItems.indexOf(item)
       const prevHeader = displayItems
         .slice(0, idx)
@@ -159,9 +120,9 @@ export function CommandPaletteOverlay({
           setHighlightedId(null)
           return
         }
-        // search within the CURRENT filtered list
+        // search within the CURRENT filtered list (same as PickerOverlay sees)
         const visible = queryRef.current
-          ? filterDisplayItems(displayItems, commands, queryRef.current)
+          ? displayItems.filter((i) => filter(i, queryRef.current))
           : displayItems
         const idx = visible.indexOf(item)
         if (idx < 0) return

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -123,13 +123,16 @@ export function CommandPaletteOverlay({
         }
       }
 
-      // Direction-aware: snap to neighbor NOT matching highlightedId
-      if (before && before.id !== highlightedId) {
-        setHighlightedId(before.id)
-      } else if (after && after.id !== highlightedId) {
-        setHighlightedId(after.id)
+      // Direction-aware: snap to neighbor matching highlightedId's direction
+      if (before && before.id === highlightedId) {
+        // Came from above (pressed down) — advance to next
+        setHighlightedId(after?.id ?? before.id)
+      } else if (after && after.id === highlightedId) {
+        // Came from below (pressed up) — go back to previous
+        setHighlightedId(before?.id ?? after.id)
       } else {
-        setHighlightedId(before?.id ?? after?.id ?? null)
+        // Initial state (null) or mismatch — prefer forward
+        setHighlightedId(after?.id ?? before?.id ?? null)
       }
     },
     [displayItems, commands, filter, highlightedId],

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -21,7 +21,6 @@ type PaletteItem =
       keybinding?: string
       run: () => void
     }
-  | { type: "spacer"; id: string }
 
 function isCmd(
   item: PaletteItem,
@@ -38,9 +37,6 @@ function buildDisplayItems(commands: CommandItem[]): PaletteItem[] {
   const items: PaletteItem[] = []
   for (const c of commands) {
     if (!seen.has(c.section)) {
-      if (seen.size > 0) {
-        items.push({ type: "spacer", id: `spacer:${c.section}` })
-      }
       seen.add(c.section)
       items.push({
         type: "header",
@@ -88,29 +84,9 @@ export function CommandPaletteOverlay({
             c.label.toLowerCase().includes(query.toLowerCase()),
         )
       }
-      // spacer: only if both adjacent sections have matching commands
-      const idx = displayItems.indexOf(item)
-      const prevHeader = displayItems
-        .slice(0, idx)
-        .reverse()
-        .find((i) => i.type === "header")
-      const nextHeader = displayItems
-        .slice(idx + 1)
-        .find((i) => i.type === "header")
-      if (!prevHeader || !nextHeader) return true
-      const prevVisible = commands.some(
-        (c) =>
-          c.section === prevHeader.section &&
-          c.label.toLowerCase().includes(query.toLowerCase()),
-      )
-      const nextVisible = commands.some(
-        (c) =>
-          c.section === nextHeader.section &&
-          c.label.toLowerCase().includes(query.toLowerCase()),
-      )
-      return prevVisible && nextVisible
+      return false
     },
-    [commands, displayItems],
+    [commands],
   )
 
   const handleHighlightChange = useCallback(
@@ -176,16 +152,27 @@ export function CommandPaletteOverlay({
       { highlighted }: { highlighted: boolean; active: boolean },
     ) => {
       if (item.type === "header") {
+        const q = queryRef.current.toLowerCase()
+        const visible = q
+          ? displayItems.filter((i) => {
+              if (i.type === "command") return i.label.toLowerCase().includes(q)
+              if (i.type === "header")
+                return commands.some(
+                  (c) =>
+                    c.section === i.section &&
+                    c.label.toLowerCase().includes(q),
+                )
+              return false
+            })
+          : displayItems
+        const isFirst = visible.find((i) => i.type === "header") === item
         return (
-          <box flexGrow={1}>
+          <box flexGrow={1} paddingTop={isFirst ? 0 : 1}>
             <text fg={theme.primary} attributes={TextAttributes.BOLD}>
               {item.section}
             </text>
           </box>
         )
-      }
-      if (item.type === "spacer") {
-        return <box height={1} />
       }
       const baseFg = highlighted ? "#1a1a1a" : theme.text
       const mutedFg = highlighted ? "#333333" : theme.textMuted

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -75,6 +75,7 @@ export function CommandPaletteOverlay({
   return (
     <PickerOverlay
       visible={visible}
+      width={60}
       title="Commands"
       placeholder="Type a command..."
       items={commands}

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -91,44 +91,48 @@ export function CommandPaletteOverlay({
 
   const handleHighlightChange = useCallback(
     (item: PaletteItem | null) => {
-      if (!item || !isNavigable(item)) {
-        if (!item) {
-          setHighlightedId(null)
+      if (!item) {
+        setHighlightedId(null)
+        return
+      }
+      if (isNavigable(item)) {
+        setHighlightedId(item.id)
+        return
+      }
+      // Header — snap to nearest navigable command, direction-aware
+      const visible = queryRef.current
+        ? displayItems.filter((i) => filter(i, queryRef.current))
+        : displayItems
+      const idx = visible.indexOf(item)
+      if (idx < 0) return
+      const before = visible.slice(0, idx).reverse().find(isNavigable)
+      const after = visible.slice(idx + 1).find(isNavigable)
+
+      // Header at start of list — handle wrap
+      if (idx === 0) {
+        const last = [...visible].reverse().find(isNavigable)
+        if (highlightedId === after?.id && last) {
+          // Was on first command, pressed up — wrap to last
+          setHighlightedId(last.id)
           return
         }
-        // search within the CURRENT filtered list (same as PickerOverlay sees)
-        const visible = queryRef.current
-          ? displayItems.filter((i) => filter(i, queryRef.current))
-          : displayItems
-        const idx = visible.indexOf(item)
-        if (idx < 0) return
-        // header at edge of filtered list (wrapping)
-        if (item.type === "header" && idx === 0) {
-          const firstCmd = visible.find(isNavigable)
-          const lastCmd = [...visible].reverse().find(isNavigable)
-          if (highlightedId === firstCmd?.id && lastCmd) {
-            setHighlightedId(lastCmd.id)
-            return
-          }
-          if (highlightedId === lastCmd?.id && firstCmd) {
-            setHighlightedId(firstCmd.id)
-            return
-          }
-        }
-        const before = visible.slice(0, idx).reverse().find(isNavigable)
-        const after = visible.slice(idx + 1).find(isNavigable)
-        if (before && before.id !== highlightedId) {
-          setHighlightedId(before.id)
-        } else if (after && after.id !== highlightedId) {
+        // Otherwise snap to first command
+        if (after) {
           setHighlightedId(after.id)
-        } else {
-          setHighlightedId(before?.id ?? after?.id ?? null)
+          return
         }
+      }
+
+      // Direction-aware: snap to neighbor NOT matching highlightedId
+      if (before && before.id !== highlightedId) {
+        setHighlightedId(before.id)
+      } else if (after && after.id !== highlightedId) {
+        setHighlightedId(after.id)
       } else {
-        setHighlightedId(item.id)
+        setHighlightedId(before?.id ?? after?.id ?? null)
       }
     },
-    [displayItems, commands, highlightedId],
+    [displayItems, commands, filter, highlightedId],
   )
 
   const highlightedItem = useMemo(() => {
@@ -152,18 +156,8 @@ export function CommandPaletteOverlay({
       { highlighted }: { highlighted: boolean; active: boolean },
     ) => {
       if (item.type === "header") {
-        const q = queryRef.current.toLowerCase()
-        const visible = q
-          ? displayItems.filter((i) => {
-              if (i.type === "command") return i.label.toLowerCase().includes(q)
-              if (i.type === "header")
-                return commands.some(
-                  (c) =>
-                    c.section === i.section &&
-                    c.label.toLowerCase().includes(q),
-                )
-              return false
-            })
+        const visible = queryRef.current
+          ? displayItems.filter((i) => filter(i, queryRef.current))
           : displayItems
         const isFirst = visible.find((i) => i.type === "header") === item
         return (

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -103,18 +103,34 @@ export function CommandPaletteOverlay({
         }
         const idx = displayItems.indexOf(item)
         if (idx < 0) return
-        const forward = displayItems.slice(idx + 1).find(isNavigable)
-        if (forward) {
-          setHighlightedId(forward.id)
-          return
+        // when wrapping hits the first header, figure direction from current highlight
+        if (item.type === "header" && idx === 0) {
+          const firstCmd = displayItems.find(isNavigable)
+          const lastCmd = [...displayItems].reverse().find(isNavigable)
+          if (highlightedId === firstCmd?.id && lastCmd) {
+            setHighlightedId(lastCmd.id)
+            return
+          }
+          if (highlightedId === lastCmd?.id && firstCmd) {
+            setHighlightedId(firstCmd.id)
+            return
+          }
         }
-        const backward = displayItems.slice(0, idx).reverse().find(isNavigable)
-        setHighlightedId(backward?.id ?? null)
+        const before = displayItems.slice(0, idx).reverse().find(isNavigable)
+        const after = displayItems.slice(idx + 1).find(isNavigable)
+        // prefer the candidate that moves away from current position
+        if (before && before.id !== highlightedId) {
+          setHighlightedId(before.id)
+        } else if (after && after.id !== highlightedId) {
+          setHighlightedId(after.id)
+        } else {
+          setHighlightedId(before?.id ?? after?.id ?? null)
+        }
       } else {
         setHighlightedId(item.id)
       }
     },
-    [displayItems],
+    [displayItems, highlightedId],
   )
 
   const handleSelect = useCallback(

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react"
+import { useCallback, useState, useEffect } from "react"
 import { PickerOverlay } from "./PickerOverlay"
 import { useTheme } from "./theme"
 
@@ -20,6 +20,15 @@ export function CommandPaletteOverlay({
   onClose: () => void
 }) {
   const theme = useTheme()
+  const [highlightedItem, setHighlightedItem] = useState<CommandItem | null>(
+    null,
+  )
+
+  useEffect(() => {
+    if (visible) {
+      setHighlightedItem(null)
+    }
+  }, [visible])
 
   const keyExtractor = useCallback((item: CommandItem) => item.id, [])
 
@@ -72,6 +81,8 @@ export function CommandPaletteOverlay({
       keyExtractor={keyExtractor}
       filter={filter}
       renderItem={renderItem}
+      highlightedItem={highlightedItem}
+      onHighlightChange={setHighlightedItem}
       onSelect={handleSelect}
       onClose={onClose}
     />

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useMemo } from "react"
+import { useCallback, useState, useEffect, useMemo, useRef } from "react"
 import { TextAttributes } from "@opentui/core"
 import { PickerOverlay } from "./PickerOverlay"
 import { useTheme } from "./theme"
@@ -23,13 +23,13 @@ type PaletteItem =
     }
   | { type: "spacer"; id: string }
 
-function isNavigable(item: PaletteItem): boolean {
-  return item.type === "command"
-}
-
 function isCmd(
   item: PaletteItem,
 ): item is PaletteItem & { type: "command"; run: () => void } {
+  return item.type === "command"
+}
+
+function isNavigable(item: PaletteItem): boolean {
   return item.type === "command"
 }
 
@@ -53,6 +53,45 @@ function buildDisplayItems(commands: CommandItem[]): PaletteItem[] {
   return items
 }
 
+function filterDisplayItems(
+  items: PaletteItem[],
+  commands: CommandItem[],
+  query: string,
+): PaletteItem[] {
+  if (!query) return items
+  return items.filter((item) => {
+    if (item.type === "command") {
+      return item.label.toLowerCase().includes(query.toLowerCase())
+    }
+    if (item.type === "header") {
+      return commands.some(
+        (c) =>
+          c.section === item.section &&
+          c.label.toLowerCase().includes(query.toLowerCase()),
+      )
+    }
+    // spacer: only visible if both adjacent sections have visible commands
+    const idx = items.indexOf(item)
+    const prevHeader = items
+      .slice(0, idx)
+      .reverse()
+      .find((i) => i.type === "header")
+    const nextHeader = items.slice(idx + 1).find((i) => i.type === "header")
+    if (!prevHeader || !nextHeader) return true
+    const prevVisible = commands.some(
+      (c) =>
+        c.section === prevHeader.section &&
+        c.label.toLowerCase().includes(query.toLowerCase()),
+    )
+    const nextVisible = commands.some(
+      (c) =>
+        c.section === nextHeader.section &&
+        c.label.toLowerCase().includes(query.toLowerCase()),
+    )
+    return prevVisible && nextVisible
+  })
+}
+
 export function CommandPaletteOverlay({
   visible,
   commands,
@@ -64,6 +103,7 @@ export function CommandPaletteOverlay({
 }) {
   const theme = useTheme()
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
+  const queryRef = useRef("")
 
   const displayItems = useMemo(() => buildDisplayItems(commands), [commands])
 
@@ -71,16 +111,15 @@ export function CommandPaletteOverlay({
     if (visible) setHighlightedId(null)
   }, [visible])
 
-  const highlightedItem = useMemo(() => {
-    if (!highlightedId) return displayItems.find(isNavigable) ?? null
-    return displayItems.find((i) => i.id === highlightedId) ?? null
-  }, [displayItems, highlightedId])
-
   const keyExtractor = useCallback((item: PaletteItem) => item.id, [])
 
   const filter = useCallback(
     (item: PaletteItem, query: string) => {
+      queryRef.current = query
       if (!query) return true
+      if (item.type === "command") {
+        return item.label.toLowerCase().includes(query.toLowerCase())
+      }
       if (item.type === "header") {
         return commands.some(
           (c) =>
@@ -88,10 +127,29 @@ export function CommandPaletteOverlay({
             c.label.toLowerCase().includes(query.toLowerCase()),
         )
       }
-      if (item.type === "spacer") return true
-      return item.label.toLowerCase().includes(query.toLowerCase())
+      // spacer: only if both adjacent sections are visible
+      const idx = displayItems.indexOf(item)
+      const prevHeader = displayItems
+        .slice(0, idx)
+        .reverse()
+        .find((i) => i.type === "header")
+      const nextHeader = displayItems
+        .slice(idx + 1)
+        .find((i) => i.type === "header")
+      if (!prevHeader || !nextHeader) return true
+      const prevVisible = commands.some(
+        (c) =>
+          c.section === prevHeader.section &&
+          c.label.toLowerCase().includes(query.toLowerCase()),
+      )
+      const nextVisible = commands.some(
+        (c) =>
+          c.section === nextHeader.section &&
+          c.label.toLowerCase().includes(query.toLowerCase()),
+      )
+      return prevVisible && nextVisible
     },
-    [commands],
+    [commands, displayItems],
   )
 
   const handleHighlightChange = useCallback(
@@ -101,12 +159,16 @@ export function CommandPaletteOverlay({
           setHighlightedId(null)
           return
         }
-        const idx = displayItems.indexOf(item)
+        // search within the CURRENT filtered list
+        const visible = queryRef.current
+          ? filterDisplayItems(displayItems, commands, queryRef.current)
+          : displayItems
+        const idx = visible.indexOf(item)
         if (idx < 0) return
-        // when wrapping hits the first header, figure direction from current highlight
+        // header at edge of filtered list (wrapping)
         if (item.type === "header" && idx === 0) {
-          const firstCmd = displayItems.find(isNavigable)
-          const lastCmd = [...displayItems].reverse().find(isNavigable)
+          const firstCmd = visible.find(isNavigable)
+          const lastCmd = [...visible].reverse().find(isNavigable)
           if (highlightedId === firstCmd?.id && lastCmd) {
             setHighlightedId(lastCmd.id)
             return
@@ -116,9 +178,8 @@ export function CommandPaletteOverlay({
             return
           }
         }
-        const before = displayItems.slice(0, idx).reverse().find(isNavigable)
-        const after = displayItems.slice(idx + 1).find(isNavigable)
-        // prefer the candidate that moves away from current position
+        const before = visible.slice(0, idx).reverse().find(isNavigable)
+        const after = visible.slice(idx + 1).find(isNavigable)
         if (before && before.id !== highlightedId) {
           setHighlightedId(before.id)
         } else if (after && after.id !== highlightedId) {
@@ -130,8 +191,13 @@ export function CommandPaletteOverlay({
         setHighlightedId(item.id)
       }
     },
-    [displayItems, highlightedId],
+    [displayItems, commands, highlightedId],
   )
+
+  const highlightedItem = useMemo(() => {
+    if (!highlightedId) return displayItems.find(isNavigable) ?? null
+    return displayItems.find((i) => i.id === highlightedId) ?? null
+  }, [displayItems, highlightedId])
 
   const handleSelect = useCallback(
     (item: PaletteItem) => {

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -1,0 +1,79 @@
+import { useCallback } from "react"
+import { PickerOverlay } from "./PickerOverlay"
+import { useTheme } from "./theme"
+
+export interface CommandItem {
+  id: string
+  label: string
+  section: string
+  keybinding?: string
+  run: () => void
+}
+
+export function CommandPaletteOverlay({
+  visible,
+  commands,
+  onClose,
+}: {
+  visible: boolean
+  commands: CommandItem[]
+  onClose: () => void
+}) {
+  const theme = useTheme()
+
+  const keyExtractor = useCallback((item: CommandItem) => item.id, [])
+
+  const filter = useCallback(
+    (item: CommandItem, query: string) =>
+      item.label.toLowerCase().includes(query.toLowerCase()),
+    [],
+  )
+
+  const handleSelect = useCallback(
+    (item: CommandItem) => {
+      item.run()
+      onClose()
+    },
+    [onClose],
+  )
+
+  const renderItem = useCallback(
+    (
+      item: CommandItem,
+      { highlighted }: { highlighted: boolean; active: boolean },
+    ) => {
+      const baseFg = highlighted ? "#1a1a1a" : theme.text
+      const mutedFg = highlighted ? "#333333" : theme.textMuted
+      return (
+        <>
+          <text fg={baseFg}>{item.label}</text>
+          <box flexGrow={1} />
+          <text fg={mutedFg}>{item.section}</text>
+          {item.keybinding && (
+            <>
+              <text fg={mutedFg}> · </text>
+              <text fg={mutedFg}>{item.keybinding}</text>
+            </>
+          )}
+        </>
+      )
+    },
+    [theme],
+  )
+
+  if (!visible) return null
+
+  return (
+    <PickerOverlay
+      visible={visible}
+      title="Commands"
+      placeholder="Type a command..."
+      items={commands}
+      keyExtractor={keyExtractor}
+      filter={filter}
+      renderItem={renderItem}
+      onSelect={handleSelect}
+      onClose={onClose}
+    />
+  )
+}

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState, useEffect } from "react"
+import { useCallback, useState, useEffect, useMemo } from "react"
+import { TextAttributes } from "@opentui/core"
 import { PickerOverlay } from "./PickerOverlay"
 import { useTheme } from "./theme"
 
@@ -8,6 +9,48 @@ export interface CommandItem {
   section: string
   keybinding?: string
   run: () => void
+}
+
+type PaletteItem =
+  | { type: "header"; id: string; section: string }
+  | {
+      type: "command"
+      id: string
+      label: string
+      section: string
+      keybinding?: string
+      run: () => void
+    }
+  | { type: "spacer"; id: string }
+
+function isNavigable(item: PaletteItem): boolean {
+  return item.type === "command"
+}
+
+function isCmd(
+  item: PaletteItem,
+): item is PaletteItem & { type: "command"; run: () => void } {
+  return item.type === "command"
+}
+
+function buildDisplayItems(commands: CommandItem[]): PaletteItem[] {
+  const seen = new Set<string>()
+  const items: PaletteItem[] = []
+  for (const c of commands) {
+    if (!seen.has(c.section)) {
+      if (seen.size > 0) {
+        items.push({ type: "spacer", id: `spacer:${c.section}` })
+      }
+      seen.add(c.section)
+      items.push({
+        type: "header",
+        id: `header:${c.section}`,
+        section: c.section,
+      })
+    }
+    items.push({ type: "command", ...c })
+  }
+  return items
 }
 
 export function CommandPaletteOverlay({
@@ -20,50 +63,94 @@ export function CommandPaletteOverlay({
   onClose: () => void
 }) {
   const theme = useTheme()
-  const [highlightedItem, setHighlightedItem] = useState<CommandItem | null>(
-    null,
-  )
+  const [highlightedId, setHighlightedId] = useState<string | null>(null)
+
+  const displayItems = useMemo(() => buildDisplayItems(commands), [commands])
 
   useEffect(() => {
-    if (visible) {
-      setHighlightedItem(null)
-    }
+    if (visible) setHighlightedId(null)
   }, [visible])
 
-  const keyExtractor = useCallback((item: CommandItem) => item.id, [])
+  const highlightedItem = useMemo(() => {
+    if (!highlightedId) return displayItems.find(isNavigable) ?? null
+    return displayItems.find((i) => i.id === highlightedId) ?? null
+  }, [displayItems, highlightedId])
+
+  const keyExtractor = useCallback((item: PaletteItem) => item.id, [])
 
   const filter = useCallback(
-    (item: CommandItem, query: string) =>
-      item.label.toLowerCase().includes(query.toLowerCase()),
-    [],
+    (item: PaletteItem, query: string) => {
+      if (!query) return true
+      if (item.type === "header") {
+        return commands.some(
+          (c) =>
+            c.section === item.section &&
+            c.label.toLowerCase().includes(query.toLowerCase()),
+        )
+      }
+      if (item.type === "spacer") return true
+      return item.label.toLowerCase().includes(query.toLowerCase())
+    },
+    [commands],
+  )
+
+  const handleHighlightChange = useCallback(
+    (item: PaletteItem | null) => {
+      if (!item || !isNavigable(item)) {
+        if (!item) {
+          setHighlightedId(null)
+          return
+        }
+        const idx = displayItems.indexOf(item)
+        if (idx < 0) return
+        const forward = displayItems.slice(idx + 1).find(isNavigable)
+        if (forward) {
+          setHighlightedId(forward.id)
+          return
+        }
+        const backward = displayItems.slice(0, idx).reverse().find(isNavigable)
+        setHighlightedId(backward?.id ?? null)
+      } else {
+        setHighlightedId(item.id)
+      }
+    },
+    [displayItems],
   )
 
   const handleSelect = useCallback(
-    (item: CommandItem) => {
-      item.run()
-      onClose()
+    (item: PaletteItem) => {
+      if (isCmd(item)) {
+        item.run()
+        onClose()
+      }
     },
     [onClose],
   )
 
   const renderItem = useCallback(
     (
-      item: CommandItem,
+      item: PaletteItem,
       { highlighted }: { highlighted: boolean; active: boolean },
     ) => {
+      if (item.type === "header") {
+        return (
+          <box flexGrow={1}>
+            <text fg={theme.primary} attributes={TextAttributes.BOLD}>
+              {item.section}
+            </text>
+          </box>
+        )
+      }
+      if (item.type === "spacer") {
+        return <box height={1} />
+      }
       const baseFg = highlighted ? "#1a1a1a" : theme.text
       const mutedFg = highlighted ? "#333333" : theme.textMuted
       return (
         <>
           <text fg={baseFg}>{item.label}</text>
           <box flexGrow={1} />
-          <text fg={mutedFg}>{item.section}</text>
-          {item.keybinding && (
-            <>
-              <text fg={mutedFg}> · </text>
-              <text fg={mutedFg}>{item.keybinding}</text>
-            </>
-          )}
+          {item.keybinding && <text fg={mutedFg}>{item.keybinding}</text>}
         </>
       )
     },
@@ -78,12 +165,12 @@ export function CommandPaletteOverlay({
       width={60}
       title="Commands"
       placeholder="Type a command..."
-      items={commands}
+      items={displayItems}
       keyExtractor={keyExtractor}
       filter={filter}
       renderItem={renderItem}
       highlightedItem={highlightedItem}
-      onHighlightChange={setHighlightedItem}
+      onHighlightChange={handleHighlightChange}
       onSelect={handleSelect}
       onClose={onClose}
     />

--- a/src/ui/PickerOverlay.tsx
+++ b/src/ui/PickerOverlay.tsx
@@ -73,7 +73,7 @@ export function PickerOverlay<T>({
     return found ?? filtered[0] ?? null
   }, [filtered, highlightedItem, keyExtractor])
 
-  const highlightRef = useRef(currentHighlight)
+  const highlightRef = useRef<T | null>(currentHighlight)
   highlightRef.current = currentHighlight
 
   const prevHighlight = useRef(currentHighlight)

--- a/src/ui/PickerOverlay.tsx
+++ b/src/ui/PickerOverlay.tsx
@@ -73,6 +73,9 @@ export function PickerOverlay<T>({
     return found ?? filtered[0] ?? null
   }, [filtered, highlightedItem, keyExtractor])
 
+  const highlightRef = useRef(currentHighlight)
+  highlightRef.current = currentHighlight
+
   const prevHighlight = useRef(currentHighlight)
   useEffect(() => {
     if (currentHighlight && prevHighlight.current !== currentHighlight) {
@@ -111,6 +114,7 @@ export function PickerOverlay<T>({
           if (filtered.length === 0 || highlightIndex < 0) return
           const nextPos =
             highlightIndex > 0 ? highlightIndex - 1 : filtered.length - 1
+          highlightRef.current = filtered[nextPos]
           onHighlightChange?.(filtered[nextPos])
         } else if (name === "down") {
           ctx.event.preventDefault()
@@ -118,11 +122,12 @@ export function PickerOverlay<T>({
           if (filtered.length === 0 || highlightIndex < 0) return
           const nextPos =
             highlightIndex < filtered.length - 1 ? highlightIndex + 1 : 0
+          highlightRef.current = filtered[nextPos]
           onHighlightChange?.(filtered[nextPos])
         } else if (name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          if (currentHighlight) onSelect(currentHighlight)
+          if (highlightRef.current) onSelect(highlightRef.current)
         }
       },
       { priority: 100 },

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path"
-import { tmpdir } from "node:os"
 import type { RefObject } from "react"
 import type { CliRenderer } from "@opentui/core"
 import type { CommandItem } from "./CommandPaletteOverlay"
@@ -264,18 +263,12 @@ export function buildCommandPaletteCommands(
         const s = responseStateRef.current
         if (s?.status !== "done") return
         const body = s.response.body
-        const tmp = join(tmpdir(), `noodle-copy-${Date.now()}`)
         try {
-          Bun.write(tmp, body)
-          Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
+          const result = Bun.spawnSync(["pbcopy"], { stdin: new TextEncoder().encode(body) })
+          if (result.exitCode !== 0) throw new Error("pbcopy failed")
         } catch {
           renderer.copyToClipboardOSC52(body)
-        } finally {
-          try {
-            Bun.spawnSync(["rm", "-f", tmp])
-          } catch {
-            // cleanup is best-effort
-          }
+          return
         }
         showToast("Response body copied", "success")
       },
@@ -350,7 +343,7 @@ export function buildCommandPaletteCommands(
         const name = envStateRef.current.activeEnv?.name
         envEditorRef.current.openEditor(name)
         setView("env-editor")
-        setFocus("env-sidebar")
+        setFocus("env-header")
       },
     },
   ]

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -1,0 +1,350 @@
+import { join } from "node:path"
+import type { RefObject } from "react"
+import type { CommandItem } from "./CommandPaletteOverlay"
+import type { Keybinds } from "./keybind"
+import { displayKey } from "./keybind"
+import { showToast } from "./Toast"
+import { findRequestById } from "./tree"
+import type { Focus } from "./focus"
+import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
+import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
+import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
+import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
+import type { Collection } from "../schema"
+import type { SendState } from "./sendState"
+
+export interface CommandBuilderContext {
+  keybinds: Keybinds
+  collectionDir: string
+  confirmUndoAll: boolean
+  trySendRef: RefObject<(() => void) | undefined>
+  draftRef: RefObject<UseRequestDraftResult>
+  folderDraftRef: RefObject<UseFolderDraftResult>
+  envStateRef: RefObject<UseEnvironmentsResult>
+  envEditorRef: RefObject<UseEnvironmentEditorResult>
+  collectionRef: RefObject<Collection | null>
+  selectedIdRef: RefObject<string | null>
+  focusRef: RefObject<Focus>
+  responseStateRef: RefObject<SendState>
+  activeIndexRef: RefObject<number>
+  savingRef: RefObject<boolean>
+  doSaveRef: RefObject<() => void>
+  focusedFolderPathRef: RefObject<string | null>
+  focusedFolderNameRef: RefObject<string | null>
+  folderDeletePathRef: RefObject<string | null>
+  getKeymapFocus: () => string
+  setLayout: (
+    v:
+      | "stacked"
+      | "side-by-side"
+      | ((prev: "stacked" | "side-by-side") => "stacked" | "side-by-side"),
+  ) => void
+  onLayoutChange: (layout: "stacked" | "side-by-side") => void
+  setHelpVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setNewRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setNewFolderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setCloneRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setEditRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setRequestDeletePending: (
+    s: string | null | ((prev: string | null) => string | null),
+  ) => void
+  setFolderDeletePending: (
+    s: string | null | ((prev: string | null) => string | null),
+  ) => void
+  setYamlEditor: (
+    v:
+      | {
+          visible: boolean
+          filePath: string
+          requestName: string
+          returnFocus: Focus
+        }
+      | ((prev: {
+          visible: boolean
+          filePath: string
+          requestName: string
+          returnFocus: Focus
+        }) => {
+          visible: boolean
+          filePath: string
+          requestName: string
+          returnFocus: Focus
+        }),
+  ) => void
+  setView: (
+    v:
+      | "main"
+      | "env-editor"
+      | ((prev: "main" | "env-editor") => "main" | "env-editor"),
+  ) => void
+  setFocus: (focus: Focus | ((prev: Focus) => Focus)) => void
+  setUndoAllPending: (v: boolean | ((prev: boolean) => boolean)) => void
+  setExpanded: (
+    v:
+      | "request"
+      | "response"
+      | null
+      | ((
+          prev: "request" | "response" | null,
+        ) => "request" | "response" | null),
+  ) => void
+  setPreviewIndexProp: (
+    n: number | null | ((prev: number | null) => number | null),
+  ) => void
+}
+
+export function buildCommandPaletteCommands(
+  ctx: CommandBuilderContext,
+): CommandItem[] {
+  const {
+    keybinds,
+    collectionDir,
+    confirmUndoAll,
+    trySendRef,
+    draftRef,
+    folderDraftRef,
+    envStateRef,
+    envEditorRef,
+    collectionRef,
+    selectedIdRef,
+    focusRef,
+    responseStateRef,
+    activeIndexRef,
+    savingRef,
+    doSaveRef,
+    focusedFolderPathRef,
+    focusedFolderNameRef,
+    folderDeletePathRef,
+    getKeymapFocus,
+    setLayout,
+    onLayoutChange,
+    setHelpVisible,
+    setNewRequestVisible,
+    setNewFolderVisible,
+    setCloneRequestVisible,
+    setEditRequestVisible,
+    setRequestDeletePending,
+    setFolderDeletePending,
+    setYamlEditor,
+    setView,
+    setFocus,
+    setUndoAllPending,
+    setExpanded,
+    setPreviewIndexProp,
+  } = ctx
+
+  return [
+    {
+      id: "request.send",
+      label: "Send Request",
+      section: "Actions",
+      keybinding: displayKey(keybinds.request_send),
+      run: () => trySendRef.current?.(),
+    },
+    {
+      id: "request.save",
+      label: "Save Request",
+      section: "Actions",
+      keybinding: displayKey(keybinds.request_save),
+      run: () => {
+        const d = draftRef.current
+        if (!savingRef.current && d.draft && d.isDirty) {
+          doSaveRef.current()
+        }
+      },
+    },
+    {
+      id: "env.cycle",
+      label: "Cycle Environment",
+      section: "Actions",
+      keybinding: displayKey(keybinds.env_cycle),
+      run: () => envStateRef.current.cycle(1),
+    },
+    {
+      id: "response.copy-body",
+      label: "Copy Response Body",
+      section: "Actions",
+      keybinding: displayKey(keybinds.response_copy_body),
+      run: () => {
+        const s = responseStateRef.current
+        if (s?.status !== "done") return
+        const body = s.response.body
+        let copied = false
+        const tmp = `/tmp/noodle-copy-${Date.now()}`
+        try {
+          Bun.write(tmp, body)
+          Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
+          copied = true
+        } catch {
+          // fallback failed — toast shows error
+        } finally {
+          try {
+            Bun.spawnSync(["rm", "-f", tmp])
+          } catch {
+            // cleanup is best-effort; ignore failures
+          }
+        }
+        showToast(
+          copied ? "Response body copied" : "Failed to copy response body",
+          copied ? "success" : "error",
+        )
+      },
+    },
+    {
+      id: "layout.toggle",
+      label: "Toggle Layout",
+      section: "View",
+      keybinding: displayKey(keybinds.layout_toggle),
+      run: () =>
+        setLayout((prev: "stacked" | "side-by-side") => {
+          const next = prev === "stacked" ? "side-by-side" : "stacked"
+          onLayoutChange(next)
+          return next
+        }),
+    },
+    {
+      id: "pane.expand",
+      label: "Expand/Collapse Pane",
+      section: "View",
+      keybinding: displayKey(keybinds.pane_expand),
+      run: () => {
+        const f = getKeymapFocus() as "request" | "response"
+        if (f !== "request" && f !== "response") return
+        setExpanded((prev: "request" | "response" | null) =>
+          prev === f ? null : f,
+        )
+      },
+    },
+    {
+      id: "app.help",
+      label: "Toggle Help",
+      section: "View",
+      keybinding: displayKey(keybinds.help_toggle),
+      run: () => setHelpVisible((prev: boolean) => !prev),
+    },
+    {
+      id: "request.new",
+      label: "New Request",
+      section: "Create",
+      keybinding: displayKey(keybinds.request_new),
+      run: () => setNewRequestVisible(true),
+    },
+    {
+      id: "folder.new",
+      label: "New Folder",
+      section: "Create",
+      keybinding: displayKey(keybinds.folder_new),
+      run: () => setNewFolderVisible(true),
+    },
+    {
+      id: "request.clone",
+      label: "Clone Request",
+      section: "Create",
+      keybinding: displayKey(keybinds.request_clone),
+      run: () => {
+        const sid = selectedIdRef.current
+        if (!sid) return
+        const col = collectionRef.current
+        if (!col) return
+        const req = findRequestById(col.items, sid)
+        if (!req) return
+        setCloneRequestVisible(true)
+      },
+    },
+    {
+      id: "request.edit-overlay",
+      label: "Edit Request Metadata",
+      section: "Edit",
+      keybinding: displayKey(keybinds.request_edit_overlay),
+      run: () => {
+        if (focusedFolderPathRef.current) return
+        const sid = selectedIdRef.current
+        if (!sid) return
+        setEditRequestVisible(true)
+      },
+    },
+    {
+      id: "request.edit-yaml",
+      label: "Edit Request YAML",
+      section: "Edit",
+      keybinding: displayKey(keybinds.request_edit_yaml),
+      run: () => {
+        if (focusedFolderPathRef.current) return
+        const sid = selectedIdRef.current
+        if (!sid || !collectionDir) return
+        const col = collectionRef.current
+        if (!col) return
+        const r = findRequestById(col.items, sid)
+        if (!r) return
+        const filePath = join(collectionDir, `${sid}.yml`)
+        setYamlEditor({
+          visible: true,
+          filePath,
+          requestName: r.name,
+          returnFocus: focusRef.current,
+        })
+      },
+    },
+    {
+      id: "request.delete",
+      label: "Delete Request",
+      section: "Delete",
+      keybinding: displayKey(keybinds.request_delete),
+      run: () => {
+        const folderPath = focusedFolderPathRef.current
+        const folderName = focusedFolderNameRef.current
+        if (folderPath && folderName) {
+          folderDeletePathRef.current = folderPath
+          setFolderDeletePending(folderName)
+          return
+        }
+        const sid = selectedIdRef.current
+        if (!sid) return
+        const col = collectionRef.current
+        if (!col) return
+        const req = findRequestById(col.items, sid)
+        if (!req) return
+        setRequestDeletePending(req.name)
+      },
+    },
+    {
+      id: "env.editor-open",
+      label: "Open Environment Editor",
+      section: "Workspace",
+      keybinding: displayKey(keybinds.env_editor),
+      run: () => {
+        const name = envStateRef.current.activeEnv?.name
+        envEditorRef.current.openEditor(name)
+        setView("env-editor")
+        setFocus("env-sidebar")
+      },
+    },
+    {
+      id: "app.theme",
+      label: "Open Theme Picker",
+      section: "Workspace",
+      keybinding: displayKey(keybinds.theme_picker),
+      run: () => setPreviewIndexProp(activeIndexRef.current),
+    },
+    {
+      id: "global.undo-all",
+      label: "Undo All Unsaved Changes",
+      section: "System",
+      keybinding: displayKey(keybinds.global_undo_all),
+      run: () => {
+        const d = draftRef.current
+        const fd = folderDraftRef.current
+        const ee = envEditorRef.current
+        const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
+        if (!hasDirty) return
+        if (confirmUndoAll) {
+          setUndoAllPending(true)
+        } else {
+          d.revertAllRequests()
+          fd.revertAllFolders()
+          ee?.revertDraft()
+        }
+      },
+    },
+  ]
+}

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -253,7 +253,7 @@ export function buildCommandPaletteCommands(
     },
     {
       id: "request.edit-overlay",
-      label: "Edit Request Metadata",
+      label: "Edit Request",
       section: "Edit",
       keybinding: displayKey(keybinds.request_edit_overlay),
       run: () => {

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path"
+import { tmpdir } from "node:os"
 import type { RefObject } from "react"
 import type { CliRenderer } from "@opentui/core"
 import type { CommandItem } from "./CommandPaletteOverlay"
@@ -263,7 +264,7 @@ export function buildCommandPaletteCommands(
         const s = responseStateRef.current
         if (s?.status !== "done") return
         const body = s.response.body
-        const tmp = `/tmp/noodle-copy-${Date.now()}`
+        const tmp = join(tmpdir(), `noodle-copy-${Date.now()}`)
         try {
           Bun.write(tmp, body)
           Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -193,7 +193,7 @@ export function buildCommandPaletteCommands(
     {
       id: "layout.toggle",
       label: "Toggle Layout",
-      section: "View",
+      section: "Actions",
       keybinding: displayKey(keybinds.layout_toggle),
       run: () =>
         setLayout((prev: "stacked" | "side-by-side") => {
@@ -205,7 +205,7 @@ export function buildCommandPaletteCommands(
     {
       id: "pane.expand",
       label: "Expand/Collapse Pane",
-      section: "View",
+      section: "Actions",
       keybinding: displayKey(keybinds.pane_expand),
       run: () => {
         const f = getKeymapFocus() as "request" | "response"
@@ -218,28 +218,28 @@ export function buildCommandPaletteCommands(
     {
       id: "app.help",
       label: "Toggle Help",
-      section: "View",
+      section: "System",
       keybinding: displayKey(keybinds.help_toggle),
       run: () => setHelpVisible((prev: boolean) => !prev),
     },
     {
       id: "request.new",
       label: "New Request",
-      section: "Create",
+      section: "Actions",
       keybinding: displayKey(keybinds.request_new),
       run: () => setNewRequestVisible(true),
     },
     {
       id: "folder.new",
       label: "New Folder",
-      section: "Create",
+      section: "Actions",
       keybinding: displayKey(keybinds.folder_new),
       run: () => setNewFolderVisible(true),
     },
     {
       id: "request.clone",
       label: "Clone Request",
-      section: "Create",
+      section: "Actions",
       keybinding: displayKey(keybinds.request_clone),
       run: () => {
         const sid = selectedIdRef.current
@@ -254,7 +254,7 @@ export function buildCommandPaletteCommands(
     {
       id: "request.edit-overlay",
       label: "Edit Request",
-      section: "Edit",
+      section: "Request Editing",
       keybinding: displayKey(keybinds.request_edit_overlay),
       run: () => {
         if (focusedFolderPathRef.current) return
@@ -266,7 +266,7 @@ export function buildCommandPaletteCommands(
     {
       id: "request.edit-yaml",
       label: "Edit Request YAML",
-      section: "Edit",
+      section: "Request Editing",
       keybinding: displayKey(keybinds.request_edit_yaml),
       run: () => {
         if (focusedFolderPathRef.current) return
@@ -288,7 +288,7 @@ export function buildCommandPaletteCommands(
     {
       id: "request.delete",
       label: "Delete Request",
-      section: "Delete",
+      section: "Actions",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
         const folderPath = focusedFolderPathRef.current
@@ -310,7 +310,7 @@ export function buildCommandPaletteCommands(
     {
       id: "env.editor-open",
       label: "Open Environment Editor",
-      section: "Workspace",
+      section: "Env Editor",
       keybinding: displayKey(keybinds.env_editor),
       run: () => {
         const name = envStateRef.current.activeEnv?.name
@@ -322,7 +322,7 @@ export function buildCommandPaletteCommands(
     {
       id: "app.theme",
       label: "Open Theme Picker",
-      section: "Workspace",
+      section: "System",
       keybinding: displayKey(keybinds.theme_picker),
       run: () => setPreviewIndexProp(activeIndexRef.current),
     },

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -264,7 +264,9 @@ export function buildCommandPaletteCommands(
         if (s?.status !== "done") return
         const body = s.response.body
         try {
-          const result = Bun.spawnSync(["pbcopy"], { stdin: new TextEncoder().encode(body) })
+          const result = Bun.spawnSync(["pbcopy"], {
+            stdin: new TextEncoder().encode(body),
+          })
           if (result.exitCode !== 0) throw new Error("pbcopy failed")
         } catch {
           renderer.copyToClipboardOSC52(body)

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path"
 import type { RefObject } from "react"
+import type { CliRenderer } from "@opentui/core"
 import type { CommandItem } from "./CommandPaletteOverlay"
 import type { Keybinds } from "./keybind"
 import { displayKey } from "./keybind"
@@ -17,6 +18,7 @@ export interface CommandBuilderContext {
   keybinds: Keybinds
   collectionDir: string
   confirmUndoAll: boolean
+  renderer: CliRenderer
   trySendRef: RefObject<(() => void) | undefined>
   draftRef: RefObject<UseRequestDraftResult>
   folderDraftRef: RefObject<UseFolderDraftResult>
@@ -100,6 +102,7 @@ export function buildCommandPaletteCommands(
     keybinds,
     collectionDir,
     confirmUndoAll,
+    renderer,
     trySendRef,
     draftRef,
     folderDraftRef,
@@ -134,6 +137,46 @@ export function buildCommandPaletteCommands(
   } = ctx
 
   return [
+    // ── Request Editing ──────────────────────────────────────────────
+    {
+      id: "request.edit-overlay",
+      label: "Edit Request",
+      section: "Request Editing",
+      keybinding: displayKey(keybinds.request_edit_overlay),
+      run: () => {
+        if (focusedFolderPathRef.current) return
+        const sid = selectedIdRef.current
+        if (!sid) return
+        const col = collectionRef.current
+        if (!col) return
+        const req = findRequestById(col.items, sid)
+        if (!req) return
+        setEditRequestVisible(true)
+      },
+    },
+    {
+      id: "request.edit-yaml",
+      label: "Edit Request YAML",
+      section: "Request Editing",
+      keybinding: displayKey(keybinds.request_edit_yaml),
+      run: () => {
+        if (focusedFolderPathRef.current) return
+        const sid = selectedIdRef.current
+        if (!sid || !collectionDir) return
+        const col = collectionRef.current
+        if (!col) return
+        const r = findRequestById(col.items, sid)
+        if (!r) return
+        const filePath = join(collectionDir, `${sid}.yml`)
+        setYamlEditor({
+          visible: true,
+          filePath,
+          requestName: r.name,
+          returnFocus: focusRef.current,
+        })
+      },
+    },
+    // ── Actions ──────────────────────────────────────────────────────
     {
       id: "request.send",
       label: "Send Request",
@@ -152,75 +195,6 @@ export function buildCommandPaletteCommands(
           doSaveRef.current()
         }
       },
-    },
-    {
-      id: "env.cycle",
-      label: "Cycle Environment",
-      section: "Actions",
-      keybinding: displayKey(keybinds.env_cycle),
-      run: () => envStateRef.current.cycle(1),
-    },
-    {
-      id: "response.copy-body",
-      label: "Copy Response Body",
-      section: "Actions",
-      keybinding: displayKey(keybinds.response_copy_body),
-      run: () => {
-        const s = responseStateRef.current
-        if (s?.status !== "done") return
-        const body = s.response.body
-        let copied = false
-        const tmp = `/tmp/noodle-copy-${Date.now()}`
-        try {
-          Bun.write(tmp, body)
-          Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
-          copied = true
-        } catch {
-          // fallback failed — toast shows error
-        } finally {
-          try {
-            Bun.spawnSync(["rm", "-f", tmp])
-          } catch {
-            // cleanup is best-effort; ignore failures
-          }
-        }
-        showToast(
-          copied ? "Response body copied" : "Failed to copy response body",
-          copied ? "success" : "error",
-        )
-      },
-    },
-    {
-      id: "layout.toggle",
-      label: "Toggle Layout",
-      section: "Actions",
-      keybinding: displayKey(keybinds.layout_toggle),
-      run: () =>
-        setLayout((prev: "stacked" | "side-by-side") => {
-          const next = prev === "stacked" ? "side-by-side" : "stacked"
-          onLayoutChange(next)
-          return next
-        }),
-    },
-    {
-      id: "pane.expand",
-      label: "Expand/Collapse Pane",
-      section: "Actions",
-      keybinding: displayKey(keybinds.pane_expand),
-      run: () => {
-        const f = getKeymapFocus() as "request" | "response"
-        if (f !== "request" && f !== "response") return
-        setExpanded((prev: "request" | "response" | null) =>
-          prev === f ? null : f,
-        )
-      },
-    },
-    {
-      id: "app.help",
-      label: "Toggle Help",
-      section: "System",
-      keybinding: displayKey(keybinds.help_toggle),
-      run: () => setHelpVisible((prev: boolean) => !prev),
     },
     {
       id: "request.new",
@@ -252,40 +226,6 @@ export function buildCommandPaletteCommands(
       },
     },
     {
-      id: "request.edit-overlay",
-      label: "Edit Request",
-      section: "Request Editing",
-      keybinding: displayKey(keybinds.request_edit_overlay),
-      run: () => {
-        if (focusedFolderPathRef.current) return
-        const sid = selectedIdRef.current
-        if (!sid) return
-        setEditRequestVisible(true)
-      },
-    },
-    {
-      id: "request.edit-yaml",
-      label: "Edit Request YAML",
-      section: "Request Editing",
-      keybinding: displayKey(keybinds.request_edit_yaml),
-      run: () => {
-        if (focusedFolderPathRef.current) return
-        const sid = selectedIdRef.current
-        if (!sid || !collectionDir) return
-        const col = collectionRef.current
-        if (!col) return
-        const r = findRequestById(col.items, sid)
-        if (!r) return
-        const filePath = join(collectionDir, `${sid}.yml`)
-        setYamlEditor({
-          visible: true,
-          filePath,
-          requestName: r.name,
-          returnFocus: focusRef.current,
-        })
-      },
-    },
-    {
       id: "request.delete",
       label: "Delete Request",
       section: "Actions",
@@ -308,16 +248,69 @@ export function buildCommandPaletteCommands(
       },
     },
     {
-      id: "env.editor-open",
-      label: "Open Environment Editor",
-      section: "Env Editor",
-      keybinding: displayKey(keybinds.env_editor),
+      id: "env.cycle",
+      label: "Cycle Environment",
+      section: "Actions",
+      keybinding: displayKey(keybinds.env_cycle),
+      run: () => envStateRef.current.cycle(1),
+    },
+    {
+      id: "response.copy-body",
+      label: "Copy Response Body",
+      section: "Actions",
+      keybinding: displayKey(keybinds.response_copy_body),
       run: () => {
-        const name = envStateRef.current.activeEnv?.name
-        envEditorRef.current.openEditor(name)
-        setView("env-editor")
-        setFocus("env-sidebar")
+        const s = responseStateRef.current
+        if (s?.status !== "done") return
+        const body = s.response.body
+        const tmp = `/tmp/noodle-copy-${Date.now()}`
+        try {
+          Bun.write(tmp, body)
+          Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
+        } catch {
+          renderer.copyToClipboardOSC52(body)
+        } finally {
+          try {
+            Bun.spawnSync(["rm", "-f", tmp])
+          } catch {
+            // cleanup is best-effort
+          }
+        }
+        showToast("Response body copied", "success")
       },
+    },
+    {
+      id: "layout.toggle",
+      label: "Toggle Layout",
+      section: "Actions",
+      keybinding: displayKey(keybinds.layout_toggle),
+      run: () =>
+        setLayout((prev: "stacked" | "side-by-side") => {
+          const next = prev === "stacked" ? "side-by-side" : "stacked"
+          onLayoutChange(next)
+          return next
+        }),
+    },
+    {
+      id: "pane.expand",
+      label: "Expand/Collapse Pane",
+      section: "Actions",
+      keybinding: displayKey(keybinds.pane_expand),
+      run: () => {
+        const f = getKeymapFocus() as "request" | "response"
+        if (f !== "request" && f !== "response") return
+        setExpanded((prev: "request" | "response" | null) =>
+          prev === f ? null : f,
+        )
+      },
+    },
+    // ── System ───────────────────────────────────────────────────────
+    {
+      id: "app.help",
+      label: "Toggle Help",
+      section: "System",
+      keybinding: displayKey(keybinds.help_toggle),
+      run: () => setHelpVisible((prev: boolean) => !prev),
     },
     {
       id: "app.theme",
@@ -344,6 +337,19 @@ export function buildCommandPaletteCommands(
           fd.revertAllFolders()
           ee?.revertDraft()
         }
+      },
+    },
+    // ── Env Editor ───────────────────────────────────────────────────
+    {
+      id: "env.editor-open",
+      label: "Open Environment Editor",
+      section: "Env Editor",
+      keybinding: displayKey(keybinds.env_editor),
+      run: () => {
+        const name = envStateRef.current.activeEnv?.name
+        envEditorRef.current.openEditor(name)
+        setView("env-editor")
+        setFocus("env-sidebar")
       },
     },
   ]

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -99,6 +99,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
       title: "System",
       keys: [
         { key: "^c", description: "Quit" },
+        {
+          key: displayKey(keybinds.command_palette),
+          description: "Open command palette",
+        },
         { key: keybinds.help_toggle, description: "Toggle help" },
         {
           key: displayKey(keybinds.theme_picker),

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -17,7 +17,7 @@ function keybind(
 export const Definitions = {
   request_send: keybind("ctrl+return", "Send request"),
   request_save: keybind("ctrl+s", "Save request to disk"),
-  env_cycle: keybind("ctrl+alt+p", "Cycle environment"),
+  env_cycle: keybind("ctrl+u", "Cycle environment"),
   command_palette: keybind("ctrl+p", "Open command palette"),
   request_new: keybind("ctrl+n", "New request"),
   folder_new: keybind("ctrl+alt+n", "New folder"),

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -17,7 +17,8 @@ function keybind(
 export const Definitions = {
   request_send: keybind("ctrl+return", "Send request"),
   request_save: keybind("ctrl+s", "Save request to disk"),
-  env_cycle: keybind("ctrl+p", "Cycle environment"),
+  env_cycle: keybind("ctrl+alt+p", "Cycle environment"),
+  command_palette: keybind("ctrl+p", "Open command palette"),
   request_new: keybind("ctrl+n", "New request"),
   folder_new: keybind("ctrl+alt+n", "New folder"),
   request_clone: keybind("ctrl+k", "Clone request"),
@@ -63,6 +64,7 @@ export const CommandMap = {
   response_copy_body: "response.copy-body",
   request_edit: "request.edit-enter",
   env_cycle: "env.cycle",
+  command_palette: "app.command-palette",
   env_editor: "env.editor-open",
   help_toggle: "app.help",
   theme_picker: "app.theme",

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -1,5 +1,6 @@
 import { useBindings, useKeymap } from "@opentui/keymap/react"
 import { join } from "node:path"
+import { tmpdir } from "node:os"
 import type { RefObject } from "react"
 import { cycleFocus, toggleExpand, type Focus } from "./focus"
 import type { Keybinds } from "./keybind"
@@ -222,7 +223,7 @@ export function useAppKeymap(
           const s = refs.responseStateRef.current
           if (s?.status !== "done") return
           const body = s.response.body
-          const tmp = `/tmp/noodle-copy-${Date.now()}`
+          const tmp = join(tmpdir(), `noodle-copy-${Date.now()}`)
           try {
             Bun.write(tmp, body)
             Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -223,7 +223,9 @@ export function useAppKeymap(
           if (s?.status !== "done") return
           const body = s.response.body
           try {
-            const result = Bun.spawnSync(["pbcopy"], { stdin: new TextEncoder().encode(body) })
+            const result = Bun.spawnSync(["pbcopy"], {
+              stdin: new TextEncoder().encode(body),
+            })
             if (result.exitCode !== 0) throw new Error("pbcopy failed")
           } catch {
             renderer.copyToClipboardOSC52(body)

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -99,6 +99,7 @@ export interface UseAppKeymapSetters {
   ) => void
   onLayoutChange: (layout: "stacked" | "side-by-side") => void
   setNewFolderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setCommandPaletteVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setFolderDeletePending: (
     s: string | null | ((prev: string | null) => string | null),
   ) => void
@@ -242,6 +243,10 @@ export function useAppKeymap(
         run: () => setters.setPreviewIndex(refs.activeIndexRef.current),
       },
       {
+        name: "app.command-palette",
+        run: () => setters.setCommandPaletteVisible((prev: boolean) => !prev),
+      },
+      {
         name: "global.undo-all",
         enabled: () => {
           const mode = keymap.getData("app.mode") as string
@@ -274,6 +279,7 @@ export function useAppKeymap(
       { key: keybinds.pane_expand, cmd: "request.expand-toggle" },
       { key: keybinds.response_copy_body, cmd: "response.copy-body" },
       { key: keybinds.theme_picker, cmd: "app.theme" },
+      { key: keybinds.command_palette, cmd: "app.command-palette" },
       { key: keybinds.global_undo_all, cmd: "global.undo-all" },
     ],
   }))

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -1,6 +1,5 @@
 import { useBindings, useKeymap } from "@opentui/keymap/react"
 import { join } from "node:path"
-import { tmpdir } from "node:os"
 import type { RefObject } from "react"
 import { cycleFocus, toggleExpand, type Focus } from "./focus"
 import type { Keybinds } from "./keybind"
@@ -223,18 +222,12 @@ export function useAppKeymap(
           const s = refs.responseStateRef.current
           if (s?.status !== "done") return
           const body = s.response.body
-          const tmp = join(tmpdir(), `noodle-copy-${Date.now()}`)
           try {
-            Bun.write(tmp, body)
-            Bun.spawnSync(["bash", "-c", `pbcopy < "${tmp}"`])
+            const result = Bun.spawnSync(["pbcopy"], { stdin: new TextEncoder().encode(body) })
+            if (result.exitCode !== 0) throw new Error("pbcopy failed")
           } catch {
             renderer.copyToClipboardOSC52(body)
-          } finally {
-            try {
-              Bun.spawnSync(["rm", "-f", tmp])
-            } catch {
-              // cleanup is best-effort; ignore failures
-            }
+            return
           }
           showToast("Response body copied", "success")
         },

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -300,7 +300,7 @@ export function useAppKeymap(
           const name = refs.envStateRef.current.activeEnv?.name
           refs.envEditorRef.current.openEditor(name)
           setters.setView("env-editor")
-          setters.setFocus("env-sidebar")
+          setters.setFocus("env-header")
         },
       },
       {

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -553,13 +553,14 @@ export function useOverlayIntercepts(opts: {
 
   // ── Env Editor Mode ───────────────────────────────────────────────
   useEffect(() => {
-    if (view !== "env-editor" || keymap.getData("app.overlay") !== "none")
-      return
+    if (view !== "env-editor") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
         const e = ctx.event
         const ee = envEditorRef.current
+
+        if (keymap.getData("app.overlay") !== "none") return
 
         const f = focusRef.current
 

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -1057,3 +1057,53 @@ describe("env-editor layer", () => {
     cleanup()
   })
 })
+
+describe("command palette", () => {
+  it("dispatches app.command-palette when ctrl+p pressed", () => {
+    const { keymap, host, cleanup } = setup()
+    keymap.setData("app.view", "main")
+    keymap.setData("app.overlay", "none")
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () => true,
+      commands: [
+        {
+          name: "app.command-palette",
+          run: () => {
+            called = true
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+p", cmd: "app.command-palette" }],
+    })
+
+    host.press("p", { ctrl: true })
+    expect(called).toBe(true)
+    cleanup()
+  })
+
+  it("dispatches app.command-palette even when overlay is active", () => {
+    const { keymap, host, cleanup } = setup()
+    keymap.setData("app.view", "main")
+    keymap.setData("app.overlay", "help")
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () => true,
+      commands: [
+        {
+          name: "app.command-palette",
+          run: () => {
+            called = true
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+p", cmd: "app.command-palette" }],
+    })
+
+    host.press("p", { ctrl: true })
+    expect(called).toBe(true)
+    cleanup()
+  })
+})

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -976,7 +976,7 @@ describe("env-editor layer", () => {
     cleanup()
   })
 
-  it("dispatches env.cycle when ctrl+p pressed in base mode", () => {
+  it("dispatches env.cycle when ctrl+alt+p pressed in base mode", () => {
     const { keymap, host, cleanup } = setup()
     keymap.setData("app.view", "main")
     keymap.setData("app.overlay", "none")
@@ -995,10 +995,10 @@ describe("env-editor layer", () => {
           },
         },
       ],
-      bindings: [{ key: "ctrl+p", cmd: "env.cycle" }],
+      bindings: [{ key: "ctrl+alt+p", cmd: "env.cycle" }],
     })
 
-    host.press("p", { ctrl: true })
+    host.press("p", { ctrl: true, meta: true })
     expect(called).toBe(true)
     cleanup()
   })
@@ -1049,10 +1049,10 @@ describe("env-editor layer", () => {
           },
         },
       ],
-      bindings: [{ key: "ctrl+p", cmd: "env.cycle" }],
+      bindings: [{ key: "ctrl+alt+p", cmd: "env.cycle" }],
     })
 
-    host.press("p", { ctrl: true })
+    host.press("p", { ctrl: true, meta: true })
     expect(called).toBe(false)
     cleanup()
   })

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -976,7 +976,7 @@ describe("env-editor layer", () => {
     cleanup()
   })
 
-  it("dispatches env.cycle when ctrl+alt+p pressed in base mode", () => {
+  it("dispatches env.cycle when ctrl+u pressed in base mode", () => {
     const { keymap, host, cleanup } = setup()
     keymap.setData("app.view", "main")
     keymap.setData("app.overlay", "none")
@@ -995,10 +995,10 @@ describe("env-editor layer", () => {
           },
         },
       ],
-      bindings: [{ key: "ctrl+alt+p", cmd: "env.cycle" }],
+      bindings: [{ key: "ctrl+u", cmd: "env.cycle" }],
     })
 
-    host.press("p", { ctrl: true, meta: true })
+    host.press("u", { ctrl: true })
     expect(called).toBe(true)
     cleanup()
   })
@@ -1049,10 +1049,10 @@ describe("env-editor layer", () => {
           },
         },
       ],
-      bindings: [{ key: "ctrl+alt+p", cmd: "env.cycle" }],
+      bindings: [{ key: "ctrl+u", cmd: "env.cycle" }],
     })
 
-    host.press("p", { ctrl: true, meta: true })
+    host.press("u", { ctrl: true })
     expect(called).toBe(false)
     cleanup()
   })

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -169,7 +169,7 @@ describe("CommandPaletteOverlay", () => {
       { id: "b", label: "Beta", section: "Sec", run: () => {} },
       { id: "c", label: "Gamma", section: "Sec", run: () => {} },
     ]
-    const { renderOnce, captureCharFrame } = await testRender(
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <CommandPaletteOverlay visible commands={commands} onClose={noop} />
@@ -178,10 +178,21 @@ describe("CommandPaletteOverlay", () => {
       { width: 80, height: 20 },
     )
     await renderOnce()
-    const frame = captureCharFrame()
+    let frame = captureCharFrame()
     expect(frame).toContain("Alpha")
     expect(frame).toContain("Beta")
     expect(frame).toContain("Gamma")
+
+    // Type "al" to filter — use waitForFrame since typeText is async
+    await act(async () => {
+      await mockInput.typeText("al")
+    })
+    await renderOnce()
+    await renderOnce()
+    frame = captureCharFrame()
+    expect(frame).toContain("Alpha")
+    expect(frame).not.toContain("Beta")
+    expect(frame).not.toContain("Gamma")
     cleanup()
   })
 

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -268,7 +268,9 @@ describe("CommandPaletteOverlay", () => {
                 id: "b",
                 label: "Beta",
                 section: "Sec",
-                run: () => { ran = "beta" },
+                run: () => {
+                  ran = "beta"
+                },
               },
             ]}
             onClose={noop}

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import {
+  registerEnabledFields,
+  registerDefaultKeys,
+} from "@opentui/keymap/addons"
+import { KeymapProvider } from "@opentui/keymap/react"
+import type { KeymapProviderProps } from "@opentui/keymap/react"
+import { ThemeProvider } from "../../src/ui/theme"
+import {
+  CommandPaletteOverlay,
+  type CommandItem,
+} from "../../src/ui/CommandPaletteOverlay"
+
+function setupKeymap() {
+  const { keymap, host, cleanup: hostCleanup } = createTestKeymap()
+  const disposeEnabled = registerEnabledFields(keymap)
+  const disposeKeys = registerDefaultKeys(keymap)
+  keymap.setData("app.mode", "base")
+  keymap.setData("app.focus", "sidebar")
+  keymap.setData("app.overlay", "none")
+  return {
+    keymap: keymap as unknown as KeymapProviderProps["keymap"],
+    host,
+    cleanup: () => {
+      disposeEnabled()
+      disposeKeys()
+      hostCleanup()
+    },
+  }
+}
+
+const testCommands: CommandItem[] = [
+  { id: "a.send", label: "Send Request", section: "Actions", run: () => {} },
+  { id: "b.save", label: "Save Request", section: "Actions", run: () => {} },
+  {
+    id: "c.new",
+    label: "New Request",
+    section: "Create",
+    keybinding: "^N",
+    run: () => {},
+  },
+  {
+    id: "d.layout",
+    label: "Toggle Layout",
+    section: "View",
+    keybinding: "^L",
+    run: () => {},
+  },
+]
+
+function noop() {}
+
+describe("CommandPaletteOverlay", () => {
+  it("renders title and placeholder", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={testCommands}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Commands")
+    expect(frame).toContain("Type a command...")
+    cleanup()
+  })
+
+  it("renders all command labels", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={testCommands}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Send Request")
+    expect(frame).toContain("Save Request")
+    expect(frame).toContain("New Request")
+    expect(frame).toContain("Toggle Layout")
+    cleanup()
+  })
+
+  it("renders section labels", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={testCommands}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Actions")
+    expect(frame).toContain("Create")
+    expect(frame).toContain("View")
+    cleanup()
+  })
+
+  it("renders keybinding hints when provided", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={testCommands}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("^N")
+    expect(frame).toContain("^L")
+    cleanup()
+  })
+
+  it("returns null when not visible", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible={false}
+            commands={testCommands}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).not.toContain("Commands")
+    expect(frame).not.toContain("Send Request")
+    cleanup()
+  })
+
+  it("filters commands by label via search input", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const commands: CommandItem[] = [
+      { id: "a", label: "Alpha", section: "Sec", run: () => {} },
+      { id: "b", label: "Beta", section: "Sec", run: () => {} },
+      { id: "c", label: "Gamma", section: "Sec", run: () => {} },
+    ]
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay visible commands={commands} onClose={noop} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Alpha")
+    expect(frame).toContain("Beta")
+    expect(frame).toContain("Gamma")
+    cleanup()
+  })
+
+  it("calls onSelect then onClose when enter is pressed", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let selected: string | null = null
+    let closed = false
+
+    const commands: CommandItem[] = [
+      {
+        id: "a",
+        label: "Alpha",
+        section: "Sec",
+        run: () => {
+          selected = "ran-a"
+        },
+      },
+      {
+        id: "b",
+        label: "Beta",
+        section: "Sec",
+        run: () => {
+          selected = "ran-b"
+        },
+      },
+    ]
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={commands}
+            onClose={() => {
+              closed = true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    host.press("return")
+    expect(selected!).toBe("ran-a")
+    expect(closed).toBe(true)
+    cleanup()
+  })
+
+  it("calls onClose when escape is pressed", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let closed = false
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={testCommands}
+            onClose={() => {
+              closed = true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    host.press("escape")
+    expect(closed).toBe(true)
+    cleanup()
+  })
+
+  it("down arrow navigates to next item", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let ran: string | null = null
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={[
+              { id: "a", label: "Alpha", section: "Sec", run: () => {} },
+              {
+                id: "b",
+                label: "Beta",
+                section: "Sec",
+                run: () => { ran = "beta" },
+              },
+            ]}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    host.press("down")
+    host.press("return")
+    expect(ran!).toBe("beta")
+    cleanup()
+  })
+})

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test"
+import { act } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -223,7 +224,7 @@ describe("CommandPaletteOverlay", () => {
       { width: 80, height: 20 },
     )
     await renderOnce()
-    host.press("return")
+    await act(async () => host.press("return"))
     expect(selected!).toBe("ran-a")
     expect(closed).toBe(true)
     cleanup()
@@ -248,7 +249,7 @@ describe("CommandPaletteOverlay", () => {
       { width: 80, height: 20 },
     )
     await renderOnce()
-    host.press("escape")
+    await act(async () => host.press("escape"))
     expect(closed).toBe(true)
     cleanup()
   })
@@ -280,9 +281,113 @@ describe("CommandPaletteOverlay", () => {
       { width: 80, height: 20 },
     )
     await renderOnce()
-    host.press("down")
-    host.press("return")
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
     expect(ran!).toBe("beta")
+    cleanup()
+  })
+
+  it("navigates to second item then first on return works", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let ran: string | null = null
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={[
+              { id: "a", label: "Alpha", section: "Sec", run: () => {} },
+              {
+                id: "b",
+                label: "Beta",
+                section: "Sec",
+                run: () => {
+                  ran = "beta"
+                },
+              },
+              { id: "c", label: "Gamma", section: "Sec", run: () => {} },
+            ]}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    expect(ran!).toBe("beta")
+    cleanup()
+  })
+
+  it("down twice then return selects third item", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let ran: string | null = null
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={[
+              { id: "a", label: "Alpha", section: "Sec", run: () => {} },
+              { id: "b", label: "Beta", section: "Sec", run: () => {} },
+              {
+                id: "c",
+                label: "Gamma",
+                section: "Sec",
+                run: () => {
+                  ran = "gamma"
+                },
+              },
+            ]}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => host.press("down"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    expect(ran!).toBe("gamma")
+    cleanup()
+  })
+
+  it("navigates across section headers to second section", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let ran: string | null = null
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={[
+              { id: "a", label: "Alpha", section: "SecA", run: () => {} },
+              { id: "b", label: "Beta", section: "SecB", run: () => {} },
+              {
+                id: "c",
+                label: "Gamma",
+                section: "SecB",
+                run: () => {
+                  ran = "gamma"
+                },
+              },
+            ]}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => host.press("down"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    expect(ran!).toBe("gamma")
     cleanup()
   })
 })

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -97,23 +97,64 @@ describe("buildCommandPaletteCommands", () => {
     expect(send.keybinding).toBe("^r")
   })
 
-  it("request.save requires draft and isDirty", () => {
+  it("request.save calls doSave when draft is dirty and not saving", () => {
     const ctx = minimalContext()
+    let saved = false
     ctx.draftRef = {
-      current: { draft: null, isDirty: false, revertAllRequests: () => {} },
+      current: {
+        draft: { id: "test" },
+        isDirty: true,
+        revertAllRequests: () => {},
+        dirtyRequestIds: new Set(),
+      },
     } as never
     ctx.savingRef = { current: false } as never
-    ctx.doSaveRef = { current: () => {} } as never
+    ctx.doSaveRef = { current: () => { saved = true } } as never
     const commands = buildCommandPaletteCommands(ctx)
     const save = commands.find((c) => c.id === "request.save")!
-    expect(save.run).toBeDefined()
+    save.run()
+    expect(saved).toBe(true)
   })
 
-  it("pane.expand ignores non-request/response focus", () => {
+  it("request.save does not call doSave when draft is not dirty", () => {
     const ctx = minimalContext()
-    ctx.getKeymapFocus = () => "sidebar"
+    let saved = false
+    ctx.draftRef = {
+      current: {
+        draft: null,
+        isDirty: false,
+        revertAllRequests: () => {},
+      },
+    } as never
+    ctx.savingRef = { current: false } as never
+    ctx.doSaveRef = { current: () => { saved = true } } as never
+    const commands = buildCommandPaletteCommands(ctx)
+    const save = commands.find((c) => c.id === "request.save")!
+    save.run()
+    expect(saved).toBe(false)
+  })
+
+  it("pane.expand toggles expanded when focus is request", () => {
+    const ctx = minimalContext()
+    ctx.getKeymapFocus = () => "request"
+    let expanded: "request" | "response" | null = null
+    ctx.setExpanded = (fn: unknown) => {
+      expanded = (fn as (prev: "request" | "response" | null) => "request" | "response" | null)(null)
+    }
     const commands = buildCommandPaletteCommands(ctx)
     const expand = commands.find((c) => c.id === "pane.expand")!
-    expect(expand.run).toBeDefined()
+    expand.run()
+    expect(expanded!).toBe("request")
+  })
+
+  it("pane.expand does nothing when focus is sidebar", () => {
+    const ctx = minimalContext()
+    ctx.getKeymapFocus = () => "sidebar"
+    let called = false
+    ctx.setExpanded = () => { called = true }
+    const commands = buildCommandPaletteCommands(ctx)
+    const expand = commands.find((c) => c.id === "pane.expand")!
+    expand.run()
+    expect(called).toBe(false)
   })
 })

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "bun:test"
+import type { CliRenderer } from "@opentui/core"
+import { buildCommandPaletteCommands } from "../../src/ui/commands"
+import type { CommandBuilderContext } from "../../src/ui/commands"
+import { bindingDefaults } from "../../src/ui/keybind"
+
+function minimalContext(): CommandBuilderContext {
+  const keybinds = bindingDefaults()
+  return {
+    keybinds,
+    collectionDir: "/tmp/collections",
+    confirmUndoAll: false,
+    renderer: { copyToClipboardOSC52: () => {} } as unknown as CliRenderer,
+    trySendRef: { current: undefined } as never,
+    draftRef: { current: null } as never,
+    folderDraftRef: { current: null } as never,
+    envStateRef: { current: null } as never,
+    envEditorRef: { current: null } as never,
+    collectionRef: { current: null } as never,
+    selectedIdRef: { current: null } as never,
+    focusRef: { current: null } as never,
+    responseStateRef: { current: null } as never,
+    activeIndexRef: { current: 0 } as never,
+    savingRef: { current: false } as never,
+    doSaveRef: { current: () => {} } as never,
+    focusedFolderPathRef: { current: null } as never,
+    focusedFolderNameRef: { current: null } as never,
+    folderDeletePathRef: { current: null } as never,
+    getKeymapFocus: () => "sidebar",
+    setLayout: () => {},
+    onLayoutChange: () => {},
+    setHelpVisible: () => {},
+    setNewRequestVisible: () => {},
+    setNewFolderVisible: () => {},
+    setCloneRequestVisible: () => {},
+    setEditRequestVisible: () => {},
+    setRequestDeletePending: () => {},
+    setFolderDeletePending: () => {},
+    setYamlEditor: () => {},
+    setView: () => {},
+    setFocus: () => {},
+    setUndoAllPending: () => {},
+    setExpanded: () => {},
+    setPreviewIndexProp: () => {},
+  }
+}
+
+describe("buildCommandPaletteCommands", () => {
+  it("returns all commands with required fields", () => {
+    const commands = buildCommandPaletteCommands(minimalContext())
+    expect(commands.length).toBe(16)
+    for (const cmd of commands) {
+      expect(cmd.id).toBeTruthy()
+      expect(cmd.label).toBeTruthy()
+      expect(cmd.section).toBeTruthy()
+      expect(typeof cmd.run).toBe("function")
+    }
+  })
+
+  it("sections appear in correct order", () => {
+    const commands = buildCommandPaletteCommands(minimalContext())
+    const sections = [...new Set(commands.map((c) => c.section))]
+    expect(sections).toEqual([
+      "Request Editing",
+      "Actions",
+      "System",
+      "Env Editor",
+    ])
+  })
+
+  it("each section has contiguous commands", () => {
+    const commands = buildCommandPaletteCommands(minimalContext())
+    let lastSection = commands[0]!.section
+    for (let i = 1; i < commands.length; i++) {
+      if (commands[i]!.section !== lastSection) {
+        lastSection = commands[i]!.section
+      }
+    }
+    // Verify no section re-appears after switching
+    const seen = new Set<string>()
+    let prevSection = ""
+    for (const cmd of commands) {
+      if (cmd.section !== prevSection) {
+        expect(seen.has(cmd.section)).toBe(false)
+        seen.add(cmd.section)
+        prevSection = cmd.section
+      }
+    }
+  })
+
+  it("displays keybinding as ^ shortcut", () => {
+    const ctx = minimalContext()
+    const custom = { ...ctx.keybinds, request_send: "ctrl+r" }
+    ctx.keybinds = custom
+    const commands = buildCommandPaletteCommands(ctx)
+    const send = commands.find((c) => c.id === "request.send")!
+    expect(send.keybinding).toBe("^r")
+  })
+
+  it("request.save requires draft and isDirty", () => {
+    const ctx = minimalContext()
+    ctx.draftRef = {
+      current: { draft: null, isDirty: false, revertAllRequests: () => {} },
+    } as never
+    ctx.savingRef = { current: false } as never
+    ctx.doSaveRef = { current: () => {} } as never
+    const commands = buildCommandPaletteCommands(ctx)
+    const save = commands.find((c) => c.id === "request.save")!
+    expect(save.run).toBeDefined()
+  })
+
+  it("pane.expand ignores non-request/response focus", () => {
+    const ctx = minimalContext()
+    ctx.getKeymapFocus = () => "sidebar"
+    const commands = buildCommandPaletteCommands(ctx)
+    const expand = commands.find((c) => c.id === "pane.expand")!
+    expect(expand.run).toBeDefined()
+  })
+})

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -109,7 +109,11 @@ describe("buildCommandPaletteCommands", () => {
       },
     } as never
     ctx.savingRef = { current: false } as never
-    ctx.doSaveRef = { current: () => { saved = true } } as never
+    ctx.doSaveRef = {
+      current: () => {
+        saved = true
+      },
+    } as never
     const commands = buildCommandPaletteCommands(ctx)
     const save = commands.find((c) => c.id === "request.save")!
     save.run()
@@ -127,7 +131,11 @@ describe("buildCommandPaletteCommands", () => {
       },
     } as never
     ctx.savingRef = { current: false } as never
-    ctx.doSaveRef = { current: () => { saved = true } } as never
+    ctx.doSaveRef = {
+      current: () => {
+        saved = true
+      },
+    } as never
     const commands = buildCommandPaletteCommands(ctx)
     const save = commands.find((c) => c.id === "request.save")!
     save.run()
@@ -139,7 +147,11 @@ describe("buildCommandPaletteCommands", () => {
     ctx.getKeymapFocus = () => "request"
     let expanded: "request" | "response" | null = null
     ctx.setExpanded = (fn: unknown) => {
-      expanded = (fn as (prev: "request" | "response" | null) => "request" | "response" | null)(null)
+      expanded = (
+        fn as (
+          prev: "request" | "response" | null,
+        ) => "request" | "response" | null
+      )(null)
     }
     const commands = buildCommandPaletteCommands(ctx)
     const expand = commands.find((c) => c.id === "pane.expand")!
@@ -151,7 +163,9 @@ describe("buildCommandPaletteCommands", () => {
     const ctx = minimalContext()
     ctx.getKeymapFocus = () => "sidebar"
     let called = false
-    ctx.setExpanded = () => { called = true }
+    ctx.setExpanded = () => {
+      called = true
+    }
     const commands = buildCommandPaletteCommands(ctx)
     const expand = commands.find((c) => c.id === "pane.expand")!
     expand.run()

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -69,12 +69,13 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^l")
   })
 
-  it("SYSTEM section contains ^c and f1", () => {
+  it("SYSTEM section contains ^c, f1, and command palette binding", () => {
     const sections = getHelpSections(defaults)
     const sys = sections.find((s) => s.title === "System")!
     const keys = sys.keys.map((k) => k.key)
     expect(keys).toContain("^c")
     expect(keys).toContain("f1")
+    expect(keys).toContain("^p")
   })
 
   it("reflects custom keybinds", () => {

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -56,7 +56,7 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^t")
   })
 
-  it("ACTIONS section shows ^return, ^s, ^n, ^k, ^w, ^p, ^l", () => {
+  it("ACTIONS section shows ^return, ^s, ^n, ^k, ^w, ^alt+p, ^l", () => {
     const sections = getHelpSections(defaults)
     const act = sections.find((s) => s.title === "Actions")!
     const keys = act.keys.map((k) => k.key)
@@ -65,7 +65,7 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^n")
     expect(keys).toContain("^k")
     expect(keys).toContain("^w")
-    expect(keys).toContain("^p")
+    expect(keys).toContain("^alt+p")
     expect(keys).toContain("^l")
   })
 

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -56,7 +56,7 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^t")
   })
 
-  it("ACTIONS section shows ^return, ^s, ^n, ^k, ^w, ^alt+p, ^l", () => {
+  it("ACTIONS section shows ^return, ^s, ^n, ^k, ^w, ^shift+p, ^l", () => {
     const sections = getHelpSections(defaults)
     const act = sections.find((s) => s.title === "Actions")!
     const keys = act.keys.map((k) => k.key)
@@ -65,7 +65,7 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^n")
     expect(keys).toContain("^k")
     expect(keys).toContain("^w")
-    expect(keys).toContain("^alt+p")
+    expect(keys).toContain("^u")
     expect(keys).toContain("^l")
   })
 


### PR DESCRIPTION
## Summary
- New `CommandPaletteOverlay` component with section-grouped commands and filter-as-you-type search
- Query-aware navigation: smart spacers between adjacent matching sections, header skipping on arrow keys
- Extracted command definitions to `src/ui/commands.ts` for testability and reuse
- Added OSC52 clipboard fallback for terminal paste support
- Added `PickerOverlay` shared component (used by command palette and theme picker)
- Renamed "Edit Request Metadata" to "Edit Request" for clarity
- Changed `env_cycle` keybinding from `ctrl+alt+p` to `ctrl+u`
- Added `command_palette` keybinding (`ctrl+p`, always-on)

## Test Plan
- [x] 1281 tests pass (0 failures)
- [x] Manual: open command palette with `Ctrl+P`, type to filter, arrow-navigate across sections, press Enter to execute
- [x] Manual: verify section headers show/hide correctly when filtering
- [x] Manual: verify up-arrow wrap from first item works
- [x] Manual: verify envelope editor doesn't intercept escape meant for command palette