### PR TITLE
refactor(ui): extract request/response views and split AppInner

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -2,17 +2,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Dispatch, SetStateAction } from "react"
 import { resolve } from "node:path"
 import { useKeymap } from "@opentui/keymap/react"
-import { Sidebar } from "./Sidebar"
-import { UrlBar } from "./UrlBar"
-import { RequestPane } from "./RequestPane"
-import { ResponsePane } from "./ResponsePane"
-import { FolderPane } from "./FolderPane"
+import { MainView } from "./MainView"
+import { EnvironmentEditorView } from "./EnvironmentEditorView"
+import { AppOverlays } from "./AppOverlays"
 import { useCollection } from "../hooks/useCollection"
 import { useTreeNavigation } from "../hooks/useTreeNavigation"
 import { deriveRequestParentFolder, getFolderPaths } from "./tree"
 import { useResponse } from "../hooks/useResponse"
 import type { SendCompleteResult } from "../hooks/useResponse"
-import type { Folder, Request as NoodleRequest, Method } from "../schema"
+import type { Request as NoodleRequest, Method } from "../schema"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
 import { useFolderDraft } from "../hooks/useFolderDraft"
@@ -20,47 +18,25 @@ import { useFolderEditBrowse } from "../hooks/useFolderEditBrowse"
 import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
 import { type Focus } from "./focus"
-import { HelpOverlay } from "./HelpOverlay"
-import { ConfirmOverlay } from "./ConfirmOverlay"
-import { YamlEditorOverlay } from "./YamlEditorOverlay"
-import {
-  NewRequestOverlay,
-  slugify,
-  type NewRequestOverlayHandle,
-} from "./NewRequestOverlay"
-import {
-  CloneRequestOverlay,
-  type CloneRequestOverlayHandle,
-} from "./CloneRequestOverlay"
-import {
-  NewFolderOverlay,
-  type NewFolderOverlayHandle,
-} from "./NewFolderOverlay"
-import { CommandPaletteOverlay } from "./CommandPaletteOverlay"
-import { CollectionSwitcherOverlay } from "./CollectionSwitcherOverlay"
+import { type NewRequestOverlayHandle } from "./NewRequestOverlay"
+import { type CloneRequestOverlayHandle } from "./CloneRequestOverlay"
+import { type NewFolderOverlayHandle } from "./NewFolderOverlay"
 import { buildCommandPaletteCommands } from "./commands"
-import {
-  saveRequest,
-  deleteRequest,
-  saveFolder,
-  deleteFolder,
-} from "../filestore/save"
-import { ThemePickerOverlay, useTheme } from "./theme"
+import { useTheme } from "./theme"
 import { StatusBar } from "./StatusBar"
 import { showToast } from "./Toast"
-import { EnvSidebar } from "./EnvSidebar"
-import { EnvHeaderPane, type EnvHeaderPaneHandle } from "./EnvHeaderPane"
-import { EnvEditorPane } from "./EnvEditorPane"
+import { type EnvHeaderPaneHandle } from "./EnvHeaderPane"
 
 import { type Keybinds, displayKey } from "./keybind"
 import { useSaveFile } from "./useSaveFile"
 import { useAppKeymap } from "./useAppKeymap"
 import { useRenderer } from "./RendererContext"
 import { useOverlayIntercepts } from "./useOverlayIntercepts"
