### PR TITLE
feat: add noodle-use globally-installable agent skill

### DIFF
--- a/.agents/skills/noodle-use/SKILL.md
+++ b/.agents/skills/noodle-use/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: noodle-use
+description: Teach agents to create, organize, maintain, evaluate, import, and convert noodle terminal REST client collections via file-level operations on YAML and dotenv files.
+---
+
+# noodle-use
+
+Terminal REST client. YAML files on disk. Dotenv environments. File-level operations only — no Bun dependency.
+
+## Quick routing
+
+| Intent | Read |
+|--------|------|
+| Create new collection, request, folder, or environment | [workflows/create.md](workflows/create.md) |
+| Refactor, rename, restructure existing collection | [workflows/organize.md](workflows/organize.md) |
+| Audit collection for REST best practices and security | [workflows/evaluate.md](workflows/evaluate.md) |
+| Import from OpenAPI or Postman via CLI | [workflows/import.md](workflows/import.md) |
+| Convert from Insomnia or Swagger 2.0 at file level | [workflows/convert.md](workflows/convert.md) |
+| Understand file formats, schemas, field rules | [schema.md](schema.md) |
+| Understand naming conventions, ID rules, variable syntax | [reference/conventions.md](reference/conventions.md) |
+| Read/write ~/.config/noodle/ settings | [reference/config.md](reference/config.md) |
+| See annotated example files | [reference/examples.md](reference/examples.md) |
+
+## Critical rules
+
+These apply to ALL operations. Read before any workflow.
+
+### File-level only
+Operate on `.yml` and `.env` files directly. Do NOT import noodle's internal modules. Do NOT run `bun`. The ONLY allowed CLI invocation is `noodle import`. Never run `noodle` in TUI mode — that's for humans.
+
+### Variable syntax
+`$VARNAME` (no braces). Regex `/\$(\w+)/g`. Applied to: url, headers, params, body, formData, filePath, auth fields. Unresolved variables cause noodle to throw at runtime — always verify all `$var` references resolve to an env declaration.
+
+### File extension
+`.yml` NOT `.yaml`. Requests are one-per-file. Folders use `folder.yml`.
+
+### ID convention
+File at `auth/login.yml` → ID = `"auth/login"` (relative path minus `.yml`). Used for: tree navigation, file I/O, timeline storage, UI state.
+
+### Environment format
+Dotenv-style `.env` files in `<collection>/.environments/`. `KEY=value` declares a variable. `# KEY=value` disables it. `_color=<name>` sets sidebar badge color. Valid colors: primary, secondary, accent, error, warning, success, info, text, textMuted, background, backgroundPanel, backgroundElement, border, borderActive, borderSubtle.
+
+### Folder inheritance
+- Headers merge additively: folder header only applies if child request doesn't have the same header key.
+- Auth: request with `type: inherit` uses nearest parent folder's auth override. Walk up the tree until a folder with an auth override is found.
+- `folder.yml` format:
+```yaml
+meta:
+  name: Display Name
+  seq: 5
+headers:
+  X-API-Key: $API_KEY
+auth:
+  type: bearer
+  token: $TOKEN
+```
+`meta` is optional. `meta.seq` controls sort order (lower = first, undefined = last). `meta.name` overrides display name (defaults to directory name).
+
+### Collection settings
+`settings.yml` at collection root: `environment: <name>` sets the default active environment. Single field only.
+
+### Path safety
+When creating/deleting files, only operate within the collection directory. Never create files outside the collection root. IDs must not contain `..`, leading `/`, or backslashes.
+
+### Authorization
+Auth types: `none`, `inherit`, `bearer`, `basic`, `api_key`.
+- `none`: No auth. Omit the `auth` field entirely (don't write `{ type: none }`).
+- `inherit`: Use parent folder's auth override. Only valid when a parent folder defines auth.
+- `bearer`: `{ type: bearer, token: "$TOKEN" }`
+- `basic`: `{ type: basic, user: "$USER", pass: "$PASS" }`
+- `api_key`: `{ type: api_key, key: "X-API-Key", value: "$KEY", placement: "header" }`. Placement is `"header"` or `"query"`.

--- a/.agents/skills/noodle-use/reference/config.md
+++ b/.agents/skills/noodle-use/reference/config.md
@@ -1,22 +1,28 @@
 # Config files
 
-Noodle's global config lives at `~/.config/noodle/`. Two files:
+Noodle's global config lives at `~/.config/noodle/`. Two files.
 
 ## config.yml
 
-User preferences for TUI appearance:
+User preferences for TUI appearance, workspace management, and undo behavior:
 
 ```yaml
-theme: nord
+theme: catppuccin
 layout: stacked
+confirm_undo_all: true
+collections:
+  - /Users/me/Projects/noodle-api
+  - /Users/me/Projects/other-api
 ```
 
-**theme**: One of the built-in theme names. Themes control colors and styling in the TUI. The full list:
-`default`, `monokai`, `solarized`, `solarized-light`, `dracula`, `nord`, `gruvbox`, `one-dark`, `github`, `github-light`, `tokyo-night`, `catppuccin`, `catppuccin-latte`, `everforest`, `everforest-light`, `rose-pine`, `rose-pine-moon`, `rose-pine-dawn`, `kanagawa`, `kanagawa-wave`, `kanagawa-lotus`, `ayu-dark`, `ayu-mirage`, `ayu-light`, `night-owl`, `night-owl-light`, `palenight`, `oceanic-next`, `cyanide`, `plastic`.
+All four fields are optional — missing fields use defaults.
 
-When reading/writing: validate the theme name against this list. Unknown themes cause noodle to fall back to `default`.
-
-**layout**: `"stacked"` (vertical arrangement) or `"side-by-side"` (horizontal split).
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `theme` | string | `"catppuccin"` | TUI theme name. Controls colors and styling. Noodle does NOT validate this value — it passes the string to OpenTUI, which falls back to its own default if unrecognized. Known theme names: `opencode`, `catppuccin`, `dracula`, `nord`, `tokyonight`, `gruvbox`, `ayu`, `monokai`, `solarized`, `onedark`, `aura`, `everforest`, `kanagawa`, `rosepine`, `material`, `carbonfox`, `synthwave84`, `catppuccin-frappe`, `catppuccin-macchiato`, `cobalt2`, `cursor`, `flexoki`, `github`, `matrix`, `mercury`, `nightowl`, `orng`, `osaka-jade`, `palenight`, `vercel`, `vesper`, `zenburn`. |
+| `layout` | `"stacked"` \| `"side-by-side"` | `"stacked"` | Pane arrangement. `stacked` = vertical (sidebar top, request middle, response bottom). `side-by-side` = horizontal split. Invalid values fall back to `"stacked"`. |
+| `confirm_undo_all` | boolean | `true` | Whether `Ctrl+R` (revert all request fields) shows a confirmation dialog before reverting. Set to `false` to skip the confirmation. |
+| `collections` | string[] | `[]` | List of absolute paths to noodle collections. These appear in the workspace selector. Paths are resolved and normalized on load/save (duplicates and empty strings removed). Noodle prepends the current collection to this list when switching directories. |
 
 ## keybinds.yml
 
@@ -29,28 +35,38 @@ command_palette: ctrl+p
 
 ### Available keybind IDs
 
-**Global (always active, gated on `!helpVisible`):**
-| ID | Default | Action |
-|----|---------|--------|
-| `focus_cycle` | `Tab` | Cycle focus (sidebar → request → response) |
-| `focus_cycle_reverse` | `Shift+Tab` | Reverse cycle focus |
-| `send_request` | `Ctrl+Return` | Send request |
-| `save_request` | `Ctrl+S` | Save request to disk |
-| `new_request` | `Ctrl+N` | New request |
-| `clone_request` | `Ctrl+K` | Clone request |
-| `delete_request` | `Ctrl+W` | Delete request |
-| `env_cycle` | `Ctrl+U` | Cycle environment |
-| `command_palette` | `Ctrl+P` | Open command palette |
-| `toggle_layout` | `Ctrl+L` | Toggle layout |
-| `toggle_focus_pane_expand` | `F2` | Expand/collapse focused pane |
-| `toggle_help` | `F1` | Toggle help overlay |
-| `theme_picker` | `Ctrl+T` | Open theme picker |
-| `edit_request` | `Ctrl+E` | Edit request in overlay |
-| `edit_request_yaml` | `Ctrl+Alt+E` | Edit request YAML in overlay |
-| `copy_body` | `Ctrl+B` | Copy response body |
-| `new_folder` | `Ctrl+Alt+N` | New folder |
-| `open_env_editor` | `e` | Open environment editor |
-| `quit` | `Ctrl+C` | Quit (copies selection first if text is selected) |
+Each entry shows: ID, default key, description, whether it's `fixed` (cannot be overridden).
+
+| ID | Default | Description | Fixed |
+|----|---------|-------------|-------|
+| `request_send` | `Ctrl+Return` | Send request | yes |
+| `request_save` | `Ctrl+S` | Save request to disk | no |
+| `env_cycle` | `Ctrl+U` | Cycle active environment | no |
+| `command_palette` | `Ctrl+P` | Open command palette | no |
+| `collection_switcher` | `Ctrl+O` | Open collection switcher | no |
+| `request_new` | `Ctrl+N` | New request | no |
+| `folder_new` | `Ctrl+Alt+N` | New folder | no |
+| `request_clone` | `Ctrl+K` | Clone request | no |
+| `request_delete` | `Ctrl+W` | Delete request | no |
+| `env_editor` | `e` | Open environment editor | no |
+| `help_toggle` | `F1` | Toggle help overlay | no |
+| `theme_picker` | `Ctrl+T` | Open theme picker | no |
+| `browse_delete` | `Ctrl+D` | Revert current field (browse mode) | no |
+| `browse_revert_all` | `Ctrl+R` | Revert all fields (browse mode) | no |
+| `global_undo_all` | `Ctrl+Z` | Undo all unsaved changes | no |
+| `focus_next` | `Tab` | Next pane in focus cycle | yes |
+| `focus_prev` | `Shift+Tab` | Previous pane in focus cycle | yes |
+| `layout_toggle` | `Ctrl+L` | Toggle layout (stacked / side-by-side) | no |
+| `pane_expand` | `F2` | Expand/collapse focused pane | no |
+| `response_copy_body` | `Ctrl+B` | Copy response body to clipboard | no |
+| `request_edit_yaml` | `Ctrl+Alt+E` | Edit request YAML in overlay | no |
+| `request_edit_overlay` | `Ctrl+E` | Edit request in overlay | no |
+| `env_save` | `Ctrl+S` | Save environment (env editor) | no |
+| `env_new` | `Ctrl+N` | Create new environment (env editor) | no |
+| `env_clone` | `Ctrl+K` | Clone environment (env editor) | no |
+| `env_delete` | `Ctrl+W` | Delete environment (env editor) | no |
+
+Browse/edit mode keys (`request_edit`, `browse_up`, `browse_down`, `browse_left`, `browse_right`, `browse_enter`, `browse_escape`, `edit_commit`, `edit_cancel`, `browse_toggle_form_type`) are all `fixed` and cannot be overridden. They are not listed in the table above — only keys usable in `keybinds.yml` are shown.
 
 ### Key syntax
 
@@ -60,8 +76,13 @@ Examples: `ctrl+s`, `alt+enter`, `shift+tab`, `f1`, `ctrl+alt+n`.
 
 ### Reading keybinds.yml
 
-Parse as YAML. Each key is a bind ID, each value is a key descriptor string. Unknown bind IDs are ignored. Invalid key descriptors fall back to default.
+Parse as YAML. Each key is a bind ID from the table above, each value is a key descriptor string. Unknown bind IDs cause `noodle` to throw — do NOT invent bind IDs. `fixed` keys are ignored even if included in the file.
 
 ### Writing keybinds.yml
 
-Serialize as YAML mapping. Only include overridden keys — don't write defaults. Use the exact keybind ID names from the table above.
+Serialize as YAML mapping. Only include overridden non-fixed keys — don't write defaults. Use the exact keybind ID names from the table above. Example for a user who remaps env_cycle and command_palette:
+
+```yaml
+env_cycle: ctrl+e
+command_palette: ctrl+p
+```

--- a/.agents/skills/noodle-use/reference/config.md
+++ b/.agents/skills/noodle-use/reference/config.md
@@ -1,0 +1,67 @@
+# Config files
+
+Noodle's global config lives at `~/.config/noodle/`. Two files:
+
+## config.yml
+
+User preferences for TUI appearance:
+
+```yaml
+theme: nord
+layout: stacked
+```
+
+**theme**: One of the built-in theme names. Themes control colors and styling in the TUI. The full list:
+`default`, `monokai`, `solarized`, `solarized-light`, `dracula`, `nord`, `gruvbox`, `one-dark`, `github`, `github-light`, `tokyo-night`, `catppuccin`, `catppuccin-latte`, `everforest`, `everforest-light`, `rose-pine`, `rose-pine-moon`, `rose-pine-dawn`, `kanagawa`, `kanagawa-wave`, `kanagawa-lotus`, `ayu-dark`, `ayu-mirage`, `ayu-light`, `night-owl`, `night-owl-light`, `palenight`, `oceanic-next`, `cyanide`, `plastic`.
+
+When reading/writing: validate the theme name against this list. Unknown themes cause noodle to fall back to `default`.
+
+**layout**: `"stacked"` (vertical arrangement) or `"side-by-side"` (horizontal split).
+
+## keybinds.yml
+
+Override built-in TUI keybindings. All keys except `fixed` keys can be rebound:
+
+```yaml
+env_cycle: ctrl+u
+command_palette: ctrl+p
+```
+
+### Available keybind IDs
+
+**Global (always active, gated on `!helpVisible`):**
+| ID | Default | Action |
+|----|---------|--------|
+| `focus_cycle` | `Tab` | Cycle focus (sidebar → request → response) |
+| `focus_cycle_reverse` | `Shift+Tab` | Reverse cycle focus |
+| `send_request` | `Ctrl+Return` | Send request |
+| `save_request` | `Ctrl+S` | Save request to disk |
+| `new_request` | `Ctrl+N` | New request |
+| `clone_request` | `Ctrl+K` | Clone request |
+| `delete_request` | `Ctrl+W` | Delete request |
+| `env_cycle` | `Ctrl+U` | Cycle environment |
+| `command_palette` | `Ctrl+P` | Open command palette |
+| `toggle_layout` | `Ctrl+L` | Toggle layout |
+| `toggle_focus_pane_expand` | `F2` | Expand/collapse focused pane |
+| `toggle_help` | `F1` | Toggle help overlay |
+| `theme_picker` | `Ctrl+T` | Open theme picker |
+| `edit_request` | `Ctrl+E` | Edit request in overlay |
+| `edit_request_yaml` | `Ctrl+Alt+E` | Edit request YAML in overlay |
+| `copy_body` | `Ctrl+B` | Copy response body |
+| `new_folder` | `Ctrl+Alt+N` | New folder |
+| `open_env_editor` | `e` | Open environment editor |
+| `quit` | `Ctrl+C` | Quit (copies selection first if text is selected) |
+
+### Key syntax
+
+Format: `modifier+key`. Supported modifiers: `ctrl`, `alt`, `shift`. Special characters: `tab`, `return`, `escape`, `space`, `backspace`, `up`, `down`, `left`, `right`, `f1`-`f12`, `delete`, `home`, `end`.
+
+Examples: `ctrl+s`, `alt+enter`, `shift+tab`, `f1`, `ctrl+alt+n`.
+
+### Reading keybinds.yml
+
+Parse as YAML. Each key is a bind ID, each value is a key descriptor string. Unknown bind IDs are ignored. Invalid key descriptors fall back to default.
+
+### Writing keybinds.yml
+
+Serialize as YAML mapping. Only include overridden keys — don't write defaults. Use the exact keybind ID names from the table above.

--- a/.agents/skills/noodle-use/reference/conventions.md
+++ b/.agents/skills/noodle-use/reference/conventions.md
@@ -1,0 +1,91 @@
+# Conventions
+
+Naming, structure, and behavioral conventions for noodle collections.
+
+## Request naming
+
+- **Display name** (`name` field): Human-readable. Use title case. Examples: `Get Users`, `Create Post`, `Delete Comment`.
+- **File name** (determines ID): Lowercase, hyphen-separated. Match the HTTP method and resource. Examples: `get-users.yml`, `create-post.yml`, `delete-comment.yml`.
+- **ID** = relative path minus `.yml`. File at `auth/login.yml` becomes ID `"auth/login"`.
+
+Good file names:
+```
+users/get-users.yml          → ID: "users/get-users"
+users/create-user.yml        → ID: "users/create-user"
+users/update-user.yml        → ID: "users/update-user"
+users/delete-user.yml        → ID: "users/delete-user"
+```
+
+Avoid generic names like `get.yml` or `post.yml` — they're ambiguous when reading a file list.
+
+## Folder structure
+
+- **Group by resource** (recommended): `users/`, `posts/`, `comments/`
+- **Group by domain** (large APIs): `billing/`, `identity/`, `catalog/`
+- **Max depth 3**: `domain/resource/request.yml`. Deeper nesting is hard to navigate.
+- **Auth at top level**: Put auth overrides in root `folder.yml` or a shared ancestor, not in every subfolder.
+
+## Environment conventions
+
+- Name env files after deployment stages: `development.env`, `staging.env`, `production.env`
+- Always include `_color` as first line. Use `success` for production, `warning` for staging, `info` for development.
+- Never commit real secrets to env files. Use placeholder values and override locally.
+- Keep all env files in sync — every env should declare the same set of variable names (different values).
+- Comment out (`#`) variables that don't apply to a specific environment, don't delete them.
+
+## Auth conventions
+
+- **Prefer `inherit`**: Requests should use `type: inherit` and get auth from a parent folder. Don't repeat auth config on every request.
+- **Root folder** is the right place for auth overrides that apply to the whole collection.
+- **Only use `type: none`** (omit auth field) for truly unauthenticated endpoints.
+
+## Headers conventions
+
+- Use folder overrides for repeated headers (`X-API-Key`, `Authorization`).
+- Use per-request headers for content-specific headers (`Content-Type`, `Accept`).
+- Disabled headers have `enabled: false`. Remove them instead of disabling — disabled headers are noise.
+
+## Body conventions
+
+- `body_type: json` for JSON APIs. Use `|`-` or `|-` for multi-line strings.
+- `body_type: urlencoded` for form submissions.
+- `body_type: multipart` with `form_data` for file uploads.
+- `body_type: binary` with `file_path` for raw binary uploads.
+- `body_type: none` for GET/DELETE/HEAD requests without a body.
+
+## Method usage
+
+| Operation | Method |
+|-----------|--------|
+| Read (list) | GET |
+| Read (single) | GET |
+| Create | POST |
+| Replace | PUT |
+| Update (partial) | PATCH |
+| Delete | DELETE |
+| Headers only | HEAD |
+| Preflight/options | OPTIONS |
+
+## File organization in collection root
+
+```
+my-collection/
+├── settings.yml              # default environment
+├── folder.yml                # (optional) root-level auth/header overrides
+├── get-health.yml             # ungrouped requests at root (flat)
+├── users/
+│   ├── folder.yml
+│   ├── get-users.yml
+│   └── create-user.yml
+├── posts/
+│   ├── folder.yml
+│   ├── get-posts.yml
+│   └── create-post.yml
+├── .environments/
+│   ├── development.env
+│   └── production.env
+└── .noodle/                   # managed by noodle, don't touch
+    ├── last-request
+    ├── expanded-folders
+    └── ui-state/
+```

--- a/.agents/skills/noodle-use/reference/examples.md
+++ b/.agents/skills/noodle-use/reference/examples.md
@@ -1,0 +1,157 @@
+# Annotated examples
+
+Complete, annotated noodle collection files. Use these as templates.
+
+## Simple GET request
+
+```yaml
+name: Get Posts
+method: GET
+url: $base_url/posts
+body_type: none
+timeout: 0
+```
+
+Minimal valid request. Fields: name, method, url, timeout. `followRedirects` and `maxRedirects` omitted (use defaults: true, 5). `body_type` explicitly `none` since no body. No `headers`, `params`, `auth`, `body` — omitted when not needed.
+
+## POST with JSON body
+
+```yaml
+name: Create Post
+method: POST
+url: $base_url/posts
+body_type: json
+timeout: 0
+headers:
+  Content-Type: application/json
+  x-api-key: $x_api_key
+body: |-
+  {
+    "title": "foo",
+    "body": "bar",
+    "userId": 1
+  }
+```
+
+JSON body with headers. `body` uses YAML literal block scalar `|-` for multi-line content. Headers include auth key (`$x_api_key`) — the env must declare `x_api_key`. `Content-Type` is per-request (not in folder override).
+
+## Bearer auth request
+
+```yaml
+name: Bearer Auth
+method: GET
+url: https://httpbin.org/bearer
+body_type: none
+timeout: 0
+auth:
+  type: bearer
+  token: $api_token
+```
+
+Auth is inline on the request. `$api_token` must be defined in the active environment. Alternative: put auth in `folder.yml` and use `type: inherit` on the request.
+
+## Inheriting auth from folder
+
+Folder (`auth/folder.yml`):
+```yaml
+auth:
+  type: basic
+  user: user
+  pass: pass
+```
+
+Request (`auth/basic-auth.yml`):
+```yaml
+name: Basic Auth
+method: GET
+url: https://httpbin.org/basic-auth/user/pass
+body_type: none
+timeout: 0
+auth:
+  type: inherit
+```
+
+Request inherits `basic` auth from parent folder. No need to repeat credentials.
+
+## Folder with headers override
+
+Folder (`posts/folder.yml`):
+```yaml
+meta:
+  name: Posts
+  seq: 1
+headers:
+  X-Custom-Header: shared-value
+```
+
+Requests in `posts/` automatically get `X-Custom-Header` unless they define it themselves.
+
+## Request with query params
+
+```yaml
+name: Get With Params
+method: GET
+url: $base_url/posts
+body_type: none
+timeout: 0
+params:
+  userId: $user_id
+  _limit: "10"
+```
+
+`params` become query string: `$base_url/posts?userId=1&_limit=10`. Values with `$` are substituted from env. Plain strings (like `"10"`) are sent literally.
+
+## Multipart form upload
+
+```yaml
+name: Upload File
+method: POST
+url: $base_url/upload
+body_type: multipart
+timeout: 0
+form_data:
+  - name: description
+    value: A photo
+  - name: file
+    value: ./photo.png
+    type: file
+```
+
+`form_data` for multipart. Text fields (default `type: "text"`) send string values. File fields (`type: "file"`) send file contents from `value` path.
+
+## Complete environment file
+
+File: `.environments/development.env`:
+```
+_color=success
+base_url=https://jsonplaceholder.typicode.com
+post_id=1
+user_id=1
+api_token=dev-token-placeholder
+x_api_key=dev-key-placeholder
+```
+
+`_color` on line 1 sets sidebar badge to green. All vars declared as `KEY=value`. No commented-out vars in this example — that would be `# disabled_key=value`.
+
+## Complete collection layout
+
+```
+my-api/
+├── settings.yml                  # environment: development
+├── folder.yml                    # auth: { type: bearer, token: $TOKEN }
+├── get-health.yml                # name: Health Check, method: GET
+├── users/
+│   ├── folder.yml                # meta: { name: "Users", seq: 1 }
+│   ├── get-users.yml             # auth: { type: inherit }
+│   ├── get-user.yml              # auth: { type: inherit }
+│   └── create-user.yml           # auth: { type: inherit }
+├── posts/
+│   ├── folder.yml                # meta: { name: "Posts", seq: 2 }
+│   ├── get-posts.yml
+│   └── create-post.yml
+└── .environments/
+    ├── development.env
+    └── production.env
+```
+
+Root `folder.yml` provides bearer auth. `users/` requests use `inherit` — they pick up the root auth. `posts/` requests don't declare auth — defaults to no auth. `settings.yml` points to `development` as the default env.

--- a/.agents/skills/noodle-use/schema.md
+++ b/.agents/skills/noodle-use/schema.md
@@ -1,0 +1,152 @@
+# Noodle schema reference
+
+Complete file format specifications for noodle collections. All fields, all types, all constraints.
+
+## Request file (`.yml`)
+
+One request per file. Fields:
+
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `name` | yes | string | — | Display name for the request |
+| `method` | yes | string | — | HTTP method: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS` |
+| `url` | yes | string | — | Full URL. May contain `$var` references |
+| `timeout` | yes | number | `0` | Request timeout in ms. `0` = no timeout |
+| `followRedirects` | no | boolean | `true` | Whether to follow HTTP redirects |
+| `maxRedirects` | no | number | `5` | Maximum redirect chain length |
+| `body_type` | no | string | `"none"` | Body encoding: `none`, `json`, `multipart`, `urlencoded`, `binary` |
+| `headers` | no | map | `{}` | Request headers. Omit if empty |
+| `params` | no | map | `{}` | URL query parameters. Omit if empty |
+| `body` | no | string | — | Raw request body. Omit if no body |
+| `form_data` | no | list | — | Multipart form entries. Omit if empty |
+| `file_path` | no | string | — | Path to file for binary uploads |
+| `auth` | no | map | — | Auth config. Omit for no auth |
+
+### Header and param values
+
+Two formats accepted:
+
+**Simple string** (enabled):
+```yaml
+headers:
+  Content-Type: application/json
+```
+
+**Disabled entry** (key is present but not sent):
+```yaml
+headers:
+  Authorization: { value: "Bearer $token", enabled: false }
+```
+
+The simple string form is shorthand for `{ value: "...", enabled: true }`. Use the expanded form only when `enabled: false`.
+
+### Form data
+
+Array of entries for `multipart` body type:
+```yaml
+form_data:
+  - name: fieldName
+    value: fieldValue
+  - name: fileField
+    value: ./path/to/file.pdf
+    type: file
+```
+Each entry: `name` (string, required), `value` (string, required), `enabled` (boolean, default true), `type` (`"text"` or `"file"`, default `"text"`).
+
+### Auth
+
+| Field | Bearer | Basic | API Key |
+|-------|--------|-------|---------|
+| `type` | `"bearer"` | `"basic"` | `"api_key"` |
+| `token` | yes | — | — |
+| `user` | — | yes | — |
+| `pass` | — | yes | — |
+| `key` | — | — | yes |
+| `value` | — | — | yes |
+| `placement` | — | — | `"header"` (default) or `"query"` |
+
+### Binary body
+
+When `body_type: binary`, set `file_path` to the file to upload:
+```yaml
+body_type: binary
+file_path: ./data/photo.png
+```
+
+### Minimal valid request
+
+```yaml
+name: My Request
+method: GET
+url: $base_url/endpoint
+timeout: 0
+```
+
+## Folder file (`folder.yml`)
+
+Optional. Defines display name, sort order, and inheritable headers/auth for requests in that directory.
+
+```yaml
+meta:
+  name: Display Name
+  seq: 5
+headers:
+  X-Custom: custom-value
+auth:
+  type: bearer
+  token: $TOKEN
+```
+
+All three sections (`meta`, `headers`, `auth`) are optional. Omit `meta` to use the directory name as display name. Omit `seq` to sort alphabetically. Omit `headers`/`auth` for no overrides.
+
+### Header inheritance
+
+Folder headers merge additively. If a request defines `Content-Type: application/json` and the folder defines `X-API-Key: $KEY`, the effective headers for the request are:
+```
+Content-Type: application/json
+X-API-Key: $KEY
+```
+If both define the same key, the request's value wins. Folder value is NOT applied.
+
+### Auth inheritance
+
+When a request has `auth: { type: inherit }`, walk up the directory tree. Use the auth from the nearest ancestor folder that defines an auth override. Example:
+
+```
+api/
+├── folder.yml          # auth: { type: bearer, token: $TOKEN }
+├── users/
+│   ├── folder.yml      # (no auth override)
+│   └── list.yml        # auth: { type: inherit } → inherits bearer from api/
+```
+
+## Environment file (`.env`)
+
+Dotenv format in `<collection>/.environments/<name>.env`:
+
+```
+_color=success
+base_url=https://api.example.com
+api_key=sk-abc123
+# disabled_key=this_var_is_disabled
+```
+
+- `_color=<name>`: sidebar badge color. Valid: `primary`, `secondary`, `accent`, `error`, `warning`, `success`, `info`, `text`, `textMuted`, `background`, `backgroundPanel`, `backgroundElement`, `border`, `borderActive`, `borderSubtle`.
+- `KEY=value`: active variable
+- `# KEY=value`: commented out = disabled variable. Noodle skips these.
+
+## Collection settings (`settings.yml`)
+
+Single file at collection root:
+```yaml
+environment: development
+```
+Sets the default active environment name. Must match an env file in `.environments/`.
+
+## Variable substitution rules
+
+- Syntax: `$VARNAME` (dollar sign + word characters)
+- Applied to: `url`, `headers` values, `params` values, `body`, `form_data` values, `file_path`, `auth` token/user/pass/key/value fields
+- All `$var` references must resolve to a variable declared in the active environment
+- Unresolved variables cause noodle to throw an error at request send time
+- Multi-level substitution is NOT supported (`$VAR1` that evaluates to `$VAR2` won't be resolved again)

--- a/.agents/skills/noodle-use/schema.md
+++ b/.agents/skills/noodle-use/schema.md
@@ -150,3 +150,46 @@ Sets the default active environment name. Must match an env file in `.environmen
 - All `$var` references must resolve to a variable declared in the active environment
 - Unresolved variables cause noodle to throw an error at request send time
 - Multi-level substitution is NOT supported (`$VAR1` that evaluates to `$VAR2` won't be resolved again)
+
+## Timeline file (`.timeline/<request-id>.yml`)
+
+Response history for each request. Stored in `<collection>/.timeline/`, one file per request. Max 50 entries, newest first (prepended on save). YAML array:
+
+```yaml
+- timestamp: 1783374564216
+  envName: production
+  request:
+    id: posts/get-posts
+    name: Get Posts
+    method: GET
+    url: https://api.example.com/posts
+    headers: {}
+    params: {}
+    auth:
+      type: none
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      content-type: application/json
+    body: "[...]"
+    timeMs: 56.27
+    size: 27520
+```
+
+Each entry has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | number | Unix timestamp in ms when the request was sent |
+| `envName` | string | Name of the active environment when sent |
+| `request` | object | Snapshot of the request at send time (id, name, method, url, headers, params, auth, body if present) |
+| `response` | object | Response data: `status` (number), `statusText` (string), `headers` (map), `body` (string), `timeMs` (number — response time in ms), `size` (number — response body size in bytes) |
+| `error` | object | Present instead of `response` if the request failed: `{ message: string }` |
+
+**Useful queries agents can answer from timeline data:**
+- Average response time for a request: sum all `response.timeMs` / count
+- Success rate: count entries with `response.status` in 2xx range / total count
+- Recent errors: filter entries where `error` is present
+- Response size trend: compare `response.size` across entries
+- Which environment was used: `envName` on each entry

--- a/.agents/skills/noodle-use/workflows/convert.md
+++ b/.agents/skills/noodle-use/workflows/convert.md
@@ -1,0 +1,212 @@
+# Convert workflow (file-level)
+
+Convert Insomnia exports and Swagger 2.0 specs to noodle collections by reading source files and writing noodle `.yml` files directly. No CLI required — pure file-level transformation.
+
+## Prerequisites
+
+None. The agent reads the source file and writes noodle files. No noodle binary needed for conversion (though the user will need noodle to use the collection).
+
+## Insomnia conversion
+
+Insomnia exports as JSON or YAML. Each export contains a list of resources (requests, folders, environments).
+
+### Step 1: Read the Insomnia export file
+
+Parse the JSON/YAML. The top-level is a single export object:
+
+```json
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2024-01-01T00:00:00.000Z",
+  "__export_source": "insomnia.desktop.app:v2024.1.0",
+  "resources": [
+    { "_type": "workspace", ... },
+    { "_type": "request_group", ... },
+    { "_type": "request", ... },
+    { "_type": "environment", ... }
+  ]
+}
+```
+
+### Step 2: Extract the workspace
+
+Find the resource with `_type: "workspace"`. This gives you the collection name. If no workspace exists, use the export filename.
+
+### Step 3: Build a folder tree
+
+Process `request_group` resources. Each group has:
+- `name`: display name
+- `parentId`: references another group (or workspace for top-level)
+- `_id`: unique identifier
+
+Build a tree: workspace → groups → subgroups → requests. Each group becomes a noodle folder.
+
+### Step 4: Convert each request
+
+For each `_type: "request"` resource:
+
+| Insomnia field | Noodle field | Notes |
+|---------------|--------------|-------|
+| `name` | `name` | Direct copy |
+| `method` | `method` | Direct copy (GET, POST, etc.) |
+| `url` | `url` | Full URL. Replace base with `$base_url` if shared across requests |
+| `headers[]` | `headers` | Each header: `{ name, value, disabled }`. Convert to noodle header format |
+| `parameters[]` | `params` | Query params: `{ name, value, disabled }` |
+| `body.mimeType` | `body_type` | Map: `application/json` → `json`, `application/x-www-form-urlencoded` → `urlencoded`, `multipart/form-data` → `multipart`. Else `none` |
+| `body.text` | `body` | Raw body text |
+| `body.params[]` | `form_data` | For multipart/urlencoded bodies |
+| `authentication` | `auth` | See auth mapping below |
+| `settingFollowRedirects` | `followRedirects` | `"global"` → true (default), `"off"` → false |
+
+**Auth mapping:**
+
+| Insomnia auth type | Noodle auth |
+|-------------------|-------------|
+| `none` / not set | Omit `auth` field |
+| `bearer` | `{ type: bearer, token: "$api_token" }` (use var, extract real token to env) |
+| `basic` | `{ type: basic, user: "$username", pass: "$password" }` (use vars) |
+| `apikey` | `{ type: api_key, key: "...", value: "$api_key", placement: "header" }` |
+| `oauth2` | Cannot map directly. Use `bearer` with token. Note to user that OAuth2 requires manual setup. |
+
+**Important**: When auth contains literal values (not variable references), extract them into environment variables and use `$var` references in the request file. Never write hardcoded credentials to noodle YAML files.
+
+### Step 5: Generate environment files
+
+Insomnia has `_type: "environment"` resources with `data` objects mapping var names to values. Separate by environment (sub-environments have `parentId` pointing to a base environment).
+
+Create `.environments/<name>.env` for each:
+```
+_color=info
+base_url=https://api.example.com
+var_name=var_value
+```
+
+Map Insomnia's environment colors to noodle `_color` values if available.
+
+### Step 6: Write the collection
+
+Create the directory structure and write all files:
+- `settings.yml` with `environment: <default-env-name>`
+- `folder.yml` for each group (with `meta.name` and `meta.seq`)
+- Request `.yml` files
+- `.environments/*.env` files
+
+### Step 7: Report
+
+List what was created. Suggest the user run the evaluate workflow on the result.
+
+## Swagger 2.0 conversion
+
+Swagger 2.0 specs are JSON or YAML files defining an API.
+
+### Step 1: Read the Swagger file
+
+Parse the JSON/YAML. Top-level keys: `swagger: "2.0"`, `info`, `host`, `basePath`, `schemes`, `paths`, `definitions`, `parameters`, `securityDefinitions`.
+
+Verify `swagger` field is `"2.0"`. If it's `openapi: 3.x.x`, this is OpenAPI 3.0 — use the `noodle import` CLI instead (see [import.md](import.md)).
+
+### Step 2: Determine base URL
+
+From `schemes`, `host`, and `basePath`:
+```
+schemes: ["https"]
+host: api.example.com
+basePath: /v2
+```
+
+Base URL = `https://api.example.com/v2`. This becomes `$base_url` in the environment.
+
+If there are multiple hosts or no host, default to `http://localhost`.
+
+### Step 3: Build environments
+
+Create at least a `development.env`:
+```
+_color=info
+base_url=https://api.example.com/v2
+```
+
+If multiple `schemes` are defined, note that production likely uses `https` and development `http`.
+
+### Step 4: Process security definitions
+
+Swagger `securityDefinitions` define auth schemes:
+
+| Swagger type | Noodle auth |
+|-------------|-------------|
+| `basic` | `{ type: basic, user: "$user", pass: "$pass" }` |
+| `apiKey` (in: "header") | `{ type: api_key, key: "...", value: "$api_key", placement: "header" }` |
+| `apiKey` (in: "query") | `{ type: api_key, key: "...", value: "$api_key", placement: "query" }` |
+| `oauth2` | `{ type: bearer, token: "$access_token" }` (simplified mapping) |
+
+The `security` array at top level or per-operation specifies which definitions apply. Use the first one as the root `folder.yml` auth override if the whole API uses the same auth.
+
+Write to root `folder.yml`:
+```yaml
+auth:
+  type: bearer
+  token: $api_token
+```
+
+Add the auth variable to environments.
+
+### Step 5: Process paths into requests
+
+For each path and HTTP method in `paths`:
+
+**URL**: `$base_url<path>`. Replace path parameters (`{id}`) with `$var` references or hardcoded values. For example, `/users/{userId}` → `$base_url/users/$user_id`.
+
+**Name**: Extract from `operationId` if present. Otherwise, construct: `<method> <path-summary>`. Example: `getUserById` → `Get User By ID`.
+
+**Method**: Direct from the operation key.
+
+**Headers and params**: From `parameters` arrays (path-level + operation-level).
+
+- `in: "query"` with `required: true` → `params` field with good default or `$var`
+- `in: "header"` → `headers` field
+- `in: "path"` → embedded in URL
+- `in: "body"` → `body` field, `body_type` from consumes
+
+**Body**: From the `body` parameter or request body schema. Generate a JSON template with empty/placeholder values. Use `body_type: json`.
+
+**Consumes/Produces**: MIME types for the operation. `consumes: [application/json]` → `body_type: json`. Set `Content-Type` and `Accept` headers accordingly.
+
+### Step 6: Group requests into folders
+
+Group by `tags` from each operation. Operations without tags go in the root or a `general/` folder.
+
+Create `folder.yml` for each group:
+```yaml
+meta:
+  name: <Tag Name>
+  seq: <index>
+```
+
+### Step 7: Handle path parameters
+
+Swagger path parameters like `/users/{userId}` need noodle `$var` references: `$base_url/users/$user_id`. Note: noodle uses `$var`, not `{var}`.
+
+Add the path parameter variable to environments. If a default is specified in the Swagger schema, use it:
+```
+user_id=1
+```
+
+### Step 8: Write the collection
+
+Create the full directory structure:
+```
+<output-dir>/
+├── settings.yml
+├── folder.yml                   (with auth from securityDefinitions)
+├── <tag-group>/
+│   ├── folder.yml               (meta.name + seq)
+│   ├── <operation>.yml
+│   └── ...
+└── .environments/
+    └── development.env
+```
+
+### Step 9: Report and suggest evaluate
+
+List created files and suggest running the evaluate workflow on the result.

--- a/.agents/skills/noodle-use/workflows/create.md
+++ b/.agents/skills/noodle-use/workflows/create.md
@@ -1,0 +1,164 @@
+# Create workflow
+
+Scaffold noodle collections, requests, folders, and environments from scratch.
+
+## Create a new collection
+
+When asked to create a new collection:
+
+### Step 1: Determine the collection directory
+
+Ask the user where to create it. Default: `./collections`. If they say "a collection for the Stripe API", suggest `./stripe-api/`.
+
+### Step 2: Create the directory structure
+
+```bash
+mkdir -p <dir>/.environments
+```
+
+### Step 3: Create settings.yml
+
+```yaml
+environment: development
+```
+
+### Step 4: Create a default environment
+
+File: `<dir>/.environments/development.env`:
+```
+_color=info
+base_url=http://localhost:3000
+```
+
+`base_url` is the standard name for the root API URL. Adjust based on the API being scaffolded.
+
+### Step 5: Report what was created
+
+List all files/dirs created so the user can verify.
+
+## Add requests to a collection
+
+When asked to add a specific endpoint:
+
+### Step 1: Listen for these details (ask if missing)
+
+- HTTP method
+- URL path (relative to `$base_url` or absolute)
+- Request name (human-readable)
+- Body (if POST/PUT/PATCH)
+- Auth requirements
+- Folder to place it in
+
+### Step 2: Determine file path
+
+Request ID = `<folder>/<hyphenated-name>`. Examples:
+- "GET /users" → `users/get-users.yml` (ID: `users/get-users`)
+- "POST /posts" → `posts/create-post.yml` (ID: `posts/create-post`)
+- "DELETE /users/:id" → `users/delete-user.yml` (ID: `users/delete-user`)
+
+### Step 3: Determine auth strategy
+
+Check if the collection already has a folder with auth overrides:
+- If yes and this endpoint uses the same auth → use `auth: { type: inherit }`
+- If yes but this endpoint is unauthenticated → omit `auth` field
+- If no and this endpoint needs auth → add `auth` inline on the request
+- If many requests will share auth → suggest creating a `folder.yml` with auth override
+
+### Step 4: Generate the YAML
+
+For a GET request with inherited auth:
+```yaml
+name: Get Users
+method: GET
+url: $base_url/users
+body_type: none
+timeout: 0
+auth:
+  type: inherit
+```
+
+For a POST request with body:
+```yaml
+name: Create User
+method: POST
+url: $base_url/users
+body_type: json
+timeout: 0
+headers:
+  Content-Type: application/json
+auth:
+  type: inherit
+body: |-
+  {
+    "name": "",
+    "email": ""
+  }
+```
+
+### Step 5: Create parent folder if needed
+
+If the parent directory doesn't exist:
+```bash
+mkdir -p <dir>/<folder-path>
+```
+
+### Step 6: Write the file
+
+Write the YAML content to `<dir>/<folder-path>/<file-name>.yml`.
+
+### Step 7: Ensure the env declares needed vars
+
+If the request uses `$base_url` or other env vars, verify they exist in the active environment. If not, add them with placeholder values.
+
+## Add a folder with auth override
+
+When asked to set up shared auth or headers:
+
+### Step 1: Determine the folder
+
+Where should the override apply? Root of collection? Specific subfolder?
+
+### Step 2: Write folder.yml
+
+```yaml
+meta:
+  name: API
+  seq: 1
+headers:
+  Content-Type: application/json
+auth:
+  type: bearer
+  token: $api_token
+```
+
+`meta.seq`: lower = first in sidebar. Use increments of 1 for clarity.
+
+### Step 3: Ensure the env has the auth variable
+
+Add `api_token=<placeholder>` to environments if `$api_token` is used and not yet declared.
+
+## Add an environment
+
+### Step 1: Determine name and base URL
+
+Ask for environment name (development, staging, production) and the base URL.
+
+### Step 2: Copy from an existing env if possible
+
+If another environment exists, copy its variable declarations and only change values. This keeps envs in sync.
+
+### Step 3: Write the file
+
+File: `<dir>/.environments/<name>.env`:
+```
+_color=success
+base_url=https://api.example.com
+api_key=sk-placeholder
+```
+
+### Step 4: Set _color appropriately
+
+- `success` (green) for production
+- `warning` (yellow) for staging
+- `info` (blue) for development
+- `accent` (purple) for other

--- a/.agents/skills/noodle-use/workflows/create.md
+++ b/.agents/skills/noodle-use/workflows/create.md
@@ -2,6 +2,26 @@
 
 Scaffold noodle collections, requests, folders, and environments from scratch.
 
+## Find an existing collection
+
+Before creating a new collection, check if the user already has one that matches.
+
+### Step 1: Read noodle's config
+
+```bash
+cat ~/.config/noodle/config.yml
+```
+
+Look for the `collections` field — an array of absolute paths to known collections.
+
+### Step 2: Match by name
+
+Extract the directory name from each path. If the user asks for "the stripe collection", look for a path ending in `/stripe` or `/stripe-api`. Return the full path.
+
+### Step 3: If not found
+
+If no collection matches, proceed to create a new one below. The new collection will be registered in config so future lookups find it.
+
 ## Create a new collection
 
 When asked to create a new collection:
@@ -32,7 +52,19 @@ base_url=http://localhost:3000
 
 `base_url` is the standard name for the root API URL. Adjust based on the API being scaffolded.
 
-### Step 5: Report what was created
+### Step 5: Register in noodle config
+
+Write the absolute path to `~/.config/noodle/config.yml` so the collection appears in noodle's workspace switcher. Read the existing config, prepend the new path to `collections`, write back:
+
+```yaml
+collections:
+  - /Users/me/Projects/stripe-api
+  - /Users/me/Projects/other-api
+```
+
+If `collections` doesn't exist yet, create it with the new path. Paths must be absolute and resolved. See [config.md](reference/config.md) for the full config schema.
+
+### Step 6: Report what was created
 
 List all files/dirs created so the user can verify.
 

--- a/.agents/skills/noodle-use/workflows/evaluate.md
+++ b/.agents/skills/noodle-use/workflows/evaluate.md
@@ -1,0 +1,295 @@
+# Evaluate workflow
+
+Audit noodle collections for REST best practices, security issues, naming conventions, and structural problems.
+
+## Audit process
+
+### Step 1: Load the entire collection
+
+Read every `.yml` file in the collection directory (recursively, excluding hidden dirs). Parse each file to extract its fields.
+
+### Step 2: Load all environments
+
+Read every `.env` file in `.environments/`. Extract declared vars, disabled vars, and `_color`.
+
+### Step 3: Run each check below
+
+### Step 4: Report findings with severity
+
+Each finding gets: **severity** (critical / warning / info), **file**, **issue**, **suggestion**. Group by severity, then by file. Present as a readable list.
+
+## Security checks
+
+### Hardcoded tokens/credentials
+
+**Pattern**: Auth fields (`token`, `pass`, `key`, `value`) containing literal strings that are not `$var` references.
+
+**Examples of problems**:
+```yaml
+auth:
+  type: bearer
+  token: sk-abc123realTokenHere
+```
+```yaml
+auth:
+  type: basic
+  user: admin
+  pass: realPassword123
+```
+
+**Why it's bad**: Secrets committed to source control. Anyone with access to the repo can see them.
+
+**Fix**: Replace with `$var` references and declare in env files:
+```yaml
+auth:
+  type: bearer
+  token: $api_token
+```
+
+**Severity**: critical
+
+### Tokens in URLs
+
+**Pattern**: URLs containing `token=`, `api_key=`, `apiKey=`, `key=`, `secret=`, `password=` as query parameters.
+
+**Example**:
+```yaml
+url: https://api.example.com/data?api_key=sk-abc123
+```
+
+**Why it's bad**: Tokens in URLs are logged by proxies, load balancers, and server access logs. Visible in browser history. Leaked via `Referer` header.
+
+**Fix**: Use header-based auth or `$var` in a header:
+```yaml
+url: $base_url/data
+headers:
+  X-API-Key: $api_key
+```
+
+**Severity**: critical
+
+### Auth fields in env files with real values
+
+**Pattern**: Environment files containing real-looking secrets (not placeholders like `PLACEHOLDER` or `changeme`).
+
+**Heuristics**:
+- Values starting with `sk-`, `pk-`, `ghp_`, `gho_`, `github_pat_`
+- Values that look like JWTs (long base64 strings with `.` separator)
+- Values matching common API key formats (alphanumeric, 32+ chars)
+
+**Why it's bad**: Env files may be shared or committed accidentally. Placeholder values are safer.
+
+**Fix**: Replace with placeholder: `api_key=sk-your-key-here`. Keep real secrets in a local-only, gitignored file or a secrets manager.
+
+**Severity**: critical
+
+### HTTP instead of HTTPS in production env
+
+**Pattern**: URLs in production environment starting with `http://` (not `https://`).
+
+**Why it's bad**: Unencrypted traffic exposes all headers/body/params to network interception.
+
+**Fix**: Use `https://` in production and staging environments.
+
+**Severity**: warning (critical for production env)
+
+### Missing auth on endpoints that should be authenticated
+
+**Pattern**: No `auth` field on requests in folders where sibling requests have auth.
+
+**Why it's bad**: Might be intentional (public endpoint) or might be an oversight.
+
+**Fix**: Confirm with user. If intentional, no change. If oversight, add `auth: { type: inherit }`.
+
+**Severity**: warning
+
+### Auth on GET without HTTPS
+
+**Pattern**: `auth` field present on a GET request whose URL starts with `http://`.
+
+**Why it's bad**: Auth tokens sent in cleartext headers over HTTP.
+
+**Fix**: Use `https://`.
+
+**Severity**: warning
+
+## REST practice checks
+
+### Wrong HTTP method for operation type
+
+**Pattern**: Request file name suggests one operation but `method` field says another.
+
+**Heuristics**:
+- File named `get-*` or `list-*` but method is POST/PUT/DELETE
+- File named `create-*` or `add-*` but method is GET/DELETE
+- File named `delete-*` or `remove-*` but method is GET/POST
+- File named `update-*` or `edit-*` but method is GET/DELETE
+
+**Why it's bad**: Misleading. Breaks HTTP semantics. Surprises readers.
+
+**Fix**: Use the correct HTTP method:
+- `get-*` / `list-*` → GET
+- `create-*` / `add-*` → POST
+- `update-*` / `edit-*` / `patch-*` → PUT or PATCH
+- `delete-*` / `remove-*` → DELETE
+
+**Severity**: warning
+
+### GET request with body
+
+**Pattern**: `method: GET` with `body` field present and non-empty.
+
+**Why it's bad**: HTTP spec allows GET bodies but most servers, proxies, and CDNs ignore or drop it. Unreliable.
+
+**Fix**: Use query params (`params` field) for GET, or change method to POST.
+
+**Severity**: warning
+
+### DELETE request with body
+
+**Pattern**: `method: DELETE` with `body` field present and non-empty.
+
+**Why it's bad**: Like GET, DELETE bodies are unreliable across infrastructure.
+
+**Fix**: Use query params or change to POST.
+
+**Severity**: info
+
+### POST/PUT/PATCH without Content-Type
+
+**Pattern**: POST/PUT/PATCH request with `body` but no `Content-Type` header.
+
+**Why it's bad**: Server may misinterpret the body format. Behavior is server-dependent.
+
+**Fix**: Add `Content-Type: application/json` (or appropriate type) to headers.
+
+**Severity**: warning
+
+### POST with body_type: none
+
+**Pattern**: `method: POST` with `body_type: none` and no `body` field.
+
+**Why it's bad**: Unusual but potentially intentional (empty POST is valid).
+
+**Severity**: info (flag for review)
+
+### Inconsistent URL patterns
+
+**Pattern**: Some requests use `$base_url/` prefix, others use hardcoded URLs.
+
+**Why it's bad**: Environment switching (dev → prod) won't work for hardcoded URLs.
+
+**Fix**: Use `$base_url` consistently. Only use hardcoded URLs for external services not controlled by the environment.
+
+**Severity**: warning
+
+## Naming and structure checks
+
+### Generic file names
+
+**Pattern**: Files named `get.yml`, `post.yml`, `list.yml`, `create.yml`, `delete.yml`, `update.yml`.
+
+**Why it's bad**: Ambiguous. When reading a file list, you can't tell what resource it operates on. Example: three `get.yml` files in different folders all look identical in search results.
+
+**Fix**: Include the resource name: `get-users.yml`, `create-post.yml`, `delete-comment.yml`.
+
+**Severity**: info
+
+### Display name doesn't match file name
+
+**Pattern**: `name: "List All Users"` in file `get-something-else.yml`.
+
+**Why it's bad**: Confusing when navigating files and sidebar simultaneously. Makes debugging harder.
+
+**Fix**: Align the display name with the resource + operation.
+
+**Severity**: info
+
+### Deep nesting (>3 levels)
+
+**Pattern**: Files at depth 4 or more: `api/v2/enterprise/users/get-users.yml`.
+
+**Why it's bad**: Hard to navigate in sidebar. Extra clicks. Often unnecessary — versioning can be expressed through environment URLs or folder names.
+
+**Fix**: Flatten to max 3 levels. Options:
+- Remove the `api/v2` prefix if the whole collection is v2
+- Use `seq` for ordering instead of nesting
+- Use display names to indicate version: `Users (v2)`
+
+**Severity**: info
+
+### Orphan requests (no folder context)
+
+**Pattern**: Requests at collection root without a parent `folder.yml` for auth/headers, while sibling requests are in folders with auth.
+
+**Why it's bad**: Root-level requests can't share auth with siblings. Each one repeats the same config.
+
+**Fix**: Move into a folder or create root `folder.yml` with shared overrides.
+
+**Severity**: info
+
+### Missing folder display names
+
+**Pattern**: `folder.yml` exists but has no `meta.name`. Directory name is used as fallback.
+
+**Why it's bad**: Directory names like `posts_v2_internal` show as display names. Ugly.
+
+**Fix**: Add `meta.name` with a clean display name:
+```yaml
+meta:
+  name: Posts (Internal v2)
+```
+
+**Severity**: info
+
+## Environment checks
+
+### Unused variables
+
+**Pattern**: Env file declares `VAR=value` but no request file references `$VAR`.
+
+**Why it's bad**: Clutter. Makes env files harder to read. Suggests the env was copy-pasted without cleanup.
+
+**Fix**: Remove unused variables from all environments.
+
+**Severity**: info
+
+### Missing variables
+
+**Pattern**: Request references `$VAR` but one or more environment files don't declare `VAR`.
+
+**Why it's bad**: Switching to that environment will cause a runtime error ("unresolved variable").
+
+**Fix**: Add the missing variable to all environments with appropriate placeholder values.
+
+**Severity**: warning
+
+### Variable declared in one env but not another
+
+**Pattern**: `development.env` has `api_key=...` but `production.env` doesn't declare `api_key`.
+
+**Why it's bad**: Environment files should have the same set of variable names. Missing declarations cause confusion and runtime errors.
+
+**Fix**: Sync variable declarations across all environments. Use placeholder values where the real value isn't known yet.
+
+**Severity**: warning
+
+### Stale commented-out variables
+
+**Pattern**: Environment files with `# VAR=value` lines that were commented out long ago and no request uses `$VAR`.
+
+**Why it's bad**: Clutter. Makes the file harder to parse.
+
+**Fix**: Remove commented-out lines for variables that are no longer referenced.
+
+**Severity**: info
+
+### Missing _color
+
+**Pattern**: Environment file without a `_color=<name>` line.
+
+**Why it's bad**: No visual badge in sidebar. Can't distinguish environments at a glance.
+
+**Fix**: Add `_color` as the first line with an appropriate color.
+
+**Severity**: info

--- a/.agents/skills/noodle-use/workflows/import.md
+++ b/.agents/skills/noodle-use/workflows/import.md
@@ -1,0 +1,105 @@
+# Import workflow (CLI)
+
+Convert OpenAPI 3.0 and Postman collections to noodle format using the `noodle import` CLI command.
+
+## Prerequisites
+
+`noodle` must be installed as a binary. The import subcommand is built into the noodle binary. Verify:
+
+```bash
+noodle import --help
+```
+
+If `noodle` is not found, guide the user to install: `brew install noodle` (macOS) or `curl -LsSf https://raw.githubusercontent.com/wilfredinni/noodle/main/scripts/install.sh | sh` (Linux/macOS).
+
+## Import workflow
+
+### Step 1: Identify the source file
+
+Get the file path from the user. Common extensions:
+- `.yaml` / `.yml` / `.json` → OpenAPI 3.0
+- `.postman_collection.json` → Postman
+
+### Step 2: Detect the format
+
+If the user doesn't specify a format:
+- Check file extension
+- Check file content for signatures:
+  - OpenAPI: contains `openapi:`, `paths:`, `info:` at top level
+  - Postman: contains `info.schema` with `postman.com` URL
+- If ambiguous, ask the user
+
+### Step 3: Run the import
+
+```bash
+noodle import <source-path> --format <openapi|postman> --output <target-dir>
+```
+
+The `--output` flag specifies where to write the collection. Defaults to `./collections` if omitted. Use a dedicated directory for the imported collection (e.g., `./my-api/`).
+
+### Step 4: Verify the output
+
+Check what was created:
+
+```bash
+ls -R <target-dir>/
+```
+
+Expected structure:
+```
+<target-dir>/
+├── settings.yml
+├── folder.yml                 (if root-level auth/headers were detected)
+├── <resource>/                (one folder per tag/path group)
+│   ├── folder.yml
+│   ├── <operation>.yml
+│   └── ...
+├── .environments/
+│   └── <env-name>.env
+└── ...
+```
+
+### Step 5: Review and organize
+
+After import, the collection may need cleanup:
+- **Check auth**: OpenAPI `securityDefinitions` and Postman auth are converted to noodle auth. Verify correctness.
+- **Check environments**: Base URL and variables from the spec are extracted to env files. Verify values.
+- **Rename folders**: Imported folder names may be tag names or path segments. Adjust `meta.name` for readability.
+- **Remove unused requests**: The importer may generate endpoints you don't need. Delete `.yml` files manually.
+- **Add `_color` to envs**: Imported environments may not have `_color`. Add it.
+
+### Step 6: Run the evaluate workflow
+
+After import, run the evaluate checks (see [evaluate.md](evaluate.md)) on the imported collection to catch common issues.
+
+## OpenAPI-specific notes
+
+OpenAPI 3.0 imports map:
+- `info.title` → collection root name
+- `servers[].url` → `$base_url` in environment
+- `paths` → request `.yml` files, one per operation
+- `parameters` → `params` field on requests
+- `requestBody` → `body` + `body_type`
+- `securityDefinitions` → `folder.yml` auth override or inline `auth` on requests
+- Tags → folder grouping
+
+Multiple servers in the spec create multiple environments.
+
+## Postman-specific notes
+
+Postman imports map:
+- Collection name → collection root name
+- Collection auth → `folder.yml` auth override
+- Folder hierarchy → noodle folder structure
+- Request auth → inline `auth` on requests (or `inherit` if same as parent)
+- Pre-request scripts → not imported (noodle doesn't support scripts)
+- Tests → not imported
+- Collection variables → environment file
+
+## After import
+
+Always suggest the user:
+1. Open the collection in noodle TUI to verify visually: `noodle -c <target-dir>`
+2. Run a few requests to verify auth and URL substitution work
+3. Adjust folder ordering with `seq`
+4. Add descriptive display names to folders

--- a/.agents/skills/noodle-use/workflows/organize.md
+++ b/.agents/skills/noodle-use/workflows/organize.md
@@ -1,0 +1,172 @@
+# Organize workflow
+
+Restructure, rename, and refactor existing noodle collections.
+
+## Principles
+
+- **Never break IDs**: Requests and folders are identified by their relative path (ID). Moving or renaming changes the ID. If the user has timeline data or UI state, the old ID will be orphaned.
+- **Always ask before bulk changes**: Restructuring affects all IDs. Confirm the plan before executing.
+- **Preserve folder.yml**: When moving files between folders, the `folder.yml` overrides may change behavior. Warn if auth/headers will change.
+
+## Rename a request
+
+### Step 1: Understand the change
+
+Renaming the display name in the `name` field is safe — it doesn't affect the ID.
+
+Renaming the file changes the ID. Example: `users/get.yml` → `users/get-users.yml` changes ID from `"users/get"` to `"users/get-users"`.
+
+### Step 2: For display name rename
+
+Read the file, change the `name` field, write back.
+
+### Step 3: For file rename (ID change)
+
+```bash
+mv <dir>/users/get.yml <dir>/users/get-users.yml
+```
+
+Update any references:
+- If there's a timeline file at `.timeline/users/get.yml`, it becomes orphaned. The old response history is lost.
+- If `last-request` points to this ID, it's now stale.
+- UI state at `.noodle/ui-state/users/get.yml` is orphaned.
+
+Warn the user about these consequences.
+
+## Move requests into a folder
+
+### Step 1: Read the collection
+
+List all `.yml` files in the target directory.
+
+### Step 2: Create the folder
+
+```bash
+mkdir -p <dir>/<new-folder>
+```
+
+Optionally create `folder.yml` if auth/headers/ordering is needed.
+
+### Step 3: Move files
+
+```bash
+mv <dir>/<old-path>.yml <dir>/<new-folder>/<old-name>.yml
+```
+
+### Step 4: Update IDs and warn
+
+All moved requests get new IDs. Old timeline data is orphaned. Suggest the user re-run the requests after moving to repopulate.
+
+## Restructure by domain
+
+Common refactor: flat list → grouped by resource.
+
+**Before:**
+```
+collection/
+├── get-users.yml
+├── create-user.yml
+├── delete-user.yml
+├── get-posts.yml
+├── create-post.yml
+└── .environments/
+```
+
+**After:**
+```
+collection/
+├── users/
+│   ├── get-users.yml
+│   ├── create-user.yml
+│   └── delete-user.yml
+├── posts/
+│   ├── get-posts.yml
+│   └── create-post.yml
+├── folder.yml        (optional: shared auth)
+└── .environments/
+```
+
+### Step 1: Group by naming pattern
+
+Look for files that share a common prefix or resource name.
+
+### Step 2: Create folders and move
+
+```bash
+mkdir -p <dir>/users <dir>/posts
+mv <dir>/get-users.yml <dir>/users/get-users.yml
+mv <dir>/create-user.yml <dir>/users/create-user.yml
+# ... etc
+```
+
+### Step 3: Check for shared auth
+
+If multiple groups use the same auth pattern, suggest creating a root `folder.yml` with the auth override and updating all requests to use `type: inherit`.
+
+### Step 4: Add folder display names
+
+```yaml
+# users/folder.yml
+meta:
+  name: Users
+  seq: 1
+```
+
+```yaml
+# posts/folder.yml
+meta:
+  name: Posts
+  seq: 2
+```
+
+## Flatten deeply nested folders
+
+If a collection has more than 3 levels of nesting:
+
+```
+collection/
+└── api/
+    └── v2/
+        └── users/
+            └── get-users.yml       # 4 levels deep
+```
+
+Suggest flattening. Options:
+- Remove the `api/v2` nesting and use display names: `Users v2`
+- Move `users/` to root, add `seq: 2` instead of nesting under `api/`
+
+## Deduplicate headers
+
+If every request in a folder repeats the same header:
+
+### Step 1: Find repeated headers
+
+Scan all requests in a folder for headers that appear on every file.
+
+### Step 2: Move to folder.yml
+
+Add the common header to `folder.yml`:
+```yaml
+headers:
+  Content-Type: application/json
+```
+
+### Step 3: Remove from individual requests
+
+Remove the duplicated header from each request file. This is a lossless change — the folder override applies the header.
+
+## Ensure env consistency
+
+When restructuring, check that all `$var` references in requests have corresponding declarations in every environment file. Missing vars cause runtime errors.
+
+### Step 1: Scan all request files for `$var` patterns
+
+Regex: `/\$(\w+)/g` across all `.yml` files.
+
+### Step 2: For each environment, check that every var is declared
+
+Read each `.env` file. Flag any missing declarations.
+
+### Step 3: Add missing vars with placeholder values
+
+Add `missing_var=PLACEHOLDER` to environments that lack it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ src/
 ├── lang/          # YAML request language: parse + serialize
 ├── filestore/     # loadCollection(dir) / saveRequest(dir, req) — disk I/O
 ├── env/           # loadEnvironment, listEnvironments — env file I/O + validation
-├── requests/      # executor.send + substitute ({{var}} replacement)
+├── requests/      # executor.send + substitute ($var replacement)
 ├── hooks/         # React hooks: useCollection, useRequestDraft, useEnvironments, etc.
 ├── converters/
 │   └── openapi/   # OpenAPI 3.0 → Collection importer (CLI only)
@@ -88,7 +88,7 @@ tests/integration/ # Integration tests
 - **Commit style:** `feat(scope):`, `fix(scope):`, `test(scope):`, `refactor(scope):`, `style:`, `docs:`.
 - **Requests are `.yml` files**, one per request. Extension is `.yml` not `.yaml`.
 - **Environments are `.env` files** under `<collection>/.environments/`. Format is `KEY=value` (dotenv-style, not YAML). Lines starting with `#` disable a var. `_color=<name>` sets sidebar badge color.
-- **`{{var}}` template syntax** for variable substitution in url/headers/params/body/auth.
+- **`$VARNAME` template syntax** for variable substitution in url/headers/params/body/auth.
 - **Error re-throws** must pass `{ cause: e }` as second arg to `new Error(...)`. This is a convention (not an ESLint rule) but is followed project-wide.
 - **UI features require loading the `opentui` skill**. The skill lives at `.agents/skills/opentui/SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Example prompts:
 - "Set Catppuccin as my theme"
 - "How many requests are in the Stripe API collection?"
 - "What's the average response time for the login request on my Stripe collection?"
+- "Order the folders on the Stripe collection from Z to A"
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Example prompts:
 - "Change the expand layout keybinding to Alt+I"
 - "Set Catppuccin as my theme"
 - "How many requests are in the Stripe API collection?"
+- "What's the average response time for the login request on my Stripe collection?"
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ brew install noodle
 
 Installs to `~/.local/bin/noodle` (curl) or your Homebrew prefix. Make sure the install directory is in your PATH.
 
+### npx skills (AI agents)
+
+```bash
+npx skills add wilfredinni/noodle --skill noodle-use -g
+```
+
+Teaches your AI coding agent to create, organize, audit, import, and convert noodle collections. Supports OpenCode, Claude Code, Cursor, Copilot, and 70+ other agents.
+
+Example prompts:
+- "Scaffold a noodle collection for the Stripe API with auth and a few endpoints"
+- "Audit my collection for security issues and REST best practices"
+- "Convert this Insomnia export to a noodle collection"
+- "Change the expand layout keybinding to Alt+I"
+- "Set Catppuccin as my theme"
+
 ## Roadmap
 
 See the [public roadmap](https://app.notion.com/p/39128d9edba9809da834f351332baf57?v=39228d9edba98042ad07000cdbe5d751&source=copy_link) for upcoming features and improvements.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Example prompts:
 - "Convert this Insomnia export to a noodle collection"
 - "Change the expand layout keybinding to Alt+I"
 - "Set Catppuccin as my theme"
+- "How many requests are in the Stripe API collection?"
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Example prompts:
 - "How many requests are in the Stripe API collection?"
 - "What's the average response time for the login request on my Stripe collection?"
 - "Order the folders on the Stripe collection from Z to A"
+- "Set up basic auth on the Posts folder for $basic_user and $basic_password"
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- New `noodle-use` skill in `.agents/skills/noodle-use/` — teaches AI coding agents to create, organize, evaluate, import, and convert noodle collections via file-level operations
- 9 markdown files: SKILL.md entry point, schema reference, 5 workflow docs (create, organize, evaluate, import, convert), 3 reference docs (conventions, config, examples)
- README updated with AI agent skills section and example prompts under Installation
- AGENTS.md fixed: `{{var}}` → `$VARNAME` variable substitution syntax

## How it works
Agents operate on `.yml` and `.env` files directly — no Bun dependency. The skill embeds noodle's schema, conventions, and constraints so agents can validate without noodle's internal modules. The only CLI invocation allowed is `noodle import` for OpenAPI/Postman conversion.

## Workflows
| Workflow | What agents can do |
|----------|-------------------|
| Create | Scaffold collections, requests, folders, environments. Register in config.yml |
| Organize | Rename, restructure, deduplicate headers, flatten deep nesting |
| Evaluate | Security audit (hardcoded tokens, HTTP vs HTTPS), REST best practices, naming conventions |
| Import | CLI-based conversion from OpenAPI 3.0 and Postman |
| Convert | File-level conversion from Insomnia exports and Swagger 2.0 specs |

## Install
```bash
npx skills add wilfredinni/noodle --skill noodle-use -g
```

Supports OpenCode, Claude Code, Cursor, Copilot, and 70+ other agents.