### PR TITLE
fix(keybindings): add linefeed as fallback for request send

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,8 @@ tests/integration/ # Integration tests
 
 All except `fixed` keys can be overridden in YAML:
 ```yaml
-request_send: ctrl+enter
 env_cycle: ctrl+u
+command_palette: ctrl+p
 ```
 
 ### Global (always active, gated on `!helpVisible`)

--- a/src/ui/HelpOverlay.tsx
+++ b/src/ui/HelpOverlay.tsx
@@ -6,6 +6,8 @@ import { TextAttributes } from "@opentui/core"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useRef } from "react"
 
+const keyColumnWidth = 16
+
 export function HelpOverlay({
   visible,
   keybinds,
@@ -58,7 +60,7 @@ export function HelpOverlay({
                   paddingRight={4}
                   style={{ flexDirection: "row" }}
                 >
-                  <text fg={theme.text}>{k.key.padEnd(11)}</text>
+                  <text fg={theme.text}>{k.key.padEnd(keyColumnWidth)}</text>
                   <text fg={theme.textMuted}>{k.description}</text>
                 </box>
               ))}

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -55,7 +55,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
     {
       title: "Actions",
       keys: [
-        { key: displayKey(keybinds.request_send), description: "Send request" },
+        {
+          key: `${displayKey(keybinds.request_send)} / ^j`,
+          description: "Send request",
+        },
         { key: displayKey(keybinds.request_save), description: "Save to disk" },
         {
           key: displayKey(keybinds.env_editor),

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -15,7 +15,7 @@ function keybind(
 }
 
 export const Definitions = {
-  request_send: keybind("ctrl+return", "Send request"),
+  request_send: keybind("ctrl+return", "Send request", true),
   request_save: keybind("ctrl+s", "Save request to disk"),
   env_cycle: keybind("ctrl+u", "Cycle environment"),
   command_palette: keybind("ctrl+p", "Open command palette"),

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -394,6 +394,7 @@ export function useAppKeymap(
     ],
     bindings: [
       { key: keybinds.request_send, cmd: "request.send" },
+      { key: "linefeed", cmd: "request.send" },
       { key: keybinds.request_save, cmd: "request.save" },
       { key: keybinds.env_cycle, cmd: "env.cycle" },
       { key: keybinds.env_editor, cmd: "env.editor-open" },
@@ -486,6 +487,7 @@ export function useAppKeymap(
       { key: keybinds.browse_revert_all, cmd: "browse.revert-all" },
       { key: "space", cmd: "browse.toggle" },
       { key: keybinds.request_send, cmd: "browse.send" },
+      { key: "linefeed", cmd: "browse.send" },
       { key: keybinds.request_save, cmd: "browse.save" },
       { key: keybinds.browse_toggle_form_type, cmd: "browse.toggle-form-type" },
     ],

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -24,6 +24,30 @@ function setup() {
 }
 
 describe("keymap dispatch", () => {
+  it("dispatches request.send when linefeed is pressed", () => {
+    const { keymap, host, cleanup } = setup()
+    let called = false
+
+    keymap.registerLayer({
+      enabled: () =>
+        keymap.getData("app.mode") === "base" &&
+        keymap.getData("app.overlay") === "none",
+      commands: [
+        {
+          name: "request.send",
+          run: () => {
+            called = true
+          },
+        },
+      ],
+      bindings: [{ key: "linefeed", cmd: "request.send" }],
+    })
+
+    host.press("linefeed")
+    expect(called).toBe(true)
+    cleanup()
+  })
+
   it("dispatches request.send when ctrl+return is pressed", () => {
     const { keymap, host, cleanup } = setup()
     let called = false

--- a/tests/unit/HelpOverlay.test.tsx
+++ b/tests/unit/HelpOverlay.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { HelpOverlay } from "../../src/ui/HelpOverlay"
+import { bindingDefaults } from "../../src/ui/keybind"
+
+describe("HelpOverlay", () => {
+  it("keeps spacing between long key hints and descriptions", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <HelpOverlay visible keybinds={bindingDefaults()} />
+      </ThemeProvider>,
+      { width: 80, height: 30 },
+    )
+
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame).toContain("^return / ^j    Send request")
+  })
+})

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -95,11 +95,11 @@ describe("buildCommandPaletteCommands", () => {
 
   it("displays keybinding as ^ shortcut", () => {
     const ctx = minimalContext()
-    const custom = { ...ctx.keybinds, request_send: "ctrl+r" }
+    const custom = { ...ctx.keybinds, request_save: "ctrl+r" }
     ctx.keybinds = custom
     const commands = buildCommandPaletteCommands(ctx)
-    const send = commands.find((c) => c.id === "request.send")!
-    expect(send.keybinding).toBe("^r")
+    const save = commands.find((c) => c.id === "request.save")!
+    expect(save.keybinding).toBe("^r")
   })
 
   it("collection.switcher runs its setter", () => {

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -56,11 +56,11 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^t")
   })
 
-  it("ACTIONS section shows ^return, ^s, ^n, ^k, ^w, ^shift+p, ^l", () => {
+  it("ACTIONS section shows ^return / ^j, ^s, ^n, ^k, ^w, ^shift+p, ^l", () => {
     const sections = getHelpSections(defaults)
     const act = sections.find((s) => s.title === "Actions")!
     const keys = act.keys.map((k) => k.key)
-    expect(keys).toContain("^return")
+    expect(keys).toContain("^return / ^j")
     expect(keys).toContain("^s")
     expect(keys).toContain("^n")
     expect(keys).toContain("^k")
@@ -80,11 +80,11 @@ describe("getHelpSections", () => {
   })
 
   it("reflects custom keybinds", () => {
-    const custom = { ...defaults, request_send: "ctrl+s", help_toggle: "f1" }
+    const custom = { ...defaults, request_save: "ctrl+x", help_toggle: "f1" }
     const sections = getHelpSections(custom)
     const act = sections.find((s) => s.title === "Actions")!
     const keys = act.keys.map((k) => k.key)
-    expect(keys).toContain("^s")
+    expect(keys).toContain("^x")
 
     const sys = sections.find((s) => s.title === "System")!
     const sysKeys = sys.keys.map((k) => k.key)

--- a/tests/unit/keybind.test.ts
+++ b/tests/unit/keybind.test.ts
@@ -18,15 +18,19 @@ describe("parseOverrides", () => {
   })
 
   it("applies custom keys for configurable bindings", () => {
-    const result = parseOverrides({ request_send: "ctrl+s", help_toggle: "f1" })
-    expect(result.request_send).toBe("ctrl+s")
+    const result = parseOverrides({ request_save: "ctrl+x", help_toggle: "f1" })
+    expect(result.request_save).toBe("ctrl+x")
     expect(result.help_toggle).toBe("f1")
-    expect(result.request_save).toBe("ctrl+s")
+    expect(result.request_send).toBe("ctrl+return")
   })
 
   it("ignores fixed key overrides (uses default)", () => {
-    const result = parseOverrides({ focus_next: "ctrl+n" })
+    const result = parseOverrides({
+      focus_next: "ctrl+n",
+      request_send: "ctrl+x",
+    })
     expect(result.focus_next).toBe("tab")
+    expect(result.request_send).toBe("ctrl+return")
   })
 
   it("throws on unknown key names", () => {
@@ -64,6 +68,21 @@ describe("CommandMap", () => {
     for (const name of Object.keys(Definitions)) {
       expect(CommandMap).toHaveProperty(name)
     }
+  })
+})
+
+describe("request_send", () => {
+  it("has default ctrl+return", () => {
+    expect(Definitions.request_send.default).toBe("ctrl+return")
+  })
+
+  it("is fixed", () => {
+    expect(Definitions.request_send.fixed).toBe(true)
+  })
+
+  it("ignores overrides", () => {
+    const result = parseOverrides({ request_send: "ctrl+x" })
+    expect(result.request_send).toBe("ctrl+return")
   })
 })
 


### PR DESCRIPTION
Adds linefeed (Ctrl+J) as alternative to Ctrl+Return for sending requests.\n\n- Makes request_send a fixed binding (cannot override)\n- Adds linefeed binding alongside ctrl+return in base + browse modes\n- Documents ^j fallback in help overlay\n- Fixes help overlay column width for longer key hints\n- Updates tests for fixed request_send