### PR TITLE
feat: command palette overhaul — P0 fixes, env commands, contextual views, shared actions

### DIFF
--- a/.agents/skills/noodle-dev/SKILL.md
+++ b/.agents/skills/noodle-dev/SKILL.md
@@ -26,11 +26,16 @@ Terminal REST client. OpenTUI (React binding) on Bun. YAML files on disk.
 - **YAML files:** `.yml` extension (not `.yaml`). Requests stored one-per-file in collection dir.
 - **Environments:** Dotenv-style `.env` files in `<collection>/.environments/`. `_color=<name>` sets sidebar badge.
 - **Draft pattern:** `useRequestDraft` holds `Map<id, Request>` of dirty edits. `DraftOp` discriminated union for mutations. Compare with `isDirty` via deep equality.
-- **Focus model:** `"sidebar" → "urlbar" → "request" → "response"` (main). `"env-sidebar" → "env-header" → "env-vars"` (env editor). Skips hidden panes.
+- **Focus model:** `"sidebar" → "urlbar" → "request" → "response"` (main). `"env-sidebar" → "env-header" → "env-vars" (env editor). Skips hidden panes.
 - **Keymap layers:** `useAppKeymap.ts` defines layered bindings gated on `focus`, `mode`, `overlay`, `view` state. `useBindings()` from `@opentui/keymap`.
 - **Edit/Browse FSM:** Three modes — `inactive → browsing → editing`. `useEditBrowse` hook manages cursor, commit, cancel.
 - **File I/O:** All writes use `validatePathId()` preventing traversal. Atomic writes via `.tmp` + `rename()`.
 - **Imports:** Module singletons (`filestore`, `lang`, `env`, `executor`). Types from `schema/index.ts`.
+- **Command actions:** Shared command logic lives in `commandActions.ts`. Both `useAppKeymap.ts` and `commands.ts` import from it. If you add a new action, add it to `commandActions.ts` and call from both places. Do not duplicate logic.
+- **CommandItem.run returns boolean:** Palette commands return `true` (close palette) or `false` (stay open). Unavailable commands (save when not dirty, copy body when no response) return `false`.
+- **Commands are contextual by view:** Build them in view-specific arrays (`requestCommands`, `mainEnvCommands`, `editorEnvCommands`, `workspaceCommands`, `systemCommands`, etc.) in `buildCommandPaletteCommands`. The function appends the right arrays based on `view === "main"` vs `view === "env-editor"`. Don't add guards inside `run()` — use the array structure.
+- **PickerOverlay isNavigable:** If items include non-selectable entries (like section headers), pass `isNavigable={(item) => item.type === "command"}`. PickerOverlay skips non-navigable items during up/down/return.
+- **getView reads React state, not keymap:** In `AppInner.tsx`, `getView: () => keymap.getData("app.view")` is stale during render. Use `getView: () => view` where `view` is the React state variable.
 
 ## Common pitfalls
 
@@ -40,3 +45,6 @@ Terminal REST client. OpenTUI (React binding) on Bun. YAML files on disk.
 - Adding keybindings without `fixed: true` for navigation keys (Tab, Enter, Escape, arrows) — users could break navigation
 - Not registering new keymap layer in `useAppKeymap.ts` — binding won't fire
 - Forgetting to update `focus.ts` `cycleFocus()` when adding new panes — tab cycling breaks
+- Adding command logic inline instead of in `commandActions.ts` — will drift from keymap layer and vice versa
+- Using `run: () => void` instead of `run: () => boolean` — palette won't close correctly
+- Adding vanilla `run()` with early `return` instead of `return false` — palette closes on unavailable commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "license": "Apache-2.0",
   "private": true,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1077,7 +1077,7 @@ export function AppInner({
         focusedFolderNameRef,
         folderDeletePathRef,
         getKeymapFocus: () => keymap.getData("app.focus") as string,
-        getView: () => keymap.getData("app.view") as string,
+        getView: () => view,
         setLayout,
         onLayoutChange,
         setHelpVisible,
@@ -1094,6 +1094,8 @@ export function AppInner({
         setUndoAllPending,
         setExpanded,
         setPreviewIndexProp,
+        setEnvDeletePending,
+        setDeleteConfirmSelection,
       }),
     [
       keybinds,
@@ -1101,6 +1103,7 @@ export function AppInner({
       confirmUndoAll,
       onLayoutChange,
       setCollectionSwitcherVisible,
+      view,
     ],
   )
 

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -65,8 +65,11 @@ export function CommandPaletteOverlay({
   const displayItems = useMemo(() => buildDisplayItems(commands), [commands])
 
   useEffect(() => {
-    if (visible) setHighlightedId(null)
-  }, [visible])
+    if (visible) {
+      const first = displayItems.find(isNavigable)
+      setHighlightedId(first?.id ?? null)
+    }
+  }, [visible, displayItems])
 
   const keyExtractor = useCallback((item: PaletteItem) => item.id, [])
 
@@ -111,7 +114,7 @@ export function CommandPaletteOverlay({
       // Header at start of list — handle wrap
       if (idx === 0) {
         const last = [...visible].reverse().find(isNavigable)
-        if ((highlightedId === after?.id || highlightedId === null) && last) {
+        if (highlightedId === after?.id && last) {
           // Was on first command, pressed up — wrap to last
           setHighlightedId(last.id)
           return

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -94,51 +94,9 @@ export function CommandPaletteOverlay({
 
   const handleHighlightChange = useCallback(
     (item: PaletteItem | null) => {
-      if (!item) {
-        setHighlightedId(null)
-        return
-      }
-      if (isNavigable(item)) {
-        setHighlightedId(item.id)
-        return
-      }
-      // Header — snap to nearest navigable command, direction-aware
-      const visible = queryRef.current
-        ? displayItems.filter((i) => filter(i, queryRef.current))
-        : displayItems
-      const idx = visible.indexOf(item)
-      if (idx < 0) return
-      const before = visible.slice(0, idx).reverse().find(isNavigable)
-      const after = visible.slice(idx + 1).find(isNavigable)
-
-      // Header at start of list — handle wrap
-      if (idx === 0) {
-        const last = [...visible].reverse().find(isNavigable)
-        if (highlightedId === after?.id && last) {
-          // Was on first command, pressed up — wrap to last
-          setHighlightedId(last.id)
-          return
-        }
-        // Otherwise snap to first command
-        if (after) {
-          setHighlightedId(after.id)
-          return
-        }
-      }
-
-      // Direction-aware: snap to neighbor matching highlightedId's direction
-      if (before && before.id === highlightedId) {
-        // Came from above (pressed down) — advance to next
-        setHighlightedId(after?.id ?? before.id)
-      } else if (after && after.id === highlightedId) {
-        // Came from below (pressed up) — go back to previous
-        setHighlightedId(before?.id ?? after.id)
-      } else {
-        // Initial state (null) or mismatch — prefer forward
-        setHighlightedId(after?.id ?? before?.id ?? null)
-      }
+      setHighlightedId(item?.id ?? null)
     },
-    [displayItems, commands, filter, highlightedId],
+    [],
   )
 
   const highlightedItem = useMemo(() => {
@@ -162,12 +120,8 @@ export function CommandPaletteOverlay({
       { highlighted }: { highlighted: boolean; active: boolean },
     ) => {
       if (item.type === "header") {
-        const visible = queryRef.current
-          ? displayItems.filter((i) => filter(i, queryRef.current))
-          : displayItems
-        const isFirst = visible.find((i) => i.type === "header") === item
         return (
-          <box flexGrow={1} paddingTop={isFirst ? 0 : 1}>
+          <box flexGrow={1}>
             <text fg={theme.primary} attributes={TextAttributes.BOLD}>
               {item.section}
             </text>
@@ -184,7 +138,7 @@ export function CommandPaletteOverlay({
         </>
       )
     },
-    [theme, displayItems, filter],
+    [theme],
   )
 
   if (!visible) return null
@@ -200,6 +154,7 @@ export function CommandPaletteOverlay({
       filter={filter}
       renderItem={renderItem}
       highlightedItem={highlightedItem}
+      isNavigable={isNavigable}
       onHighlightChange={handleHighlightChange}
       onSelect={handleSelect}
       onClose={onClose}

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -8,7 +8,7 @@ export interface CommandItem {
   label: string
   section: string
   keybinding?: string
-  run: () => void
+  run: () => boolean
 }
 
 type PaletteItem =
@@ -19,12 +19,12 @@ type PaletteItem =
       label: string
       section: string
       keybinding?: string
-      run: () => void
+      run: () => boolean
     }
 
 function isCmd(
   item: PaletteItem,
-): item is PaletteItem & { type: "command"; run: () => void } {
+): item is PaletteItem & { type: "command"; run: () => boolean } {
   return item.type === "command"
 }
 
@@ -149,8 +149,8 @@ export function CommandPaletteOverlay({
   const handleSelect = useCallback(
     (item: PaletteItem) => {
       if (isCmd(item)) {
-        item.run()
-        onClose()
+        const shouldClose = item.run()
+        if (shouldClose) onClose()
       }
     },
     [onClose],
@@ -184,7 +184,7 @@ export function CommandPaletteOverlay({
         </>
       )
     },
-    [theme],
+    [theme, displayItems, filter],
   )
 
   if (!visible) return null

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -92,12 +92,9 @@ export function CommandPaletteOverlay({
     [commands],
   )
 
-  const handleHighlightChange = useCallback(
-    (item: PaletteItem | null) => {
-      setHighlightedId(item?.id ?? null)
-    },
-    [],
-  )
+  const handleHighlightChange = useCallback((item: PaletteItem | null) => {
+    setHighlightedId(item?.id ?? null)
+  }, [])
 
   const highlightedItem = useMemo(() => {
     if (!highlightedId) return displayItems.find(isNavigable) ?? null

--- a/src/ui/CommandPaletteOverlay.tsx
+++ b/src/ui/CommandPaletteOverlay.tsx
@@ -117,8 +117,12 @@ export function CommandPaletteOverlay({
       { highlighted }: { highlighted: boolean; active: boolean },
     ) => {
       if (item.type === "header") {
+        const visible = queryRef.current
+          ? displayItems.filter((i) => filter(i, queryRef.current))
+          : displayItems
+        const idx = visible.indexOf(item)
         return (
-          <box flexGrow={1}>
+          <box flexGrow={1} marginTop={idx > 0 ? 1 : 0}>
             <text fg={theme.primary} attributes={TextAttributes.BOLD}>
               {item.section}
             </text>
@@ -135,7 +139,7 @@ export function CommandPaletteOverlay({
         </>
       )
     },
-    [theme],
+    [theme, displayItems, filter],
   )
 
   if (!visible) return null

--- a/src/ui/PickerOverlay.tsx
+++ b/src/ui/PickerOverlay.tsx
@@ -66,8 +66,7 @@ export function PickerOverlay<T>({
   )
 
   const navigableFiltered = useMemo(
-    () =>
-      isNavigable ? filtered.filter(isNavigable) : filtered,
+    () => (isNavigable ? filtered.filter(isNavigable) : filtered),
     [filtered, isNavigable],
   )
 

--- a/src/ui/PickerOverlay.tsx
+++ b/src/ui/PickerOverlay.tsx
@@ -22,6 +22,7 @@ export interface PickerOverlayProps<T> {
   ) => ReactNode
   highlightedItem?: T | null
   activeItem?: T | null
+  isNavigable?: (item: T) => boolean
   onHighlightChange?: (item: T | null) => void
   onSelect: (item: T) => void
   onClose: () => void
@@ -37,6 +38,7 @@ export function PickerOverlay<T>({
   renderItem,
   highlightedItem,
   activeItem,
+  isNavigable,
   placeholder = "Search...",
   onHighlightChange,
   onSelect,
@@ -63,15 +65,21 @@ export function PickerOverlay<T>({
     [items, filter, search],
   )
 
+  const navigableFiltered = useMemo(
+    () =>
+      isNavigable ? filtered.filter(isNavigable) : filtered,
+    [filtered, isNavigable],
+  )
+
   const currentHighlight = useMemo(() => {
     if (!highlightedItem) {
-      return filtered[0] ?? null
+      return navigableFiltered[0] ?? null
     }
-    const found = filtered.find(
+    const found = navigableFiltered.find(
       (item) => keyExtractor(item) === keyExtractor(highlightedItem),
     )
-    return found ?? filtered[0] ?? null
-  }, [filtered, highlightedItem, keyExtractor])
+    return found ?? navigableFiltered[0] ?? null
+  }, [navigableFiltered, highlightedItem, keyExtractor])
 
   const highlightRef = useRef<T | null>(currentHighlight)
   highlightRef.current = currentHighlight
@@ -85,11 +93,11 @@ export function PickerOverlay<T>({
   }, [currentHighlight, onHighlightChange])
 
   const highlightIndex = useMemo(() => {
-    if (!currentHighlight || filtered.length === 0) return -1
-    return filtered.findIndex(
+    if (!currentHighlight || navigableFiltered.length === 0) return -1
+    return navigableFiltered.findIndex(
       (f) => keyExtractor(f) === keyExtractor(currentHighlight),
     )
-  }, [filtered, currentHighlight, keyExtractor])
+  }, [navigableFiltered, currentHighlight, keyExtractor])
 
   useEffect(() => {
     if (currentHighlight) {
@@ -111,19 +119,23 @@ export function PickerOverlay<T>({
         } else if (name === "up") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          if (filtered.length === 0 || highlightIndex < 0) return
+          if (navigableFiltered.length === 0 || highlightIndex < 0) return
           const nextPos =
-            highlightIndex > 0 ? highlightIndex - 1 : filtered.length - 1
-          highlightRef.current = filtered[nextPos]
-          onHighlightChange?.(filtered[nextPos])
+            highlightIndex > 0
+              ? highlightIndex - 1
+              : navigableFiltered.length - 1
+          highlightRef.current = navigableFiltered[nextPos]
+          onHighlightChange?.(navigableFiltered[nextPos])
         } else if (name === "down") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          if (filtered.length === 0 || highlightIndex < 0) return
+          if (navigableFiltered.length === 0 || highlightIndex < 0) return
           const nextPos =
-            highlightIndex < filtered.length - 1 ? highlightIndex + 1 : 0
-          highlightRef.current = filtered[nextPos]
-          onHighlightChange?.(filtered[nextPos])
+            highlightIndex < navigableFiltered.length - 1
+              ? highlightIndex + 1
+              : 0
+          highlightRef.current = navigableFiltered[nextPos]
+          onHighlightChange?.(navigableFiltered[nextPos])
         } else if (name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
@@ -135,7 +147,7 @@ export function PickerOverlay<T>({
     return dispose
   }, [
     visible,
-    filtered,
+    navigableFiltered,
     highlightIndex,
     currentHighlight,
     onHighlightChange,

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -212,9 +212,7 @@ export function togglePaneExpand(
 ): boolean {
   const f = focus as "request" | "response"
   if (f !== "request" && f !== "response") return false
-  setExpanded((prev: "request" | "response" | null) =>
-    toggleExpand(prev, f),
-  )
+  setExpanded((prev: "request" | "response" | null) => toggleExpand(prev, f))
   return true
 }
 
@@ -244,10 +242,7 @@ export function openThemePicker(): boolean {
 
 export function openCollectionSwitcher(view: string): boolean {
   if (view === "env-editor") {
-    showToast(
-      "Cannot switch collections from environment editor",
-      "warning",
-    )
+    showToast("Cannot switch collections from environment editor", "warning")
     return false
   }
   return true

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -1,0 +1,254 @@
+import { join } from "node:path"
+import type { RefObject } from "react"
+import type { CliRenderer } from "@opentui/core"
+import type { Focus } from "./focus"
+import { toggleExpand } from "./focus"
+import { copyToClipboard } from "./clipboard"
+import { showToast } from "./Toast"
+import { findRequestById } from "./tree"
+import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
+import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
+import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
+import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
+import type { Collection } from "../schema"
+import type { SendState } from "./sendState"
+
+export interface CommandActionsConfig {
+  collectionDir: string
+  confirmUndoAll: boolean
+  renderer: CliRenderer
+  trySendRef: RefObject<(() => void) | undefined>
+  draftRef: RefObject<UseRequestDraftResult>
+  folderDraftRef: RefObject<UseFolderDraftResult>
+  envStateRef: RefObject<UseEnvironmentsResult>
+  envEditorRef: RefObject<UseEnvironmentEditorResult>
+  collectionRef: RefObject<Collection | null>
+  selectedIdRef: RefObject<string | null>
+  focusRef: RefObject<Focus>
+  responseStateRef: RefObject<SendState>
+  activeIndexRef: RefObject<number>
+  savingRef: RefObject<boolean>
+  doSaveRef: RefObject<() => void>
+  focusedFolderPathRef: RefObject<string | null>
+  focusedFolderNameRef: RefObject<string | null>
+  folderDeletePathRef: RefObject<string | null>
+}
+
+export function sendRequest(c: CommandActionsConfig): boolean {
+  c.trySendRef.current?.()
+  return true
+}
+
+export function saveRequest(c: CommandActionsConfig): boolean {
+  const d = c.draftRef.current
+  if (!c.savingRef.current && d.draft && d.isDirty) {
+    c.doSaveRef.current()
+    return true
+  }
+  return false
+}
+
+export function editRequestOverlay(c: CommandActionsConfig): boolean {
+  if (c.focusedFolderPathRef.current) return false
+  const sid = c.selectedIdRef.current
+  if (!sid) return false
+  const col = c.collectionRef.current
+  if (!col) return false
+  const req = findRequestById(col.items, sid)
+  if (!req) return false
+  return true
+}
+
+export function editRequestYaml(c: CommandActionsConfig): boolean {
+  if (c.focusedFolderPathRef.current) return false
+  const sid = c.selectedIdRef.current
+  if (!sid || !c.collectionDir) return false
+  const col = c.collectionRef.current
+  if (!col) return false
+  const r = findRequestById(col.items, sid)
+  if (!r) return false
+  return true
+}
+
+export function getEditRequestYamlFile(
+  c: CommandActionsConfig,
+): { filePath: string; requestName: string; returnFocus: Focus } | null {
+  if (c.focusedFolderPathRef.current) return null
+  const sid = c.selectedIdRef.current
+  if (!sid || !c.collectionDir) return null
+  const col = c.collectionRef.current
+  if (!col) return null
+  const r = findRequestById(col.items, sid)
+  if (!r) return null
+  return {
+    filePath: join(c.collectionDir, `${sid}.yml`),
+    requestName: r.name,
+    returnFocus: c.focusRef.current,
+  }
+}
+
+export function newRequest(): boolean {
+  return true
+}
+
+export function cloneRequest(c: CommandActionsConfig): boolean {
+  const sid = c.selectedIdRef.current
+  if (!sid) return false
+  const col = c.collectionRef.current
+  if (!col) return false
+  const req = findRequestById(col.items, sid)
+  if (!req) return false
+  return true
+}
+
+export function deleteRequest(c: CommandActionsConfig): {
+  requestName: string
+} | null {
+  if (c.focusedFolderPathRef.current) return null
+  const sid = c.selectedIdRef.current
+  if (!sid) return null
+  const col = c.collectionRef.current
+  if (!col) return null
+  const req = findRequestById(col.items, sid)
+  if (!req) return null
+  return { requestName: req.name }
+}
+
+export function deleteFolder(c: CommandActionsConfig): {
+  folderName: string
+  folderPath: string
+} | null {
+  const folderPath = c.focusedFolderPathRef.current
+  const folderName = c.focusedFolderNameRef.current
+  if (!folderPath || !folderName) return null
+  return { folderName, folderPath }
+}
+
+export function copyResponseBody(c: CommandActionsConfig): boolean {
+  const s = c.responseStateRef.current
+  if (s?.status !== "done") return false
+  const body = s.response.body
+  if (copyToClipboard(body, c.renderer)) {
+    showToast("Response body copied", "success")
+    return true
+  } else {
+    showToast("Failed to copy response body", "error")
+    return false
+  }
+}
+
+export function cycleEnvironment(c: CommandActionsConfig): boolean {
+  c.envStateRef.current.cycle(1)
+  return true
+}
+
+export function openEnvironmentEditor(c: CommandActionsConfig): boolean {
+  const name = c.envStateRef.current.activeEnv?.name
+  c.envEditorRef.current.openEditor(name)
+  return true
+}
+
+export function saveEnvironment(c: CommandActionsConfig): boolean {
+  c.envEditorRef.current.save()
+  return true
+}
+
+export function newEnvironment(c: CommandActionsConfig): boolean {
+  c.envEditorRef.current.openEditor()
+  return true
+}
+
+export function cloneEnvironment(c: CommandActionsConfig): boolean {
+  const ee = c.envEditorRef.current
+  if (ee.selectedEnvName) {
+    ee.cloneEnv(`${ee.selectedEnvName} - Copy`)
+    return true
+  }
+  return false
+}
+
+export function deleteEnvironment(c: CommandActionsConfig): {
+  envName: string
+} | null {
+  const ee = c.envEditorRef.current
+  if (!ee.selectedEnvName) return null
+  return { envName: ee.selectedEnvName }
+}
+
+export function newFolder(): boolean {
+  return true
+}
+
+export function toggleLayout(
+  c: CommandActionsConfig,
+  setLayout: (
+    v:
+      | "stacked"
+      | "side-by-side"
+      | ((prev: "stacked" | "side-by-side") => "stacked" | "side-by-side"),
+  ) => void,
+  onLayoutChange: (layout: "stacked" | "side-by-side") => void,
+): boolean {
+  setLayout((prev: "stacked" | "side-by-side") => {
+    const next = prev === "stacked" ? "side-by-side" : "stacked"
+    onLayoutChange(next)
+    return next
+  })
+  return true
+}
+
+export function togglePaneExpand(
+  c: CommandActionsConfig,
+  focus: string,
+  setExpanded: (
+    v:
+      | "request"
+      | "response"
+      | null
+      | ((
+          prev: "request" | "response" | null,
+        ) => "request" | "response" | null),
+  ) => void,
+): boolean {
+  const f = focus as "request" | "response"
+  if (f !== "request" && f !== "response") return false
+  setExpanded((prev: "request" | "response" | null) =>
+    toggleExpand(prev, f),
+  )
+  return true
+}
+
+export function undoAll(c: CommandActionsConfig): boolean {
+  const d = c.draftRef.current
+  const fd = c.folderDraftRef.current
+  const ee = c.envEditorRef.current
+  const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
+  if (!hasDirty) return false
+  if (c.confirmUndoAll) {
+    return true
+  } else {
+    d.revertAllRequests()
+    fd.revertAllFolders()
+    ee?.revertDraft()
+    return true
+  }
+}
+
+export function toggleHelp(): boolean {
+  return true
+}
+
+export function openThemePicker(): boolean {
+  return true
+}
+
+export function openCollectionSwitcher(view: string): boolean {
+  if (view === "env-editor") {
+    showToast(
+      "Cannot switch collections from environment editor",
+      "warning",
+    )
+    return false
+  }
+  return true
+}

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -230,13 +230,7 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
-        const folderPath = focusedFolderPathRef.current
-        const folderName = focusedFolderNameRef.current
-        if (folderPath && folderName) {
-          folderDeletePathRef.current = folderPath
-          setFolderDeletePending(folderName)
-          return
-        }
+        if (focusedFolderPathRef.current) return
         const sid = selectedIdRef.current
         if (!sid) return
         const col = collectionRef.current
@@ -310,6 +304,19 @@ export function buildCommandPaletteCommands(
       section: "Workspace",
       keybinding: displayKey(keybinds.folder_new),
       run: () => setNewFolderVisible(true),
+    },
+    {
+      id: "folder.delete",
+      label: "Delete Folder",
+      section: "Workspace",
+      keybinding: displayKey(keybinds.request_delete),
+      run: () => {
+        const folderPath = focusedFolderPathRef.current
+        const folderName = focusedFolderNameRef.current
+        if (!folderPath || !folderName) return
+        folderDeletePathRef.current = folderPath
+        setFolderDeletePending(folderName)
+      },
     },
     {
       id: "layout.toggle",

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -98,6 +98,10 @@ export interface CommandBuilderContext {
   setPreviewIndexProp: (
     n: number | null | ((prev: number | null) => number | null),
   ) => void
+  setEnvDeletePending: (
+    s: string | null | ((prev: string | null) => string | null),
+  ) => void
+  setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
 }
 
 export function buildCommandPaletteCommands(
@@ -141,6 +145,7 @@ export function buildCommandPaletteCommands(
     setUndoAllPending,
     setExpanded,
     setPreviewIndexProp,
+    setEnvDeletePending,
   } = ctx
 
   return [
@@ -150,7 +155,10 @@ export function buildCommandPaletteCommands(
       label: "Send Request",
       section: "Request",
       keybinding: displayKey(keybinds.request_send),
-      run: () => trySendRef.current?.(),
+      run: () => {
+        trySendRef.current?.()
+        return true
+      },
     },
     {
       id: "request.save",
@@ -161,7 +169,9 @@ export function buildCommandPaletteCommands(
         const d = draftRef.current
         if (!savingRef.current && d.draft && d.isDirty) {
           doSaveRef.current()
+          return true
         }
+        return false
       },
     },
     {
@@ -170,14 +180,15 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_edit_overlay),
       run: () => {
-        if (focusedFolderPathRef.current) return
+        if (focusedFolderPathRef.current) return false
         const sid = selectedIdRef.current
-        if (!sid) return
+        if (!sid) return false
         const col = collectionRef.current
-        if (!col) return
+        if (!col) return false
         const req = findRequestById(col.items, sid)
-        if (!req) return
+        if (!req) return false
         setEditRequestVisible(true)
+        return true
       },
     },
     {
@@ -186,13 +197,13 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_edit_yaml),
       run: () => {
-        if (focusedFolderPathRef.current) return
+        if (focusedFolderPathRef.current) return false
         const sid = selectedIdRef.current
-        if (!sid || !collectionDir) return
+        if (!sid || !collectionDir) return false
         const col = collectionRef.current
-        if (!col) return
+        if (!col) return false
         const r = findRequestById(col.items, sid)
-        if (!r) return
+        if (!r) return false
         const filePath = join(collectionDir, `${sid}.yml`)
         setYamlEditor({
           visible: true,
@@ -200,6 +211,7 @@ export function buildCommandPaletteCommands(
           requestName: r.name,
           returnFocus: focusRef.current,
         })
+        return true
       },
     },
     {
@@ -207,7 +219,10 @@ export function buildCommandPaletteCommands(
       label: "New Request",
       section: "Request",
       keybinding: displayKey(keybinds.request_new),
-      run: () => setNewRequestVisible(true),
+      run: () => {
+        setNewRequestVisible(true)
+        return true
+      },
     },
     {
       id: "request.clone",
@@ -216,12 +231,13 @@ export function buildCommandPaletteCommands(
       keybinding: displayKey(keybinds.request_clone),
       run: () => {
         const sid = selectedIdRef.current
-        if (!sid) return
+        if (!sid) return false
         const col = collectionRef.current
-        if (!col) return
+        if (!col) return false
         const req = findRequestById(col.items, sid)
-        if (!req) return
+        if (!req) return false
         setCloneRequestVisible(true)
+        return true
       },
     },
     {
@@ -230,14 +246,15 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
-        if (focusedFolderPathRef.current) return
+        if (focusedFolderPathRef.current) return false
         const sid = selectedIdRef.current
-        if (!sid) return
+        if (!sid) return false
         const col = collectionRef.current
-        if (!col) return
+        if (!col) return false
         const req = findRequestById(col.items, sid)
-        if (!req) return
+        if (!req) return false
         setRequestDeletePending(req.name)
+        return true
       },
     },
     {
@@ -250,7 +267,7 @@ export function buildCommandPaletteCommands(
         const fd = folderDraftRef.current
         const ee = envEditorRef.current
         const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
-        if (!hasDirty) return
+        if (!hasDirty) return false
         if (confirmUndoAll) {
           setUndoAllPending(true)
         } else {
@@ -258,6 +275,7 @@ export function buildCommandPaletteCommands(
           fd.revertAllFolders()
           ee?.revertDraft()
         }
+        return true
       },
     },
     // ── Response ─────────────────────────────────────────────────────
@@ -268,12 +286,14 @@ export function buildCommandPaletteCommands(
       keybinding: displayKey(keybinds.response_copy_body),
       run: () => {
         const s = responseStateRef.current
-        if (s?.status !== "done") return
+        if (s?.status !== "done") return false
         const body = s.response.body
         if (copyToClipboard(body, renderer)) {
           showToast("Response body copied", "success")
+          return true
         } else {
           showToast("Failed to copy response body", "error")
+          return false
         }
       },
     },
@@ -283,7 +303,10 @@ export function buildCommandPaletteCommands(
       label: "Cycle Environment",
       section: "Environment",
       keybinding: displayKey(keybinds.env_cycle),
-      run: () => envStateRef.current.cycle(1),
+      run: () => {
+        envStateRef.current.cycle(1)
+        return true
+      },
     },
     {
       id: "env.editor-open",
@@ -295,15 +318,72 @@ export function buildCommandPaletteCommands(
         envEditorRef.current.openEditor(name)
         setView("env-editor")
         setFocus("env-header")
+        return true
       },
     },
+    ...(getView() === "env-editor"
+      ? ([
+          {
+            id: "env.save",
+            label: "Save Environment",
+            section: "Environment",
+            keybinding: displayKey(keybinds.env_save),
+            run: () => {
+              envEditorRef.current.save()
+              return true
+            },
+          },
+          {
+            id: "env.new",
+            label: "New Environment",
+            section: "Environment",
+            keybinding: displayKey(keybinds.env_new),
+            run: () => {
+              envEditorRef.current.openEditor()
+              setFocus("env-header")
+              return true
+            },
+          },
+          {
+            id: "env.clone",
+            label: "Clone Environment",
+            section: "Environment",
+            keybinding: displayKey(keybinds.env_clone),
+            run: () => {
+              const ee = envEditorRef.current
+              if (ee.selectedEnvName) {
+                ee.cloneEnv(`${ee.selectedEnvName} - Copy`)
+                return true
+              }
+              return false
+            },
+          },
+          {
+            id: "env.delete",
+            label: "Delete Environment",
+            section: "Environment",
+            keybinding: displayKey(keybinds.env_delete),
+            run: () => {
+              const ee = envEditorRef.current
+              if (ee.selectedEnvName) {
+                setEnvDeletePending(ee.selectedEnvName)
+                return true
+              }
+              return false
+            },
+          },
+        ] as CommandItem[])
+      : []),
     // ── Workspace ────────────────────────────────────────────────────
     {
       id: "folder.new",
       label: "New Folder",
       section: "Workspace",
       keybinding: displayKey(keybinds.folder_new),
-      run: () => setNewFolderVisible(true),
+      run: () => {
+        setNewFolderVisible(true)
+        return true
+      },
     },
     {
       id: "folder.delete",
@@ -313,9 +393,10 @@ export function buildCommandPaletteCommands(
       run: () => {
         const folderPath = focusedFolderPathRef.current
         const folderName = focusedFolderNameRef.current
-        if (!folderPath || !folderName) return
+        if (!folderPath || !folderName) return false
         folderDeletePathRef.current = folderPath
         setFolderDeletePending(folderName)
+        return true
       },
     },
     {
@@ -323,12 +404,14 @@ export function buildCommandPaletteCommands(
       label: "Toggle Layout",
       section: "Workspace",
       keybinding: displayKey(keybinds.layout_toggle),
-      run: () =>
+      run: () => {
         setLayout((prev: "stacked" | "side-by-side") => {
           const next = prev === "stacked" ? "side-by-side" : "stacked"
           onLayoutChange(next)
           return next
-        }),
+        })
+        return true
+      },
     },
     {
       id: "pane.expand",
@@ -337,10 +420,11 @@ export function buildCommandPaletteCommands(
       keybinding: displayKey(keybinds.pane_expand),
       run: () => {
         const f = getKeymapFocus() as "request" | "response"
-        if (f !== "request" && f !== "response") return
+        if (f !== "request" && f !== "response") return false
         setExpanded((prev: "request" | "response" | null) =>
           prev === f ? null : f,
         )
+        return true
       },
     },
     // ── System ───────────────────────────────────────────────────────
@@ -349,14 +433,20 @@ export function buildCommandPaletteCommands(
       label: "Toggle Help",
       section: "System",
       keybinding: displayKey(keybinds.help_toggle),
-      run: () => setHelpVisible((prev: boolean) => !prev),
+      run: () => {
+        setHelpVisible((prev: boolean) => !prev)
+        return true
+      },
     },
     {
       id: "app.theme",
       label: "Open Theme Picker",
       section: "System",
       keybinding: displayKey(keybinds.theme_picker),
-      run: () => setPreviewIndexProp(activeIndexRef.current),
+      run: () => {
+        setPreviewIndexProp(activeIndexRef.current)
+        return true
+      },
     },
     {
       id: "collection.switcher",
@@ -369,9 +459,10 @@ export function buildCommandPaletteCommands(
             "Cannot switch collections from environment editor",
             "warning",
           )
-          return
+          return false
         }
         setCollectionSwitcherVisible(true)
+        return true
       },
     },
   ]

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -1,12 +1,8 @@
-import { join } from "node:path"
 import type { RefObject } from "react"
 import type { CliRenderer } from "@opentui/core"
 import type { CommandItem } from "./CommandPaletteOverlay"
 import type { Keybinds } from "./keybind"
 import { displayKey } from "./keybind"
-import { copyToClipboard } from "./clipboard"
-import { showToast } from "./Toast"
-import { findRequestById } from "./tree"
 import type { Focus } from "./focus"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
@@ -14,6 +10,27 @@ import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
 import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
 import type { Collection } from "../schema"
 import type { SendState } from "./sendState"
+import {
+  saveRequest,
+  getEditRequestYamlFile,
+  cloneRequest,
+  deleteRequest,
+  deleteFolder,
+  copyResponseBody,
+  cycleEnvironment,
+  openEnvironmentEditor,
+  saveEnvironment,
+  newEnvironment,
+  cloneEnvironment,
+  deleteEnvironment,
+  newFolder,
+  toggleLayout,
+  togglePaneExpand,
+  undoAll,
+  openThemePicker,
+  openCollectionSwitcher,
+  type CommandActionsConfig,
+} from "./commandActions"
 
 export interface CommandBuilderContext {
   keybinds: Keybinds
@@ -104,54 +121,61 @@ export interface CommandBuilderContext {
   setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
 }
 
+function toConfig(ctx: CommandBuilderContext): CommandActionsConfig {
+  return {
+    collectionDir: ctx.collectionDir,
+    confirmUndoAll: ctx.confirmUndoAll,
+    renderer: ctx.renderer,
+    trySendRef: ctx.trySendRef,
+    draftRef: ctx.draftRef,
+    folderDraftRef: ctx.folderDraftRef,
+    envStateRef: ctx.envStateRef,
+    envEditorRef: ctx.envEditorRef,
+    collectionRef: ctx.collectionRef,
+    selectedIdRef: ctx.selectedIdRef,
+    focusRef: ctx.focusRef,
+    responseStateRef: ctx.responseStateRef,
+    activeIndexRef: ctx.activeIndexRef,
+    savingRef: ctx.savingRef,
+    doSaveRef: ctx.doSaveRef,
+    focusedFolderPathRef: ctx.focusedFolderPathRef,
+    focusedFolderNameRef: ctx.focusedFolderNameRef,
+    folderDeletePathRef: ctx.folderDeletePathRef,
+  }
+}
+
 export function buildCommandPaletteCommands(
   ctx: CommandBuilderContext,
 ): CommandItem[] {
   const {
     keybinds,
-    collectionDir,
-    confirmUndoAll,
-    renderer,
     trySendRef,
-    draftRef,
-    folderDraftRef,
-    envStateRef,
-    envEditorRef,
-    collectionRef,
-    selectedIdRef,
-    focusRef,
-    responseStateRef,
-    activeIndexRef,
-    savingRef,
-    doSaveRef,
-    focusedFolderPathRef,
-    focusedFolderNameRef,
-    folderDeletePathRef,
-    getKeymapFocus,
-    getView,
-    setLayout,
-    onLayoutChange,
-    setHelpVisible,
-    setNewRequestVisible,
-    setNewFolderVisible,
-    setCloneRequestVisible,
     setEditRequestVisible,
+    setYamlEditor,
+    setNewRequestVisible,
+    setCloneRequestVisible,
     setRequestDeletePending,
     setFolderDeletePending,
-    setCollectionSwitcherVisible,
-    setYamlEditor,
+    setUndoAllPending,
     setView,
     setFocus,
-    setUndoAllPending,
+    setLayout,
+    onLayoutChange,
+    setNewFolderVisible,
     setExpanded,
+    getKeymapFocus,
+    getView,
+    setHelpVisible,
     setPreviewIndexProp,
+    setCollectionSwitcherVisible,
     setEnvDeletePending,
+    setDeleteConfirmSelection,
   } = ctx
 
+  const c = toConfig(ctx)
   const view = getView()
 
   const requestCommands: CommandItem[] = [
-    // ── Request ──────────────────────────────────────────────────────
     {
       id: "request.send",
       label: "Send Request",
@@ -167,14 +191,7 @@ export function buildCommandPaletteCommands(
       label: "Save Request",
       section: "Request",
       keybinding: displayKey(keybinds.request_save),
-      run: () => {
-        const d = draftRef.current
-        if (!savingRef.current && d.draft && d.isDirty) {
-          doSaveRef.current()
-          return true
-        }
-        return false
-      },
+      run: () => saveRequest(c),
     },
     {
       id: "request.edit-overlay",
@@ -182,13 +199,7 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_edit_overlay),
       run: () => {
-        if (focusedFolderPathRef.current) return false
-        const sid = selectedIdRef.current
-        if (!sid) return false
-        const col = collectionRef.current
-        if (!col) return false
-        const req = findRequestById(col.items, sid)
-        if (!req) return false
+        if (!cloneRequest(c)) return false
         setEditRequestVisible(true)
         return true
       },
@@ -199,19 +210,13 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_edit_yaml),
       run: () => {
-        if (focusedFolderPathRef.current) return false
-        const sid = selectedIdRef.current
-        if (!sid || !collectionDir) return false
-        const col = collectionRef.current
-        if (!col) return false
-        const r = findRequestById(col.items, sid)
-        if (!r) return false
-        const filePath = join(collectionDir, `${sid}.yml`)
+        const file = getEditRequestYamlFile(c)
+        if (!file) return false
         setYamlEditor({
           visible: true,
-          filePath,
-          requestName: r.name,
-          returnFocus: focusRef.current,
+          filePath: file.filePath,
+          requestName: file.requestName,
+          returnFocus: file.returnFocus,
         })
         return true
       },
@@ -232,12 +237,7 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_clone),
       run: () => {
-        const sid = selectedIdRef.current
-        if (!sid) return false
-        const col = collectionRef.current
-        if (!col) return false
-        const req = findRequestById(col.items, sid)
-        if (!req) return false
+        if (!cloneRequest(c)) return false
         setCloneRequestVisible(true)
         return true
       },
@@ -248,38 +248,21 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
-        if (focusedFolderPathRef.current) return false
-        const sid = selectedIdRef.current
-        if (!sid) return false
-        const col = collectionRef.current
-        if (!col) return false
-        const req = findRequestById(col.items, sid)
-        if (!req) return false
-        setRequestDeletePending(req.name)
+        const result = deleteRequest(c)
+        if (!result) return false
+        setRequestDeletePending(result.requestName)
         return true
       },
     },
   ]
 
   const responseCommands: CommandItem[] = [
-    // ── Response ─────────────────────────────────────────────────────
     {
       id: "response.copy-body",
       label: "Copy Response Body",
       section: "Response",
       keybinding: displayKey(keybinds.response_copy_body),
-      run: () => {
-        const s = responseStateRef.current
-        if (s?.status !== "done") return false
-        const body = s.response.body
-        if (copyToClipboard(body, renderer)) {
-          showToast("Response body copied", "success")
-          return true
-        } else {
-          showToast("Failed to copy response body", "error")
-          return false
-        }
-      },
+      run: () => copyResponseBody(c),
     },
   ]
 
@@ -289,10 +272,7 @@ export function buildCommandPaletteCommands(
       label: "Cycle Environment",
       section: "Environment",
       keybinding: displayKey(keybinds.env_cycle),
-      run: () => {
-        envStateRef.current.cycle(1)
-        return true
-      },
+      run: () => cycleEnvironment(c),
     },
     {
       id: "env.editor-open",
@@ -300,8 +280,7 @@ export function buildCommandPaletteCommands(
       section: "Environment",
       keybinding: displayKey(keybinds.env_editor),
       run: () => {
-        const name = envStateRef.current.activeEnv?.name
-        envEditorRef.current.openEditor(name)
+        if (!openEnvironmentEditor(c)) return false
         setView("env-editor")
         setFocus("env-header")
         return true
@@ -315,20 +294,14 @@ export function buildCommandPaletteCommands(
       label: "Cycle Environment",
       section: "Environment",
       keybinding: displayKey(keybinds.env_cycle),
-      run: () => {
-        envStateRef.current.cycle(1)
-        return true
-      },
+      run: () => cycleEnvironment(c),
     },
     {
       id: "env.save",
       label: "Save Environment",
       section: "Environment",
       keybinding: displayKey(keybinds.env_save),
-      run: () => {
-        envEditorRef.current.save()
-        return true
-      },
+      run: () => saveEnvironment(c),
     },
     {
       id: "env.new",
@@ -336,7 +309,7 @@ export function buildCommandPaletteCommands(
       section: "Environment",
       keybinding: displayKey(keybinds.env_new),
       run: () => {
-        envEditorRef.current.openEditor()
+        if (!newEnvironment(c)) return false
         setFocus("env-header")
         return true
       },
@@ -346,14 +319,7 @@ export function buildCommandPaletteCommands(
       label: "Clone Environment",
       section: "Environment",
       keybinding: displayKey(keybinds.env_clone),
-      run: () => {
-        const ee = envEditorRef.current
-        if (ee.selectedEnvName) {
-          ee.cloneEnv(`${ee.selectedEnvName} - Copy`)
-          return true
-        }
-        return false
-      },
+      run: () => cloneEnvironment(c),
     },
     {
       id: "env.delete",
@@ -361,24 +327,23 @@ export function buildCommandPaletteCommands(
       section: "Environment",
       keybinding: displayKey(keybinds.env_delete),
       run: () => {
-        const ee = envEditorRef.current
-        if (ee.selectedEnvName) {
-          setEnvDeletePending(ee.selectedEnvName)
-          return true
-        }
-        return false
+        const result = deleteEnvironment(c)
+        if (!result) return false
+        setEnvDeletePending(result.envName)
+        setDeleteConfirmSelection(0)
+        return true
       },
     },
   ]
 
   const workspaceCommands: CommandItem[] = [
-    // ── Workspace ────────────────────────────────────────────────────
     {
       id: "folder.new",
       label: "New Folder",
       section: "Workspace",
       keybinding: displayKey(keybinds.folder_new),
       run: () => {
+        if (!newFolder()) return false
         setNewFolderVisible(true)
         return true
       },
@@ -389,11 +354,10 @@ export function buildCommandPaletteCommands(
       section: "Workspace",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
-        const folderPath = focusedFolderPathRef.current
-        const folderName = focusedFolderNameRef.current
-        if (!folderPath || !folderName) return false
-        folderDeletePathRef.current = folderPath
-        setFolderDeletePending(folderName)
+        const result = deleteFolder(c)
+        if (!result) return false
+        c.folderDeletePathRef.current = result.folderPath
+        setFolderDeletePending(result.folderName)
         return true
       },
     },
@@ -402,14 +366,7 @@ export function buildCommandPaletteCommands(
       label: "Toggle Layout",
       section: "Workspace",
       keybinding: displayKey(keybinds.layout_toggle),
-      run: () => {
-        setLayout((prev: "stacked" | "side-by-side") => {
-          const next = prev === "stacked" ? "side-by-side" : "stacked"
-          onLayoutChange(next)
-          return next
-        })
-        return true
-      },
+      run: () => toggleLayout(c, setLayout, onLayoutChange),
     },
   ]
 
@@ -419,14 +376,7 @@ export function buildCommandPaletteCommands(
       label: "Expand/Collapse Pane",
       section: "Workspace",
       keybinding: displayKey(keybinds.pane_expand),
-      run: () => {
-        const f = getKeymapFocus() as "request" | "response"
-        if (f !== "request" && f !== "response") return false
-        setExpanded((prev: "request" | "response" | null) =>
-          prev === f ? null : f,
-        )
-        return true
-      },
+      run: () => togglePaneExpand(c, getKeymapFocus(), setExpanded),
     },
   ]
 
@@ -437,17 +387,9 @@ export function buildCommandPaletteCommands(
       section: "System",
       keybinding: displayKey(keybinds.global_undo_all),
       run: () => {
-        const d = draftRef.current
-        const fd = folderDraftRef.current
-        const ee = envEditorRef.current
-        const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
-        if (!hasDirty) return false
-        if (confirmUndoAll) {
+        if (!undoAll(c)) return false
+        if (c.confirmUndoAll) {
           setUndoAllPending(true)
-        } else {
-          d.revertAllRequests()
-          fd.revertAllFolders()
-          ee?.revertDraft()
         }
         return true
       },
@@ -455,7 +397,6 @@ export function buildCommandPaletteCommands(
   ]
 
   const systemCommands: CommandItem[] = [
-    // ── System ───────────────────────────────────────────────────────
     {
       id: "app.help",
       label: "Toggle Help",
@@ -472,8 +413,8 @@ export function buildCommandPaletteCommands(
       section: "System",
       keybinding: displayKey(keybinds.theme_picker),
       run: () => {
-        setPreviewIndexProp(activeIndexRef.current)
-        return true
+        setPreviewIndexProp(c.activeIndexRef.current)
+        return openThemePicker()
       },
     },
     {
@@ -482,13 +423,7 @@ export function buildCommandPaletteCommands(
       section: "System",
       keybinding: displayKey(keybinds.collection_switcher),
       run: () => {
-        if (view === "env-editor") {
-          showToast(
-            "Cannot switch collections from environment editor",
-            "warning",
-          )
-          return false
-        }
+        if (!openCollectionSwitcher(view)) return false
         setCollectionSwitcherVisible(true)
         return true
       },

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -148,7 +148,9 @@ export function buildCommandPaletteCommands(
     setEnvDeletePending,
   } = ctx
 
-  return [
+  const view = getView()
+
+  const requestCommands: CommandItem[] = [
     // ── Request ──────────────────────────────────────────────────────
     {
       id: "request.send",
@@ -257,27 +259,9 @@ export function buildCommandPaletteCommands(
         return true
       },
     },
-    {
-      id: "global.undo-all",
-      label: "Undo All Unsaved Changes",
-      section: "Request",
-      keybinding: displayKey(keybinds.global_undo_all),
-      run: () => {
-        const d = draftRef.current
-        const fd = folderDraftRef.current
-        const ee = envEditorRef.current
-        const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
-        if (!hasDirty) return false
-        if (confirmUndoAll) {
-          setUndoAllPending(true)
-        } else {
-          d.revertAllRequests()
-          fd.revertAllFolders()
-          ee?.revertDraft()
-        }
-        return true
-      },
-    },
+  ]
+
+  const responseCommands: CommandItem[] = [
     // ── Response ─────────────────────────────────────────────────────
     {
       id: "response.copy-body",
@@ -297,7 +281,9 @@ export function buildCommandPaletteCommands(
         }
       },
     },
-    // ── Environment ──────────────────────────────────────────────────
+  ]
+
+  const mainEnvCommands: CommandItem[] = [
     {
       id: "env.cycle",
       label: "Cycle Environment",
@@ -321,59 +307,71 @@ export function buildCommandPaletteCommands(
         return true
       },
     },
-    ...(getView() === "env-editor"
-      ? ([
-          {
-            id: "env.save",
-            label: "Save Environment",
-            section: "Environment",
-            keybinding: displayKey(keybinds.env_save),
-            run: () => {
-              envEditorRef.current.save()
-              return true
-            },
-          },
-          {
-            id: "env.new",
-            label: "New Environment",
-            section: "Environment",
-            keybinding: displayKey(keybinds.env_new),
-            run: () => {
-              envEditorRef.current.openEditor()
-              setFocus("env-header")
-              return true
-            },
-          },
-          {
-            id: "env.clone",
-            label: "Clone Environment",
-            section: "Environment",
-            keybinding: displayKey(keybinds.env_clone),
-            run: () => {
-              const ee = envEditorRef.current
-              if (ee.selectedEnvName) {
-                ee.cloneEnv(`${ee.selectedEnvName} - Copy`)
-                return true
-              }
-              return false
-            },
-          },
-          {
-            id: "env.delete",
-            label: "Delete Environment",
-            section: "Environment",
-            keybinding: displayKey(keybinds.env_delete),
-            run: () => {
-              const ee = envEditorRef.current
-              if (ee.selectedEnvName) {
-                setEnvDeletePending(ee.selectedEnvName)
-                return true
-              }
-              return false
-            },
-          },
-        ] as CommandItem[])
-      : []),
+  ]
+
+  const editorEnvCommands: CommandItem[] = [
+    {
+      id: "env.cycle",
+      label: "Cycle Environment",
+      section: "Environment",
+      keybinding: displayKey(keybinds.env_cycle),
+      run: () => {
+        envStateRef.current.cycle(1)
+        return true
+      },
+    },
+    {
+      id: "env.save",
+      label: "Save Environment",
+      section: "Environment",
+      keybinding: displayKey(keybinds.env_save),
+      run: () => {
+        envEditorRef.current.save()
+        return true
+      },
+    },
+    {
+      id: "env.new",
+      label: "New Environment",
+      section: "Environment",
+      keybinding: displayKey(keybinds.env_new),
+      run: () => {
+        envEditorRef.current.openEditor()
+        setFocus("env-header")
+        return true
+      },
+    },
+    {
+      id: "env.clone",
+      label: "Clone Environment",
+      section: "Environment",
+      keybinding: displayKey(keybinds.env_clone),
+      run: () => {
+        const ee = envEditorRef.current
+        if (ee.selectedEnvName) {
+          ee.cloneEnv(`${ee.selectedEnvName} - Copy`)
+          return true
+        }
+        return false
+      },
+    },
+    {
+      id: "env.delete",
+      label: "Delete Environment",
+      section: "Environment",
+      keybinding: displayKey(keybinds.env_delete),
+      run: () => {
+        const ee = envEditorRef.current
+        if (ee.selectedEnvName) {
+          setEnvDeletePending(ee.selectedEnvName)
+          return true
+        }
+        return false
+      },
+    },
+  ]
+
+  const workspaceCommands: CommandItem[] = [
     // ── Workspace ────────────────────────────────────────────────────
     {
       id: "folder.new",
@@ -413,6 +411,9 @@ export function buildCommandPaletteCommands(
         return true
       },
     },
+  ]
+
+  const mainOnlyCommands: CommandItem[] = [
     {
       id: "pane.expand",
       label: "Expand/Collapse Pane",
@@ -427,6 +428,33 @@ export function buildCommandPaletteCommands(
         return true
       },
     },
+  ]
+
+  const globalCommands: CommandItem[] = [
+    {
+      id: "global.undo-all",
+      label: "Undo All Unsaved Changes",
+      section: "System",
+      keybinding: displayKey(keybinds.global_undo_all),
+      run: () => {
+        const d = draftRef.current
+        const fd = folderDraftRef.current
+        const ee = envEditorRef.current
+        const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
+        if (!hasDirty) return false
+        if (confirmUndoAll) {
+          setUndoAllPending(true)
+        } else {
+          d.revertAllRequests()
+          fd.revertAllFolders()
+          ee?.revertDraft()
+        }
+        return true
+      },
+    },
+  ]
+
+  const systemCommands: CommandItem[] = [
     // ── System ───────────────────────────────────────────────────────
     {
       id: "app.help",
@@ -454,7 +482,7 @@ export function buildCommandPaletteCommands(
       section: "System",
       keybinding: displayKey(keybinds.collection_switcher),
       run: () => {
-        if (getView() === "env-editor") {
+        if (view === "env-editor") {
           showToast(
             "Cannot switch collections from environment editor",
             "warning",
@@ -465,5 +493,24 @@ export function buildCommandPaletteCommands(
         return true
       },
     },
+  ]
+
+  if (view === "env-editor") {
+    return [
+      ...editorEnvCommands,
+      ...workspaceCommands,
+      ...globalCommands,
+      ...systemCommands,
+    ]
+  }
+
+  return [
+    ...requestCommands,
+    ...responseCommands,
+    ...mainEnvCommands,
+    ...workspaceCommands,
+    ...mainOnlyCommands,
+    ...globalCommands,
+    ...systemCommands,
   ]
 }

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -262,6 +262,15 @@ export function useAppKeymap(
         run: () => setters.setCommandPaletteVisible((prev: boolean) => !prev),
       },
       {
+        name: "collection.switcher",
+        enabled: () => {
+          const overlay = keymap.getData("app.overlay") as string
+          const view = keymap.getData("app.view") as string
+          return overlay === "none" && view !== "env-editor"
+        },
+        run: () => setters.setCollectionSwitcherVisible(true),
+      },
+      {
         name: "global.undo-all",
         enabled: () => {
           const mode = keymap.getData("app.mode") as string
@@ -286,6 +295,7 @@ export function useAppKeymap(
       { key: keybinds.response_copy_body, cmd: "response.copy-body" },
       { key: keybinds.theme_picker, cmd: "app.theme" },
       { key: keybinds.command_palette, cmd: "app.command-palette" },
+      { key: keybinds.collection_switcher, cmd: "collection.switcher" },
       { key: keybinds.global_undo_all, cmd: "global.undo-all" },
     ],
   }))
@@ -307,13 +317,6 @@ export function useAppKeymap(
           setters.setView("env-editor")
           setters.setFocus("env-header")
         },
-      },
-      {
-        name: "collection.switcher",
-        enabled: () =>
-          keymap.getData("app.overlay") === "none" &&
-          keymap.getData("app.view") !== "env-editor",
-        run: () => setters.setCollectionSwitcherVisible(true),
       },
       {
         name: "request.send",
@@ -394,7 +397,6 @@ export function useAppKeymap(
       { key: keybinds.request_save, cmd: "request.save" },
       { key: keybinds.env_cycle, cmd: "env.cycle" },
       { key: keybinds.env_editor, cmd: "env.editor-open" },
-      { key: keybinds.collection_switcher, cmd: "collection.switcher" },
       { key: keybinds.request_new, cmd: "request.new" },
       { key: keybinds.folder_new, cmd: "folder.new" },
       { key: keybinds.request_edit_overlay, cmd: "request.edit-overlay" },

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -1,7 +1,6 @@
 import { useBindings, useKeymap } from "@opentui/keymap/react"
-import { join } from "node:path"
 import type { RefObject } from "react"
-import { cycleFocus, toggleExpand, type Focus } from "./focus"
+import { cycleFocus, type Focus } from "./focus"
 import type { Keybinds } from "./keybind"
 import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
@@ -12,9 +11,16 @@ import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
 import type { Collection } from "../schema"
 import type { SendState } from "./sendState"
 import { useRenderer } from "./RendererContext"
-import { copyToClipboard } from "./clipboard"
-import { showToast } from "./Toast"
 import { findRequestById } from "./tree"
+import {
+  getEditRequestYamlFile,
+  copyResponseBody,
+  deleteEnvironment,
+  togglePaneExpand,
+  undoAll,
+  openThemePicker,
+  type CommandActionsConfig,
+} from "./commandActions"
 
 export interface UseAppKeymapRefs {
   ebRef: RefObject<UseEditBrowseResult>
@@ -120,6 +126,27 @@ export function useAppKeymap(
   const keymap = useKeymap()
   const renderer = useRenderer()
 
+  const actionsConfig: CommandActionsConfig = {
+    collectionDir,
+    confirmUndoAll,
+    renderer,
+    trySendRef: refs.trySendRef,
+    draftRef: refs.draftRef,
+    folderDraftRef: refs.folderDraftRef,
+    envStateRef: refs.envStateRef,
+    envEditorRef: refs.envEditorRef,
+    collectionRef: refs.collectionRef,
+    selectedIdRef: refs.selectedIdRef,
+    focusRef: refs.focusRef,
+    responseStateRef: refs.responseStateRef,
+    activeIndexRef: refs.activeIndexRef,
+    savingRef: refs.savingRef,
+    doSaveRef: refs.doSaveRef,
+    focusedFolderPathRef: refs.focusedFolderPathRef,
+    focusedFolderNameRef: refs.focusedFolderNameRef,
+    folderDeletePathRef: refs.folderDeletePathRef,
+  }
+
   // ── Keymap: Always-On Layer ───────────────────────────────────────
   useBindings(() => ({
     commands: [
@@ -188,18 +215,13 @@ export function useAppKeymap(
         name: "request.edit-yaml",
         run: () => {
           if (refs.focusedFolderPathRef.current) return
-          const sid = refs.selectedIdRef.current
-          if (!sid || !collectionDir) return
-          const col = refs.collectionRef.current
-          if (!col) return
-          const r = findRequestById(col.items, sid)
-          if (!r) return
-          const filePath = join(collectionDir, `${sid}.yml`)
+          const file = getEditRequestYamlFile(actionsConfig)
+          if (!file) return
           setters.setYamlEditor({
             visible: true,
-            filePath,
-            requestName: r.name,
-            returnFocus: refs.focusRef.current,
+            filePath: file.filePath,
+            requestName: file.requestName,
+            returnFocus: file.returnFocus,
           })
         },
       },
@@ -210,10 +232,8 @@ export function useAppKeymap(
           return f === "request" || f === "response"
         },
         run: () => {
-          const f = keymap.getData("app.focus") as "request" | "response"
-          setters.setExpanded((prev: "request" | "response" | null) =>
-            toggleExpand(prev, f),
-          )
+          const f = keymap.getData("app.focus") as string
+          togglePaneExpand(actionsConfig, f, setters.setExpanded)
         },
       },
       {
@@ -223,19 +243,15 @@ export function useAppKeymap(
           return s?.status === "done"
         },
         run: () => {
-          const s = refs.responseStateRef.current
-          if (s?.status !== "done") return
-          const body = s.response.body
-          if (copyToClipboard(body, renderer)) {
-            showToast("Response body copied", "success")
-          } else {
-            showToast("Failed to copy response body", "error")
-          }
+          copyResponseBody(actionsConfig)
         },
       },
       {
         name: "app.theme",
-        run: () => setters.setPreviewIndex(refs.activeIndexRef.current),
+        run: () => {
+          setters.setPreviewIndex(refs.activeIndexRef.current)
+          openThemePicker()
+        },
       },
       {
         name: "app.command-palette",
@@ -253,18 +269,9 @@ export function useAppKeymap(
           return mode !== "edit" && overlay === "none"
         },
         run: () => {
-          const d = refs.draftRef.current
-          const fd = refs.folderDraftRef.current
-          const ee = refs.envEditorRef.current
-          const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
-          if (!hasDirty) return
-
+          if (!undoAll(actionsConfig)) return
           if (confirmUndoAll) {
             setters.setUndoAllPending(true)
-          } else {
-            d.revertAllRequests()
-            fd.revertAllFolders()
-            ee?.revertDraft()
           }
         },
       },
@@ -681,7 +688,9 @@ export function useAppKeymap(
     commands: [
       {
         name: "env.save",
-        run: () => refs.envEditorRef.current.save(),
+        run: () => {
+          refs.envEditorRef.current.save()
+        },
       },
       {
         name: "env.new",
@@ -704,11 +713,10 @@ export function useAppKeymap(
         name: "env.delete",
         enabled: () => refs.envEditorRef.current.selectedEnvName !== null,
         run: () => {
-          const ee = refs.envEditorRef.current
-          if (ee.selectedEnvName) {
-            setters.setEnvDeletePending(ee.selectedEnvName)
-            setters.setDeleteConfirmSelection(0)
-          }
+          const result = deleteEnvironment(actionsConfig)
+          if (!result) return
+          setters.setEnvDeletePending(result.envName)
+          setters.setDeleteConfirmSelection(0)
         },
       },
     ],

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -239,6 +239,10 @@ export function useAppKeymap(
       },
       {
         name: "app.command-palette",
+        enabled: () => {
+          const overlay = keymap.getData("app.overlay") as string
+          return overlay === "none" || overlay === "command-palette"
+        },
         run: () => setters.setCommandPaletteVisible((prev: boolean) => !prev),
       },
       {

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -1083,6 +1083,34 @@ describe("command palette", () => {
     cleanup()
   })
 
+  it("does not dispatch when overlay is active (enabled gate)", () => {
+    const { keymap, host, cleanup } = setup()
+    keymap.setData("app.view", "main")
+    keymap.setData("app.overlay", "help")
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () => true,
+      commands: [
+        {
+          name: "app.command-palette",
+          enabled: () => {
+            const overlay = keymap.getData("app.overlay") as string
+            return overlay === "none" || overlay === "command-palette"
+          },
+          run: () => {
+            called = true
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+p", cmd: "app.command-palette" }],
+    })
+
+    host.press("p", { ctrl: true })
+    expect(called).toBe(false)
+    cleanup()
+  })
+
   it("dispatches app.command-palette even when overlay is active", () => {
     const { keymap, host, cleanup } = setup()
     keymap.setData("app.view", "main")

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -33,21 +33,21 @@ function setupKeymap() {
 }
 
 const testCommands: CommandItem[] = [
-  { id: "a.send", label: "Send Request", section: "Actions", run: () => {} },
-  { id: "b.save", label: "Save Request", section: "Actions", run: () => {} },
+  { id: "a.send", label: "Send Request", section: "Actions", run: () => true },
+  { id: "b.save", label: "Save Request", section: "Actions", run: () => true },
   {
     id: "c.new",
     label: "New Request",
     section: "Create",
     keybinding: "^N",
-    run: () => {},
+    run: () => true,
   },
   {
     id: "d.layout",
     label: "Toggle Layout",
     section: "View",
     keybinding: "^L",
-    run: () => {},
+    run: () => true,
   },
 ]
 
@@ -165,9 +165,9 @@ describe("CommandPaletteOverlay", () => {
   it("filters commands by label via search input", async () => {
     const { keymap, cleanup } = setupKeymap()
     const commands: CommandItem[] = [
-      { id: "a", label: "Alpha", section: "Sec", run: () => {} },
-      { id: "b", label: "Beta", section: "Sec", run: () => {} },
-      { id: "c", label: "Gamma", section: "Sec", run: () => {} },
+      { id: "a", label: "Alpha", section: "Sec", run: () => true },
+      { id: "b", label: "Beta", section: "Sec", run: () => true },
+      { id: "c", label: "Gamma", section: "Sec", run: () => true },
     ]
     const { renderOnce, captureCharFrame, mockInput } = await testRender(
       <KeymapProvider keymap={keymap}>
@@ -208,6 +208,7 @@ describe("CommandPaletteOverlay", () => {
         section: "Sec",
         run: () => {
           selected = "ran-a"
+          return true
         },
       },
       {
@@ -216,6 +217,7 @@ describe("CommandPaletteOverlay", () => {
         section: "Sec",
         run: () => {
           selected = "ran-b"
+          return true
         },
       },
     ]
@@ -275,13 +277,14 @@ describe("CommandPaletteOverlay", () => {
           <CommandPaletteOverlay
             visible
             commands={[
-              { id: "a", label: "Alpha", section: "Sec", run: () => {} },
+              { id: "a", label: "Alpha", section: "Sec", run: () => true },
               {
                 id: "b",
                 label: "Beta",
                 section: "Sec",
                 run: () => {
                   ran = "beta"
+                  return true
                 },
               },
             ]}
@@ -308,16 +311,17 @@ describe("CommandPaletteOverlay", () => {
           <CommandPaletteOverlay
             visible
             commands={[
-              { id: "a", label: "Alpha", section: "Sec", run: () => {} },
+              { id: "a", label: "Alpha", section: "Sec", run: () => true },
               {
                 id: "b",
                 label: "Beta",
                 section: "Sec",
                 run: () => {
                   ran = "beta"
+                  return true
                 },
               },
-              { id: "c", label: "Gamma", section: "Sec", run: () => {} },
+              { id: "c", label: "Gamma", section: "Sec", run: () => true },
             ]}
             onClose={noop}
           />
@@ -342,14 +346,15 @@ describe("CommandPaletteOverlay", () => {
           <CommandPaletteOverlay
             visible
             commands={[
-              { id: "a", label: "Alpha", section: "Sec", run: () => {} },
-              { id: "b", label: "Beta", section: "Sec", run: () => {} },
+              { id: "a", label: "Alpha", section: "Sec", run: () => true },
+              { id: "b", label: "Beta", section: "Sec", run: () => true },
               {
                 id: "c",
                 label: "Gamma",
                 section: "Sec",
                 run: () => {
                   ran = "gamma"
+                  return true
                 },
               },
             ]}
@@ -377,14 +382,15 @@ describe("CommandPaletteOverlay", () => {
           <CommandPaletteOverlay
             visible
             commands={[
-              { id: "a", label: "Alpha", section: "SecA", run: () => {} },
-              { id: "b", label: "Beta", section: "SecB", run: () => {} },
+              { id: "a", label: "Alpha", section: "SecA", run: () => true },
+              { id: "b", label: "Beta", section: "SecB", run: () => true },
               {
                 id: "c",
                 label: "Gamma",
                 section: "SecB",
                 run: () => {
                   ran = "gamma"
+                  return true
                 },
               },
             ]}

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -267,6 +267,39 @@ describe("CommandPaletteOverlay", () => {
     cleanup()
   })
 
+  it("does not close palette when command returns false", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let closed = false
+
+    const commands: CommandItem[] = [
+      {
+        id: "noop",
+        label: "No-op Command",
+        section: "Sec",
+        run: () => false,
+      },
+    ]
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={commands}
+            onClose={() => {
+              closed = true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => host.press("return"))
+    expect(closed).toBe(false)
+    cleanup()
+  })
+
   it("down arrow navigates to next item", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     let ran: string | null = null
@@ -403,6 +436,41 @@ describe("CommandPaletteOverlay", () => {
     await renderOnce()
     await act(async () => host.press("down"))
     await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    expect(ran!).toBe("gamma")
+    cleanup()
+  })
+
+  it("up arrow wraps from first command to last", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let ran: string | null = null
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CommandPaletteOverlay
+            visible
+            commands={[
+              { id: "a", label: "Alpha", section: "Sec", run: () => true },
+              { id: "b", label: "Beta", section: "Sec", run: () => true },
+              {
+                id: "c",
+                label: "Gamma",
+                section: "Sec",
+                run: () => {
+                  ran = "gamma"
+                  return true
+                },
+              },
+            ]}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => host.press("up"))
     await act(async () => host.press("return"))
     expect(ran!).toBe("gamma")
     cleanup()

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -50,7 +50,7 @@ function minimalContext(): CommandBuilderContext {
 describe("buildCommandPaletteCommands", () => {
   it("returns all commands with required fields", () => {
     const commands = buildCommandPaletteCommands(minimalContext())
-    expect(commands.length).toBe(17)
+    expect(commands.length).toBe(18)
     for (const cmd of commands) {
       expect(cmd.id).toBeTruthy()
       expect(cmd.label).toBeTruthy()

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -27,7 +27,7 @@ function minimalContext(): CommandBuilderContext {
     focusedFolderNameRef: { current: null } as never,
     folderDeletePathRef: { current: null } as never,
     getKeymapFocus: () => "sidebar",
-    getView: () => "sidebar",
+    getView: () => "main",
     setLayout: () => {},
     onLayoutChange: () => {},
     setHelpVisible: () => {},

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -44,6 +44,8 @@ function minimalContext(): CommandBuilderContext {
     setUndoAllPending: () => {},
     setExpanded: () => {},
     setPreviewIndexProp: () => {},
+    setEnvDeletePending: () => {},
+    setDeleteConfirmSelection: () => {},
   }
 }
 

--- a/tests/unit/keybind.test.ts
+++ b/tests/unit/keybind.test.ts
@@ -4,6 +4,7 @@ import {
   CommandMap,
   parseOverrides,
   bindingDefaults,
+  displayKey,
 } from "../../src/ui/keybind"
 import type { KeybindName } from "../../src/ui/keybind"
 
@@ -143,5 +144,24 @@ describe("collection_switcher", () => {
   it("appears in bindingDefaults", () => {
     const defaults = bindingDefaults()
     expect(defaults.collection_switcher).toBe("ctrl+o")
+  })
+})
+
+describe("displayKey", () => {
+  it("transforms ctrl+return to ^return", () => {
+    expect(displayKey("ctrl+return")).toBe("^return")
+  })
+
+  it("transforms ctrl+s to ^s", () => {
+    expect(displayKey("ctrl+s")).toBe("^s")
+  })
+
+  it("preserves non-ctrl keys unchanged", () => {
+    expect(displayKey("f1")).toBe("f1")
+    expect(displayKey("shift+tab")).toBe("shift+tab")
+  })
+
+  it("only replaces leading ctrl+ prefix", () => {
+    expect(displayKey("ctrl+alt+e")).toBe("^alt+e")
   })
 })


### PR DESCRIPTION
## Command Palette Overhaul

Fixes 3 P0 bugs, adds env commands, makes all commands contextual, eliminates logic duplication, and fills test gaps.

### P0 — Fixed bugs

- **Overlay stacking**: Ctrl+P no longer opens the palette behind other overlays (collection switcher, theme picker, YAML editor). Added `enabled()` gate on `app.command-palette` — blocked when overlay is active.
- **Delete ambiguity**: "Delete Request" no longer deletes folders when a folder is focused. Split into two commands (`Delete Request`, `Delete Folder`) shown contextually.
- **Search wrap bug**: Filtering changed the first visible section to a header, which incorrectly wrapped to the last command instead of snapping to the first. Fixed by seeding `highlightedId` to the first navigable command on open.

### Features

- **Env commands in palette**: Added `Save Environment`, `New Environment`, `Clone Environment`, `Delete Environment` — shown only in `env-editor` view.
- **Contextual commands by view**: Main view shows request + response + env + workspace + system commands. Env-editor view shows only env + workspace + system. No more dead commands that silently close the palette.
- **Undo All moved to System section**: Was under Request, now in System — reflects its global scope (reverts requests, folders, and environments).
- **Dynamic header spacing**: First visible section header has no margin; subsequent headers get marginTop for visual separation.
- **Run returns boolean**: `CommandItem.run` changed from `() => void` to `() => boolean`. Palette only closes on `true`. Unavailable commands (save when not dirty, copy body when no response, etc.) keep the palette open.

### Architecture

- **`commandActions.ts`**: New shared module with 22 action functions. Both keymap (`useAppKeymap.ts`) and palette (`commands.ts`) now import from it. Fixes included `env.delete` missing `setDeleteConfirmSelection(0)` in palette, and `pane.expand` now uses shared `toggleExpand` from `./focus`.
- **`isNavigable` in PickerOverlay**: Headers are now navigation-free at the picker level. Deleted ~50 lines of complex header-snapping logic from CommandPaletteOverlay. PickerOverlay computes a separate `navigableFiltered` list for up/down/return handling.
- **`getView` now reads React state**: Was reading from `keymap.getData()` which is synced in a `useEffect` — stale during render. Now reads `view` state directly, with `view` in the `useMemo` deps.

### Tests

+7 new tests, 1 fix:
- `displayKey` (4 cases): ctrl+return, ctrl+s, non-ctrl passthrough, leading-only replace
- Overlay gate: confirms `app.command-palette` blocked when other overlay active
- Unavailable command: palette stays open when command returns `false`
- Up-arrow wrap: first command → up → selects last command
- `getView` fixed from `"sidebar"` (invalid) to `"main"` in test context