### PR TITLE
fix: various bug fixes across overlay, sidebar, timeline, folder auth, and save-toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "license": "Apache-2.0",
   "private": true,

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -82,7 +82,6 @@ function authEqual(a: Auth | undefined, b: Auth | undefined): boolean {
   }
   if (a.type !== b.type) return false
   if (a.type === "none" && b.type === "none") return true
-  if (a.type === "inherit" && b.type === "inherit") return true
   if (a.type === "bearer" && b.type === "bearer") return a.token === b.token
   if (a.type === "basic" && b.type === "basic") {
     return a.user === b.user && a.pass === b.pass
@@ -115,14 +114,14 @@ function defaultAuth(authType: Auth["type"]): Auth {
   switch (authType) {
     case "none":
       return { type: "none" }
-    case "inherit":
-      return { type: "inherit" }
     case "bearer":
       return { type: "bearer", token: "" }
     case "basic":
       return { type: "basic", user: "", pass: "" }
     case "api_key":
       return { type: "api_key", key: "", value: "", placement: "header" }
+    default:
+      return { type: "none" }
   }
 }
 

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -1,6 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import type { Auth, Folder, KvEntry } from "../schema"
 
+const CACHE_MAX = 100
+
+const authTypeCache = new Map<string, Record<string, Auth>>()
+
+function cacheSet<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.set(key, value)
+  if (map.size > CACHE_MAX) {
+    const first = map.keys().next().value as K | undefined
+    if (first !== undefined) map.delete(first)
+  }
+}
+
 export type FolderDraftOp =
   | { kind: "setName"; name: string }
   | { kind: "setSeq"; seq: number }
@@ -114,6 +126,8 @@ function defaultAuth(authType: Auth["type"]): Auth {
   switch (authType) {
     case "none":
       return { type: "none" }
+    case "inherit":
+      return { type: "inherit" }
     case "bearer":
       return { type: "bearer", token: "" }
     case "basic":
@@ -125,9 +139,14 @@ function defaultAuth(authType: Auth["type"]): Auth {
   }
 }
 
+export function clearFolderAuthTypeCache(): void {
+  authTypeCache.clear()
+}
+
 export function applyDraftOp(
   folder: Folder | null,
   op: FolderDraftOp,
+  originalFolder: Folder | null = null,
 ): Folder | null {
   if (!folder) return null
   if (op.kind === "revert") return null
@@ -179,12 +198,26 @@ export function applyDraftOp(
       }
       break
     }
-    case "setAuthType":
-      draft.overrides = {
-        ...draft.overrides,
-        auth: defaultAuth(op.authType),
+    case "setAuthType": {
+      const curAuth = draft.overrides?.auth
+      if (curAuth && curAuth.type !== "none") {
+        const idCache = authTypeCache.get(draft.path) ?? {}
+        idCache[curAuth.type] = curAuth
+        cacheSet(authTypeCache, draft.path, idCache)
+      }
+      const cached = authTypeCache.get(draft.path)?.[op.authType]
+      if (cached && cached.type === op.authType) {
+        draft.overrides = { ...draft.overrides, auth: { ...cached } }
+      } else if (originalFolder?.overrides?.auth?.type === op.authType) {
+        draft.overrides = {
+          ...draft.overrides,
+          auth: { ...originalFolder.overrides.auth },
+        }
+      } else {
+        draft.overrides = { ...draft.overrides, auth: defaultAuth(op.authType) }
       }
       break
+    }
     case "setAuthField": {
       const currentAuth = draft.overrides?.auth
       if (!currentAuth || currentAuth.type !== op.authType) break
@@ -279,7 +312,8 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       setDraftMap((prev) => {
         if (!folder) return prev
         const current = prev.get(key) ?? folder
-        const result = applyDraftOp(current, op)
+        const original = originalMap.get(key) ?? folder
+        const result = applyDraftOp(current, op, original)
         if (result === null) {
           const next = new Map(prev)
           next.delete(key)
@@ -290,7 +324,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
         return next
       })
     },
-    [folder, key],
+    [folder, key, originalMap],
   )
 
   const setName = useCallback(
@@ -336,6 +370,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
   const revertAll = useCallback(() => dispatch({ kind: "revert" }), [dispatch])
   const markSaved = useCallback(() => {
     if (!folderDraft || !folder) return
+    authTypeCache.delete(key)
     setOriginalMap((prev) => {
       const next = new Map(prev)
       next.set(key, { ...folderDraft })
@@ -348,6 +383,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
     })
   }, [folderDraft, folder, key])
   const revertAllFolders = useCallback(() => {
+    authTypeCache.clear()
     setDraftMap(new Map())
   }, [])
 

--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -58,6 +58,7 @@ export function useTreeNavigation(
   cursorIndexRef.current = cursorIndex
 
   const initialCursorSet = useRef(false)
+  const prevSelectedIdRef = useRef(selectedId)
 
   const flatReqs = flattenRequests(items)
 
@@ -127,10 +128,13 @@ export function useTreeNavigation(
         }
       }
       if (selectedId) {
-        const idx = vis.findIndex(
-          (n) => n.type === "request" && n.id === selectedId,
-        )
-        if (idx >= 0) setCursorIndex(idx)
+        const currentNode = visRef.current[cursorIndexRef.current]
+        if (currentNode?.type !== "folder") {
+          const idx = vis.findIndex(
+            (n) => n.type === "request" && n.id === selectedId,
+          )
+          if (idx >= 0) setCursorIndex(idx)
+        }
       }
     } else {
       setSelectedIdState(null)
@@ -138,6 +142,9 @@ export function useTreeNavigation(
   }, [items])
 
   useEffect(() => {
+    const selectedIdChanged = prevSelectedIdRef.current !== selectedId
+    prevSelectedIdRef.current = selectedId
+
     if (initialCursorSet.current) return
     if (vis.length === 0) return
 
@@ -158,6 +165,8 @@ export function useTreeNavigation(
     }
 
     if (!selectedId) return
+    const currentNode = visRef.current[cursorIndexRef.current]
+    if (currentNode?.type === "folder" && !selectedIdChanged) return
     const idx = vis.findIndex(
       (n) => n.type === "request" && n.id === selectedId,
     )

--- a/src/lang/folder.ts
+++ b/src/lang/folder.ts
@@ -63,7 +63,6 @@ export function parseFolder(yamlText: string): {
 
 type RawFolderAuth =
   | { type: "none"; [k: string]: unknown }
-  | { type: "inherit"; [k: string]: unknown }
   | { type: "bearer"; token: string; [k: string]: unknown }
   | { type: "basic"; user: string; pass: string; [k: string]: unknown }
   | {
@@ -81,7 +80,6 @@ function parseFolderAuth(value: unknown): Auth {
   }
   const a = value as RawFolderAuth
   if (a.type === "none") return { type: "none" }
-  if (a.type === "inherit") return { type: "inherit" }
   if (a.type === "bearer") {
     if (typeof a.token !== "string")
       throw new Error('lang.parseFolder: auth.bearer requires "token"')
@@ -149,8 +147,6 @@ export function serializeFolder(folder: Folder): string {
       out += "auth:\n"
       if (o.auth.type === "none") {
         out += "  type: none\n"
-      } else if (o.auth.type === "inherit") {
-        out += "  type: inherit\n"
       } else if (o.auth.type === "bearer") {
         out += "  type: bearer\n"
         out += `  token: ${yamlVal(o.auth.token)}\n`

--- a/src/requests/mergeFolderOverrides.ts
+++ b/src/requests/mergeFolderOverrides.ts
@@ -53,11 +53,7 @@ export function mergeFolderOverrides(
   if (requestAuth.type === "inherit") {
     const reversed = [...folders].reverse()
     for (const folder of reversed) {
-      if (
-        folder.overrides?.auth &&
-        folder.overrides.auth.type !== "none" &&
-        folder.overrides.auth.type !== "inherit"
-      ) {
+      if (folder.overrides?.auth && folder.overrides.auth.type !== "none") {
         return {
           ...request,
           headers: { ...mergedHeaders, ...request.headers },

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -36,6 +36,7 @@ import { useCollectionFileActions } from "./useCollectionFileActions"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
+import type { SubstitutedRequest } from "../requests/substitute"
 import { getRequestIds, findFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import {
@@ -469,17 +470,17 @@ export function AppInner({
     (_req: NoodleRequest, _result: SendCompleteResult) => {},
   )
   onCompleteRef.current = (req: NoodleRequest, result: SendCompleteResult) => {
-    let resolvedUrl: string | undefined
+    let substituted: SubstitutedRequest | undefined
     const activeEnv = envStateRef.current.activeEnv
     if (activeEnv) {
       try {
-        resolvedUrl = substitute(req, activeEnv).url
+        substituted = substitute(req, activeEnv)
       } catch {
-        resolvedUrl = undefined
+        substituted = undefined
       }
     }
     timelineAppendRef.current(
-      buildTimelineEntry(req, result, envNameRef.current, resolvedUrl),
+      buildTimelineEntry(req, result, envNameRef.current, substituted),
     )
   }
 

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -66,8 +66,7 @@ export function FolderPane({
     )
     const hasAuth =
       folder.overrides?.auth?.type !== undefined &&
-      folder.overrides.auth.type !== "none" &&
-      folder.overrides.auth.type !== "inherit"
+      folder.overrides.auth.type !== "none"
     return [
       { id: "meta", label: "General" },
       { id: "headers", label: hasHeaders ? "Headers \u2022" : "Headers" },
@@ -160,7 +159,7 @@ export function FolderPane({
                       onApiKeyPlacementChange ?? (() => {})
                     }
                     onSelectOpenChange={onSelectOpenChange}
-                    showInherit={true}
+                    showInherit={false}
                   />
                 </box>
               )}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
+import { useKeymap } from "@opentui/keymap/react"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import type { SendState } from "./sendState"
 import type { TimelineEntry } from "../schema"
@@ -37,6 +38,7 @@ export function ResponsePane({
   expandHint?: string
 }) {
   const theme = useTheme()
+  const keymap = useKeymap()
   const focusedRef = useRef(focused)
   focusedRef.current = focused
 
@@ -50,6 +52,7 @@ export function ResponsePane({
   useKeyboard((key) => {
     if (!focusedRef.current) return
     if (!isDone) return
+    if (keymap.getData("app.overlay") !== "none") return
     if (key.name === "left")
       setActiveTab((prev) => {
         const ids = ["body", "headers", "timeline"] as const

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -1,6 +1,7 @@
 import type { TimelineEntry, Method } from "../../schema"
 import type { Request } from "../../schema"
 import type { SendCompleteResult } from "../../hooks/useResponse"
+import type { SubstitutedRequest } from "../../requests/substitute"
 
 const MAX_BODY_LENGTH = 10_000
 
@@ -21,7 +22,7 @@ export function buildTimelineEntry(
   req: Request,
   result: SendCompleteResult,
   envName?: string,
-  resolvedUrl?: string,
+  substituted?: SubstitutedRequest,
 ): TimelineEntry {
   return {
     timestamp: Date.now(),
@@ -30,11 +31,25 @@ export function buildTimelineEntry(
       id: req.id,
       name: req.name,
       method: req.method,
-      url: resolvedUrl ?? req.url,
-      headers: { ...req.headers },
-      params: { ...req.params },
-      body: truncateBody(req.body),
-      auth: req.auth ? { ...req.auth } : undefined,
+      url: substituted?.url ?? req.url,
+      headers: substituted
+        ? Object.fromEntries(
+            Object.entries(substituted.headers).map(([k, v]) => [
+              k,
+              { value: v, enabled: true },
+            ]),
+          )
+        : { ...req.headers },
+      params: substituted
+        ? Object.fromEntries(
+            Object.entries(substituted.params).map(([k, v]) => [
+              k,
+              { value: v, enabled: true },
+            ]),
+          )
+        : { ...req.params },
+      body: truncateBody(substituted?.body ?? req.body),
+      auth: substituted?.auth ?? (req.auth ? { ...req.auth } : undefined),
     },
     response:
       result.status === "done"

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -158,6 +158,8 @@ export function useAppKeymap(
             const f = e.editState.cursor.field
             if (f === "headers" || f === "params") return false
           }
+          const overlay = keymap.getData("app.overlay") as string
+          if (overlay !== "none") return false
           return true
         },
         run: () =>
@@ -191,6 +193,8 @@ export function useAppKeymap(
             const f = e.editState.cursor.field
             if (f === "headers" || f === "params") return false
           }
+          const overlay = keymap.getData("app.overlay") as string
+          if (overlay !== "none") return false
           return true
         },
         run: () =>

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -312,6 +312,7 @@ export function useCollectionFileActions({
       savePromise
         .then(() => {
           setCollectionReloadToken((n) => n + 1)
+          setSelectedId(newId)
           setEditRequestVisible(false)
           setFocus("sidebar")
           if (newFolder) expandFolder(newFolder)
@@ -329,6 +330,7 @@ export function useCollectionFileActions({
       setCollectionReloadToken,
       setEditRequestVisible,
       setFocus,
+      setSelectedId,
       showError,
       showSaveResult,
     ],

--- a/src/ui/useFolderActivity.ts
+++ b/src/ui/useFolderActivity.ts
@@ -28,7 +28,9 @@ export function computeFolderActivity(
 ): FolderActivityStats {
   const requests: RequestActivityStats[] = childRequests.map((req) => {
     const entries = timelines.get(req.id) ?? []
-    const successEntries = entries.filter((e) => e.response !== undefined)
+    const successEntries = entries.filter(
+      (e) => e.response && e.response.status >= 200 && e.response.status < 400,
+    )
     const callCount = entries.length
     const successRate = callCount > 0 ? successEntries.length / callCount : null
     const avgTimeMs =

--- a/src/ui/useSaveFile.ts
+++ b/src/ui/useSaveFile.ts
@@ -54,7 +54,7 @@ export function useSaveFile(
         clearSaveTimer()
         setSaveState({
           kind: "success",
-          message: `Successfully edited ${requestId}`,
+          message: `Successfully edited ${req.name}`,
         })
         saveTimerRef.current = setTimeout(() => {
           setSaveState({ kind: "idle" })

--- a/tests/integration/keymap.test.ts
+++ b/tests/integration/keymap.test.ts
@@ -183,7 +183,7 @@ describe("keymap dispatch", () => {
     cleanup()
   })
 
-  it("dispatches tab to focus.next even without mode gating", () => {
+  it("dispatches tab to focus.next without mode gating but blocked by overlay", () => {
     const { keymap, host, cleanup } = setup()
     let called = false
 
@@ -191,6 +191,10 @@ describe("keymap dispatch", () => {
       commands: [
         {
           name: "focus.next",
+          enabled: () => {
+            const overlay = keymap.getData("app.overlay") as string
+            return overlay === "none"
+          },
           run: () => {
             called = true
           },
@@ -199,8 +203,49 @@ describe("keymap dispatch", () => {
       bindings: [{ key: "tab", cmd: "focus.next" }],
     })
 
+    // works with no overlay
     host.press("tab")
     expect(called).toBe(true)
+
+    // blocked when overlay is active
+    called = false
+    keymap.setData("app.overlay", "help")
+    host.press("tab")
+    expect(called).toBe(false)
+
+    cleanup()
+  })
+
+  it("dispatches shift+tab to focus.prev without mode gating but blocked by overlay", () => {
+    const { keymap, host, cleanup } = setup()
+    let called = false
+
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "focus.prev",
+          enabled: () => {
+            const overlay = keymap.getData("app.overlay") as string
+            return overlay === "none"
+          },
+          run: () => {
+            called = true
+          },
+        },
+      ],
+      bindings: [{ key: "shift+tab", cmd: "focus.prev" }],
+    })
+
+    // works with no overlay
+    host.press("tab", { shift: true })
+    expect(called).toBe(true)
+
+    // blocked when overlay is active
+    called = false
+    keymap.setData("app.overlay", "help")
+    host.press("tab", { shift: true })
+    expect(called).toBe(false)
+
     cleanup()
   })
 

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -11,6 +11,12 @@ import { initialEditState } from "../src/ui/editMode"
 import type { EditState } from "../src/ui/editMode"
 
 import { ThemeProvider } from "../src/ui/theme"
+import type { Keymap } from "@opentui/keymap"
+import type { Renderable, KeyEvent } from "@opentui/core"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { createTestKeymap } from "@opentui/keymap/testing"
+
+type OpenTuiKeymap = Keymap<Renderable, KeyEvent>
 
 function makeRequest(i: number): Request {
   return {
@@ -51,8 +57,13 @@ describe("ResponsePane scrollbox", () => {
       },
     } satisfies SendState
 
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
     const { renderOnce, captureCharFrame } = await testRender(
-      <ResponsePane state={state} focused={true} />,
+      <KeymapProvider keymap={keymap}>
+        <ResponsePane state={state} focused={true} />
+      </KeymapProvider>,
       { width: 80, height: 12 },
     )
     await renderOnce()
@@ -323,34 +334,39 @@ describe("App layout stability", () => {
       },
     } satisfies SendState
 
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
     const { renderOnce, captureCharFrame } = await testRender(
-      <box style={{ width: "100%", height: "100%", flexDirection: "column" }}>
-        <box style={{ flexDirection: "row", flexGrow: 1 }}>
-          <Sidebar
-            items={items}
-            loading={false}
-            error={null}
-            visibleItems={visibleItems}
-            cursorIndex={3}
-            selectedId="req-3"
-            expanded={new Set()}
-            focused={false}
-          />
-          <box style={{ flexDirection: "column", flexGrow: 1 }}>
-            <RequestPane
-              request={request}
-              editState={initialEditState()}
-              editKey=""
-              editValue=""
-              setEditKey={() => {}}
-              setEditValue={() => {}}
+      <KeymapProvider keymap={keymap}>
+        <box style={{ width: "100%", height: "100%", flexDirection: "column" }}>
+          <box style={{ flexDirection: "row", flexGrow: 1 }}>
+            <Sidebar
+              items={items}
+              loading={false}
+              error={null}
+              visibleItems={visibleItems}
+              cursorIndex={3}
+              selectedId="req-3"
+              expanded={new Set()}
               focused={false}
-              activeTab="headers"
             />
-            <ResponsePane state={responseState} focused={false} />
+            <box style={{ flexDirection: "column", flexGrow: 1 }}>
+              <RequestPane
+                request={request}
+                editState={initialEditState()}
+                editKey=""
+                editValue=""
+                setEditKey={() => {}}
+                setEditValue={() => {}}
+                focused={false}
+                activeTab="headers"
+              />
+              <ResponsePane state={responseState} focused={false} />
+            </box>
           </box>
         </box>
-      </box>,
+      </KeymapProvider>,
       { width: 80, height: 24 },
     )
     await renderOnce()

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -292,12 +292,15 @@ describe("buildTimelineEntry", () => {
       request: req,
       envName: "dev",
     }
-    const entry = buildTimelineEntry(
-      req,
-      result,
-      "dev",
-      "https://api.example.com/v1/path",
-    )
+    const entry = buildTimelineEntry(req, result, "dev", {
+      id: req.id,
+      name: req.name,
+      method: req.method,
+      url: "https://api.example.com/v1/path",
+      timeout: req.timeout,
+      headers: {},
+      params: {},
+    })
     expect(entry.request.url).toBe("https://api.example.com/v1/path")
   })
 

--- a/tests/unit/folder-activity.test.ts
+++ b/tests/unit/folder-activity.test.ts
@@ -43,6 +43,21 @@ function makeTimeline(
 }
 
 describe("computeFolderActivity", () => {
+  it("counts only 2xx/3xx as success, not 4xx/5xx", () => {
+    const timeline = makeTimeline("user/list", [
+      { response: { ...makeEntry().response!, status: 200 } },
+      { response: { ...makeEntry().response!, status: 401 } },
+      { response: { ...makeEntry().response!, status: 500 } },
+      { response: { ...makeEntry().response!, status: 302 } },
+    ])
+    const result = computeFolderActivity(
+      [{ id: "user/list", name: "List Users", method: "GET" }],
+      timeline,
+    )
+    expect(result.requests[0]!.callCount).toBe(4)
+    expect(result.requests[0]!.successRate).toBe(0.5) // 200 + 302 = 2 out of 4
+  })
+
   it("returns zeroed per-request stats for empty timeline map", () => {
     const result = computeFolderActivity(
       [{ id: "user/list", name: "List Users", method: "GET" }],

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "bun:test"
-import { applyDraftOp, folderEqual } from "../../src/hooks/useFolderDraft"
+import { describe, it, expect, beforeEach } from "bun:test"
+import {
+  applyDraftOp,
+  clearFolderAuthTypeCache,
+  folderEqual,
+} from "../../src/hooks/useFolderDraft"
 import type { Folder } from "../../src/schema"
 
 function makeFolder(overrides?: Partial<Folder>): Folder {
@@ -13,6 +17,10 @@ function makeFolder(overrides?: Partial<Folder>): Folder {
 }
 
 describe("applyDraftOp", () => {
+  beforeEach(() => {
+    clearFolderAuthTypeCache()
+  })
+
   it("setName changes folder name", () => {
     const f = makeFolder({ name: "Old" })
     const r = applyDraftOp(f, { kind: "setName", name: "New" })
@@ -175,6 +183,104 @@ describe("applyDraftOp", () => {
     const f = makeFolder()
     const r = applyDraftOp(f, { kind: "markSaved" })
     expect(r).toBe(f)
+  })
+
+  it("setAuthType saves current auth to cache and restores it on switch back", () => {
+    const f = makeFolder({
+      path: "cache-save-restore",
+      overrides: { auth: { type: "basic", user: "admin", pass: "secret" } },
+    })
+    const bearer = applyDraftOp(f, { kind: "setAuthType", authType: "bearer" })
+    expect(bearer?.overrides?.auth).toEqual({ type: "bearer", token: "" })
+
+    const backToBasic = applyDraftOp(bearer, {
+      kind: "setAuthType",
+      authType: "basic",
+    })
+    expect(backToBasic?.overrides?.auth).toEqual({
+      type: "basic",
+      user: "admin",
+      pass: "secret",
+    })
+  })
+
+  it("setAuthType restores cached auth across multiple switches", () => {
+    const f = makeFolder({
+      path: "multi-switch",
+      overrides: { auth: { type: "basic", user: "u", pass: "p" } },
+    })
+    const apiKey = applyDraftOp(f, { kind: "setAuthType", authType: "api_key" })
+    expect(apiKey?.overrides?.auth).toEqual({
+      type: "api_key",
+      key: "",
+      value: "",
+      placement: "header",
+    })
+
+    const bearer = applyDraftOp(apiKey, {
+      kind: "setAuthType",
+      authType: "bearer",
+    })
+    expect(bearer?.overrides?.auth).toEqual({ type: "bearer", token: "" })
+
+    const backToBasic = applyDraftOp(bearer, {
+      kind: "setAuthType",
+      authType: "basic",
+    })
+    expect(backToBasic?.overrides?.auth).toEqual({
+      type: "basic",
+      user: "u",
+      pass: "p",
+    })
+
+    const backToApiKey = applyDraftOp(backToBasic, {
+      kind: "setAuthType",
+      authType: "api_key",
+    })
+    expect(backToApiKey?.overrides?.auth).toEqual({
+      type: "api_key",
+      key: "",
+      value: "",
+      placement: "header",
+    })
+  })
+
+  it("setAuthType falls back to original auth when cache misses", () => {
+    const original = makeFolder({
+      path: "orig-fallback",
+      overrides: {
+        auth: { type: "basic", user: "saved-user", pass: "saved-pass" },
+      },
+    })
+    const current = makeFolder({
+      path: "orig-fallback",
+      overrides: { auth: { type: "bearer", token: "unsaved" } },
+    })
+    const result = applyDraftOp(
+      current,
+      { kind: "setAuthType", authType: "basic" },
+      original,
+    )
+    expect(result?.overrides?.auth).toEqual({
+      type: "basic",
+      user: "saved-user",
+      pass: "saved-pass",
+    })
+  })
+
+  it("setAuthType saves none-auth override does not cache", () => {
+    const f = makeFolder({
+      path: "none-no-cache",
+      overrides: { auth: { type: "none" } },
+    })
+    const bearer = applyDraftOp(f, { kind: "setAuthType", authType: "bearer" })
+    expect(bearer?.overrides?.auth).toEqual({ type: "bearer", token: "" })
+
+    const backToNone = applyDraftOp(bearer, {
+      kind: "setAuthType",
+      authType: "none",
+    })
+    expect(backToNone?.overrides?.auth).toEqual({ type: "none" })
   })
 })
 

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -87,12 +87,6 @@ describe("applyDraftOp", () => {
     expect(r?.overrides?.auth).toEqual({ type: "none" })
   })
 
-  it("setAuthType sets auth to inherit", () => {
-    const f = makeFolder()
-    const r = applyDraftOp(f, { kind: "setAuthType", authType: "inherit" })
-    expect(r?.overrides?.auth).toEqual({ type: "inherit" })
-  })
-
   it("setAuthField updates token for bearer", () => {
     const f = makeFolder({
       overrides: { auth: { type: "bearer", token: "" } },

--- a/tests/unit/mergeFolderOverrides.test.ts
+++ b/tests/unit/mergeFolderOverrides.test.ts
@@ -261,18 +261,4 @@ describe("mergeFolderOverrides", () => {
     const result = mergeFolderOverrides(req, col, "api/v2/endpoint")
     expect(result.auth).toEqual({ type: "basic", user: "admin", pass: "pw" })
   })
-
-  it("inherit skips folder auth marked as inherit", () => {
-    const folder = makeFolder("auth", {
-      auth: { type: "inherit" },
-    })
-    const req = makeRequest({ auth: { type: "inherit" } })
-    const col: Collection = {
-      id: "c",
-      name: "C",
-      items: [{ type: "folder", data: folder }],
-    }
-    const result = mergeFolderOverrides(req, col, "auth/login")
-    expect(result.auth).toEqual({ type: "none" })
-  })
 })


### PR DESCRIPTION
## Changes

Branch `fix/bugs` — 7 bug fixes + 1 refactor:

```
b3336dc fix: prevent overlay key events from leaking to background panes
b7b8d90 fix(save-toast): show request name instead of id path
1305b95 fix(timeline): substitute $VARS in timeline entry body, headers, params, auth
85d209d fix(sidebar): prevent cursor jump on folder save and Ctrl+E edit
c98ceb1 fix(folder-activity): count only 2xx/3xx as success in OK%
6784a9e fix(useFolderDraft): preserve auth values when switching auth types
a5ae1f4 refactor: remove inherit from folder auth type
```

Not included: uncommitted working tree changes.