+import { useCollectionFileActions } from "./useCollectionFileActions"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
-import { getRequestIds, findFolderByPath, updateFolderByPath } from "./tree"
+import { getRequestIds, findFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import {
   saveLastRequest,
@@ -241,7 +217,6 @@ export function AppInner({
   const folderEbRef = useRef(folderEb)
   folderEbRef.current = folderEb
 
-  const dirtyFolderPaths = folderDraft.dirtyPaths
   const folderDraftRef = useRef(folderDraft)
   folderDraftRef.current = folderDraft
 
@@ -342,361 +317,40 @@ export function AppInner({
     }
   }, [saveState])
 
-  // ── Folder save ────────────────────────────────────────────────────
   const folderSaveRef = useRef<() => void>(() => {})
 
-  const handleFolderSave = useCallback(async () => {
-    const draftFolder = folderDraftRef.current?.folderDraft
-    if (!draftFolder || !collection) return
-    try {
-      await saveFolder(collectionDir, draftFolder)
-      folderDraftRef.current?.markSaved()
-      updateCollection({
-        ...collection,
-        items: updateFolderByPath(
-          collection.items,
-          draftFolder.path,
-          draftFolder,
-        ),
-      })
-      setSaveState({
-        kind: "success",
-        message: `Successfully saved folder ${draftFolder.name}`,
-      })
-      clearSaveTimer()
-      saveTimerRef.current = setTimeout(
-        () => setSaveState({ kind: "idle" }),
-        2000,
-      )
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e)
-      setSaveState({ kind: "error", message: msg })
-      clearSaveTimer()
-      saveTimerRef.current = setTimeout(
-        () => setSaveState({ kind: "idle" }),
-        2000,
-      )
-    }
-  }, [
+  const {
+    handleFolderSave,
+    handleNewRequestConfirm,
+    handleCloneRequestConfirm,
+    handleNewFolderConfirm,
+    handleFolderDeleteConfirm,
+    handleEditRequestConfirm,
+    handleRequestDeleteConfirm,
+  } = useCollectionFileActions({
     collection,
     collectionDir,
-    setSaveState,
     updateCollection,
+    selectedRequest,
+    folderDraftRef,
+    newRequestFolderRef,
+    folderDeletePathRef,
+    setCollectionReloadToken,
+    setFocus,
+    setSaveState,
     clearSaveTimer,
     saveTimerRef,
-  ])
+    setSelectedId,
+    expandFolder,
+    setNewRequestVisible,
+    setCloneRequestVisible,
+    setNewFolderVisible,
+    setEditRequestVisible,
+    setRequestDeletePending,
+    setFolderDeletePending,
+  })
 
   folderSaveRef.current = handleFolderSave
-
-  const handleNewRequestConfirm = useCallback(
-    (name: string, method: Method, url: string) => {
-      const baseId = slugify(name)
-      if (!baseId) return
-      const folder = newRequestFolderRef.current
-      const id = folder ? `${folder}/${baseId}` : baseId
-
-      const req: NoodleRequest = {
-        id,
-        name,
-        method,
-        url,
-        timeout: 0,
-        followRedirects: true,
-        maxRedirects: 5,
-        headers: {},
-        params: {},
-        auth: { type: "none" },
-        bodyType: "none",
-        body: "",
-      }
-
-      saveRequest(collectionDir, req)
-        .then(() => {
-          if (folder) expandFolder(folder)
-          setCollectionReloadToken((n) => n + 1)
-          setSelectedId(id)
-          setNewRequestVisible(false)
-          setFocus("sidebar")
-          setSaveState({
-            kind: "success",
-            message: `Successfully created ${name}`,
-          })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-        .catch((e: unknown) => {
-          const msg = e instanceof Error ? e.message : String(e)
-          setSaveState({ kind: "error", message: msg })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-    },
-    [
-      collectionDir,
-      setCollectionReloadToken,
-      setFocus,
-      setSaveState,
-      clearSaveTimer,
-      saveTimerRef,
-      setSelectedId,
-      expandFolder,
-    ],
-  )
-
-  const handleCloneRequestConfirm = useCallback(
-    (newName: string) => {
-      const req = selectedRequest
-      if (!req) return
-      const baseId = slugify(newName)
-      if (!baseId) return
-      const lastSlash = req.id.lastIndexOf("/")
-      const id =
-        lastSlash >= 0 ? `${req.id.slice(0, lastSlash)}/${baseId}` : baseId
-
-      const cloned: NoodleRequest = {
-        ...req,
-        id,
-        name: newName,
-      }
-
-      saveRequest(collectionDir, cloned)
-        .then(() => {
-          setCollectionReloadToken((n) => n + 1)
-          setCloneRequestVisible(false)
-          setFocus("sidebar")
-          setSelectedId(id)
-          const lastSlash = id.lastIndexOf("/")
-          if (lastSlash >= 0) expandFolder(id.slice(0, lastSlash))
-          setSaveState({
-            kind: "success",
-            message: `Successfully created ${newName}`,
-          })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-        .catch((e: unknown) => {
-          const msg = e instanceof Error ? e.message : String(e)
-          setSaveState({ kind: "error", message: msg })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-    },
-    [
-      selectedRequest,
-      collectionDir,
-      setCollectionReloadToken,
-      setFocus,
-      setSaveState,
-      clearSaveTimer,
-      saveTimerRef,
-      setSelectedId,
-      expandFolder,
-    ],
-  )
-
-  const handleNewFolderConfirm = useCallback(
-    (name: string) => {
-      const baseId = slugify(name)
-      if (!baseId) return
-      const folder = newRequestFolderRef.current
-      const path = folder ? `${folder}/${baseId}` : baseId
-
-      const newFolder: Folder = {
-        id: baseId,
-        name,
-        path,
-        children: [],
-      }
-
-      saveFolder(collectionDir, newFolder)
-        .then(() => {
-          if (folder) expandFolder(folder)
-          setCollectionReloadToken((n) => n + 1)
-          setNewFolderVisible(false)
-          setFocus("sidebar")
-          setSaveState({
-            kind: "success",
-            message: `Successfully created folder ${name}`,
-          })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-        .catch((e: unknown) => {
-          const msg = e instanceof Error ? e.message : String(e)
-          setSaveState({ kind: "error", message: msg })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-    },
-    [
-      collectionDir,
-      setCollectionReloadToken,
-      setFocus,
-      setSaveState,
-      clearSaveTimer,
-      saveTimerRef,
-      expandFolder,
-    ],
-  )
-
-  const handleFolderDeleteConfirm = useCallback(() => {
-    const path = folderDeletePathRef.current
-    if (!path) return
-
-    deleteFolder(collectionDir, path)
-      .then(() => {
-        setCollectionReloadToken((n) => n + 1)
-        setFolderDeletePending(null)
-        setFocus("sidebar")
-        setSaveState({
-          kind: "success",
-          message: `Successfully deleted folder ${path}`,
-        })
-        clearSaveTimer()
-        saveTimerRef.current = setTimeout(() => {
-          setSaveState({ kind: "idle" })
-        }, 2000)
-      })
-      .catch((e: unknown) => {
-        const msg = e instanceof Error ? e.message : String(e)
-        setSaveState({ kind: "error", message: msg })
-        clearSaveTimer()
-        saveTimerRef.current = setTimeout(() => {
-          setSaveState({ kind: "idle" })
-        }, 2000)
-      })
-  }, [
-    collectionDir,
-    setCollectionReloadToken,
-    setFocus,
-    setSaveState,
-    clearSaveTimer,
-    saveTimerRef,
-  ])
-
-  const handleEditRequestConfirm = useCallback(
-    (name: string, method: Method, url: string, folderPath?: string) => {
-      const req = selectedRequest
-      if (!req) return
-      const baseId = slugify(name)
-      if (!baseId) return
-
-      const newFolder = folderPath ?? ""
-      const newId = newFolder ? `${newFolder}/${baseId}` : baseId
-
-      const oldFolder = req.id.includes("/")
-        ? req.id.slice(0, req.id.lastIndexOf("/"))
-        : ""
-
-      const nameChanged = newId !== req.id
-      const folderChanged = newFolder !== oldFolder
-      const changed = nameChanged || method !== req.method || url !== req.url
-
-      if (!changed) {
-        setEditRequestVisible(false)
-        setFocus("sidebar")
-        return
-      }
-
-      const updated: NoodleRequest = {
-        ...req,
-        id: newId,
-        name,
-        method,
-        url,
-      }
-
-      const savePromise = saveRequest(collectionDir, updated).then(() => {
-        if (nameChanged || folderChanged) {
-          deleteRequest(collectionDir, req.id).catch(() => {
-            /* stale file not cleaned up — new file is safe */
-          })
-        }
-      })
-
-      savePromise
-        .then(() => {
-          setCollectionReloadToken((n) => n + 1)
-          setEditRequestVisible(false)
-          setFocus("sidebar")
-          if (newFolder) expandFolder(newFolder)
-          setSaveState({
-            kind: "success",
-            message: `Successfully edited ${name}`,
-          })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-        .catch((e: unknown) => {
-          const msg = e instanceof Error ? e.message : String(e)
-          setSaveState({ kind: "error", message: msg })
-          clearSaveTimer()
-          saveTimerRef.current = setTimeout(() => {
-            setSaveState({ kind: "idle" })
-          }, 2000)
-        })
-    },
-    [
-      selectedRequest,
-      collectionDir,
-      setCollectionReloadToken,
-      setFocus,
-      setSaveState,
-      clearSaveTimer,
-      saveTimerRef,
-      expandFolder,
-    ],
-  )
-
-  const handleRequestDeleteConfirm = useCallback(() => {
-    const req = selectedRequest
-    if (!req) return
-
-    deleteRequest(collectionDir, req.id)
-      .then(() => {
-        setCollectionReloadToken((n) => n + 1)
-        setRequestDeletePending(null)
-        setFocus("sidebar")
-        setSaveState({
-          kind: "success",
-          message: `Successfully deleted ${req.name}`,
-        })
-        clearSaveTimer()
-        saveTimerRef.current = setTimeout(() => {
-          setSaveState({ kind: "idle" })
-        }, 2000)
-      })
-      .catch((e: unknown) => {
-        const msg = e instanceof Error ? e.message : String(e)
-        setSaveState({ kind: "error", message: msg })
-        clearSaveTimer()
-        saveTimerRef.current = setTimeout(() => {
-          setSaveState({ kind: "idle" })
-        }, 2000)
-      })
-  }, [
-    selectedRequest,
-    collectionDir,
-    setCollectionReloadToken,
-    setFocus,
-    setSaveState,
-    clearSaveTimer,
-    saveTimerRef,
-  ])
 
   // ── keymap.setData effects ─────────────────────────────────────────
   useEffect(() => {
@@ -1129,327 +783,88 @@ export function AppInner({
         }}
       >
         {view === "main" ? (
-          <box
-            style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}
-          >
-            <Sidebar
-              items={items}
-              loading={loading}
-              error={error}
-              visibleItems={visibleItems}
-              cursorIndex={cursorIndex}
-              selectedId={selectedId}
-              expanded={expandedFolders}
-              focused={focus === "sidebar"}
-              keybinds={keybinds}
-              dirtyRequestIds={draft.dirtyRequestIds}
-              dirtyFolderPaths={dirtyFolderPaths}
-            />
-            <box
-              style={{
-                flexDirection: "column",
-                flexGrow: 1,
-                gap: 1,
-                minHeight: 0,
-              }}
-            >
-              {focusedFolder !== null ? (
-                <FolderPane
-                  collectionDir={collectionDir}
-                  folder={folderDraft.folderDraft}
-                  focused={focus === "folder"}
-                  editState={folderEb.editState}
-                  editKey={folderEb.editKey}
-                  editValue={folderEb.editValue}
-                  setEditKey={folderEb.setEditKey}
-                  setEditValue={folderEb.setEditValue}
-                  activeTab={folderEb.activeTab}
-                  onAuthTypeChange={folderDraft.setAuthType}
-                  onApiKeyPlacementChange={folderDraft.setApiKeyPlacement}
-                  onSelectOpenChange={setSelectOpen}
-                  activeEnv={envState.activeEnv}
-                  theme={theme}
-                />
-              ) : (
-                <>
-                  <UrlBar
-                    method={draft.draft?.method ?? ""}
-                    url={draft.draft?.url ?? ""}
-                    params={draft.draft?.params ?? {}}
-                    setUrl={draft.setUrl}
-                    onDefocus={draft.syncUrlParams}
-                    focused={focus === "urlbar"}
-                    activeEnv={envState.activeEnv}
-                  />
-                  {layout === "side-by-side" ? (
-                    <box
-                      style={{
-                        flexDirection: "row",
-                        flexGrow: 1,
-                        gap: 1,
-                        minHeight: 0,
-                      }}
-                    >
-                      {expanded !== "response" && (
-                        <RequestPane
-                          request={draft.draft}
-                          error={error}
-                          editState={eb.editState}
-                          editKey={eb.editKey}
-                          editValue={eb.editValue}
-                          setEditKey={eb.setEditKey}
-                          setEditValue={eb.setEditValue}
-                          focused={focus === "request"}
-                          activeTab={eb.activeTab}
-                          activeEnv={envState.activeEnv}
-                          onAuthTypeChange={draft.setAuthType}
-                          onApiKeyPlacementChange={draft.setApiKeyPlacement}
-                          onBodyTypeChange={draft.setBodyType}
-                          onSelectOpenChange={setSelectOpen}
-                          expandHint={expandHint}
-                        />
-                      )}
-                      {expanded !== "request" && (
-                        <ResponsePane
-                          state={responseState}
-                          focused={focus === "response"}
-                          timelineEntries={timeline.entries}
-                          initialTab={initialResponseTab}
-                          onTabChange={onResponseTabChange}
-                          expandHint={expandHint}
-                        />
-                      )}
-                    </box>
-                  ) : (
-                    <>
-                      {expanded !== "response" && (
-                        <RequestPane
-                          request={draft.draft}
-                          error={error}
-                          editState={eb.editState}
-                          editKey={eb.editKey}
-                          editValue={eb.editValue}
-                          setEditKey={eb.setEditKey}
-                          setEditValue={eb.setEditValue}
-                          focused={focus === "request"}
-                          activeTab={eb.activeTab}
-                          activeEnv={envState.activeEnv}
-                          onAuthTypeChange={draft.setAuthType}
-                          onApiKeyPlacementChange={draft.setApiKeyPlacement}
-                          onBodyTypeChange={draft.setBodyType}
-                          onSelectOpenChange={setSelectOpen}
-                          expandHint={expandHint}
-                        />
-                      )}
-                      {expanded !== "request" && (
-                        <ResponsePane
-                          state={responseState}
-                          focused={focus === "response"}
-                          timelineEntries={timeline.entries}
-                          initialTab={initialResponseTab}
-                          onTabChange={onResponseTabChange}
-                          expandHint={expandHint}
-                        />
-                      )}
-                    </>
-                  )}
-                </>
-              )}
-            </box>
-          </box>
+          <MainView
+            items={items}
+            collectionDir={collectionDir}
+            loading={loading}
+            error={error}
+            visibleItems={visibleItems}
+            cursorIndex={cursorIndex}
+            selectedId={selectedId}
+            expandedFolders={expandedFolders}
+            focusedFolderPresent={focusedFolder !== null}
+            focus={focus}
+            keybinds={keybinds}
+            draft={draft}
+            folderDraft={folderDraft}
+            folderEb={folderEb}
+            eb={eb}
+            layout={layout}
+            expanded={expanded}
+            activeEnv={envState.activeEnv}
+            responseState={responseState}
+            timelineEntries={timeline.entries}
+            initialResponseTab={initialResponseTab}
+            onResponseTabChange={onResponseTabChange}
+            setSelectOpen={setSelectOpen}
+            expandHint={expandHint}
+          />
         ) : (
-          <box
-            style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}
-          >
-            <EnvSidebar
-              envNames={envEditor.envNames}
-              selectedEnvName={envEditor.selectedEnvName}
-              activeEnvName={envState.activeEnv?.name}
-              envColors={envColors}
-              dirty={envEditor.dirty}
-              onSelectEnv={envEditor.selectEnv}
-              onCreate={() => {
-                envEditor.openEditor()
-                setFocus("env-vars")
-              }}
-              onClone={() => {
-                if (envEditor.selectedEnvName) {
-                  const target = `${envEditor.selectedEnvName} - Copy`
-                  envEditor.cloneEnv(target)
-                }
-              }}
-              onDelete={() => {
-                if (envEditor.selectedEnvName) {
-                  setEnvDeletePending(envEditor.selectedEnvName)
-                  setDeleteConfirmSelection(0)
-                }
-              }}
-              focused={focus === "env-sidebar"}
-            />
-            <box
-              style={{
-                flexDirection: "column",
-                flexGrow: 1,
-                gap: 1,
-                minHeight: 0,
-              }}
-            >
-              <EnvHeaderPane
-                ref={envHeaderRef}
-                name={envEditor.draft?.name ?? ""}
-                color={envEditor.draft?.color}
-                onNameChange={envEditor.setName}
-                onColorChange={envEditor.setColor}
-                focused={focus === "env-header"}
-              />
-              <EnvEditorPane
-                draft={envEditor.draft}
-                selectedRowIndex={envEditor.selectedRowIndex}
-                editingField={envEditor.editingField}
-                saving={envEditor.saving}
-                error={envEditor.error}
-                onSelectRow={envEditor.selectRow}
-                onUpdateVarKey={envEditor.updateVarKey}
-                onUpdateVarValue={envEditor.updateVarValue}
-                onToggleVar={envEditor.toggleVar}
-                onDeleteVar={envEditor.deleteVar}
-                focused={focus === "env-vars"}
-              />
-            </box>
-          </box>
-        )}
-        {helpVisible && <HelpOverlay visible keybinds={keybinds} />}
-        {saveState.kind === "confirming" && (
-          <ConfirmOverlay
-            visible
-            message={`Save changes to ${saveState.requestId}?`}
-            selectedIndex={confirmSelection}
-          />
-        )}
-        {envDeletePending !== null && (
-          <ConfirmOverlay
-            visible
-            message={`Delete environment "${envDeletePending}"?`}
-            selectedIndex={deleteConfirmSelection}
-          />
-        )}
-        {undoAllPending && (
-          <ConfirmOverlay
-            visible
-            message="Discard all unsaved changes? (y/n)"
-            selectedIndex={confirmSelection}
-          />
-        )}
-        {collectionSwitchPending !== null && (
-          <ConfirmOverlay
-            visible
-            message={`Switch to "${collectionSwitchPending}" and discard unsaved changes?`}
-            selectedIndex={collectionSwitchSelection}
-          />
-        )}
-        {commandPaletteVisible && (
-          <CommandPaletteOverlay
-            visible
-            commands={commandPaletteCommands}
-            onClose={() => setCommandPaletteVisible(false)}
-          />
-        )}
-        {collectionSwitcherVisible && (
-          <CollectionSwitcherOverlay
-            visible
-            collections={collectionPaths}
-            activeCollectionDir={collectionDir}
-            onSelect={requestCollectionSwitch}
-            onClose={() => setCollectionSwitcherVisible(false)}
-          />
-        )}
-        {previewIndex !== null && (
-          <ThemePickerOverlay
-            visible
-            activeIndex={activeIndex}
-            previewIndex={previewIndex}
-            setPreviewIndex={setPreviewIndexProp}
-            onThemeChange={onThemeChange}
-          />
-        )}
-        {yamlEditor.visible && (
-          <YamlEditorOverlay
-            visible
-            filePath={yamlEditor.filePath}
-            requestName={yamlEditor.requestName}
-            onSaved={() => {
-              setCollectionReloadToken((n) => n + 1)
-              setYamlEditor({
-                visible: false,
-                filePath: "",
-                requestName: "",
-                returnFocus: "sidebar",
-              })
-              setFocus(yamlEditor.returnFocus)
-              setSaveState({
-                kind: "success",
-                message: `Successfully edited ${yamlEditor.filePath.split("/").pop() ?? ""}`,
-              })
-              clearSaveTimer()
-              saveTimerRef.current = setTimeout(() => {
-                setSaveState({ kind: "idle" })
-              }, 2000)
-            }}
-            onClose={() => {
-              setYamlEditor({
-                visible: false,
-                filePath: "",
-                requestName: "",
-                returnFocus: "sidebar",
-              })
-              setFocus(yamlEditor.returnFocus)
-            }}
-          />
-        )}
-        {newRequestVisible && (
-          <NewRequestOverlay
-            visible
-            ref={newRequestRef}
+          <EnvironmentEditorView
+            envEditor={envEditor}
             activeEnv={envState.activeEnv}
+            envColors={envColors}
+            focus={focus}
+            envHeaderRef={envHeaderRef}
+            setFocus={setFocus}
+            setEnvDeletePending={setEnvDeletePending}
+            setDeleteConfirmSelection={setDeleteConfirmSelection}
           />
         )}
-        {editRequestVisible && (
-          <NewRequestOverlay
-            visible
-            mode="edit"
-            initialName={selectedRequest?.name}
-            initialMethod={selectedRequest?.method}
-            initialUrl={selectedRequest?.url}
-            folderPaths={folderPaths}
-            initialFolderPath={editRequestInitialFolder}
-            ref={editRequestRef}
-            activeEnv={envState.activeEnv}
-          />
-        )}
-        {cloneRequestVisible && (
-          <CloneRequestOverlay
-            visible
-            initialName={
-              selectedRequest ? `${selectedRequest.name} - Copy` : ""
-            }
-            ref={cloneRequestRef}
-          />
-        )}
-        {newFolderVisible && <NewFolderOverlay visible ref={newFolderRef} />}
-        {folderDeletePending !== null && (
-          <ConfirmOverlay
-            visible
-            message={`Delete folder "${folderDeletePending}" and all requests inside?`}
-            selectedIndex={0}
-          />
-        )}
-        {requestDeletePending !== null && (
-          <ConfirmOverlay
-            visible
-            message={`Delete "${requestDeletePending}"?`}
-            selectedIndex={0}
-          />
-        )}
+        <AppOverlays
+          keybinds={keybinds}
+          helpVisible={helpVisible}
+          saveState={saveState}
+          confirmSelection={confirmSelection}
+          envDeletePending={envDeletePending}
+          deleteConfirmSelection={deleteConfirmSelection}
+          undoAllPending={undoAllPending}
+          collectionSwitchPending={collectionSwitchPending}
+          collectionSwitchSelection={collectionSwitchSelection}
+          commandPaletteVisible={commandPaletteVisible}
+          commandPaletteCommands={commandPaletteCommands}
+          setCommandPaletteVisible={setCommandPaletteVisible}
+          collectionSwitcherVisible={collectionSwitcherVisible}
+          collectionPaths={collectionPaths}
+          collectionDir={collectionDir}
+          requestCollectionSwitch={requestCollectionSwitch}
+          setCollectionSwitcherVisible={setCollectionSwitcherVisible}
+          previewIndex={previewIndex}
+          activeIndex={activeIndex}
+          setPreviewIndex={setPreviewIndexProp}
+          onThemeChange={onThemeChange}
+          yamlEditor={yamlEditor}
+          setYamlEditor={setYamlEditor}
+          setCollectionReloadToken={setCollectionReloadToken}
+          setFocus={setFocus}
+          setSaveState={setSaveState}
+          clearSaveTimer={clearSaveTimer}
+          saveTimerRef={saveTimerRef}
+          newRequestVisible={newRequestVisible}
+          newRequestRef={newRequestRef}
+          activeEnv={envState.activeEnv}
+          editRequestVisible={editRequestVisible}
+          selectedRequest={selectedRequest}
+          folderPaths={folderPaths}
+          editRequestInitialFolder={editRequestInitialFolder}
+          editRequestRef={editRequestRef}
+          cloneRequestVisible={cloneRequestVisible}
+          cloneRequestRef={cloneRequestRef}
+          newFolderVisible={newFolderVisible}
+          newFolderRef={newFolderRef}
+          folderDeletePending={folderDeletePending}
+          requestDeletePending={requestDeletePending}
+        />
       </box>
       <StatusBar
         method={draft.draft?.method ?? ""}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -1,0 +1,259 @@
+import type { RefObject } from "react"
+import { HelpOverlay } from "./HelpOverlay"
+import { ConfirmOverlay } from "./ConfirmOverlay"
+import {
+  CommandPaletteOverlay,
+  type CommandItem,
+} from "./CommandPaletteOverlay"
+import { CollectionSwitcherOverlay } from "./CollectionSwitcherOverlay"
+import { ThemePickerOverlay } from "./theme"
+import { YamlEditorOverlay } from "./YamlEditorOverlay"
+import {
+  NewRequestOverlay,
+  type NewRequestOverlayHandle,
+} from "./NewRequestOverlay"
+import {
+  CloneRequestOverlay,
+  type CloneRequestOverlayHandle,
+} from "./CloneRequestOverlay"
+import {
+  NewFolderOverlay,
+  type NewFolderOverlayHandle,
+} from "./NewFolderOverlay"
+import type { Environment, Request as NoodleRequest } from "../schema"
+import type { Keybinds } from "./keybind"
+import type { Focus } from "./focus"
+import type { SaveState } from "./saveState"
+
+interface FolderPathOption {
+  id: string
+  label: string
+}
+
+interface YamlEditorState {
+  visible: boolean
+  filePath: string
+  requestName: string
+  returnFocus: Focus
+}
+
+interface AppOverlaysProps {
+  keybinds: Keybinds
+  helpVisible: boolean
+  saveState: SaveState
+  confirmSelection: number
+  envDeletePending: string | null
+  deleteConfirmSelection: number
+  undoAllPending: boolean
+  collectionSwitchPending: string | null
+  collectionSwitchSelection: number
+  commandPaletteVisible: boolean
+  commandPaletteCommands: CommandItem[]
+  setCommandPaletteVisible: (visible: boolean) => void
+  collectionSwitcherVisible: boolean
+  collectionPaths: string[]
+  collectionDir: string
+  requestCollectionSwitch: (nextDir: string) => void
+  setCollectionSwitcherVisible: (visible: boolean) => void
+  previewIndex: number | null
+  activeIndex: number
+  setPreviewIndex: (value: number | null) => void
+  onThemeChange: (index: number) => void
+  yamlEditor: YamlEditorState
+  setYamlEditor: (state: YamlEditorState) => void
+  setCollectionReloadToken: (fn: (n: number) => number) => void
+  setFocus: (focus: Focus) => void
+  setSaveState: (state: SaveState) => void
+  clearSaveTimer: () => void
+  saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
+  newRequestVisible: boolean
+  newRequestRef: RefObject<NewRequestOverlayHandle | null>
+  activeEnv: Environment | null
+  editRequestVisible: boolean
+  selectedRequest: NoodleRequest | null
+  folderPaths: FolderPathOption[]
+  editRequestInitialFolder: string
+  editRequestRef: RefObject<NewRequestOverlayHandle | null>
+  cloneRequestVisible: boolean
+  cloneRequestRef: RefObject<CloneRequestOverlayHandle | null>
+  newFolderVisible: boolean
+  newFolderRef: RefObject<NewFolderOverlayHandle | null>
+  folderDeletePending: string | null
+  requestDeletePending: string | null
+}
+
+export function AppOverlays({
+  keybinds,
+  helpVisible,
+  saveState,
+  confirmSelection,
+  envDeletePending,
+  deleteConfirmSelection,
+  undoAllPending,
+  collectionSwitchPending,
+  collectionSwitchSelection,
+  commandPaletteVisible,
+  commandPaletteCommands,
+  setCommandPaletteVisible,
+  collectionSwitcherVisible,
+  collectionPaths,
+  collectionDir,
+  requestCollectionSwitch,
+  setCollectionSwitcherVisible,
+  previewIndex,
+  activeIndex,
+  setPreviewIndex,
+  onThemeChange,
+  yamlEditor,
+  setYamlEditor,
+  setCollectionReloadToken,
+  setFocus,
+  setSaveState,
+  clearSaveTimer,
+  saveTimerRef,
+  newRequestVisible,
+  newRequestRef,
+  activeEnv,
+  editRequestVisible,
+  selectedRequest,
+  folderPaths,
+  editRequestInitialFolder,
+  editRequestRef,
+  cloneRequestVisible,
+  cloneRequestRef,
+  newFolderVisible,
+  newFolderRef,
+  folderDeletePending,
+  requestDeletePending,
+}: AppOverlaysProps) {
+  return (
+    <>
+      {helpVisible && <HelpOverlay visible keybinds={keybinds} />}
+      {saveState.kind === "confirming" && (
+        <ConfirmOverlay
+          visible
+          message={`Save changes to ${saveState.requestId}?`}
+          selectedIndex={confirmSelection}
+        />
+      )}
+      {envDeletePending !== null && (
+        <ConfirmOverlay
+          visible
+          message={`Delete environment "${envDeletePending}"?`}
+          selectedIndex={deleteConfirmSelection}
+        />
+      )}
+      {undoAllPending && (
+        <ConfirmOverlay
+          visible
+          message="Discard all unsaved changes? (y/n)"
+          selectedIndex={confirmSelection}
+        />
+      )}
+      {collectionSwitchPending !== null && (
+        <ConfirmOverlay
+          visible
+          message={`Switch to "${collectionSwitchPending}" and discard unsaved changes?`}
+          selectedIndex={collectionSwitchSelection}
+        />
+      )}
+      {commandPaletteVisible && (
+        <CommandPaletteOverlay
+          visible
+          commands={commandPaletteCommands}
+          onClose={() => setCommandPaletteVisible(false)}
+        />
+      )}
+      {collectionSwitcherVisible && (
+        <CollectionSwitcherOverlay
+          visible
+          collections={collectionPaths}
+          activeCollectionDir={collectionDir}
+          onSelect={requestCollectionSwitch}
+          onClose={() => setCollectionSwitcherVisible(false)}
+        />
+      )}
+      {previewIndex !== null && (
+        <ThemePickerOverlay
+          visible
+          activeIndex={activeIndex}
+          previewIndex={previewIndex}
+          setPreviewIndex={setPreviewIndex}
+          onThemeChange={onThemeChange}
+        />
+      )}
+      {yamlEditor.visible && (
+        <YamlEditorOverlay
+          visible
+          filePath={yamlEditor.filePath}
+          requestName={yamlEditor.requestName}
+          onSaved={() => {
+            setCollectionReloadToken((n) => n + 1)
+            setYamlEditor({
+              visible: false,
+              filePath: "",
+              requestName: "",
+              returnFocus: "sidebar",
+            })
+            setFocus(yamlEditor.returnFocus)
+            setSaveState({
+              kind: "success",
+              message: `Successfully edited ${yamlEditor.filePath.split("/").pop() ?? ""}`,
+            })
+            clearSaveTimer()
+            saveTimerRef.current = setTimeout(() => {
+              setSaveState({ kind: "idle" })
+            }, 2000)
+          }}
+          onClose={() => {
+            setYamlEditor({
+              visible: false,
+              filePath: "",
+              requestName: "",
+              returnFocus: "sidebar",
+            })
+            setFocus(yamlEditor.returnFocus)
+          }}
+        />
+      )}
+      {newRequestVisible && (
+        <NewRequestOverlay visible ref={newRequestRef} activeEnv={activeEnv} />
+      )}
+      {editRequestVisible && (
+        <NewRequestOverlay
+          visible
+          mode="edit"
+          initialName={selectedRequest?.name}
+          initialMethod={selectedRequest?.method}
+          initialUrl={selectedRequest?.url}
+          folderPaths={folderPaths}
+          initialFolderPath={editRequestInitialFolder}
+          ref={editRequestRef}
+          activeEnv={activeEnv}
+        />
+      )}
+      {cloneRequestVisible && (
+        <CloneRequestOverlay
+          visible
+          initialName={selectedRequest ? `${selectedRequest.name} - Copy` : ""}
+          ref={cloneRequestRef}
+        />
+      )}
+      {newFolderVisible && <NewFolderOverlay visible ref={newFolderRef} />}
+      {folderDeletePending !== null && (
+        <ConfirmOverlay
+          visible
+          message={`Delete folder "${folderDeletePending}" and all requests inside?`}
+          selectedIndex={0}
+        />
+      )}
+      {requestDeletePending !== null && (
+        <ConfirmOverlay
+          visible
+          message={`Delete "${requestDeletePending}"?`}
+          selectedIndex={0}
+        />
+      )}
+    </>
+  )
+}

--- a/src/ui/EnvironmentEditorView.tsx
+++ b/src/ui/EnvironmentEditorView.tsx
@@ -1,0 +1,89 @@
+import { EnvSidebar } from "./EnvSidebar"
+import { EnvHeaderPane, type EnvHeaderPaneHandle } from "./EnvHeaderPane"
+import { EnvEditorPane } from "./EnvEditorPane"
+import type { RefObject } from "react"
+import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
+import type { Environment } from "../schema"
+import type { Focus } from "./focus"
+
+interface EnvironmentEditorViewProps {
+  envEditor: UseEnvironmentEditorResult
+  activeEnv: Environment | null
+  envColors: Record<string, string | undefined>
+  focus: Focus
+  envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
+  setFocus: (focus: Focus) => void
+  setEnvDeletePending: (name: string | null) => void
+  setDeleteConfirmSelection: (selection: number) => void
+}
+
+export function EnvironmentEditorView({
+  envEditor,
+  activeEnv,
+  envColors,
+  focus,
+  envHeaderRef,
+  setFocus,
+  setEnvDeletePending,
+  setDeleteConfirmSelection,
+}: EnvironmentEditorViewProps) {
+  return (
+    <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
+      <EnvSidebar
+        envNames={envEditor.envNames}
+        selectedEnvName={envEditor.selectedEnvName}
+        activeEnvName={activeEnv?.name}
+        envColors={envColors}
+        dirty={envEditor.dirty}
+        onSelectEnv={envEditor.selectEnv}
+        onCreate={() => {
+          envEditor.openEditor()
+          setFocus("env-vars")
+        }}
+        onClone={() => {
+          if (envEditor.selectedEnvName) {
+            const target = `${envEditor.selectedEnvName} - Copy`
+            envEditor.cloneEnv(target)
+          }
+        }}
+        onDelete={() => {
+          if (envEditor.selectedEnvName) {
+            setEnvDeletePending(envEditor.selectedEnvName)
+            setDeleteConfirmSelection(0)
+          }
+        }}
+        focused={focus === "env-sidebar"}
+      />
+      <box
+        style={{
+          flexDirection: "column",
+          flexGrow: 1,
+          gap: 1,
+          minHeight: 0,
+        }}
+      >
+        <EnvHeaderPane
+          ref={envHeaderRef}
+          name={envEditor.draft?.name ?? ""}
+          color={envEditor.draft?.color}
+          onNameChange={envEditor.setName}
+          onColorChange={envEditor.setColor}
+          focused={focus === "env-header"}
+        />
+        <EnvEditorPane
+          draft={envEditor.draft}
+          selectedRowIndex={envEditor.selectedRowIndex}
+          editingField={envEditor.editingField}
+          saving={envEditor.saving}
+          error={envEditor.error}
+          onSelectRow={envEditor.selectRow}
+          onUpdateVarKey={envEditor.updateVarKey}
+          onUpdateVarValue={envEditor.updateVarValue}
+          onToggleVar={envEditor.toggleVar}
+          onDeleteVar={envEditor.deleteVar}
+          focused={focus === "env-vars"}
+        />
+      </box>
+    </box>
+  )
+}

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -1,0 +1,222 @@
+import { Sidebar } from "./Sidebar"
+import { UrlBar } from "./UrlBar"
+import { RequestPane } from "./RequestPane"
+import { ResponsePane } from "./ResponsePane"
+import { FolderPane } from "./FolderPane"
+import { useTheme } from "./theme"
+import type { CollectionItem, Environment } from "../schema"
+import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
+import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
+import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
+import type { UseFolderEditBrowseResult } from "../hooks/useFolderEditBrowse"
+import type { Focus } from "./focus"
+import type { Keybinds } from "./keybind"
+import type { VisibleNode } from "./tree"
+import type { ResponseTabKind } from "./tabs/uiState"
+import type { SendState } from "./sendState"
+import type { TimelineEntry } from "../schema"
+
+interface MainViewProps {
+  items: CollectionItem[]
+  collectionDir: string
+  loading: boolean
+  error: Error | null
+  visibleItems: VisibleNode[]
+  cursorIndex: number
+  selectedId: string | null
+  expandedFolders: Set<string>
+  focusedFolderPresent: boolean
+  focus: Focus
+  keybinds: Keybinds
+  draft: UseRequestDraftResult
+  folderDraft: UseFolderDraftResult
+  folderEb: UseFolderEditBrowseResult
+  eb: UseEditBrowseResult
+  layout: "stacked" | "side-by-side"
+  expanded: "request" | "response" | null
+  activeEnv: Environment | null
+  responseState: SendState
+  timelineEntries: TimelineEntry[]
+  initialResponseTab?: ResponseTabKind
+  onResponseTabChange: (tab: ResponseTabKind) => void
+  setSelectOpen: (open: boolean) => void
+  expandHint: string
+}
+
+export function MainView({
+  items,
+  collectionDir,
+  loading,
+  error,
+  visibleItems,
+  cursorIndex,
+  selectedId,
+  expandedFolders,
+  focusedFolderPresent,
+  focus,
+  keybinds,
+  draft,
+  folderDraft,
+  folderEb,
+  eb,
+  layout,
+  expanded,
+  activeEnv,
+  responseState,
+  timelineEntries,
+  initialResponseTab,
+  onResponseTabChange,
+  setSelectOpen,
+  expandHint,
+}: MainViewProps) {
+  const theme = useTheme()
+
+  return (
+    <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
+      <Sidebar
+        items={items}
+        loading={loading}
+        error={error}
+        visibleItems={visibleItems}
+        cursorIndex={cursorIndex}
+        selectedId={selectedId}
+        expanded={expandedFolders}
+        focused={focus === "sidebar"}
+        keybinds={keybinds}
+        dirtyRequestIds={draft.dirtyRequestIds}
+        dirtyFolderPaths={folderDraft.dirtyPaths}
+      />
+      <box
+        style={{
+          flexDirection: "column",
+          flexGrow: 1,
+          gap: 1,
+          minHeight: 0,
+        }}
+      >
+        {focusedFolderPresent ? (
+          <FolderPane
+            collectionDir={collectionDir}
+            folder={folderDraft.folderDraft}
+            focused={focus === "folder"}
+            editState={folderEb.editState}
+            editKey={folderEb.editKey}
+            editValue={folderEb.editValue}
+            setEditKey={folderEb.setEditKey}
+            setEditValue={folderEb.setEditValue}
+            activeTab={folderEb.activeTab}
+            onAuthTypeChange={folderDraft.setAuthType}
+            onApiKeyPlacementChange={folderDraft.setApiKeyPlacement}
+            onSelectOpenChange={setSelectOpen}
+            activeEnv={activeEnv}
+            theme={theme}
+          />
+        ) : (
+          <RequestResponseView
+            draft={draft}
+            eb={eb}
+            error={error}
+            focus={focus}
+            layout={layout}
+            expanded={expanded}
+            activeEnv={activeEnv}
+            responseState={responseState}
+            timelineEntries={timelineEntries}
+            initialResponseTab={initialResponseTab}
+            onResponseTabChange={onResponseTabChange}
+            setSelectOpen={setSelectOpen}
+            expandHint={expandHint}
+          />
+        )}
+      </box>
+    </box>
+  )
+}
+
+function RequestResponseView({
+  draft,
+  eb,
+  error,
+  focus,
+  layout,
+  expanded,
+  activeEnv,
+  responseState,
+  timelineEntries,
+  initialResponseTab,
+  onResponseTabChange,
+  setSelectOpen,
+  expandHint,
+}: Pick<
+  MainViewProps,
+  | "draft"
+  | "eb"
+  | "error"
+  | "focus"
+  | "layout"
+  | "expanded"
+  | "activeEnv"
+  | "responseState"
+  | "timelineEntries"
+  | "initialResponseTab"
+  | "onResponseTabChange"
+  | "setSelectOpen"
+  | "expandHint"
+>) {
+  const content = (
+    <>
+      {expanded !== "response" && (
+        <RequestPane
+          request={draft.draft}
+          error={error}
+          editState={eb.editState}
+          editKey={eb.editKey}
+          editValue={eb.editValue}
+          setEditKey={eb.setEditKey}
+          setEditValue={eb.setEditValue}
+          focused={focus === "request"}
+          activeTab={eb.activeTab}
+          activeEnv={activeEnv}
+          onAuthTypeChange={draft.setAuthType}
+          onApiKeyPlacementChange={draft.setApiKeyPlacement}
+          onBodyTypeChange={draft.setBodyType}
+          onSelectOpenChange={setSelectOpen}
+          expandHint={expandHint}
+        />
+      )}
+      {expanded !== "request" && (
+        <ResponsePane
+          state={responseState}
+          focused={focus === "response"}
+          timelineEntries={timelineEntries}
+          initialTab={initialResponseTab}
+          onTabChange={onResponseTabChange}
+          expandHint={expandHint}
+        />
+      )}
+    </>
+  )
+
+  return (
+    <>
+      <UrlBar
+        method={draft.draft?.method ?? ""}
+        url={draft.draft?.url ?? ""}
+        params={draft.draft?.params ?? {}}
+        setUrl={draft.setUrl}
+        onDefocus={draft.syncUrlParams}
+        focused={focus === "urlbar"}
+        activeEnv={activeEnv}
+      />
+      {layout === "side-by-side" ? (
+        <box
+          style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}
+        >
+          {content}
+        </box>
+      ) : (
+        content
+      )}
+    </>
+  )
+}

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -1,7 +1,4 @@
 import { Sidebar } from "./Sidebar"
-import { UrlBar } from "./UrlBar"
-import { RequestPane } from "./RequestPane"
-import { ResponsePane } from "./ResponsePane"
 import { FolderPane } from "./FolderPane"
 import { useTheme } from "./theme"
 import type { CollectionItem, Environment } from "../schema"
@@ -12,9 +9,7 @@ import type { UseFolderEditBrowseResult } from "../hooks/useFolderEditBrowse"
 import type { Focus } from "./focus"
 import type { Keybinds } from "./keybind"
 import type { VisibleNode } from "./tree"
-import type { ResponseTabKind } from "./tabs/uiState"
-import type { SendState } from "./sendState"
-import type { TimelineEntry } from "../schema"
+import { RequestResponseView } from "./RequestResponseView"
 
 interface MainViewProps {
   items: CollectionItem[]
@@ -35,10 +30,12 @@ interface MainViewProps {
   layout: "stacked" | "side-by-side"
   expanded: "request" | "response" | null
   activeEnv: Environment | null
-  responseState: SendState
-  timelineEntries: TimelineEntry[]
-  initialResponseTab?: ResponseTabKind
-  onResponseTabChange: (tab: ResponseTabKind) => void
+  responseState: import("./sendState").SendState
+  timelineEntries: import("../schema").TimelineEntry[]
+  initialResponseTab?: import("./tabs/uiState").ResponseTabKind
+  onResponseTabChange: (
+    tab: import("./tabs/uiState").ResponseTabKind,
+  ) => void
   setSelectOpen: (open: boolean) => void
   expandHint: string
 }
@@ -130,93 +127,5 @@ export function MainView({
         )}
       </box>
     </box>
-  )
-}
-
-function RequestResponseView({
-  draft,
-  eb,
-  error,
-  focus,
-  layout,
-  expanded,
-  activeEnv,
-  responseState,
-  timelineEntries,
-  initialResponseTab,
-  onResponseTabChange,
-  setSelectOpen,
-  expandHint,
-}: Pick<
-  MainViewProps,
-  | "draft"
-  | "eb"
-  | "error"
-  | "focus"
-  | "layout"
-  | "expanded"
-  | "activeEnv"
-  | "responseState"
-  | "timelineEntries"
-  | "initialResponseTab"
-  | "onResponseTabChange"
-  | "setSelectOpen"
-  | "expandHint"
->) {
-  const content = (
-    <>
-      {expanded !== "response" && (
-        <RequestPane
-          request={draft.draft}
-          error={error}
-          editState={eb.editState}
-          editKey={eb.editKey}
-          editValue={eb.editValue}
-          setEditKey={eb.setEditKey}
-          setEditValue={eb.setEditValue}
-          focused={focus === "request"}
-          activeTab={eb.activeTab}
-          activeEnv={activeEnv}
-          onAuthTypeChange={draft.setAuthType}
-          onApiKeyPlacementChange={draft.setApiKeyPlacement}
-          onBodyTypeChange={draft.setBodyType}
-          onSelectOpenChange={setSelectOpen}
-          expandHint={expandHint}
-        />
-      )}
-      {expanded !== "request" && (
-        <ResponsePane
-          state={responseState}
-          focused={focus === "response"}
-          timelineEntries={timelineEntries}
-          initialTab={initialResponseTab}
-          onTabChange={onResponseTabChange}
-          expandHint={expandHint}
-        />
-      )}
-    </>
-  )
-
-  return (
-    <>
-      <UrlBar
-        method={draft.draft?.method ?? ""}
-        url={draft.draft?.url ?? ""}
-        params={draft.draft?.params ?? {}}
-        setUrl={draft.setUrl}
-        onDefocus={draft.syncUrlParams}
-        focused={focus === "urlbar"}
-        activeEnv={activeEnv}
-      />
-      {layout === "side-by-side" ? (
-        <box
-          style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}
-        >
-          {content}
-        </box>
-      ) : (
-        content
-      )}
-    </>
   )
 }

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -33,9 +33,7 @@ interface MainViewProps {
   responseState: import("./sendState").SendState
   timelineEntries: import("../schema").TimelineEntry[]
   initialResponseTab?: import("./tabs/uiState").ResponseTabKind
-  onResponseTabChange: (
-    tab: import("./tabs/uiState").ResponseTabKind,
-  ) => void
+  onResponseTabChange: (tab: import("./tabs/uiState").ResponseTabKind) => void
   setSelectOpen: (open: boolean) => void
   expandHint: string
 }

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -1,0 +1,98 @@
+import { UrlBar } from "./UrlBar"
+import { RequestPane } from "./RequestPane"
+import { ResponsePane } from "./ResponsePane"
+import type { Environment, TimelineEntry } from "../schema"
+import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
+import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
+import type { Focus } from "./focus"
+import type { ResponseTabKind } from "./tabs/uiState"
+import type { SendState } from "./sendState"
+
+interface RequestResponseViewProps {
+  draft: UseRequestDraftResult
+  eb: UseEditBrowseResult
+  error: Error | null
+  focus: Focus
+  layout: "stacked" | "side-by-side"
+  expanded: "request" | "response" | null
+  activeEnv: Environment | null
+  responseState: SendState
+  timelineEntries: TimelineEntry[]
+  initialResponseTab?: ResponseTabKind
+  onResponseTabChange: (tab: ResponseTabKind) => void
+  setSelectOpen: (open: boolean) => void
+  expandHint: string
+}
+
+export function RequestResponseView({
+  draft,
+  eb,
+  error,
+  focus,
+  layout,
+  expanded,
+  activeEnv,
+  responseState,
+  timelineEntries,
+  initialResponseTab,
+  onResponseTabChange,
+  setSelectOpen,
+  expandHint,
+}: RequestResponseViewProps) {
+  const content = (
+    <>
+      {expanded !== "response" && (
+        <RequestPane
+          request={draft.draft}
+          error={error}
+          editState={eb.editState}
+          editKey={eb.editKey}
+          editValue={eb.editValue}
+          setEditKey={eb.setEditKey}
+          setEditValue={eb.setEditValue}
+          focused={focus === "request"}
+          activeTab={eb.activeTab}
+          activeEnv={activeEnv}
+          onAuthTypeChange={draft.setAuthType}
+          onApiKeyPlacementChange={draft.setApiKeyPlacement}
+          onBodyTypeChange={draft.setBodyType}
+          onSelectOpenChange={setSelectOpen}
+          expandHint={expandHint}
+        />
+      )}
+      {expanded !== "request" && (
+        <ResponsePane
+          state={responseState}
+          focused={focus === "response"}
+          timelineEntries={timelineEntries}
+          initialTab={initialResponseTab}
+          onTabChange={onResponseTabChange}
+          expandHint={expandHint}
+        />
+      )}
+    </>
+  )
+
+  return (
+    <>
+      <UrlBar
+        method={draft.draft?.method ?? ""}
+        url={draft.draft?.url ?? ""}
+        params={draft.draft?.params ?? {}}
+        setUrl={draft.setUrl}
+        onDefocus={draft.syncUrlParams}
+        focused={focus === "urlbar"}
+        activeEnv={activeEnv}
+      />
+      {layout === "side-by-side" ? (
+        <box
+          style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}
+        >
+          {content}
+        </box>
+      ) : (
+        content
+      )}
+    </>
+  )
+}

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -1,0 +1,371 @@
+import { useCallback } from "react"
+import type { Dispatch, MutableRefObject, SetStateAction } from "react"
+import type {
+  Collection,
+  Folder,
+  Method,
+  Request as NoodleRequest,
+} from "../schema"
+import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
+import {
+  saveRequest,
+  deleteRequest,
+  saveFolder,
+  deleteFolder,
+} from "../filestore/save"
+import { slugify } from "./NewRequestOverlay"
+import { updateFolderByPath } from "./tree"
+import type { Focus } from "./focus"
+import type { SaveState } from "./saveState"
+
+interface UseCollectionFileActionsOptions {
+  collectionDir: string
+  collection: Collection | null
+  updateCollection: (collection: Collection) => void
+  selectedRequest: NoodleRequest | null
+  folderDraftRef: MutableRefObject<UseFolderDraftResult>
+  newRequestFolderRef: MutableRefObject<string | null>
+  folderDeletePathRef: MutableRefObject<string | null>
+  setCollectionReloadToken: Dispatch<SetStateAction<number>>
+  setFocus: Dispatch<SetStateAction<Focus>>
+  setSaveState: Dispatch<SetStateAction<SaveState>>
+  clearSaveTimer: () => void
+  saveTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>
+  setSelectedId: (id: string) => void
+  expandFolder: (path: string) => void
+  setNewRequestVisible: Dispatch<SetStateAction<boolean>>
+  setCloneRequestVisible: Dispatch<SetStateAction<boolean>>
+  setNewFolderVisible: Dispatch<SetStateAction<boolean>>
+  setEditRequestVisible: Dispatch<SetStateAction<boolean>>
+  setRequestDeletePending: Dispatch<SetStateAction<string | null>>
+  setFolderDeletePending: Dispatch<SetStateAction<string | null>>
+}
+
+export function useCollectionFileActions({
+  collectionDir,
+  collection,
+  updateCollection,
+  selectedRequest,
+  folderDraftRef,
+  newRequestFolderRef,
+  folderDeletePathRef,
+  setCollectionReloadToken,
+  setFocus,
+  setSaveState,
+  clearSaveTimer,
+  saveTimerRef,
+  setSelectedId,
+  expandFolder,
+  setNewRequestVisible,
+  setCloneRequestVisible,
+  setNewFolderVisible,
+  setEditRequestVisible,
+  setRequestDeletePending,
+  setFolderDeletePending,
+}: UseCollectionFileActionsOptions) {
+  const showSaveResult = useCallback(
+    (state: SaveState) => {
+      setSaveState(state)
+      clearSaveTimer()
+      saveTimerRef.current = setTimeout(() => {
+        setSaveState({ kind: "idle" })
+      }, 2000)
+    },
+    [clearSaveTimer, saveTimerRef, setSaveState],
+  )
+
+  const showError = useCallback(
+    (e: unknown) => {
+      const msg = e instanceof Error ? e.message : String(e)
+      showSaveResult({ kind: "error", message: msg })
+    },
+    [showSaveResult],
+  )
+
+  const handleFolderSave = useCallback(async () => {
+    const draftFolder = folderDraftRef.current?.folderDraft
+    if (!draftFolder || !collection) return
+    try {
+      await saveFolder(collectionDir, draftFolder)
+      folderDraftRef.current?.markSaved()
+      updateCollection({
+        ...collection,
+        items: updateFolderByPath(
+          collection.items,
+          draftFolder.path,
+          draftFolder,
+        ),
+      })
+      showSaveResult({
+        kind: "success",
+        message: `Successfully saved folder ${draftFolder.name}`,
+      })
+    } catch (e: unknown) {
+      showError(e)
+    }
+  }, [
+    collection,
+    collectionDir,
+    folderDraftRef,
+    showError,
+    showSaveResult,
+    updateCollection,
+  ])
+
+  const handleNewRequestConfirm = useCallback(
+    (name: string, method: Method, url: string) => {
+      const baseId = slugify(name)
+      if (!baseId) return
+      const folder = newRequestFolderRef.current
+      const id = folder ? `${folder}/${baseId}` : baseId
+
+      const req: NoodleRequest = {
+        id,
+        name,
+        method,
+        url,
+        timeout: 0,
+        followRedirects: true,
+        maxRedirects: 5,
+        headers: {},
+        params: {},
+        auth: { type: "none" },
+        bodyType: "none",
+        body: "",
+      }
+
+      saveRequest(collectionDir, req)
+        .then(() => {
+          if (folder) expandFolder(folder)
+          setCollectionReloadToken((n) => n + 1)
+          setSelectedId(id)
+          setNewRequestVisible(false)
+          setFocus("sidebar")
+          showSaveResult({
+            kind: "success",
+            message: `Successfully created ${name}`,
+          })
+        })
+        .catch(showError)
+    },
+    [
+      collectionDir,
+      expandFolder,
+      newRequestFolderRef,
+      setCollectionReloadToken,
+      setFocus,
+      setNewRequestVisible,
+      setSelectedId,
+      showError,
+      showSaveResult,
+    ],
+  )
+
+  const handleCloneRequestConfirm = useCallback(
+    (newName: string) => {
+      const req = selectedRequest
+      if (!req) return
+      const baseId = slugify(newName)
+      if (!baseId) return
+      const lastSlash = req.id.lastIndexOf("/")
+      const id =
+        lastSlash >= 0 ? `${req.id.slice(0, lastSlash)}/${baseId}` : baseId
+
+      const cloned: NoodleRequest = {
+        ...req,
+        id,
+        name: newName,
+      }
+
+      saveRequest(collectionDir, cloned)
+        .then(() => {
+          setCollectionReloadToken((n) => n + 1)
+          setCloneRequestVisible(false)
+          setFocus("sidebar")
+          setSelectedId(id)
+          const lastSlash = id.lastIndexOf("/")
+          if (lastSlash >= 0) expandFolder(id.slice(0, lastSlash))
+          showSaveResult({
+            kind: "success",
+            message: `Successfully created ${newName}`,
+          })
+        })
+        .catch(showError)
+    },
+    [
+      collectionDir,
+      expandFolder,
+      selectedRequest,
+      setCloneRequestVisible,
+      setCollectionReloadToken,
+      setFocus,
+      setSelectedId,
+      showError,
+      showSaveResult,
+    ],
+  )
+
+  const handleNewFolderConfirm = useCallback(
+    (name: string) => {
+      const baseId = slugify(name)
+      if (!baseId) return
+      const folder = newRequestFolderRef.current
+      const path = folder ? `${folder}/${baseId}` : baseId
+
+      const newFolder: Folder = {
+        id: baseId,
+        name,
+        path,
+        children: [],
+      }
+
+      saveFolder(collectionDir, newFolder)
+        .then(() => {
+          if (folder) expandFolder(folder)
+          setCollectionReloadToken((n) => n + 1)
+          setNewFolderVisible(false)
+          setFocus("sidebar")
+          showSaveResult({
+            kind: "success",
+            message: `Successfully created folder ${name}`,
+          })
+        })
+        .catch(showError)
+    },
+    [
+      collectionDir,
+      expandFolder,
+      newRequestFolderRef,
+      setCollectionReloadToken,
+      setFocus,
+      setNewFolderVisible,
+      showError,
+      showSaveResult,
+    ],
+  )
+
+  const handleFolderDeleteConfirm = useCallback(() => {
+    const path = folderDeletePathRef.current
+    if (!path) return
+
+    deleteFolder(collectionDir, path)
+      .then(() => {
+        setCollectionReloadToken((n) => n + 1)
+        setFolderDeletePending(null)
+        setFocus("sidebar")
+        showSaveResult({
+          kind: "success",
+          message: `Successfully deleted folder ${path}`,
+        })
+      })
+      .catch(showError)
+  }, [
+    collectionDir,
+    folderDeletePathRef,
+    setCollectionReloadToken,
+    setFocus,
+    setFolderDeletePending,
+    showError,
+    showSaveResult,
+  ])
+
+  const handleEditRequestConfirm = useCallback(
+    (name: string, method: Method, url: string, folderPath?: string) => {
+      const req = selectedRequest
+      if (!req) return
+      const baseId = slugify(name)
+      if (!baseId) return
+
+      const newFolder = folderPath ?? ""
+      const newId = newFolder ? `${newFolder}/${baseId}` : baseId
+
+      const oldFolder = req.id.includes("/")
+        ? req.id.slice(0, req.id.lastIndexOf("/"))
+        : ""
+
+      const nameChanged = newId !== req.id
+      const folderChanged = newFolder !== oldFolder
+      const changed = nameChanged || method !== req.method || url !== req.url
+
+      if (!changed) {
+        setEditRequestVisible(false)
+        setFocus("sidebar")
+        return
+      }
+
+      const updated: NoodleRequest = {
+        ...req,
+        id: newId,
+        name,
+        method,
+        url,
+      }
+
+      const savePromise = saveRequest(collectionDir, updated).then(() => {
+        if (nameChanged || folderChanged) {
+          deleteRequest(collectionDir, req.id).catch(() => {
+            /* stale file not cleaned up - new file is safe */
+          })
+        }
+      })
+
+      savePromise
+        .then(() => {
+          setCollectionReloadToken((n) => n + 1)
+          setEditRequestVisible(false)
+          setFocus("sidebar")
+          if (newFolder) expandFolder(newFolder)
+          showSaveResult({
+            kind: "success",
+            message: `Successfully edited ${name}`,
+          })
+        })
+        .catch(showError)
+    },
+    [
+      collectionDir,
+      expandFolder,
+      selectedRequest,
+      setCollectionReloadToken,
+      setEditRequestVisible,
+      setFocus,
+      showError,
+      showSaveResult,
+    ],
+  )
+
+  const handleRequestDeleteConfirm = useCallback(() => {
+    const req = selectedRequest
+    if (!req) return
+
+    deleteRequest(collectionDir, req.id)
+      .then(() => {
+        setCollectionReloadToken((n) => n + 1)
+        setRequestDeletePending(null)
+        setFocus("sidebar")
+        showSaveResult({
+          kind: "success",
+          message: `Successfully deleted ${req.name}`,
+        })
+      })
+      .catch(showError)
+  }, [
+    collectionDir,
+    selectedRequest,
+    setCollectionReloadToken,
+    setFocus,
+    setRequestDeletePending,
+    showError,
+    showSaveResult,
+  ])
+
+  return {
+    handleFolderSave,
+    handleNewRequestConfirm,
+    handleCloneRequestConfirm,
+    handleNewFolderConfirm,
+    handleFolderDeleteConfirm,
+    handleEditRequestConfirm,
+    handleRequestDeleteConfirm,
+  }
+}


### PR DESCRIPTION
## Summary
- Split AppInner into focused, composable pieces
- Extract request and response views into separate components

## Test Plan
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes