### PR TITLE
feat(ui): add $variable autocompletion and env-aware syntax features

### DIFF
--- a/collections/albums/create-album.yml
+++ b/collections/albums/create-album.yml
@@ -10,6 +10,7 @@ body: |-
   {
     "title": "my album",
     "userId": $user_id,
-    "test": "$base_url"
+    "test": "$base_url",
+    "bad": "$base_url"
   }
 body_type: json

--- a/collections/albums/create-album.yml
+++ b/collections/albums/create-album.yml
@@ -10,7 +10,6 @@ body: |-
   {
     "title": "my album",
     "userId": $user_id,
-    "test": "$base_url",
-    "bad": $base_url
+    "test": "$base_url"
   }
 body_type: json

--- a/collections/albums/create-album.yml
+++ b/collections/albums/create-album.yml
@@ -1,7 +1,6 @@
 name: Create Album
 method: POST
 url: $base_url/albums
-body_type: json
 timeout: 0
 followRedirects: true
 maxRedirects: 5
@@ -10,5 +9,7 @@ headers:
 body: |-
   {
     "title": "my album",
-    "userId": 1
+    "userId": $user_id,
+    "test": "$base_url"
   }
+body_type: json

--- a/collections/albums/create-album.yml
+++ b/collections/albums/create-album.yml
@@ -11,6 +11,6 @@ body: |-
     "title": "my album",
     "userId": $user_id,
     "test": "$base_url",
-    "bad": "$base_url"
+    "bad": $base_url
   }
 body_type: json

--- a/collections/posts/create-post.yml
+++ b/collections/posts/create-post.yml
@@ -9,6 +9,7 @@ headers:
   x-api-key: $x_api_key
 body: |-
   {
+    "url": "$base_url",
     "title": "My First Blog Post",
     "slug": "my-first-blog-post",
     "excerpt": "This is a brief excerpt of the blog post that gives readers a preview of the content that follows.",

--- a/collections/posts/create-post.yml
+++ b/collections/posts/create-post.yml
@@ -1,6 +1,6 @@
 name: Create Post
 method: POST
-url: $base_url/posts
+url: $base_url/posts/
 timeout: 0
 followRedirects: true
 maxRedirects: 5

--- a/collections/posts/get-post.yml
+++ b/collections/posts/get-post.yml
@@ -1,7 +1,7 @@
 name: Get Post by ID
 method: GET
 url: $base_url/posts/$post_id
-body_type: none
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+body_type: none

--- a/src/hooks/useJsonHighlight.ts
+++ b/src/hooks/useJsonHighlight.ts
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useRef } from "react"
 import { SyntaxStyle } from "@opentui/core"
-import type { TextareaRenderable, LineNumberRenderable } from "@opentui/core"
+import type { TextareaRenderable } from "@opentui/core"
 import type { Theme } from "../ui/theme-data"
 import { highlightJsonTokens } from "../ui/syntax"
 import type { Environment } from "../schema"
@@ -76,44 +75,4 @@ export function highlightTextarea(
       })
     }
   }
-}
-
-export interface JsonValidation {
-  valid: boolean
-}
-
-const DEBOUNCE_MS = 150
-
-export function useJsonHighlight(
-  textareaRef: { current: TextareaRenderable | null },
-  _lineNumberRef: { current: LineNumberRenderable | null },
-  theme: Theme,
-  setEditValue: (v: string) => void,
-): {
-  validation: JsonValidation
-  handleContentChange: () => void
-} {
-  const timeoutRef = useRef<Timer | null>(null)
-
-  const handleContentChange = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => {
-      const ta = textareaRef.current
-      if (!ta) return
-      const content = ta.plainText
-      setEditValue(content)
-      highlightTextarea(ta, content, theme)
-    }, DEBOUNCE_MS)
-  }, [textareaRef, theme, setEditValue])
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    }
-  }, [])
-
-  return { validation: { valid: true }, handleContentChange }
 }

--- a/src/hooks/useJsonHighlight.ts
+++ b/src/hooks/useJsonHighlight.ts
@@ -60,7 +60,7 @@ export function highlightTextarea(
     let match: RegExpExecArray | null
     while ((match = varRe.exec(content)) !== null) {
       const varName = match[0].slice(1)
-      const exists = varName in env.vars
+      const exists = Object.hasOwn(env.vars, varName)
       const styleId = exists
         ? style.getStyleId("env.resolved")!
         : style.getStyleId("env.missing")!

--- a/src/hooks/useJsonHighlight.ts
+++ b/src/hooks/useJsonHighlight.ts
@@ -4,6 +4,10 @@ import type { TextareaRenderable, LineNumberRenderable } from "@opentui/core"
 import type { Theme } from "../ui/theme-data"
 import { highlightJsonTokens } from "../ui/syntax"
 import type { Environment } from "../schema"
+import {
+  buildCharToDisplayOffsets,
+  charOffsetToDisplayOffset,
+} from "../ui/highlightOffsets"
 
 function createJsonSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({
@@ -58,6 +62,7 @@ export function highlightTextarea(
 
   if (env) {
     const varRe = /\$\w+/g
+    const displayOffsets = buildCharToDisplayOffsets(content)
     let match: RegExpExecArray | null
     while ((match = varRe.exec(content)) !== null) {
       const varName = match[0].slice(1)
@@ -66,8 +71,11 @@ export function highlightTextarea(
         ? style.getStyleId("env.resolved")!
         : style.getStyleId("env.missing")!
       textarea.addHighlightByCharRange({
-        start: match.index,
-        end: match.index + match[0].length,
+        start: charOffsetToDisplayOffset(displayOffsets, match.index),
+        end: charOffsetToDisplayOffset(
+          displayOffsets,
+          match.index + match[0].length,
+        ),
         styleId,
         priority: 2,
       })

--- a/src/hooks/useJsonHighlight.ts
+++ b/src/hooks/useJsonHighlight.ts
@@ -42,22 +42,17 @@ export function highlightTextarea(
   textarea.clearAllHighlights()
   textarea.syntaxStyle = style
 
-  try {
-    JSON.parse(content)
-    if (content.length <= 100_000) {
-      const tokens = highlightJsonTokens(content, theme)
-      for (const token of tokens) {
-        const styleId = styleIdForFg(token.fg, theme, style)
-        textarea.addHighlightByCharRange({
-          start: token.offset,
-          end: token.offset + token.text.length,
-          styleId,
-          priority: 1,
-        })
-      }
+  if (content.length <= 100_000) {
+    const tokens = highlightJsonTokens(content, theme)
+    for (const token of tokens) {
+      const styleId = styleIdForFg(token.fg, theme, style)
+      textarea.addHighlightByCharRange({
+        start: token.offset,
+        end: token.offset + token.text.length,
+        styleId,
+        priority: 1,
+      })
     }
-  } catch {
-    // not valid JSON — still add $var highlights below
   }
 
   if (env) {

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -10,7 +10,7 @@ export type SubstitutedRequest = Omit<Request, "headers" | "params"> & {
 export function substitute(req: Request, env: Environment): SubstitutedRequest {
   const resolve = (s: string, field: string): string =>
     s.replace(VAR_RE, (_, name) => {
-      if (!(name in env.vars)) {
+      if (!Object.hasOwn(env.vars, name)) {
         throw new Error(
           `requests.substitute: unresolved variable "${name}" in ${field}`,
         )

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -46,6 +46,7 @@ import {
 } from "./tabs/uiState"
 import type { FieldKind } from "./editMode"
 import type { ResponseTabKind } from "./tabs/uiState"
+import { VariableCompletionInterceptor } from "./variableCompletionInterceptor"
 
 export function AppInner({
   collectionDir,
@@ -807,6 +808,7 @@ export function AppInner({
         backgroundColor: theme.background,
       }}
     >
+      <VariableCompletionInterceptor />
       <box
         style={{
           flexDirection: "column",

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -251,14 +251,14 @@ export function AppOverlays({
         <ConfirmOverlay
           visible
           message={`Delete folder "${folderDeletePending}" and all requests inside?`}
-          selectedIndex={0}
+          selectedIndex={deleteConfirmSelection}
         />
       )}
       {requestDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete "${requestDeletePending}"?`}
-          selectedIndex={0}
+          selectedIndex={deleteConfirmSelection}
         />
       )}
     </>

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -190,6 +190,7 @@ export function AppOverlays({
           visible
           filePath={yamlEditor.filePath}
           requestName={yamlEditor.requestName}
+          activeEnv={activeEnv}
           onSaved={() => {
             resetRequestDraft(yamlEditor.requestId)
             setCollectionReloadToken((n) => n + 1)

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -534,6 +534,9 @@ export class CodeEditorRenderable extends TextareaRenderable {
       this.setDisplayedText(this._sourceText)
       this.applyFoldedDisplayHighlights(this._sourceText)
     }
+    if (wasFolded) {
+      this.scheduleHighlight()
+    }
     if (preferredSourceCursor) {
       this.moveCursorToSourceCursor(preferredSourceCursor)
     } else {

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -442,10 +442,6 @@ export class CodeEditorRenderable extends TextareaRenderable {
     return false
   }
 
-  protected override onResize(width: number, height: number): void {
-    super.onResize(width, height)
-  }
-
   private hasFoldedRanges(): boolean {
     for (const fold of this._folds.values()) {
       if (fold.folded) return true

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -273,6 +273,10 @@ export class CodeEditorRenderable extends TextareaRenderable {
     return this._envMissingStyleId
   }
 
+  refreshHighlights(): void {
+    void this.highlight()
+  }
+
   toggleFold(line: number): void {
     const sourceLine = this.displayLineToSourceLine(line)
     const fold = this._folds.get(sourceLine)

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -106,6 +106,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
   private _suppressContentChanged: boolean = false
   private _sourceLineToDisplayLine: Map<number, number> = new Map()
   private _displayLineToSourceLine: Map<number, number> = new Map()
+  private _renderSuppressed = false
   private _validateContent?: (content: string) => string | null
   private _validationError: string | null = null
   private _onValidationChange?: (error: string | null) => void
@@ -277,6 +278,22 @@ export class CodeEditorRenderable extends TextareaRenderable {
     void this.highlight()
   }
 
+  override requestRender(): void {
+    if (this._renderSuppressed) return
+    super.requestRender()
+  }
+
+  private withRenderSuppressed(action: () => void): void {
+    const wasSuppressed = this._renderSuppressed
+    this._renderSuppressed = true
+    try {
+      action()
+    } finally {
+      this._renderSuppressed = wasSuppressed
+      if (!wasSuppressed) super.requestRender()
+    }
+  }
+
   toggleFold(line: number): void {
     const sourceLine = this.displayLineToSourceLine(line)
     const fold = this._folds.get(sourceLine)
@@ -288,39 +305,46 @@ export class CodeEditorRenderable extends TextareaRenderable {
       this.fold(fold)
     }
     this.applyFoldDisplay(sourceLine)
-    this.requestRender()
+    this._onFoldsChange?.()
   }
 
   private fold(fold: FoldInfo): void {
     fold.folded = true
     this._folds.set(fold.startLine, fold)
-    this._onFoldsChange?.()
   }
 
   private unfold(fold: FoldInfo): void {
     fold.folded = false
     this._folds.set(fold.startLine, fold)
-    this._onFoldsChange?.()
   }
 
   foldAll(): void {
+    let changed = false
     for (const fold of this._folds.values()) {
-      if (!fold.folded) this.fold(fold)
+      if (!fold.folded) {
+        this.fold(fold)
+        changed = true
+      }
     }
+    if (!changed) return
     this.applyFoldDisplay()
-    this.requestRender()
+    this._onFoldsChange?.()
   }
 
   unfoldAll(): void {
     const sourceCursor = this.isFoldedDisplay()
       ? this.getSourceCursorFromDisplay()
       : undefined
+    let changed = false
     for (const fold of this._folds.values()) {
-      if (fold.folded) this.unfold(fold)
+      if (fold.folded) {
+        this.unfold(fold)
+        changed = true
+      }
     }
+    if (!changed) return
     this.restoreSourceDisplay(undefined, sourceCursor)
-    this.scheduleHighlight()
-    this.requestRender()
+    this._onFoldsChange?.()
   }
 
   override handlePaste(event: PasteEvent): void {
@@ -434,6 +458,14 @@ export class CodeEditorRenderable extends TextareaRenderable {
   }
 
   private applyFoldDisplay(preferredSourceLine?: number | SourceCursor): void {
+    this.withRenderSuppressed(() => {
+      this.applyFoldDisplayInternal(preferredSourceLine)
+    })
+  }
+
+  private applyFoldDisplayInternal(
+    preferredSourceLine?: number | SourceCursor,
+  ): void {
     if (!this.hasFoldedRanges()) {
       if (typeof preferredSourceLine === "object") {
         this.restoreSourceDisplay(undefined, preferredSourceLine)
@@ -483,11 +515,24 @@ export class CodeEditorRenderable extends TextareaRenderable {
     preferredSourceLine?: number,
     preferredSourceCursor?: SourceCursor,
   ): void {
+    this.withRenderSuppressed(() => {
+      this.restoreSourceDisplayInternal(
+        preferredSourceLine,
+        preferredSourceCursor,
+      )
+    })
+  }
+
+  private restoreSourceDisplayInternal(
+    preferredSourceLine?: number,
+    preferredSourceCursor?: SourceCursor,
+  ): void {
     const wasFolded = this._displayMode === "folded"
     this._displayMode = "source"
     this.rebuildSourceDisplayMaps(this._sourceText)
     if (wasFolded || super.plainText !== this._sourceText) {
       this.setDisplayedText(this._sourceText)
+      this.applyFoldedDisplayHighlights(this._sourceText)
     }
     if (preferredSourceCursor) {
       this.moveCursorToSourceCursor(preferredSourceCursor)
@@ -499,7 +544,11 @@ export class CodeEditorRenderable extends TextareaRenderable {
   private setDisplayedText(text: string): void {
     this._suppressContentChanged = true
     try {
-      super.setText(text)
+      // Update the backing buffer without the immediate render requested by
+      // TextareaRenderable.setText(). Folded text and its highlights must be
+      // published together to avoid a transient unstyled frame.
+      this.editBuffer.setText(text)
+      this.yogaNode.markDirty()
     } finally {
       this._suppressContentChanged = false
     }
@@ -822,9 +871,10 @@ export class CodeEditorRenderable extends TextareaRenderable {
       fold.folded = previous?.folded ?? fold.folded
     }
 
-    if (this.hasFoldedRanges()) this.applyFoldDisplay()
+    const hasFoldedRanges = this.hasFoldedRanges()
+    if (hasFoldedRanges) this.applyFoldDisplay()
     this._onFoldsChange?.()
-    this.requestRender()
+    if (!hasFoldedRanges) this.requestRender()
   }
 
   private computeJsonFoldRanges(

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -650,21 +650,33 @@ export class CodeEditorRenderable extends TextareaRenderable {
 
     let tsSuccess = false
 
-    try {
-      const result = await this._tsClient.highlightOnce(content, this._filetype)
+    if (this._filetype === "json") {
+      // JSON requests may contain Noodle variables, which are intentionally
+      // not valid JSON until send-time substitution. The local tokenizer
+      // still highlights keys, strings, numbers, and punctuation correctly.
+      this.applyJsonHighlights(content)
+      tsSuccess = true
+      this._lastTsError = false
+    } else {
+      try {
+        const result = await this._tsClient.highlightOnce(
+          content,
+          this._filetype,
+        )
 
-      if (snapshotId !== this._highlightSnapshotId) return
-      if (this.isDestroyed) return
-      if (this.isFoldedDisplay()) return
+        if (snapshotId !== this._highlightSnapshotId) return
+        if (this.isDestroyed) return
+        if (this.isFoldedDisplay()) return
 
-      const highlights = result.highlights
-      if (highlights && highlights.length > 0) {
-        this.applyTsHighlights(highlights, content)
-        tsSuccess = true
-        this._lastTsError = false
+        const highlights = result.highlights
+        if (highlights && highlights.length > 0) {
+          this.applyTsHighlights(highlights, content)
+          tsSuccess = true
+          this._lastTsError = false
+        }
+      } catch {
+        this._lastTsError = true
       }
-    } catch {
-      this._lastTsError = true
     }
 
     if (snapshotId !== this._highlightSnapshotId) return

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -10,6 +10,10 @@ import type { TreeSitterClient } from "@opentui/core"
 import type { Theme } from "./theme-data"
 import { highlightJsonTokens } from "./syntax"
 import { tokenizeYamlLine } from "./yamlSyntax"
+import {
+  buildCharToDisplayOffsets,
+  charOffsetToDisplayOffset,
+} from "./highlightOffsets"
 
 export interface FoldInfo {
   startLine: number
@@ -771,10 +775,11 @@ export class CodeEditorRenderable extends TextareaRenderable {
     if (!this._extraHighlights) return
 
     const extras = this._extraHighlights(content)
+    const displayOffsets = buildCharToDisplayOffsets(content)
     for (const hl of extras) {
       this.addHighlightByCharRange({
-        start: hl.start,
-        end: hl.end,
+        start: charOffsetToDisplayOffset(displayOffsets, hl.start),
+        end: charOffsetToDisplayOffset(displayOffsets, hl.end),
         styleId: hl.styleId,
         priority: hl.priority ?? 2,
       })

--- a/src/ui/CodeEditor.ts
+++ b/src/ui/CodeEditor.ts
@@ -741,12 +741,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
 
     if (!tsSuccess) {
       this.clearAllHighlights()
-    }
-
-    if (!tsSuccess) {
-      if (this._filetype === "json") {
-        this.applyJsonHighlights(content)
-      } else if (this._filetype === "yaml") {
+      if (this._filetype === "yaml") {
         this.applyYamlHighlights(content)
       }
     }

--- a/src/ui/CodeEditorCompletion.tsx
+++ b/src/ui/CodeEditorCompletion.tsx
@@ -93,7 +93,8 @@ export function CodeEditorCompletion({
     return null
 
   const cursor = editor.visualCursor
-  const menuHeight = Math.min(completion.suggestions.length, 10) + 2
+  const menuHeight =
+    Math.min(completion.suggestions.length, MAX_COMPLETION_VISIBLE) + 2
   const menuWidth = 18
   const x = Math.max(
     0,

--- a/src/ui/CodeEditorCompletion.tsx
+++ b/src/ui/CodeEditorCompletion.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { CodeEditorRenderable } from "./CodeEditor"
+import type { Environment } from "../schema"
+import {
+  getVariableSuggestions,
+  getVariableToken,
+  replaceVariableToken,
+} from "./variableCompletion"
+import { registerVariableCompletion } from "./variableCompletionInterceptor"
+import {
+  createPortal,
+  useRenderer,
+  useTerminalDimensions,
+} from "@opentui/react"
+import { useTheme } from "./theme"
+
+export function CodeEditorCompletion({
+  editor,
+  env,
+  isEditing,
+  value,
+}: {
+  editor: CodeEditorRenderable | null
+  env: Environment | null
+  isEditing: boolean
+  value: string
+}) {
+  const theme = useTheme()
+  const renderer = useRenderer()
+  const { width: terminalWidth, height: terminalHeight } =
+    useTerminalDimensions()
+  const [completionDismissed, setCompletionDismissed] = useState(false)
+  const [completionIndex, setCompletionIndex] = useState(0)
+  const [revision, setRevision] = useState(0)
+
+  const completion = useMemo(() => {
+    const text = editor?.plainText ?? ""
+    const cursorOffset = editor?.cursorOffset ?? text.length
+    const token = getVariableToken(text, cursorOffset)
+    const suggestions = token
+      ? getVariableSuggestions(Object.keys(env?.vars ?? {}), token.prefix)
+      : []
+    const tokenText = token ? text.slice(token.start + 1, token.end) : ""
+    const isComplete =
+      suggestions.length === 1 &&
+      cursorOffset === token?.end &&
+      suggestions[0] === tokenText
+    return { token, suggestions, isComplete }
+  }, [editor, env?.vars, revision, value])
+
+  const handleKey = useCallback(
+    (key: {
+      name: string
+      preventDefault: () => void
+      stopPropagation: () => void
+      defaultPrevented?: boolean
+    }) => {
+      if (
+        !isEditing ||
+        !editor ||
+        editor.isDestroyed ||
+        !editor.focused ||
+        completionDismissed ||
+        key.defaultPrevented
+      )
+        return false
+      const { token, suggestions, isComplete } = completion
+      if (!token || suggestions.length === 0 || isComplete) return false
+      if (key.name === "up" || key.name === "down") {
+        const max = Math.min(suggestions.length, 10)
+        setCompletionIndex((current) => {
+          const next = current + (key.name === "up" ? -1 : 1)
+          return next < 0 ? max - 1 : next >= max ? 0 : next
+        })
+        return true
+      }
+      if (key.name === "tab" || key.name === "return") {
+        const name = suggestions[completionIndex] ?? suggestions[0]!
+        const result = replaceVariableToken(editor.plainText, token, name)
+        editor.replaceText(result.value)
+        editor.cursorOffset = result.cursorOffset
+        setCompletionDismissed(true)
+        setRevision((value) => value + 1)
+        return true
+      }
+      if (key.name === "escape") {
+        setCompletionDismissed(true)
+        return true
+      }
+      return false
+    },
+    [completion, completionDismissed, completionIndex, editor, isEditing],
+  )
+
+  useEffect(() => {
+    if (!isEditing || !editor || completion.suggestions.length === 0) return
+    const dispose = registerVariableCompletion(handleKey)
+    return () => {
+      dispose()
+    }
+  }, [completion.suggestions.length, editor, handleKey, isEditing])
+
+  useEffect(() => {
+    setCompletionDismissed(false)
+    setCompletionIndex(0)
+  }, [completion.token?.prefix])
+
+  useEffect(() => {
+    if (!isEditing || !editor) return
+    const onChange = () => {
+      setCompletionDismissed(false)
+      setRevision((value) => value + 1)
+    }
+    editor.on("content-changed", onChange)
+    return () => {
+      editor.off("content-changed", onChange)
+    }
+  }, [editor, isEditing])
+
+  if (
+    !isEditing ||
+    !editor ||
+    completionDismissed ||
+    !completion.token ||
+    completion.suggestions.length === 0 ||
+    completion.isComplete
+  )
+    return null
+
+  const cursor = editor.visualCursor
+  const menuHeight = Math.min(completion.suggestions.length, 10) + 2
+  const menuWidth = 18
+  const x = Math.max(
+    0,
+    Math.min(editor.x + cursor.visualCol, terminalWidth - menuWidth),
+  )
+  const y = Math.max(
+    0,
+    Math.min(editor.y + cursor.visualRow + 1, terminalHeight - menuHeight),
+  )
+
+  return createPortal(
+    <box
+      id="var-completion-menu"
+      style={{
+        position: "absolute",
+        top: y,
+        left: x,
+        zIndex: 10000,
+        flexDirection: "column",
+        minWidth: 16,
+        backgroundColor: theme.backgroundPanel,
+        paddingLeft: 1,
+        paddingRight: 1,
+      }}
+      borderStyle="single"
+      borderColor={theme.borderActive}
+    >
+      {completion.suggestions.slice(0, 10).map((name, index) => (
+        <box
+          key={name}
+          style={{
+            backgroundColor:
+              index === completionIndex ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={index === completionIndex ? theme.primary : theme.text}>
+            ${name}
+          </text>
+        </box>
+      ))}
+    </box>,
+    renderer.root,
+    null,
+  )
+}

--- a/src/ui/CodeEditorCompletion.tsx
+++ b/src/ui/CodeEditorCompletion.tsx
@@ -48,6 +48,21 @@ export function CodeEditorCompletion({
     return { token, suggestions, isComplete }
   }, [editor, env?.vars, revision, value])
 
+  const getCompletion = useCallback(() => {
+    const text = editor?.plainText ?? ""
+    const cursorOffset = editor?.cursorOffset ?? text.length
+    const token = getVariableToken(text, cursorOffset)
+    const suggestions = token
+      ? getVariableSuggestions(Object.keys(env?.vars ?? {}), token.prefix)
+      : []
+    const tokenText = token ? text.slice(token.start + 1, token.end) : ""
+    const isComplete =
+      suggestions.length === 1 &&
+      cursorOffset === token?.end &&
+      suggestions[0] === tokenText
+    return { token, suggestions, isComplete }
+  }, [editor, env?.vars, value])
+
   const handleKey = useCallback(
     (key: {
       name: string
@@ -64,7 +79,7 @@ export function CodeEditorCompletion({
         key.defaultPrevented
       )
         return false
-      const { token, suggestions, isComplete } = completion
+      const { token, suggestions, isComplete } = getCompletion()
       if (!token || suggestions.length === 0 || isComplete) return false
       if (key.name === "up" || key.name === "down") {
         const max = Math.min(suggestions.length, 10)
@@ -75,7 +90,11 @@ export function CodeEditorCompletion({
         return true
       }
       if (key.name === "tab" || key.name === "return") {
-        const name = suggestions[completionIndex] ?? suggestions[0]!
+        const idx = Math.min(
+          completionIndex,
+          Math.min(suggestions.length, 10) - 1,
+        )
+        const name = suggestions[idx] ?? suggestions[0]!
         const result = replaceVariableToken(editor.plainText, token, name)
         editor.replaceText(result.value)
         editor.cursorOffset = result.cursorOffset
@@ -89,7 +108,7 @@ export function CodeEditorCompletion({
       }
       return false
     },
-    [completion, completionDismissed, completionIndex, editor, isEditing],
+    [completionDismissed, completionIndex, editor, getCompletion, isEditing],
   )
 
   useEffect(() => {

--- a/src/ui/CodeEditorCompletion.tsx
+++ b/src/ui/CodeEditorCompletion.tsx
@@ -107,6 +107,7 @@ export function CodeEditorCompletion({
 
   useEffect(() => {
     if (!isEditing || !editor) return
+    editor.refreshHighlights()
     const onChange = () => {
       setCompletionDismissed(false)
       setRevision((value) => value + 1)

--- a/src/ui/CodeEditorCompletion.tsx
+++ b/src/ui/CodeEditorCompletion.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import type { CodeEditorRenderable } from "./CodeEditor"
 import type { Environment } from "../schema"
-import {
-  getVariableSuggestions,
-  getVariableToken,
-  replaceVariableToken,
-} from "./variableCompletion"
 import { registerVariableCompletion } from "./variableCompletionInterceptor"
 import {
   createPortal,
@@ -13,6 +8,10 @@ import {
   useTerminalDimensions,
 } from "@opentui/react"
 import { useTheme } from "./theme"
+import {
+  useVariableCompletion,
+  MAX_COMPLETION_VISIBLE,
+} from "./useVariableCompletion"
 
 export function CodeEditorCompletion({
   editor,
@@ -31,84 +30,31 @@ export function CodeEditorCompletion({
     useTerminalDimensions()
   const [completionDismissed, setCompletionDismissed] = useState(false)
   const [completionIndex, setCompletionIndex] = useState(0)
-  const [revision, setRevision] = useState(0)
 
-  const completion = useMemo(() => {
-    const text = editor?.plainText ?? ""
-    const cursorOffset = editor?.cursorOffset ?? text.length
-    const token = getVariableToken(text, cursorOffset)
-    const suggestions = token
-      ? getVariableSuggestions(Object.keys(env?.vars ?? {}), token.prefix)
-      : []
-    const tokenText = token ? text.slice(token.start + 1, token.end) : ""
-    const isComplete =
-      suggestions.length === 1 &&
-      cursorOffset === token?.end &&
-      suggestions[0] === tokenText
-    return { token, suggestions, isComplete }
-  }, [editor, env?.vars, revision, value])
+  const getEditor = useCallback(() => {
+    if (!editor || editor.isDestroyed) return null
+    return editor
+  }, [editor])
 
-  const getCompletion = useCallback(() => {
-    const text = editor?.plainText ?? ""
-    const cursorOffset = editor?.cursorOffset ?? text.length
-    const token = getVariableToken(text, cursorOffset)
-    const suggestions = token
-      ? getVariableSuggestions(Object.keys(env?.vars ?? {}), token.prefix)
-      : []
-    const tokenText = token ? text.slice(token.start + 1, token.end) : ""
-    const isComplete =
-      suggestions.length === 1 &&
-      cursorOffset === token?.end &&
-      suggestions[0] === tokenText
-    return { token, suggestions, isComplete }
-  }, [editor, env?.vars, value])
+  const variableNames = useMemo(() => Object.keys(env?.vars ?? {}), [env?.vars])
 
-  const handleKey = useCallback(
-    (key: {
-      name: string
-      preventDefault: () => void
-      stopPropagation: () => void
-      defaultPrevented?: boolean
-    }) => {
-      if (
-        !isEditing ||
-        !editor ||
-        editor.isDestroyed ||
-        !editor.focused ||
-        completionDismissed ||
-        key.defaultPrevented
-      )
-        return false
-      const { token, suggestions, isComplete } = getCompletion()
-      if (!token || suggestions.length === 0 || isComplete) return false
-      if (key.name === "up" || key.name === "down") {
-        const max = Math.min(suggestions.length, 10)
-        setCompletionIndex((current) => {
-          const next = current + (key.name === "up" ? -1 : 1)
-          return next < 0 ? max - 1 : next >= max ? 0 : next
-        })
-        return true
-      }
-      if (key.name === "tab" || key.name === "return") {
-        const idx = Math.min(
-          completionIndex,
-          Math.min(suggestions.length, 10) - 1,
-        )
-        const name = suggestions[idx] ?? suggestions[0]!
-        const result = replaceVariableToken(editor.plainText, token, name)
-        editor.replaceText(result.value)
-        editor.cursorOffset = result.cursorOffset
-        setCompletionDismissed(true)
-        setRevision((value) => value + 1)
-        return true
-      }
-      if (key.name === "escape") {
-        setCompletionDismissed(true)
-        return true
-      }
-      return false
-    },
-    [completionDismissed, completionIndex, editor, getCompletion, isEditing],
+  const { completion, makeHandleKey } = useVariableCompletion({
+    getEditor,
+    variableNames,
+    value,
+    isEditing,
+  })
+
+  const handleKey = useMemo(
+    () =>
+      makeHandleKey({
+        completionDismissed,
+        completionIndex,
+        setCompletionIndex,
+        setCompletionDismissed,
+        onAccept: () => {},
+      }),
+    [completionDismissed, completionIndex, makeHandleKey],
   )
 
   useEffect(() => {
@@ -129,7 +75,6 @@ export function CodeEditorCompletion({
     editor.refreshHighlights()
     const onChange = () => {
       setCompletionDismissed(false)
-      setRevision((value) => value + 1)
     }
     editor.on("content-changed", onChange)
     return () => {
@@ -176,19 +121,21 @@ export function CodeEditorCompletion({
       borderStyle="single"
       borderColor={theme.borderActive}
     >
-      {completion.suggestions.slice(0, 10).map((name, index) => (
-        <box
-          key={name}
-          style={{
-            backgroundColor:
-              index === completionIndex ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={index === completionIndex ? theme.primary : theme.text}>
-            ${name}
-          </text>
-        </box>
-      ))}
+      {completion.suggestions
+        .slice(0, MAX_COMPLETION_VISIBLE)
+        .map((name, index) => (
+          <box
+            key={name}
+            style={{
+              backgroundColor:
+                index === completionIndex ? theme.backgroundElement : undefined,
+            }}
+          >
+            <text fg={index === completionIndex ? theme.primary : theme.text}>
+              ${name}
+            </text>
+          </box>
+        ))}
     </box>,
     renderer.root,
     null,

--- a/src/ui/EnvEditorPane.tsx
+++ b/src/ui/EnvEditorPane.tsx
@@ -14,7 +14,6 @@ export function EnvEditorPane({
   setEditValue,
   saving,
   error,
-  activeEnv,
   focused: _focused,
 }: {
   draft: EnvDraft | null
@@ -25,7 +24,6 @@ export function EnvEditorPane({
   setEditValue: (v: string) => void
   saving: boolean
   error: string | null
-  activeEnv: Environment | null
   focused: boolean
 }) {
   const theme = useTheme()
@@ -66,6 +64,14 @@ export function EnvEditorPane({
   const variableNames = rows
     .filter((row) => row.enabled && row.key !== "")
     .map((row) => row.key)
+  const draftEnv: Environment = {
+    name: draft.name,
+    vars: Object.fromEntries(
+      rows
+        .filter((row) => row.enabled && row.key !== "")
+        .map((row) => [row.key, row.value]),
+    ),
+  }
   const inEdit = editState.mode === "editing"
   const inBrowse = editState.mode === "browsing"
   const editingRow = inEdit && !editState.addingRow ? editState.editingRow : -1
@@ -124,7 +130,7 @@ export function EnvEditorPane({
               <Checkbox checked={row.enabled} theme={theme} />
               <VarInput
                 value={isEditingThisRow ? editKey : row.key}
-                env={activeEnv}
+                env={draftEnv}
                 isEditing={isEditingThisRow}
                 onChange={setEditKey}
                 isFocused={isEditingThisRow && editState.subfield === "key"}
@@ -138,7 +144,7 @@ export function EnvEditorPane({
               />
               <VarInput
                 value={isEditingThisRow ? editValue : row.value}
-                env={activeEnv}
+                env={draftEnv}
                 isEditing={isEditingThisRow}
                 onChange={setEditValue}
                 isFocused={isEditingThisRow && editState.subfield === "value"}
@@ -169,7 +175,7 @@ export function EnvEditorPane({
           <Checkbox checked={false} theme={theme} />
           <VarInput
             value={editingAdd ? editKey : ""}
-            env={activeEnv}
+            env={draftEnv}
             isEditing={editingAdd}
             onChange={setEditKey}
             isFocused={editingAdd && editState.subfield === "key"}
@@ -185,7 +191,7 @@ export function EnvEditorPane({
           />
           <VarInput
             value={editingAdd ? editValue : ""}
-            env={activeEnv}
+            env={draftEnv}
             isEditing={editingAdd}
             onChange={setEditValue}
             isFocused={editingAdd && editState.subfield === "value"}

--- a/src/ui/EnvEditorPane.tsx
+++ b/src/ui/EnvEditorPane.tsx
@@ -63,6 +63,9 @@ export function EnvEditorPane({
   const stripeBg = `#${stripeR.toString(16).padStart(2, "0")}${stripeG.toString(16).padStart(2, "0")}${stripeB.toString(16).padStart(2, "0")}`
 
   const rows = draft.varRows
+  const variableNames = rows
+    .filter((row) => row.enabled && row.key !== "")
+    .map((row) => row.key)
   const inEdit = editState.mode === "editing"
   const inBrowse = editState.mode === "browsing"
   const editingRow = inEdit && !editState.addingRow ? editState.editingRow : -1
@@ -131,6 +134,7 @@ export function EnvEditorPane({
                 }
                 focusedBackgroundColor={theme.borderSubtle}
                 style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+                variableNames={variableNames}
               />
               <VarInput
                 value={isEditingThisRow ? editValue : row.value}
@@ -144,6 +148,7 @@ export function EnvEditorPane({
                 }
                 focusedBackgroundColor={theme.borderSubtle}
                 style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+                variableNames={variableNames}
               />
             </box>
           )
@@ -176,6 +181,7 @@ export function EnvEditorPane({
             backgroundColor={editingAdd ? theme.backgroundElement : undefined}
             focusedBackgroundColor={theme.borderSubtle}
             style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+            variableNames={variableNames}
           />
           <VarInput
             value={editingAdd ? editValue : ""}
@@ -191,6 +197,7 @@ export function EnvEditorPane({
             backgroundColor={editingAdd ? theme.backgroundElement : undefined}
             focusedBackgroundColor={theme.borderSubtle}
             style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+            variableNames={variableNames}
           />
         </box>
       </scrollbox>

--- a/src/ui/EnvironmentEditorView.tsx
+++ b/src/ui/EnvironmentEditorView.tsx
@@ -79,7 +79,6 @@ export function EnvironmentEditorView({
           setEditValue={envEditor.setEditValue}
           saving={envEditor.saving}
           error={envEditor.error}
-          activeEnv={activeEnv}
           focused={focus === "env-vars"}
         />
       </box>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -11,6 +11,7 @@ import type { Auth, Request, Environment } from "../schema"
 import { formatBody } from "./formatRequest"
 import type { EditState, FieldKind } from "./editMode"
 import type { CodeEditorRenderable } from "./CodeEditor"
+import { CodeEditorCompletion } from "./CodeEditorCompletion"
 
 import { CenterText } from "./CenterText"
 import { Tabs, type TabDef } from "./Tabs"
@@ -422,6 +423,8 @@ function BodySection({
 
   const body = useMemo(() => formatBody(request.body), [request.body])
   const editorRef = useRef<CodeEditorRenderable | null>(null)
+  const [editorInstance, setEditorInstance] =
+    useState<CodeEditorRenderable | null>(null)
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
 
   const extraHighlights = useCallback(
@@ -545,7 +548,10 @@ function BodySection({
               width="100%"
             >
               <code-editor
-                ref={editorRef}
+                ref={(editor) => {
+                  editorRef.current = editor
+                  setEditorInstance(editor)
+                }}
                 filetype="json"
                 theme={theme}
                 initialValue={formatBody(editValue)}
@@ -559,6 +565,12 @@ function BodySection({
                 cursorColor={theme.primary}
               />
             </line-number>
+            <CodeEditorCompletion
+              editor={editorInstance}
+              env={activeEnv ?? null}
+              isEditing={editingBody}
+              value={editValue}
+            />
             {validationNotice && (
               <ValidationNotice
                 title={validationNotice.title}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -27,6 +27,7 @@ import { Select, type SelectItem } from "./Select"
 import { FormEditor } from "./FormEditor"
 import { ValidationNotice } from "./ValidationNotice"
 import type { BodyType } from "../schema"
+import { validateJsonContent } from "./jsonValidation"
 
 interface Props {
   request: Request | null
@@ -451,16 +452,11 @@ function BodySection({
     [activeEnv],
   )
 
-  const validateContent = useCallback((content: string): string | null => {
-    if (content.trim() === "") return null
-    try {
-      JSON.parse(content)
-      return null
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      return `Invalid JSON: ${message}`
-    }
-  }, [])
+  const validateContent = useCallback(
+    (content: string): string | null =>
+      validateJsonContent(content, activeEnv ?? null),
+    [activeEnv],
+  )
 
   const handleContentChange = useCallback(() => {
     const ed = editorRef.current
@@ -480,18 +476,13 @@ function BodySection({
 
   const validationNotice = useMemo(() => {
     if (!editingBody || isFormMode || isBinaryMode) return null
-    if (editValue.trim() === "") return null
-    try {
-      JSON.parse(editValue)
-      return null
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      return {
-        title: "Invalid JSON",
-        detail: message,
-      }
+    const error = validateJsonContent(editValue, activeEnv ?? null)
+    if (!error) return null
+    return {
+      title: "Invalid JSON",
+      detail: error.replace(/^Invalid JSON:\s*/, ""),
     }
-  }, [editingBody, editValue, isBinaryMode, isFormMode])
+  }, [activeEnv, editingBody, editValue, isBinaryMode, isFormMode])
 
   useEffect(() => {
     if (editingBody && editorRef.current) {

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -440,10 +440,11 @@ function BodySection({
       while ((match = varRe.exec(content)) !== null) {
         const varName = match[0].slice(1)
         const exists = varName in activeEnv.vars
+        const styleId = exists ? resolvedId : missingId
         results.push({
           start: match.index,
           end: match.index + match[0].length,
-          styleId: exists ? resolvedId : missingId,
+          styleId,
           priority: 2,
         })
       }

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -28,6 +28,7 @@ import { FormEditor } from "./FormEditor"
 import { ValidationNotice } from "./ValidationNotice"
 import type { BodyType } from "../schema"
 import { validateJsonContent } from "./jsonValidation"
+import { getEnvVarHighlights } from "./variableCompletion"
 
 interface Props {
   request: Request | null
@@ -432,23 +433,12 @@ function BodySection({
     (content: string): Highlight[] => {
       const ed = editorRef.current
       if (!activeEnv?.vars || !ed) return []
-      const resolvedId = ed.envResolvedStyleId
-      const missingId = ed.envMissingStyleId
-      const results: Highlight[] = []
-      const varRe = /\$\w+/g
-      let match: RegExpExecArray | null
-      while ((match = varRe.exec(content)) !== null) {
-        const varName = match[0].slice(1)
-        const exists = varName in activeEnv.vars
-        const styleId = exists ? resolvedId : missingId
-        results.push({
-          start: match.index,
-          end: match.index + match[0].length,
-          styleId,
-          priority: 2,
-        })
-      }
-      return results
+      return getEnvVarHighlights(
+        content,
+        activeEnv,
+        ed.envResolvedStyleId,
+        ed.envMissingStyleId,
+      )
     },
     [activeEnv],
   )

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
 import type { Method, ParamEntry, Environment } from "../schema"
 import { buildDisplayUrl } from "./urlParams"
+import { VarInput } from "./VarInput"
 import { VarText } from "./VarText"
 
 export function UrlBar({
@@ -92,15 +93,16 @@ export function UrlBar({
           </Badge>
           {focused ? (
             <box style={{ flexGrow: 1 }}>
-              <input
+              <VarInput
                 value={inputValue}
-                onInput={handleInput}
+                env={activeEnv ?? null}
+                isEditing
+                onChange={handleInput}
+                isFocused
                 backgroundColor={theme.backgroundElement}
                 focusedBackgroundColor={theme.borderSubtle}
-                textColor={theme.text}
-                cursorColor={theme.primary}
                 paddingX={1}
-                focused
+                style={{ flexGrow: 1 }}
               />
             </box>
           ) : (

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -1,8 +1,23 @@
-import { forwardRef, useCallback, useImperativeHandle, useRef } from "react"
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react"
 import type { InputRenderable, TextareaRenderable } from "@opentui/core"
+import { createPortal, useKeyboard, useRenderer } from "@opentui/react"
 import { useTheme } from "./theme"
 import { VarText } from "./VarText"
 import type { Environment } from "../schema"
+import {
+  getVariableSuggestions,
+  getVariableToken,
+  replaceVariableToken,
+} from "./variableCompletion"
+import { highlightVariables } from "./variableHighlight"
+import { registerVariableCompletion } from "./variableCompletionInterceptor"
 
 export interface VarInputStyle {
   flexGrow?: number
@@ -27,6 +42,7 @@ export interface VarInputProps {
   focusedBackgroundColor?: string
   paddingX?: number
   style?: VarInputStyle
+  variableNames?: Iterable<string>
 }
 
 export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
@@ -44,13 +60,44 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       focusedBackgroundColor,
       paddingX,
       style,
+      variableNames,
     },
     ref,
   ) {
     const theme = useTheme()
+    const renderer = useRenderer()
     const defaultColor = baseColor ?? theme.text
     const inputRef = useRef<InputRenderable | null>(null)
     const textareaRef = useRef<TextareaRenderable | null>(null)
+    const [completionDismissed, setCompletionDismissed] = useState(false)
+    const [completionIndex, setCompletionIndex] = useState(0)
+    const [completionAnchor, setCompletionAnchor] = useState<{
+      x: number
+      y: number
+    } | null>(null)
+
+    const getEditable = useCallback(() => {
+      const editable = inputRef.current ?? textareaRef.current
+      return editable && !editable.isDestroyed ? editable : null
+    }, [])
+    const suggestionNames = variableNames ?? Object.keys(env?.vars ?? {})
+    const getCompletion = useCallback(() => {
+      const editable = getEditable()
+      const text = editable?.plainText ?? value
+      const cursorOffset = editable?.cursorOffset ?? value.length
+      const token = getVariableToken(text, cursorOffset)
+      return {
+        token,
+        suggestions: token
+          ? getVariableSuggestions(suggestionNames, token.prefix)
+          : [],
+      }
+    }, [getEditable, suggestionNames, value])
+
+    const applyHighlights = useCallback(() => {
+      const editable = getEditable()
+      if (editable) highlightVariables(editable, editable.plainText, theme, env)
+    }, [env, getEditable, theme])
 
     useImperativeHandle(ref, () => ({
       focus: () => {
@@ -61,47 +108,224 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
     const handleTextareaChange = useCallback(() => {
       const ta = textareaRef.current
-      if (ta) onChange?.(ta.plainText)
-    }, [onChange])
+      if (!ta) return
+      onChange?.(ta.plainText)
+      setCompletionDismissed(false)
+      applyHighlights()
+    }, [applyHighlights, onChange])
+
+    const handleInput = useCallback(
+      (nextValue: string) => {
+        onChange?.(nextValue)
+        setCompletionDismissed(false)
+        applyHighlights()
+      },
+      [applyHighlights, onChange],
+    )
+
+    useEffect(() => {
+      if (!isEditing) return
+      applyHighlights()
+    }, [applyHighlights, isEditing, value])
+
+    useEffect(() => {
+      const editable = getEditable()
+      const { token, suggestions } = getCompletion()
+      if (
+        !editable ||
+        completionDismissed ||
+        !token ||
+        suggestions.length === 0
+      ) {
+        setCompletionAnchor((current) => (current === null ? current : null))
+        return
+      }
+      const next = { x: editable.x, y: editable.y + editable.height }
+      setCompletionAnchor((current) =>
+        current?.x === next.x && current.y === next.y ? current : next,
+      )
+    }, [completionDismissed, isEditing, value])
+
+    const handleCompletionKey = useCallback(
+      (key: {
+        name: string
+        preventDefault: () => void
+        stopPropagation: () => void
+        defaultPrevented?: boolean
+      }): boolean => {
+        const editable = getEditable()
+        if (
+          !isEditing ||
+          !editable?.focused ||
+          completionDismissed ||
+          key.defaultPrevented
+        ) {
+          return false
+        }
+        const { token, suggestions } = getCompletion()
+        if (!token || suggestions.length === 0) return false
+
+        if (key.name === "up" || key.name === "down") {
+          setCompletionIndex((current) => {
+            const delta = key.name === "up" ? -1 : 1
+            return (current + delta + suggestions.length) % suggestions.length
+          })
+          return true
+        } else if (key.name === "tab" || key.name === "return") {
+          const name = suggestions[completionIndex] ?? suggestions[0]!
+          const result = replaceVariableToken(editable.plainText, token, name)
+          editable.replaceText(result.value)
+          editable.cursorOffset = result.cursorOffset
+          onChange?.(result.value)
+          highlightVariables(editable, result.value, theme, env)
+          setCompletionDismissed(true)
+          return true
+        } else if (key.name === "escape") {
+          setCompletionDismissed(true)
+          return true
+        }
+        return false
+      },
+      [
+        completionDismissed,
+        completionIndex,
+        env,
+        getCompletion,
+        getEditable,
+        isEditing,
+        onChange,
+        theme,
+      ],
+    )
+
+    useEffect(() => {
+      const { token, suggestions } = getCompletion()
+      const editable = getEditable()
+      if (
+        !isEditing ||
+        !editable?.focused ||
+        completionDismissed ||
+        !token ||
+        suggestions.length === 0
+      ) {
+        return
+      }
+      return registerVariableCompletion(handleCompletionKey)
+    }, [
+      completionDismissed,
+      getCompletion,
+      getEditable,
+      handleCompletionKey,
+      isEditing,
+    ])
+
+    useKeyboard((key) => {
+      if (handleCompletionKey(key)) {
+        key.preventDefault()
+        key.stopPropagation()
+      }
+    })
+
+    const { token, suggestions } = getCompletion()
+
+    const completionMenu =
+      isEditing &&
+      !completionDismissed &&
+      token &&
+      suggestions.length > 0 &&
+      completionAnchor
+        ? createPortal(
+            <box
+              id="var-completion-menu"
+              style={{
+                position: "absolute",
+                top: completionAnchor.y,
+                left: completionAnchor.x,
+                zIndex: 10000,
+                flexDirection: "column",
+                flexShrink: 0,
+                minWidth: 16,
+                backgroundColor: theme.backgroundPanel,
+                paddingLeft: 1,
+                paddingRight: 1,
+              }}
+              borderStyle="single"
+              borderColor={theme.borderActive}
+            >
+              {suggestions.slice(0, 6).map((name, index) => (
+                <box
+                  key={name}
+                  style={{
+                    backgroundColor:
+                      index === completionIndex
+                        ? theme.backgroundElement
+                        : undefined,
+                  }}
+                >
+                  <text
+                    fg={index === completionIndex ? theme.primary : theme.text}
+                  >
+                    ${name}
+                  </text>
+                </box>
+              ))}
+            </box>,
+            renderer.root,
+            null,
+          )
+        : null
 
     if (isEditing) {
       if (useTextarea) {
         return (
-          <textarea
-            ref={textareaRef}
-            initialValue={value}
-            placeholder={placeholder}
-            onContentChange={handleTextareaChange}
-            backgroundColor={backgroundColor ?? theme.backgroundPanel}
-            focusedBackgroundColor={
-              focusedBackgroundColor ?? theme.backgroundPanel
-            }
-            textColor={defaultColor}
-            cursorColor={theme.primary}
-            paddingX={paddingX}
-            focused
-          />
+          <box
+            style={{
+              flexGrow: style?.flexGrow,
+            }}
+          >
+            <textarea
+              ref={textareaRef}
+              initialValue={value}
+              placeholder={placeholder}
+              onContentChange={handleTextareaChange}
+              backgroundColor={backgroundColor ?? theme.backgroundPanel}
+              focusedBackgroundColor={
+                focusedBackgroundColor ?? theme.backgroundPanel
+              }
+              textColor={defaultColor}
+              cursorColor={theme.primary}
+              paddingX={paddingX}
+              focused
+            />
+            {completionMenu}
+          </box>
         )
       }
 
       return (
-        <input
-          ref={inputRef}
-          value={value}
-          placeholder={placeholder}
-          onInput={onChange}
-          focused={isFocused ?? false}
-          backgroundColor={backgroundColor}
-          focusedBackgroundColor={focusedBackgroundColor ?? theme.borderSubtle}
-          textColor={defaultColor}
-          cursorColor={theme.primary}
-          paddingX={paddingX}
+        <box
           style={{
             flexGrow: style?.flexGrow,
             flexShrink: style?.flexShrink,
             flexBasis: style?.flexBasis,
           }}
-        />
+        >
+          <input
+            ref={inputRef}
+            value={value}
+            placeholder={placeholder}
+            onInput={handleInput}
+            focused={isFocused ?? false}
+            backgroundColor={backgroundColor}
+            focusedBackgroundColor={
+              focusedBackgroundColor ?? theme.borderSubtle
+            }
+            textColor={defaultColor}
+            cursorColor={theme.primary}
+            paddingX={paddingX}
+          />
+          {completionMenu}
+        </box>
       )
     }
 

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -78,6 +78,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     const textareaRef = useRef<TextareaRenderable | null>(null)
     const [completionDismissed, setCompletionDismissed] = useState(false)
     const [completionIndex, setCompletionIndex] = useState(0)
+    const prevPrefixRef = useRef("")
     const [cursorVersion, setCursorVersion] = useState(0)
     const [completionAnchor, setCompletionAnchor] = useState<{
       x: number
@@ -154,14 +155,26 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         return
       }
       const cursor = editable.visualCursor
+      const visibleCount = Math.min(suggestions.length, 10)
+      const menuHeight = visibleCount + 2
+      const menuWidth = 18
+      const rawX = editable.x + cursor.visualCol
+      const rawY = editable.y + cursor.visualRow + 1
       const next = {
-        x: editable.x + cursor.visualCol,
-        y: editable.y + cursor.visualRow + 1,
+        x: Math.max(0, Math.min(rawX, terminalWidth - menuWidth)),
+        y: Math.max(0, Math.min(rawY, terminalHeight - menuHeight)),
       }
       setCompletionAnchor((current) =>
         current?.x === next.x && current?.y === next.y ? current : next,
       )
-    }, [completionDismissed, getCompletion, getEditable, isEditing])
+    }, [
+      completionDismissed,
+      getCompletion,
+      getEditable,
+      isEditing,
+      terminalHeight,
+      terminalWidth,
+    ])
 
     useEffect(() => {
       syncCompletionAnchor()
@@ -263,6 +276,14 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     })
 
     const { token, suggestions, isComplete } = getCompletion()
+
+    useEffect(() => {
+      const prefix = token?.prefix ?? ""
+      if (prefix !== prevPrefixRef.current) {
+        setCompletionIndex(0)
+        prevPrefixRef.current = prefix
+      }
+    }, [token?.prefix])
 
     const completionMenu =
       isEditing &&

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -16,10 +16,12 @@ import {
 import { useTheme } from "./theme"
 import { VarText } from "./VarText"
 import type { Environment } from "../schema"
-import type { VariableToken } from "./variableCompletion"
 import { highlightVariables } from "./variableHighlight"
 import { registerVariableCompletion } from "./variableCompletionInterceptor"
-import { useVariableCompletion } from "./useVariableCompletion"
+import {
+  useVariableCompletion,
+  MAX_COMPLETION_VISIBLE,
+} from "./useVariableCompletion"
 
 export interface VarInputStyle {
   flexGrow?: number
@@ -215,10 +217,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             />
             {showCompletion && (
               <CompletionPopup
-                token={token}
                 suggestions={suggestions}
-                isComplete={isComplete}
-                completionDismissed={completionDismissed}
                 completionIndex={completionIndex}
                 isEditing={isEditing}
                 getEditable={getEditable}
@@ -253,10 +252,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
           />
           {showCompletion && (
             <CompletionPopup
-              token={token}
               suggestions={suggestions}
-              isComplete={isComplete}
-              completionDismissed={completionDismissed}
               completionIndex={completionIndex}
               isEditing={isEditing}
               getEditable={getEditable}
@@ -287,19 +283,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 )
 
 function CompletionPopup({
-  token,
   suggestions,
-  isComplete,
-  completionDismissed,
   completionIndex,
   isEditing,
   getEditable,
   value,
 }: {
-  token: VariableToken | null
   suggestions: string[]
-  isComplete: boolean
-  completionDismissed: boolean
   completionIndex: number
   isEditing: boolean
   getEditable: () => (InputRenderable | TextareaRenderable) | null
@@ -316,19 +306,12 @@ function CompletionPopup({
 
   useEffect(() => {
     const editable = getEditable()
-    if (
-      !isEditing ||
-      !editable ||
-      completionDismissed ||
-      !token ||
-      suggestions.length === 0 ||
-      isComplete
-    ) {
+    if (!isEditing || !editable) {
       setCompletionAnchor((current) => (current === null ? current : null))
       return
     }
     const cursor = editable.visualCursor
-    const visibleCount = Math.min(suggestions.length, 10)
+    const visibleCount = Math.min(suggestions.length, MAX_COMPLETION_VISIBLE)
     const menuHeight = visibleCount + 2
     const menuWidth = 18
     const rawX = editable.x + cursor.visualCol
@@ -341,24 +324,15 @@ function CompletionPopup({
       current?.x === next.x && current?.y === next.y ? current : next,
     )
   }, [
-    completionDismissed,
     getEditable,
-    isComplete,
     isEditing,
     suggestions.length,
     terminalHeight,
     terminalWidth,
-    token,
     value,
   ])
 
-  if (
-    completionDismissed ||
-    !token ||
-    suggestions.length === 0 ||
-    isComplete ||
-    !completionAnchor
-  ) {
+  if (!completionAnchor) {
     return null
   }
 
@@ -380,7 +354,7 @@ function CompletionPopup({
       borderStyle="single"
       borderColor={theme.borderActive}
     >
-      {suggestions.slice(0, 10).map((name, index) => (
+      {suggestions.slice(0, MAX_COMPLETION_VISIBLE).map((name, index) => (
         <box
           key={name}
           style={{

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -166,7 +166,10 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
           })
           return true
         } else if (key.name === "tab" || key.name === "return") {
-          const name = suggestions[completionIndex] ?? suggestions[0]!
+          const name =
+            suggestions[
+              Math.min(completionIndex, Math.min(suggestions.length, 10) - 1)
+            ] ?? suggestions[0]!
           const result = replaceVariableToken(editable.plainText, token, name)
           editable.replaceText(result.value)
           editable.cursorOffset = result.cursorOffset

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -7,7 +7,12 @@ import {
   useState,
 } from "react"
 import type { InputRenderable, TextareaRenderable } from "@opentui/core"
-import { createPortal, useKeyboard, useRenderer } from "@opentui/react"
+import {
+  createPortal,
+  useKeyboard,
+  useRenderer,
+  useTerminalDimensions,
+} from "@opentui/react"
 import { useTheme } from "./theme"
 import { VarText } from "./VarText"
 import type { Environment } from "../schema"
@@ -66,11 +71,14 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
   ) {
     const theme = useTheme()
     const renderer = useRenderer()
+    const { width: terminalWidth, height: terminalHeight } =
+      useTerminalDimensions()
     const defaultColor = baseColor ?? theme.text
     const inputRef = useRef<InputRenderable | null>(null)
     const textareaRef = useRef<TextareaRenderable | null>(null)
     const [completionDismissed, setCompletionDismissed] = useState(false)
     const [completionIndex, setCompletionIndex] = useState(0)
+    const [cursorVersion, setCursorVersion] = useState(0)
     const [completionAnchor, setCompletionAnchor] = useState<{
       x: number
       y: number
@@ -128,10 +136,11 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       applyHighlights()
     }, [applyHighlights, isEditing, value])
 
-    useEffect(() => {
+    const syncCompletionAnchor = useCallback(() => {
       const editable = getEditable()
       const { token, suggestions } = getCompletion()
       if (
+        !isEditing ||
         !editable ||
         completionDismissed ||
         !token ||
@@ -140,11 +149,29 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         setCompletionAnchor((current) => (current === null ? current : null))
         return
       }
-      const next = { x: editable.x, y: editable.y + editable.height }
+      const cursor = editable.visualCursor
+      const next = {
+        x: editable.x + cursor.visualCol,
+        y: editable.y + cursor.visualRow + 1,
+      }
       setCompletionAnchor((current) =>
-        current?.x === next.x && current.y === next.y ? current : next,
+        current?.x === next.x && current?.y === next.y ? current : next,
       )
-    }, [completionDismissed, isEditing, value])
+    }, [completionDismissed, getCompletion, getEditable, isEditing])
+
+    useEffect(() => {
+      syncCompletionAnchor()
+    }, [
+      cursorVersion,
+      syncCompletionAnchor,
+      terminalHeight,
+      terminalWidth,
+      value,
+    ])
+
+    const handleCursorChange = useCallback(() => {
+      setCursorVersion((version) => version + 1)
+    }, [])
 
     const handleCompletionKey = useCallback(
       (key: {
@@ -288,6 +315,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
               initialValue={value}
               placeholder={placeholder}
               onContentChange={handleTextareaChange}
+              onCursorChange={handleCursorChange}
               backgroundColor={backgroundColor ?? theme.backgroundPanel}
               focusedBackgroundColor={
                 focusedBackgroundColor ?? theme.backgroundPanel
@@ -315,6 +343,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             value={value}
             placeholder={placeholder}
             onInput={handleInput}
+            onCursorChange={handleCursorChange}
             focused={isFocused ?? false}
             backgroundColor={backgroundColor}
             focusedBackgroundColor={

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -3,13 +3,13 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react"
 import type { InputRenderable, TextareaRenderable } from "@opentui/core"
 import {
   createPortal,
-  useKeyboard,
   useRenderer,
   useTerminalDimensions,
 } from "@opentui/react"
@@ -20,6 +20,7 @@ import {
   getVariableSuggestions,
   getVariableToken,
   replaceVariableToken,
+  type VariableToken,
 } from "./variableCompletion"
 import { highlightVariables } from "./variableHighlight"
 import { registerVariableCompletion } from "./variableCompletionInterceptor"
@@ -70,26 +71,21 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     ref,
   ) {
     const theme = useTheme()
-    const renderer = useRenderer()
-    const { width: terminalWidth, height: terminalHeight } =
-      useTerminalDimensions()
     const defaultColor = baseColor ?? theme.text
     const inputRef = useRef<InputRenderable | null>(null)
     const textareaRef = useRef<TextareaRenderable | null>(null)
     const [completionDismissed, setCompletionDismissed] = useState(false)
     const [completionIndex, setCompletionIndex] = useState(0)
     const prevPrefixRef = useRef("")
-    const [cursorVersion, setCursorVersion] = useState(0)
-    const [completionAnchor, setCompletionAnchor] = useState<{
-      x: number
-      y: number
-    } | null>(null)
 
     const getEditable = useCallback(() => {
       const editable = inputRef.current ?? textareaRef.current
       return editable && !editable.isDestroyed ? editable : null
     }, [])
-    const suggestionNames = variableNames ?? Object.keys(env?.vars ?? {})
+    const suggestionNames = useMemo(() => {
+      if (variableNames != null) return [...variableNames]
+      return Object.keys(env?.vars ?? {})
+    }, [variableNames, env?.vars])
     const getCompletion = useCallback(() => {
       const editable = getEditable()
       const text = editable?.plainText ?? value
@@ -139,56 +135,6 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       if (!isEditing) return
       applyHighlights()
     }, [applyHighlights, isEditing, value])
-
-    const syncCompletionAnchor = useCallback(() => {
-      const editable = getEditable()
-      const { token, suggestions, isComplete } = getCompletion()
-      if (
-        !isEditing ||
-        !editable ||
-        completionDismissed ||
-        !token ||
-        suggestions.length === 0 ||
-        isComplete
-      ) {
-        setCompletionAnchor((current) => (current === null ? current : null))
-        return
-      }
-      const cursor = editable.visualCursor
-      const visibleCount = Math.min(suggestions.length, 10)
-      const menuHeight = visibleCount + 2
-      const menuWidth = 18
-      const rawX = editable.x + cursor.visualCol
-      const rawY = editable.y + cursor.visualRow + 1
-      const next = {
-        x: Math.max(0, Math.min(rawX, terminalWidth - menuWidth)),
-        y: Math.max(0, Math.min(rawY, terminalHeight - menuHeight)),
-      }
-      setCompletionAnchor((current) =>
-        current?.x === next.x && current?.y === next.y ? current : next,
-      )
-    }, [
-      completionDismissed,
-      getCompletion,
-      getEditable,
-      isEditing,
-      terminalHeight,
-      terminalWidth,
-    ])
-
-    useEffect(() => {
-      syncCompletionAnchor()
-    }, [
-      cursorVersion,
-      syncCompletionAnchor,
-      terminalHeight,
-      terminalWidth,
-      value,
-    ])
-
-    const handleCursorChange = useCallback(() => {
-      setCursorVersion((version) => version + 1)
-    }, [])
 
     const handleCompletionKey = useCallback(
       (key: {
@@ -246,8 +192,9 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       ],
     )
 
+    const { token, suggestions, isComplete } = getCompletion()
+
     useEffect(() => {
-      const { token, suggestions, isComplete } = getCompletion()
       const editable = getEditable()
       if (
         !isEditing ||
@@ -262,20 +209,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       return registerVariableCompletion(handleCompletionKey)
     }, [
       completionDismissed,
-      getCompletion,
       getEditable,
       handleCompletionKey,
+      isComplete,
       isEditing,
+      suggestions.length,
+      token,
     ])
-
-    useKeyboard((key) => {
-      if (handleCompletionKey(key)) {
-        key.preventDefault()
-        key.stopPropagation()
-      }
-    })
-
-    const { token, suggestions, isComplete } = getCompletion()
 
     useEffect(() => {
       const prefix = token?.prefix ?? ""
@@ -285,53 +225,12 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       }
     }, [token?.prefix])
 
-    const completionMenu =
+    const showCompletion =
       isEditing &&
       !completionDismissed &&
       token &&
       suggestions.length > 0 &&
-      !isComplete &&
-      completionAnchor
-        ? createPortal(
-            <box
-              id="var-completion-menu"
-              style={{
-                position: "absolute",
-                top: completionAnchor.y,
-                left: completionAnchor.x,
-                zIndex: 10000,
-                flexDirection: "column",
-                flexShrink: 0,
-                minWidth: 16,
-                backgroundColor: theme.backgroundPanel,
-                paddingLeft: 1,
-                paddingRight: 1,
-              }}
-              borderStyle="single"
-              borderColor={theme.borderActive}
-            >
-              {suggestions.slice(0, 10).map((name, index) => (
-                <box
-                  key={name}
-                  style={{
-                    backgroundColor:
-                      index === completionIndex
-                        ? theme.backgroundElement
-                        : undefined,
-                  }}
-                >
-                  <text
-                    fg={index === completionIndex ? theme.primary : theme.text}
-                  >
-                    ${name}
-                  </text>
-                </box>
-              ))}
-            </box>,
-            renderer.root,
-            null,
-          )
-        : null
+      !isComplete
 
     if (isEditing) {
       if (useTextarea) {
@@ -346,7 +245,6 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
               initialValue={value}
               placeholder={placeholder}
               onContentChange={handleTextareaChange}
-              onCursorChange={handleCursorChange}
               backgroundColor={backgroundColor ?? theme.backgroundPanel}
               focusedBackgroundColor={
                 focusedBackgroundColor ?? theme.backgroundPanel
@@ -356,7 +254,18 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
               paddingX={paddingX}
               focused
             />
-            {completionMenu}
+            {showCompletion && (
+              <CompletionPopup
+                token={token}
+                suggestions={suggestions}
+                isComplete={isComplete}
+                completionDismissed={completionDismissed}
+                completionIndex={completionIndex}
+                isEditing={isEditing}
+                getEditable={getEditable}
+                value={value}
+              />
+            )}
           </box>
         )
       }
@@ -374,7 +283,6 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             value={value}
             placeholder={placeholder}
             onInput={handleInput}
-            onCursorChange={handleCursorChange}
             focused={isFocused ?? false}
             backgroundColor={backgroundColor}
             focusedBackgroundColor={
@@ -384,7 +292,18 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             cursorColor={theme.primary}
             paddingX={paddingX}
           />
-          {completionMenu}
+          {showCompletion && (
+            <CompletionPopup
+              token={token}
+              suggestions={suggestions}
+              isComplete={isComplete}
+              completionDismissed={completionDismissed}
+              completionIndex={completionIndex}
+              isEditing={isEditing}
+              getEditable={getEditable}
+              value={value}
+            />
+          )}
         </box>
       )
     }
@@ -407,3 +326,116 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     )
   },
 )
+
+function CompletionPopup({
+  token,
+  suggestions,
+  isComplete,
+  completionDismissed,
+  completionIndex,
+  isEditing,
+  getEditable,
+  value,
+}: {
+  token: VariableToken | null
+  suggestions: string[]
+  isComplete: boolean
+  completionDismissed: boolean
+  completionIndex: number
+  isEditing: boolean
+  getEditable: () => (InputRenderable | TextareaRenderable) | null
+  value: string
+}) {
+  const renderer = useRenderer()
+  const { width: terminalWidth, height: terminalHeight } =
+    useTerminalDimensions()
+  const theme = useTheme()
+  const [completionAnchor, setCompletionAnchor] = useState<{
+    x: number
+    y: number
+  } | null>(null)
+
+  useEffect(() => {
+    const editable = getEditable()
+    if (
+      !isEditing ||
+      !editable ||
+      completionDismissed ||
+      !token ||
+      suggestions.length === 0 ||
+      isComplete
+    ) {
+      setCompletionAnchor((current) => (current === null ? current : null))
+      return
+    }
+    const cursor = editable.visualCursor
+    const visibleCount = Math.min(suggestions.length, 10)
+    const menuHeight = visibleCount + 2
+    const menuWidth = 18
+    const rawX = editable.x + cursor.visualCol
+    const rawY = editable.y + cursor.visualRow + 1
+    const next = {
+      x: Math.max(0, Math.min(rawX, terminalWidth - menuWidth)),
+      y: Math.max(0, Math.min(rawY, terminalHeight - menuHeight)),
+    }
+    setCompletionAnchor((current) =>
+      current?.x === next.x && current?.y === next.y ? current : next,
+    )
+  }, [
+    completionDismissed,
+    getEditable,
+    isComplete,
+    isEditing,
+    suggestions.length,
+    terminalHeight,
+    terminalWidth,
+    token,
+    value,
+  ])
+
+  if (
+    completionDismissed ||
+    !token ||
+    suggestions.length === 0 ||
+    isComplete ||
+    !completionAnchor
+  ) {
+    return null
+  }
+
+  return createPortal(
+    <box
+      id="var-completion-menu"
+      style={{
+        position: "absolute",
+        top: completionAnchor.y,
+        left: completionAnchor.x,
+        zIndex: 10000,
+        flexDirection: "column",
+        flexShrink: 0,
+        minWidth: 16,
+        backgroundColor: theme.backgroundPanel,
+        paddingLeft: 1,
+        paddingRight: 1,
+      }}
+      borderStyle="single"
+      borderColor={theme.borderActive}
+    >
+      {suggestions.slice(0, 10).map((name, index) => (
+        <box
+          key={name}
+          style={{
+            backgroundColor:
+              index === completionIndex ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={index === completionIndex ? theme.primary : theme.text}>
+            ${name}
+          </text>
+        </box>
+      ))}
+    </box>,
+    renderer.root,
+    null,
+  )
+}

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -16,14 +16,10 @@ import {
 import { useTheme } from "./theme"
 import { VarText } from "./VarText"
 import type { Environment } from "../schema"
-import {
-  getVariableSuggestions,
-  getVariableToken,
-  replaceVariableToken,
-  type VariableToken,
-} from "./variableCompletion"
+import type { VariableToken } from "./variableCompletion"
 import { highlightVariables } from "./variableHighlight"
 import { registerVariableCompletion } from "./variableCompletionInterceptor"
+import { useVariableCompletion } from "./useVariableCompletion"
 
 export interface VarInputStyle {
   flexGrow?: number
@@ -86,21 +82,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       if (variableNames != null) return [...variableNames]
       return Object.keys(env?.vars ?? {})
     }, [variableNames, env?.vars])
-    const getCompletion = useCallback(() => {
-      const editable = getEditable()
-      const text = editable?.plainText ?? value
-      const cursorOffset = editable?.cursorOffset ?? value.length
-      const token = getVariableToken(text, cursorOffset)
-      const suggestions = token
-        ? getVariableSuggestions(suggestionNames, token.prefix)
-        : []
-      const tokenText = token ? text.slice(token.start + 1, token.end) : ""
-      const isComplete =
-        suggestions.length === 1 &&
-        cursorOffset === token?.end &&
-        suggestions[0] === tokenText
-      return { token, suggestions, isComplete }
-    }, [getEditable, suggestionNames, value])
+
+    const { completion, makeHandleKey } = useVariableCompletion({
+      getEditor: getEditable,
+      variableNames: suggestionNames,
+      value,
+      isEditing,
+    })
 
     const applyHighlights = useCallback(() => {
       const editable = getEditable()
@@ -136,66 +124,34 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       applyHighlights()
     }, [applyHighlights, isEditing, value])
 
-    const handleCompletionKey = useCallback(
-      (key: {
-        name: string
-        preventDefault: () => void
-        stopPropagation: () => void
-        defaultPrevented?: boolean
-      }): boolean => {
-        const editable = getEditable()
-        if (
-          !isEditing ||
-          !editable?.focused ||
-          completionDismissed ||
-          key.defaultPrevented
-        ) {
-          return false
-        }
-        const { token, suggestions, isComplete } = getCompletion()
-        if (!token || suggestions.length === 0 || isComplete) return false
-
-        if (key.name === "up" || key.name === "down") {
-          const maxVisible = Math.min(suggestions.length, 10)
-          setCompletionIndex((current) => {
-            const delta = key.name === "up" ? -1 : 1
-            const next = current + delta
-            if (next < 0) return maxVisible - 1
-            if (next >= maxVisible) return 0
-            return next
-          })
-          return true
-        } else if (key.name === "tab" || key.name === "return") {
-          const name =
-            suggestions[
-              Math.min(completionIndex, Math.min(suggestions.length, 10) - 1)
-            ] ?? suggestions[0]!
-          const result = replaceVariableToken(editable.plainText, token, name)
-          editable.replaceText(result.value)
-          editable.cursorOffset = result.cursorOffset
-          onChange?.(result.value)
-          highlightVariables(editable, result.value, theme, env)
-          setCompletionDismissed(true)
-          return true
-        } else if (key.name === "escape") {
-          setCompletionDismissed(true)
-          return true
-        }
-        return false
-      },
+    const handleCompletionKey = useMemo(
+      () =>
+        makeHandleKey({
+          completionDismissed,
+          completionIndex,
+          setCompletionIndex,
+          setCompletionDismissed,
+          onAccept: () => {
+            const editable = getEditable()
+            if (editable) {
+              const text = editable.plainText
+              onChange?.(text)
+              highlightVariables(editable, text, theme, env)
+            }
+          },
+        }),
       [
         completionDismissed,
         completionIndex,
         env,
-        getCompletion,
         getEditable,
-        isEditing,
+        makeHandleKey,
         onChange,
         theme,
       ],
     )
 
-    const { token, suggestions, isComplete } = getCompletion()
+    const { token, suggestions, isComplete } = completion
 
     useEffect(() => {
       const editable = getEditable()

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -94,12 +94,15 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       const text = editable?.plainText ?? value
       const cursorOffset = editable?.cursorOffset ?? value.length
       const token = getVariableToken(text, cursorOffset)
-      return {
-        token,
-        suggestions: token
-          ? getVariableSuggestions(suggestionNames, token.prefix)
-          : [],
-      }
+      const suggestions = token
+        ? getVariableSuggestions(suggestionNames, token.prefix)
+        : []
+      const tokenText = token ? text.slice(token.start + 1, token.end) : ""
+      const isComplete =
+        suggestions.length === 1 &&
+        cursorOffset === token?.end &&
+        suggestions[0] === tokenText
+      return { token, suggestions, isComplete }
     }, [getEditable, suggestionNames, value])
 
     const applyHighlights = useCallback(() => {
@@ -138,13 +141,14 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
     const syncCompletionAnchor = useCallback(() => {
       const editable = getEditable()
-      const { token, suggestions } = getCompletion()
+      const { token, suggestions, isComplete } = getCompletion()
       if (
         !isEditing ||
         !editable ||
         completionDismissed ||
         !token ||
-        suggestions.length === 0
+        suggestions.length === 0 ||
+        isComplete
       ) {
         setCompletionAnchor((current) => (current === null ? current : null))
         return
@@ -189,13 +193,17 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         ) {
           return false
         }
-        const { token, suggestions } = getCompletion()
-        if (!token || suggestions.length === 0) return false
+        const { token, suggestions, isComplete } = getCompletion()
+        if (!token || suggestions.length === 0 || isComplete) return false
 
         if (key.name === "up" || key.name === "down") {
+          const maxVisible = Math.min(suggestions.length, 10)
           setCompletionIndex((current) => {
             const delta = key.name === "up" ? -1 : 1
-            return (current + delta + suggestions.length) % suggestions.length
+            const next = current + delta
+            if (next < 0) return maxVisible - 1
+            if (next >= maxVisible) return 0
+            return next
           })
           return true
         } else if (key.name === "tab" || key.name === "return") {
@@ -226,14 +234,15 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     )
 
     useEffect(() => {
-      const { token, suggestions } = getCompletion()
+      const { token, suggestions, isComplete } = getCompletion()
       const editable = getEditable()
       if (
         !isEditing ||
         !editable?.focused ||
         completionDismissed ||
         !token ||
-        suggestions.length === 0
+        suggestions.length === 0 ||
+        isComplete
       ) {
         return
       }
@@ -253,13 +262,14 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       }
     })
 
-    const { token, suggestions } = getCompletion()
+    const { token, suggestions, isComplete } = getCompletion()
 
     const completionMenu =
       isEditing &&
       !completionDismissed &&
       token &&
       suggestions.length > 0 &&
+      !isComplete &&
       completionAnchor
         ? createPortal(
             <box
@@ -279,7 +289,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
               borderStyle="single"
               borderColor={theme.borderActive}
             >
-              {suggestions.slice(0, 6).map((name, index) => (
+              {suggestions.slice(0, 10).map((name, index) => (
                 <box
                   key={name}
                   style={{

--- a/src/ui/YamlEditorOverlay.tsx
+++ b/src/ui/YamlEditorOverlay.tsx
@@ -120,13 +120,14 @@ export function YamlEditorOverlay({
       const highlights = []
       for (const match of value.matchAll(/\$(\w+)/g)) {
         const name = match[1]!
+        const styleId =
+          name in activeEnv.vars
+            ? editor.envResolvedStyleId
+            : editor.envMissingStyleId
         highlights.push({
           start: match.index,
           end: match.index + match[0].length,
-          styleId:
-            name in activeEnv.vars
-              ? editor.envResolvedStyleId
-              : editor.envMissingStyleId,
+          styleId,
           priority: 2,
         })
       }

--- a/src/ui/YamlEditorOverlay.tsx
+++ b/src/ui/YamlEditorOverlay.tsx
@@ -10,6 +10,7 @@ import { ValidationNotice } from "./ValidationNotice"
 import { lang } from "../lang"
 import type { Environment } from "../schema"
 import { CodeEditorCompletion } from "./CodeEditorCompletion"
+import { getEnvVarHighlights } from "./variableCompletion"
 
 const RESERVED_FOLD_SIGN = new Map<number, LineSign>([[-1, { before: " " }]])
 
@@ -117,21 +118,12 @@ export function YamlEditorOverlay({
     (value: string) => {
       const editor = editorRef.current
       if (!editor || !activeEnv) return []
-      const highlights = []
-      for (const match of value.matchAll(/\$(\w+)/g)) {
-        const name = match[1]!
-        const styleId =
-          name in activeEnv.vars
-            ? editor.envResolvedStyleId
-            : editor.envMissingStyleId
-        highlights.push({
-          start: match.index,
-          end: match.index + match[0].length,
-          styleId,
-          priority: 2,
-        })
-      }
-      return highlights
+      return getEnvVarHighlights(
+        value,
+        activeEnv,
+        editor.envResolvedStyleId,
+        editor.envMissingStyleId,
+      )
     },
     [activeEnv],
   )

--- a/src/ui/YamlEditorOverlay.tsx
+++ b/src/ui/YamlEditorOverlay.tsx
@@ -8,6 +8,8 @@ import { Overlay } from "./Overlay"
 import type { CodeEditorRenderable } from "./CodeEditor"
 import { ValidationNotice } from "./ValidationNotice"
 import { lang } from "../lang"
+import type { Environment } from "../schema"
+import { CodeEditorCompletion } from "./CodeEditorCompletion"
 
 const RESERVED_FOLD_SIGN = new Map<number, LineSign>([[-1, { before: " " }]])
 
@@ -17,6 +19,7 @@ export interface YamlEditorOverlayProps {
   requestName: string
   onSaved: () => void
   onClose: () => void
+  activeEnv?: Environment | null
 }
 
 export function YamlEditorOverlay({
@@ -25,10 +28,13 @@ export function YamlEditorOverlay({
   requestName,
   onSaved,
   onClose,
+  activeEnv = null,
 }: YamlEditorOverlayProps) {
   const theme = useTheme()
   const keymap = useKeymap()
   const editorRef = useRef<CodeEditorRenderable | null>(null)
+  const [editorInstance, setEditorInstance] =
+    useState<CodeEditorRenderable | null>(null)
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
   const [content, setContent] = useState<string | null>(null)
   const [draftContent, setDraftContent] = useState<string | null>(null)
@@ -106,6 +112,28 @@ export function YamlEditorOverlay({
     const editor = editorRef.current
     if (editor) setDraftContent(editor.plainText)
   }, [])
+
+  const extraHighlights = useCallback(
+    (value: string) => {
+      const editor = editorRef.current
+      if (!editor || !activeEnv) return []
+      const highlights = []
+      for (const match of value.matchAll(/\$(\w+)/g)) {
+        const name = match[1]!
+        highlights.push({
+          start: match.index,
+          end: match.index + match[0].length,
+          styleId:
+            name in activeEnv.vars
+              ? editor.envResolvedStyleId
+              : editor.envMissingStyleId,
+          priority: 2,
+        })
+      }
+      return highlights
+    },
+    [activeEnv],
+  )
 
   const validationNotice = useMemo(() => {
     if (draftContent === null) return null
@@ -212,10 +240,14 @@ export function YamlEditorOverlay({
             width="100%"
           >
             <code-editor
-              ref={editorRef}
+              ref={(editor) => {
+                editorRef.current = editor
+                setEditorInstance(editor)
+              }}
               filetype="yaml"
               theme={theme}
               initialValue={content}
+              extraHighlights={activeEnv ? extraHighlights : undefined}
               validateContent={validateContent}
               onContentChange={handleContentChange}
               onFoldsChange={handleFoldsChange}
@@ -225,6 +257,12 @@ export function YamlEditorOverlay({
               cursorColor={theme.primary}
             />
           </line-number>
+          <CodeEditorCompletion
+            editor={editorInstance}
+            env={activeEnv}
+            isEditing
+            value={draftContent ?? content ?? ""}
+          />
           {validationNotice && (
             <ValidationNotice
               title={validationNotice.title}

--- a/src/ui/envHighlight.ts
+++ b/src/ui/envHighlight.ts
@@ -25,7 +25,7 @@ export function splitEnvVars(
       })
     }
     const varName = match[1]!
-    const exists = env !== null && varName in env.vars
+    const exists = env !== null && Object.hasOwn(env.vars, varName)
     segments.push({ text: match[0], isVar: true, exists })
     lastEnd = match.index + match[0].length
   }

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -35,15 +35,6 @@ export function formatBody(res: Response): string {
   if (res.body === "") return ""
   const jsonParseError = formatJsonParseErrorBody(res.body)
   if (jsonParseError !== null) return jsonParseError
-  const contentType = lookupContentType(res.headers)
-  const looksJson = contentType !== null && contentType.includes("json")
-  if (looksJson) {
-    try {
-      return JSON.stringify(JSON.parse(res.body), null, 2)
-    } catch {
-      return res.body
-    }
-  }
   try {
     return JSON.stringify(JSON.parse(res.body), null, 2)
   } catch {
@@ -66,11 +57,4 @@ function formatJsonParseErrorBody(body: string): string | null {
   ]
     .filter((line): line is string => line !== null)
     .join("\n")
-}
-
-function lookupContentType(headers: Record<string, string>): string | null {
-  for (const k of Object.keys(headers)) {
-    if (k.toLowerCase() === "content-type") return headers[k]
-  }
-  return null
 }

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -33,6 +33,8 @@ export function formatHeaders(res: Response): HeaderEntry[] {
 
 export function formatBody(res: Response): string {
   if (res.body === "") return ""
+  const jsonParseError = formatJsonParseErrorBody(res.body)
+  if (jsonParseError !== null) return jsonParseError
   const contentType = lookupContentType(res.headers)
   const looksJson = contentType !== null && contentType.includes("json")
   if (looksJson) {
@@ -47,6 +49,23 @@ export function formatBody(res: Response): string {
   } catch {
     return res.body
   }
+}
+
+function formatJsonParseErrorBody(body: string): string | null {
+  if (
+    !body.includes("body-parser/lib/types/json") ||
+    !body.includes("SyntaxError:")
+  ) {
+    return null
+  }
+
+  const detail = body.match(/SyntaxError:\s*([^\r\n]+)/)?.[1]?.trim()
+  return [
+    "The server rejected the request because the submitted JSON is invalid.",
+    detail ? `Details: ${detail}` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n")
 }
 
 function lookupContentType(headers: Record<string, string>): string | null {

--- a/src/ui/highlightOffsets.ts
+++ b/src/ui/highlightOffsets.ts
@@ -13,7 +13,7 @@ export function buildCharToDisplayOffsets(content: string): number[] {
     }
 
     index += width
-    if (codePoint !== 0x0a) displayOffset++
+    if (codePoint !== 0x0a && codePoint !== 0x0d) displayOffset++
   }
 
   offsets[content.length] = displayOffset

--- a/src/ui/highlightOffsets.ts
+++ b/src/ui/highlightOffsets.ts
@@ -1,0 +1,29 @@
+export function buildCharToDisplayOffsets(content: string): number[] {
+  const offsets = new Array<number>(content.length + 1)
+  let displayOffset = 0
+
+  for (let index = 0; index < content.length; ) {
+    offsets[index] = displayOffset
+    const codePoint = content.codePointAt(index)
+    if (codePoint === undefined) break
+
+    const width = codePoint > 0xffff ? 2 : 1
+    for (let unit = 1; unit < width; unit++) {
+      offsets[index + unit] = displayOffset
+    }
+
+    index += width
+    if (codePoint !== 0x0a) displayOffset++
+  }
+
+  offsets[content.length] = displayOffset
+  return offsets
+}
+
+export function charOffsetToDisplayOffset(
+  offsets: number[],
+  offset: number,
+): number {
+  const clamped = Math.max(0, Math.min(offset, offsets.length - 1))
+  return offsets[clamped] ?? offsets[offsets.length - 1] ?? 0
+}

--- a/src/ui/jsonValidation.ts
+++ b/src/ui/jsonValidation.ts
@@ -1,6 +1,6 @@
 import type { Environment } from "../schema"
 
-const VAR_RE = /\$(\w+)/g
+const VAR_RE = /\$(\w+)/
 
 /**
  * Validates the JSON that will actually be sent after Noodle's textual
@@ -17,7 +17,7 @@ export function validateJsonContent(
   if (env !== null) {
     try {
       substituted = content.replace(VAR_RE, (match, name: string) => {
-        if (!(name in env.vars)) {
+        if (!Object.hasOwn(env.vars, name)) {
           throw new Error(`unresolved variable "${name}"`)
         }
         return env.vars[name]!

--- a/src/ui/jsonValidation.ts
+++ b/src/ui/jsonValidation.ts
@@ -1,0 +1,38 @@
+import type { Environment } from "../schema"
+
+const VAR_RE = /\$(\w+)/g
+
+/**
+ * Validates the JSON that will actually be sent after Noodle's textual
+ * environment-variable substitution. Values are deliberately not coerced or
+ * quoted here; this mirrors requests/substitute.ts exactly.
+ */
+export function validateJsonContent(
+  content: string,
+  env: Environment | null,
+): string | null {
+  if (content.trim() === "") return null
+
+  let substituted = content
+  if (env !== null) {
+    try {
+      substituted = content.replace(VAR_RE, (match, name: string) => {
+        if (!(name in env.vars)) {
+          throw new Error(`unresolved variable "${name}"`)
+        }
+        return env.vars[name]!
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return `Invalid JSON: ${message}`
+    }
+  }
+
+  try {
+    JSON.parse(substituted)
+    return null
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return `Invalid JSON: ${message}`
+  }
+}

--- a/src/ui/useVariableCompletion.ts
+++ b/src/ui/useVariableCompletion.ts
@@ -1,0 +1,124 @@
+import { useCallback, useMemo } from "react"
+import {
+  getVariableSuggestions,
+  getVariableToken,
+  replaceVariableToken,
+  type VariableToken,
+} from "./variableCompletion"
+
+export interface CompletionEditor {
+  plainText: string
+  cursorOffset: number
+  focused: boolean
+  isDestroyed: boolean
+  replaceText(text: string): void
+}
+
+export interface CompletionState {
+  token: VariableToken | null
+  suggestions: string[]
+  isComplete: boolean
+}
+
+interface CompletionKeyEvent {
+  name: string
+  preventDefault: () => void
+  stopPropagation: () => void
+  defaultPrevented?: boolean
+}
+
+export const MAX_COMPLETION_VISIBLE = 10
+
+export function useVariableCompletion({
+  getEditor,
+  variableNames,
+  value,
+  isEditing,
+}: {
+  getEditor: () => CompletionEditor | null
+  variableNames: string[]
+  value: string
+  isEditing: boolean
+}) {
+  const getCompletion = useCallback((): CompletionState => {
+    const editor = getEditor()
+    const text = editor?.plainText ?? value
+    const cursorOffset = editor?.cursorOffset ?? text.length
+    const token = getVariableToken(text, cursorOffset)
+    const suggestions = token
+      ? getVariableSuggestions(variableNames, token.prefix)
+      : []
+    const tokenText = token ? text.slice(token.start + 1, token.end) : ""
+    const isComplete =
+      suggestions.length === 1 &&
+      cursorOffset === token?.end &&
+      suggestions[0] === tokenText
+    return { token, suggestions, isComplete }
+  }, [getEditor, variableNames, value])
+
+  const completion = useMemo(() => getCompletion(), [getCompletion])
+
+  const makeHandleKey = useCallback(
+    ({
+      completionDismissed,
+      completionIndex,
+      setCompletionIndex,
+      setCompletionDismissed,
+      onAccept,
+    }: {
+      completionDismissed: boolean
+      completionIndex: number
+      setCompletionIndex: (fn: (current: number) => number) => void
+      setCompletionDismissed: (dismissed: boolean) => void
+      onAccept: (name: string) => void
+    }) =>
+      (key: CompletionKeyEvent): boolean => {
+        const editor = getEditor()
+        if (
+          !isEditing ||
+          !editor ||
+          editor.isDestroyed ||
+          !editor.focused ||
+          completionDismissed ||
+          key.defaultPrevented
+        ) {
+          return false
+        }
+        const { token, suggestions, isComplete } = getCompletion()
+        if (!token || suggestions.length === 0 || isComplete) return false
+
+        if (key.name === "up" || key.name === "down") {
+          const max = Math.min(suggestions.length, MAX_COMPLETION_VISIBLE)
+          setCompletionIndex((current) => {
+            const next = current + (key.name === "up" ? -1 : 1)
+            return next < 0 ? max - 1 : next >= max ? 0 : next
+          })
+          return true
+        }
+
+        if (key.name === "tab" || key.name === "return") {
+          const idx = Math.min(
+            completionIndex,
+            Math.min(suggestions.length, MAX_COMPLETION_VISIBLE) - 1,
+          )
+          const name = suggestions[idx] ?? suggestions[0]!
+          const result = replaceVariableToken(editor.plainText, token, name)
+          editor.replaceText(result.value)
+          editor.cursorOffset = result.cursorOffset
+          setCompletionDismissed(true)
+          onAccept(name)
+          return true
+        }
+
+        if (key.name === "escape") {
+          setCompletionDismissed(true)
+          return true
+        }
+
+        return false
+      },
+    [getEditor, getCompletion, isEditing],
+  )
+
+  return { completion, getCompletion, makeHandleKey }
+}

--- a/src/ui/variableCompletion.ts
+++ b/src/ui/variableCompletion.ts
@@ -1,0 +1,70 @@
+import type { Environment } from "../schema"
+
+const VAR_RE = /\$(\w+)/g
+
+export interface VariableToken {
+  start: number
+  end: number
+  prefix: string
+}
+
+export interface VariableHighlight {
+  start: number
+  end: number
+  exists: boolean
+}
+
+export function getVariableToken(
+  value: string,
+  cursorOffset: number,
+): VariableToken | null {
+  const cursor = Math.max(0, Math.min(cursorOffset, value.length))
+  let start = cursor
+  while (start > 0 && /\w/.test(value[start - 1]!)) start--
+  if (start === 0 || value[start - 1] !== "$") return null
+
+  start--
+  let end = cursor
+  while (end < value.length && /\w/.test(value[end]!)) end++
+
+  return { start, end, prefix: value.slice(start + 1, cursor) }
+}
+
+export function getVariableSuggestions(
+  names: Iterable<string>,
+  prefix: string,
+): string[] {
+  const normalizedPrefix = prefix.toLowerCase()
+  return [...new Set(names)]
+    .filter((name) => name.toLowerCase().startsWith(normalizedPrefix))
+    .sort((a, b) => a.localeCompare(b))
+}
+
+export function replaceVariableToken(
+  value: string,
+  token: VariableToken,
+  name: string,
+): { value: string; cursorOffset: number } {
+  const replacement = `$${name}`
+  return {
+    value: value.slice(0, token.start) + replacement + value.slice(token.end),
+    cursorOffset: token.start + replacement.length,
+  }
+}
+
+export function getVariableHighlights(
+  value: string,
+  env: Environment | null,
+): VariableHighlight[] {
+  VAR_RE.lastIndex = 0
+  const highlights: VariableHighlight[] = []
+  let match: RegExpExecArray | null
+  while ((match = VAR_RE.exec(value)) !== null) {
+    highlights.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      exists: env !== null && match[1]! in env.vars,
+    })
+  }
+  return highlights
+}

--- a/src/ui/variableCompletion.ts
+++ b/src/ui/variableCompletion.ts
@@ -1,4 +1,5 @@
 import type { Environment } from "../schema"
+import type { Highlight } from "@opentui/core"
 
 export interface VariableToken {
   start: number
@@ -60,6 +61,25 @@ export function getVariableHighlights(
       start: match.index,
       end: match.index + match[0].length,
       exists: env !== null && match[1]! in env.vars,
+    })
+  }
+  return highlights
+}
+
+export function getEnvVarHighlights(
+  value: string,
+  env: Environment,
+  resolvedStyleId: number,
+  missingStyleId: number,
+): Highlight[] {
+  const highlights: Highlight[] = []
+  for (const match of value.matchAll(/\$(\w+)/g)) {
+    const name = match[1]!
+    highlights.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      styleId: name in env.vars ? resolvedStyleId : missingStyleId,
+      priority: 2,
     })
   }
   return highlights

--- a/src/ui/variableCompletion.ts
+++ b/src/ui/variableCompletion.ts
@@ -1,7 +1,5 @@
 import type { Environment } from "../schema"
 
-const VAR_RE = /\$(\w+)/g
-
 export interface VariableToken {
   start: number
   end: number
@@ -56,10 +54,8 @@ export function getVariableHighlights(
   value: string,
   env: Environment | null,
 ): VariableHighlight[] {
-  VAR_RE.lastIndex = 0
   const highlights: VariableHighlight[] = []
-  let match: RegExpExecArray | null
-  while ((match = VAR_RE.exec(value)) !== null) {
+  for (const match of value.matchAll(/\$(\w+)/g)) {
     highlights.push({
       start: match.index,
       end: match.index + match[0].length,

--- a/src/ui/variableCompletion.ts
+++ b/src/ui/variableCompletion.ts
@@ -60,7 +60,7 @@ export function getVariableHighlights(
     highlights.push({
       start: match.index,
       end: match.index + match[0].length,
-      exists: env !== null && match[1]! in env.vars,
+      exists: env !== null && Object.hasOwn(env.vars, match[1]!),
     })
   }
   return highlights
@@ -78,7 +78,7 @@ export function getEnvVarHighlights(
     highlights.push({
       start: match.index,
       end: match.index + match[0].length,
-      styleId: name in env.vars ? resolvedStyleId : missingStyleId,
+      styleId: Object.hasOwn(env.vars, name) ? resolvedStyleId : missingStyleId,
       priority: 2,
     })
   }

--- a/src/ui/variableCompletionInterceptor.tsx
+++ b/src/ui/variableCompletionInterceptor.tsx
@@ -4,14 +4,14 @@ import { useKeymap } from "@opentui/keymap/react"
 
 type CompletionHandler = (event: KeyEvent) => boolean
 
-let activeHandler: CompletionHandler | null = null
+const activeHandlers = new Set<CompletionHandler>()
 
 export function registerVariableCompletion(
   handler: CompletionHandler,
 ): () => void {
-  activeHandler = handler
+  activeHandlers.add(handler)
   return () => {
-    if (activeHandler === handler) activeHandler = null
+    activeHandlers.delete(handler)
   }
 }
 
@@ -22,9 +22,12 @@ export function VariableCompletionInterceptor() {
     return keymap.intercept(
       "key",
       (ctx) => {
-        if (activeHandler?.(ctx.event)) {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
+        for (const handler of activeHandlers) {
+          if (handler(ctx.event)) {
+            ctx.event.preventDefault()
+            ctx.event.stopPropagation()
+            return
+          }
         }
       },
       { priority: 200 },

--- a/src/ui/variableCompletionInterceptor.tsx
+++ b/src/ui/variableCompletionInterceptor.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react"
+import type { KeyEvent } from "@opentui/core"
+import { useKeymap } from "@opentui/keymap/react"
+
+type CompletionHandler = (event: KeyEvent) => boolean
+
+let activeHandler: CompletionHandler | null = null
+
+export function registerVariableCompletion(
+  handler: CompletionHandler,
+): () => void {
+  activeHandler = handler
+  return () => {
+    if (activeHandler === handler) activeHandler = null
+  }
+}
+
+export function VariableCompletionInterceptor() {
+  const keymap = useKeymap()
+
+  useEffect(() => {
+    return keymap.intercept(
+      "key",
+      (ctx) => {
+        if (activeHandler?.(ctx.event)) {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+        }
+      },
+      { priority: 200 },
+    )
+  }, [keymap])
+
+  return null
+}

--- a/src/ui/variableHighlight.ts
+++ b/src/ui/variableHighlight.ts
@@ -3,6 +3,10 @@ import type { InputRenderable, TextareaRenderable } from "@opentui/core"
 import type { Environment } from "../schema"
 import type { Theme } from "./theme"
 import { getVariableHighlights } from "./variableCompletion"
+import {
+  buildCharToDisplayOffsets,
+  charOffsetToDisplayOffset,
+} from "./highlightOffsets"
 
 export function highlightVariables(
   input: InputRenderable | TextareaRenderable,
@@ -16,11 +20,12 @@ export function highlightVariables(
   })
   input.clearAllHighlights()
   input.syntaxStyle = style
+  const displayOffsets = buildCharToDisplayOffsets(value)
 
   for (const highlight of getVariableHighlights(value, env)) {
     input.addHighlightByCharRange({
-      start: highlight.start,
-      end: highlight.end,
+      start: charOffsetToDisplayOffset(displayOffsets, highlight.start),
+      end: charOffsetToDisplayOffset(displayOffsets, highlight.end),
       styleId: style.getStyleId(
         highlight.exists ? "env.resolved" : "env.missing",
       )!,

--- a/src/ui/variableHighlight.ts
+++ b/src/ui/variableHighlight.ts
@@ -1,7 +1,7 @@
 import { SyntaxStyle } from "@opentui/core"
 import type { InputRenderable, TextareaRenderable } from "@opentui/core"
 import type { Environment } from "../schema"
-import type { Theme } from "./theme"
+import type { Theme } from "./theme-data"
 import { getVariableHighlights } from "./variableCompletion"
 import {
   buildCharToDisplayOffsets,

--- a/src/ui/variableHighlight.ts
+++ b/src/ui/variableHighlight.ts
@@ -1,0 +1,30 @@
+import { SyntaxStyle } from "@opentui/core"
+import type { InputRenderable, TextareaRenderable } from "@opentui/core"
+import type { Environment } from "../schema"
+import type { Theme } from "./theme"
+import { getVariableHighlights } from "./variableCompletion"
+
+export function highlightVariables(
+  input: InputRenderable | TextareaRenderable,
+  value: string,
+  theme: Theme,
+  env: Environment | null,
+): void {
+  const style = SyntaxStyle.fromStyles({
+    "env.resolved": { fg: theme.primary },
+    "env.missing": { fg: theme.error },
+  })
+  input.clearAllHighlights()
+  input.syntaxStyle = style
+
+  for (const highlight of getVariableHighlights(value, env)) {
+    input.addHighlightByCharRange({
+      start: highlight.start,
+      end: highlight.end,
+      styleId: style.getStyleId(
+        highlight.exists ? "env.resolved" : "env.missing",
+      )!,
+      priority: 2,
+    })
+  }
+}

--- a/tests/JsonBodyViewer.test.tsx
+++ b/tests/JsonBodyViewer.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { RGBA } from "@opentui/core"
+import { ThemeProvider, THEMES } from "../src/ui/theme"
+import { JsonBodyViewer } from "../src/ui/JsonBodyViewer"
+
+describe("JsonBodyViewer", () => {
+  it("keeps JSON syntax highlighting when variables make raw JSON invalid", async () => {
+    const theme = THEMES[0]!
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <JsonBodyViewer
+          body={
+            '{\n  "title": "my album",\n  "userId": $user_id,\n  "test": "$base_url"\n}'
+          }
+          theme={theme}
+          activeEnv={{
+            name: "production",
+            vars: { user_id: "42", base_url: "https://example.com" },
+          }}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 10 },
+    )
+
+    await renderOnce()
+    await renderOnce()
+
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    const title = spans.find((span) => span.text === '"my album"')
+    const variable = spans.find((span) => span.text === "$user_id")
+
+    expect(title).toBeDefined()
+    expect(title!.fg.equals(RGBA.fromHex(theme.success))).toBe(true)
+    expect(variable).toBeDefined()
+    expect(variable!.fg.equals(RGBA.fromHex(theme.primary))).toBe(true)
+  })
+})

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -124,6 +124,22 @@ describe("formatBody", () => {
   it("returns empty string for empty body", () => {
     expect(formatBody(makeRes({ body: "" }))).toBe("")
   })
+
+  it("replaces body-parser JSON stack traces with a helpful message", () => {
+    const body = `SyntaxError: Unexpected token h in JSON at position 99
+    at JSON.parse (<anonymous>)
+    at parse (/app/node_modules/body-parser/lib/types/json.js:89:19)`
+    expect(formatBody(makeRes({ body }))).toBe(
+      "The server rejected the request because the submitted JSON is invalid.\n" +
+        "Details: Unexpected token h in JSON at position 99",
+    )
+  })
+
+  it("does not rewrite unrelated error bodies", () => {
+    expect(formatBody(makeRes({ body: "SyntaxError: invalid input" }))).toBe(
+      "SyntaxError: invalid input",
+    )
+  })
   it("pretty-prints when content-type is json even if body is already formatted", () => {
     const res = makeRes({
       headers: { "content-type": "application/json; charset=utf-8" },

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -316,6 +316,55 @@ describe("CodeEditorRenderable", () => {
     expect(getHighlightCount(editor!)).toBeGreaterThan(0)
   })
 
+  it("converts extra highlight offsets across multiline content", async () => {
+    let editor: CodeEditorRenderable | null = null
+    const content = '{\n  "url": "$base_url"\n}'
+
+    const { renderOnce } = await testRender(
+      <box width={40} height={4}>
+        <code-editor
+          ref={(r) => {
+            editor = r
+          }}
+          filetype="json"
+          theme={opencodeTheme}
+          initialValue={content}
+          debounceMs={0}
+          extraHighlights={(value) => {
+            if (!editor) return []
+            const start = value.indexOf("$base_url")
+            return [
+              {
+                start,
+                end: start + 9,
+                styleId: editor.envResolvedStyleId,
+                priority: 2,
+              },
+            ]
+          }}
+          backgroundColor={opencodeTheme.backgroundPanel}
+          focusedBackgroundColor={opencodeTheme.backgroundPanel}
+          textColor={opencodeTheme.text}
+          cursorColor={opencodeTheme.primary}
+        />
+      </box>,
+      { width: 40, height: 4 },
+    )
+
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await renderOnce()
+    const highlights = editor!.getLineHighlights(1)
+    expect(
+      highlights.some(
+        (highlight) =>
+          highlight.styleId === editor!.envResolvedStyleId &&
+          highlight.start === 10 &&
+          highlight.end === 19,
+      ),
+    ).toBe(true)
+  })
+
   it("keeps YAML highlighting when folded", async () => {
     let editor: CodeEditorRenderable | null = null
     const content = `name: demo

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -461,4 +461,97 @@ body_type: json`
     expect(frame).toContain("body:")
     expect(frame).not.toContain("title: hello")
   })
+
+  it("restores source text and highlights after YAML toggleFold unfolds the last fold", async () => {
+    let editor: CodeEditorRenderable | null = null
+    const content = `name: demo
+body:
+  title: hello
+  published: true`
+    const originalLineCount = content.split("\n").length
+
+    const { renderOnce } = await testRender(
+      <box width={80} height={10}>
+        <code-editor
+          ref={(r) => {
+            editor = r
+          }}
+          filetype="yaml"
+          theme={opencodeTheme}
+          initialValue={content}
+          debounceMs={0}
+          backgroundColor={opencodeTheme.backgroundPanel}
+          focusedBackgroundColor={opencodeTheme.backgroundPanel}
+          textColor={opencodeTheme.text}
+          cursorColor={opencodeTheme.primary}
+        />
+      </box>,
+      { width: 80, height: 10 },
+    )
+
+    await renderOnce()
+    expect(editor).toBeDefined()
+    computeFolds(editor!)
+
+    editor!.toggleFold(1)
+    await renderOnce()
+    expect(editor!.lineCount).toBeLessThan(originalLineCount)
+
+    editor!.toggleFold(1)
+    await renderOnce()
+    expect(editor!.lineCount).toBe(originalLineCount)
+    expect(editor!.plainText).toBe(content)
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    await renderOnce()
+    expect(getHighlightCount(editor!)).toBeGreaterThan(0)
+  })
+
+  it("restores source text and highlights after YAML unfoldAll", async () => {
+    let editor: CodeEditorRenderable | null = null
+    const content = `name: demo
+headers:
+  accept: application/json
+  x-enabled: true
+body:
+  title: hello
+  published: true`
+    const originalLineCount = content.split("\n").length
+
+    const { renderOnce } = await testRender(
+      <box width={80} height={10}>
+        <code-editor
+          ref={(r) => {
+            editor = r
+          }}
+          filetype="yaml"
+          theme={opencodeTheme}
+          initialValue={content}
+          debounceMs={0}
+          backgroundColor={opencodeTheme.backgroundPanel}
+          focusedBackgroundColor={opencodeTheme.backgroundPanel}
+          textColor={opencodeTheme.text}
+          cursorColor={opencodeTheme.primary}
+        />
+      </box>,
+      { width: 80, height: 10 },
+    )
+
+    await renderOnce()
+    expect(editor).toBeDefined()
+    computeFolds(editor!)
+
+    editor!.foldAll()
+    await renderOnce()
+    expect(editor!.lineCount).toBeLessThan(originalLineCount)
+
+    editor!.unfoldAll()
+    await renderOnce()
+    expect(editor!.lineCount).toBe(originalLineCount)
+    expect(editor!.plainText).toBe(content)
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    await renderOnce()
+    expect(getHighlightCount(editor!)).toBeGreaterThan(0)
+  })
 })

--- a/tests/unit/CodeEditorCompletion.test.tsx
+++ b/tests/unit/CodeEditorCompletion.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { useState } from "react"
+import { extend } from "@opentui/react"
+import { testRender } from "@opentui/react/test-utils"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import { KeymapProvider } from "@opentui/keymap/react"
+import type { KeymapProviderProps } from "@opentui/keymap/react"
+import { CodeEditorRenderable } from "../../src/ui/CodeEditor"
+import { CodeEditorCompletion } from "../../src/ui/CodeEditorCompletion"
+import { VariableCompletionInterceptor } from "../../src/ui/variableCompletionInterceptor"
+import { ThemeProvider } from "../../src/ui/theme"
+import type { Environment } from "../../src/schema"
+import { opencodeTheme } from "../../src/ui/theme-data"
+
+extend({ "code-editor": CodeEditorRenderable })
+
+function Harness({ env }: { env: Environment }) {
+  const [editor, setEditor] = useState<CodeEditorRenderable | null>(null)
+  return (
+    <box width={60} height={10}>
+      <code-editor
+        ref={(next) => {
+          setEditor(next)
+          next?.focus()
+          if (next) next.cursorOffset = next.plainText.length
+        }}
+        filetype="json"
+        theme={opencodeTheme}
+        initialValue="$ho"
+        backgroundColor="transparent"
+        focusedBackgroundColor="transparent"
+        textColor="#fff"
+        cursorColor="#fff"
+      />
+      <CodeEditorCompletion editor={editor} env={env} isEditing value="$ho" />
+    </box>
+  )
+}
+
+describe("CodeEditorCompletion", () => {
+  it("shows and accepts active environment variables", async () => {
+    const { keymap, host, cleanup } = createTestKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider
+        keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <VariableCompletionInterceptor />
+          <Harness
+            env={{ name: "test", vars: { host: "localhost", token: "secret" } }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 10 },
+    )
+
+    await renderOnce()
+    await act(async () => {
+      host.press("tab")
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("$host")
+    cleanup()
+  })
+})

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test"
+import { act, useState } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { UrlBar } from "../../src/ui/UrlBar"
+
+function UrlBarHarness() {
+  const [url, setUrl] = useState("https://example.com")
+  return (
+    <UrlBar
+      method="GET"
+      url={url}
+      params={[]}
+      setUrl={setUrl}
+      onDefocus={() => {}}
+      focused
+      activeEnv={{
+        name: "test",
+        vars: { base_url: "https://api.example.com" },
+      }}
+    />
+  )
+}
+
+describe("UrlBar", () => {
+  it("shows variable suggestions while editing the URL", async () => {
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <UrlBarHarness />
+      </ThemeProvider>,
+      { width: 100, height: 12 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$")
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("$base_url")
+  })
+})

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -1,15 +1,34 @@
 import { describe, it, expect } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { RGBA } from "@opentui/core"
+import { act } from "react"
+import { useState } from "react"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import { KeymapProvider } from "@opentui/keymap/react"
+import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { VarInput } from "../../src/ui/VarInput"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import type { Environment } from "../../src/schema"
+import { VariableCompletionInterceptor } from "../../src/ui/variableCompletionInterceptor"
 
 function env(vars: Record<string, string>): Environment {
   return { name: "test-env", vars }
 }
 
 const theme = THEMES[0]!
+
+function CompletionHarness({ environment }: { environment: Environment }) {
+  const [value, setValue] = useState("")
+  return (
+    <VarInput
+      value={value}
+      env={environment}
+      isEditing
+      isFocused
+      onChange={setValue}
+    />
+  )
+}
 
 function hexToRgba(hex: string): RGBA {
   return RGBA.fromInts(
@@ -141,6 +160,95 @@ describe("VarInput — display mode (isEditing=false)", () => {
 })
 
 describe("VarInput — edit mode (isEditing=true)", () => {
+  it("shows filtered suggestions after typing a variable prefix", async () => {
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <CompletionHarness
+          environment={env({ host: "localhost", token: "secret" })}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$ho")
+    })
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("$host")
+    expect(frame).not.toContain("$token")
+  })
+
+  it("accepts a suggestion with Tab", async () => {
+    const { keymap, host, cleanup } = createTestKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider
+        keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <VariableCompletionInterceptor />
+          <CompletionHarness
+            environment={env({ host: "localhost", token: "secret" })}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$ho")
+    })
+    await renderOnce()
+    await act(async () => {
+      host.press("tab")
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("$host")
+    cleanup()
+  })
+
+  it("highlights resolved variables while editing", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$host"
+          env={env({ host: "localhost" })}
+          isEditing
+          isFocused
+          onChange={() => {}}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    const variable = spans.find((span) => span.text.includes("$host"))
+    expect(variable).toBeDefined()
+    expect(variable!.fg.equals(hexToRgba(theme.primary))).toBe(true)
+  })
+
+  it("highlights missing variables while editing", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$missing"
+          env={env({})}
+          isEditing
+          isFocused
+          onChange={() => {}}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    const variable = spans.find((span) => span.text.includes("$missing"))
+    expect(variable).toBeDefined()
+    expect(variable!.fg.equals(hexToRgba(theme.error))).toBe(true)
+  })
+
   it("renders input element with value", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -296,6 +296,168 @@ describe("VarInput — edit mode (isEditing=true)", () => {
     const frame = captureCharFrame()
     expect(frame).toContain("custom")
   })
+  it("accepts a suggestion with Return", async () => {
+    const { keymap, host, cleanup } = createTestKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider
+        keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <VariableCompletionInterceptor />
+          <CompletionHarness
+            environment={env({ host: "localhost", token: "secret" })}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$ho")
+    })
+    await renderOnce()
+    await act(async () => {
+      host.press("return")
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("$host")
+    cleanup()
+  })
+
+  it("dismisses completion with Escape, reopens on new $ token", async () => {
+    const { keymap, host, cleanup } = createTestKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider
+        keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <VariableCompletionInterceptor />
+          <CompletionHarness
+            environment={env({ host: "localhost", port: "8080" })}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$ho")
+    })
+    await renderOnce()
+    await act(async () => {
+      host.press("escape")
+    })
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("st$")
+    })
+    await renderOnce()
+    // "$port" only appears in the reopened menu, not in the input value
+    expect(captureCharFrame()).toContain("$port")
+    cleanup()
+  })
+
+  it("resets highlighted index after refiltering suggestions", async () => {
+    const { keymap, host, cleanup } = createTestKeymap()
+    const { renderOnce, captureSpans, mockInput } = await testRender(
+      <KeymapProvider
+        keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <VariableCompletionInterceptor />
+          <CompletionHarness
+            environment={env({
+              bear: "x",
+              brown: "y",
+              branch: "z",
+              bry: "w",
+            })}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$br")
+    })
+    await renderOnce()
+    await act(async () => {
+      host.press("down")
+    })
+    await act(async () => {
+      host.press("down")
+    })
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("o")
+    })
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const primaryRgba = hexToRgba(theme.primary)
+    const brownHighlights = spans.filter(
+      (s) => s.text.includes("$brown") && s.fg.equals(primaryRgba),
+    )
+    expect(brownHighlights.length).toBeGreaterThanOrEqual(1)
+    cleanup()
+  })
+
+  it("does not open completion menu for a fully typed token", async () => {
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <CompletionHarness environment={env({ host: "localhost" })} />
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$host")
+    })
+    await renderOnce()
+    const frame = captureCharFrame()
+    // Without the isComplete fix, the menu would show "$host" as a suggestion.
+    // With the fix, only the input itself renders.
+    // The input is on line 0; any menu would create extra content below.
+    // Check that no border chars from the completion menu appear.
+    expect(frame).not.toContain("┌")
+  })
+
+  it("does not crash with many suggestions navigating within visible range", async () => {
+    const manyVars: Record<string, string> = {}
+    for (let i = 0; i < 12; i++) manyVars[`a${i}`] = String(i)
+    const { keymap, host, cleanup } = createTestKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider
+        keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <VariableCompletionInterceptor />
+          <CompletionHarness environment={env(manyVars)} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 15 },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$a")
+    })
+    await renderOnce()
+    // Navigate past visible range multiple times
+    for (let i = 0; i < 15; i++) {
+      await act(async () => {
+        host.press("down")
+      })
+    }
+    await renderOnce()
+    // Accept current suggestion with Return
+    await act(async () => {
+      host.press("return")
+    })
+    await renderOnce()
+    // Should have replaced with a visible suggestion (no crash)
+    expect(captureCharFrame().length).toBeGreaterThan(0)
+    cleanup()
+  })
 })
 
 describe("VarInput — textarea mode (isEditing=true, useTextarea=true)", () => {
@@ -333,5 +495,23 @@ describe("VarInput — textarea mode (isEditing=true, useTextarea=true)", () => 
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame.length).toBeGreaterThanOrEqual(0)
+  })
+
+  it("shows filtered suggestions while typing in textarea mode", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value=""
+          env={env({ host: "localhost", token: "secret" })}
+          isEditing
+          useTextarea
+          onChange={() => {}}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    await renderOnce()
+    expect(captureCharFrame()).toBeDefined()
   })
 })

--- a/tests/unit/highlightOffsets.test.ts
+++ b/tests/unit/highlightOffsets.test.ts
@@ -58,12 +58,21 @@ describe("buildCharToDisplayOffsets", () => {
     expect(offsets[2]).toBe(1)
   })
 
-  it("treats carriage return as a display character", () => {
+  it("treats carriage return as zero-width like newline", () => {
     const offsets = buildCharToDisplayOffsets("a\rb")
     expect(offsets[0]).toBe(0)
     expect(offsets[1]).toBe(1)
-    expect(offsets[2]).toBe(2)
-    expect(offsets[3]).toBe(3)
+    expect(offsets[2]).toBe(1)
+    expect(offsets[3]).toBe(2)
+  })
+
+  it("handles CRLF as two zero-width chars", () => {
+    const offsets = buildCharToDisplayOffsets("a\r\nb")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(1)
+    expect(offsets[3]).toBe(1)
+    expect(offsets[4]).toBe(2)
   })
 
   it("handles surrogate pairs as single display column", () => {

--- a/tests/unit/highlightOffsets.test.ts
+++ b/tests/unit/highlightOffsets.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test"
+import {
+  buildCharToDisplayOffsets,
+  charOffsetToDisplayOffset,
+} from "../../src/ui/highlightOffsets"
+
+describe("buildCharToDisplayOffsets", () => {
+  it("maps empty string to a single-element array", () => {
+    const offsets = buildCharToDisplayOffsets("")
+    expect(offsets).toEqual([0])
+    expect(offsets[0]).toBe(0)
+  })
+
+  it("maps plain ASCII without newlines 1:1", () => {
+    const offsets = buildCharToDisplayOffsets("hello")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[5]).toBe(5)
+    expect(offsets[5]).toBe(5)
+  })
+
+  it("skips newline in display offset increment", () => {
+    const offsets = buildCharToDisplayOffsets("a\nb")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(1)
+    expect(offsets[3]).toBe(2)
+  })
+
+  it("handles multiple newlines correctly", () => {
+    const offsets = buildCharToDisplayOffsets('{\n  "x": 1\n}')
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(1)
+    expect(offsets[3]).toBe(2)
+    expect(offsets[10]).toBe(9)
+    expect(offsets[11]).toBe(9)
+  })
+
+  it("handles consecutive newlines", () => {
+    const offsets = buildCharToDisplayOffsets("\n\n")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(0)
+    expect(offsets[2]).toBe(0)
+  })
+
+  it("handles newline as first character", () => {
+    const offsets = buildCharToDisplayOffsets("\na")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(0)
+    expect(offsets[2]).toBe(1)
+  })
+
+  it("handles newline as last character", () => {
+    const offsets = buildCharToDisplayOffsets("a\n")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(1)
+  })
+
+  it("treats carriage return as a display character", () => {
+    const offsets = buildCharToDisplayOffsets("a\rb")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(2)
+    expect(offsets[3]).toBe(3)
+  })
+
+  it("handles surrogate pairs as single display column", () => {
+    const offsets = buildCharToDisplayOffsets("a😀b")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(1)
+    expect(offsets[3]).toBe(2)
+  })
+
+  it("handles surrogate pairs with newlines", () => {
+    const offsets = buildCharToDisplayOffsets("a\n😀")
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(1)
+    expect(offsets[2]).toBe(1)
+    expect(offsets[3]).toBe(1)
+    expect(offsets[4]).toBe(2)
+  })
+
+  it("last element equals display length excluding newlines", () => {
+    const offsets = buildCharToDisplayOffsets('{\n  "x": 1\n}')
+    expect(offsets[offsets.length - 1]).toBe(10)
+  })
+})
+
+describe("charOffsetToDisplayOffset", () => {
+  it("returns 0 for offsets of empty string", () => {
+    const offsets = buildCharToDisplayOffsets("")
+    expect(charOffsetToDisplayOffset(offsets, 0)).toBe(0)
+  })
+
+  it("returns correct display offset for plain text", () => {
+    const offsets = buildCharToDisplayOffsets("hello")
+    expect(charOffsetToDisplayOffset(offsets, 0)).toBe(0)
+    expect(charOffsetToDisplayOffset(offsets, 3)).toBe(3)
+    expect(charOffsetToDisplayOffset(offsets, 5)).toBe(5)
+  })
+
+  it("maps char offset to display offset skipping newlines", () => {
+    const offsets = buildCharToDisplayOffsets('{\n  "x": 1\n}')
+    expect(charOffsetToDisplayOffset(offsets, 0)).toBe(0)
+    expect(charOffsetToDisplayOffset(offsets, 1)).toBe(1)
+    expect(charOffsetToDisplayOffset(offsets, 2)).toBe(1)
+    expect(charOffsetToDisplayOffset(offsets, 11)).toBe(9)
+  })
+
+  it("clamps negative offsets to 0", () => {
+    const offsets = buildCharToDisplayOffsets("hello")
+    expect(charOffsetToDisplayOffset(offsets, -1)).toBe(0)
+    expect(charOffsetToDisplayOffset(offsets, -100)).toBe(0)
+  })
+
+  it("clamps offsets beyond length to last element", () => {
+    const offsets = buildCharToDisplayOffsets("hello")
+    expect(charOffsetToDisplayOffset(offsets, 10)).toBe(5)
+    expect(charOffsetToDisplayOffset(offsets, 999)).toBe(5)
+  })
+})

--- a/tests/unit/jsonValidation.test.ts
+++ b/tests/unit/jsonValidation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test"
+import type { Environment } from "../../src/schema"
+import { validateJsonContent } from "../../src/ui/jsonValidation"
+
+function env(vars: Record<string, string>): Environment {
+  return { name: "test", vars }
+}
+
+describe("validateJsonContent", () => {
+  it("accepts a numeric variable without quotes", () => {
+    expect(validateJsonContent('{"id": $ID}', env({ ID: "42" }))).toBeNull()
+  })
+
+  it("accepts a boolean variable without quotes", () => {
+    expect(
+      validateJsonContent('{"enabled": $ENABLED}', env({ ENABLED: "true" })),
+    ).toBeNull()
+  })
+
+  it("accepts any valid JSON value without quotes", () => {
+    expect(
+      validateJsonContent('{"data": $DATA}', env({ DATA: "[1,2,3]" })),
+    ).toBeNull()
+  })
+
+  it("rejects a string variable without quotes", () => {
+    const error = validateJsonContent('{"user": $USER}', env({ USER: "john" }))
+    expect(error).toContain("Invalid JSON:")
+  })
+
+  it("accepts a string variable inside quotes", () => {
+    expect(
+      validateJsonContent('{"user": "$USER"}', env({ USER: "john" })),
+    ).toBeNull()
+  })
+
+  it("reports unresolved variables", () => {
+    expect(validateJsonContent('{"id": $ID}', env({}))).toBe(
+      'Invalid JSON: unresolved variable "ID"',
+    )
+  })
+
+  it("falls back to normal JSON validation without an environment", () => {
+    expect(validateJsonContent('{"id": 42}', null)).toBeNull()
+    expect(validateJsonContent('{"id": $ID}', null)).toContain("Invalid JSON:")
+  })
+})

--- a/tests/unit/variableCompletion.test.ts
+++ b/tests/unit/variableCompletion.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test"
+import {
+  getVariableHighlights,
+  getVariableSuggestions,
+  getVariableToken,
+  replaceVariableToken,
+} from "../../src/ui/variableCompletion"
+import type { Environment } from "../../src/schema"
+
+function env(vars: Record<string, string>): Environment {
+  return { name: "test", vars }
+}
+
+describe("variable completion", () => {
+  it("finds an empty token immediately after a dollar sign", () => {
+    expect(getVariableToken("https://$", 9)).toEqual({
+      start: 8,
+      end: 9,
+      prefix: "",
+    })
+  })
+
+  it("finds the token containing the cursor and its typed prefix", () => {
+    expect(getVariableToken("$baseUrl/api", 5)).toEqual({
+      start: 0,
+      end: 8,
+      prefix: "base",
+    })
+  })
+
+  it("does not complete outside a variable token", () => {
+    expect(getVariableToken("https://example.com", 8)).toBeNull()
+  })
+
+  it("filters, deduplicates, and sorts variable names", () => {
+    expect(
+      getVariableSuggestions(["team", "baseUrl", "team", "tenant"], "te"),
+    ).toEqual(["team", "tenant"])
+  })
+
+  it("replaces the full token and moves the cursor after the selection", () => {
+    expect(
+      replaceVariableToken(
+        "$baseUrl/api",
+        { start: 0, end: 8, prefix: "base" },
+        "host",
+      ),
+    ).toEqual({
+      value: "$host/api",
+      cursorOffset: 5,
+    })
+  })
+
+  it("returns resolved and missing highlight ranges", () => {
+    expect(
+      getVariableHighlights("$host/$missing", env({ host: "example.com" })),
+    ).toEqual([
+      { start: 0, end: 5, exists: true },
+      { start: 6, end: 14, exists: false },
+    ])
+  })
+})

--- a/tests/unit/variableCompletion.test.ts
+++ b/tests/unit/variableCompletion.test.ts
@@ -59,4 +59,88 @@ describe("variable completion", () => {
       { start: 6, end: 14, exists: false },
     ])
   })
+
+  it("returns null for empty string", () => {
+    expect(getVariableToken("", 0)).toBeNull()
+  })
+
+  it("returns null when cursor is before the $ sign", () => {
+    expect(getVariableToken("$host", 0)).toBeNull()
+  })
+
+  it("finds token with cursor in the middle of the variable name", () => {
+    expect(getVariableToken("$host", 3)).toEqual({
+      start: 0,
+      end: 5,
+      prefix: "ho",
+    })
+  })
+
+  it("returns null when no dollar sign precedes the cursor", () => {
+    expect(getVariableToken("hello world", 5)).toBeNull()
+  })
+
+  it("returns null when cursor is before a non-variable dollar sign", () => {
+    expect(getVariableToken("$10", 0)).toBeNull()
+  })
+
+  it("returns all names sorted when prefix is empty", () => {
+    expect(getVariableSuggestions(["host", "port", "path"], "")).toEqual([
+      "host",
+      "path",
+      "port",
+    ])
+  })
+
+  it("filters case-insensitively matching all variations", () => {
+    const result = getVariableSuggestions(["Host", "host"], "hOs")
+    expect(result).toHaveLength(2)
+    expect(result).toContain("Host")
+    expect(result).toContain("host")
+  })
+
+  it("returns empty array when no names match", () => {
+    expect(getVariableSuggestions(["host", "port"], "xyz")).toEqual([])
+  })
+
+  it("handles empty names list", () => {
+    expect(getVariableSuggestions([], "h")).toEqual([])
+  })
+
+  it("replaces token at value start", () => {
+    expect(
+      replaceVariableToken(
+        "$host/api",
+        { start: 0, end: 5, prefix: "host" },
+        "newHost",
+      ),
+    ).toEqual({
+      value: "$newHost/api",
+      cursorOffset: 8,
+    })
+  })
+
+  it("replaces token at value end", () => {
+    const result = replaceVariableToken(
+      "prefix/$host",
+      { start: 7, end: 12, prefix: "host" },
+      "newHost",
+    )
+    expect(result.value).toBe("prefix/$newHost")
+    expect(result.cursorOffset).toBe(15)
+  })
+
+  it("returns empty highlights for empty value", () => {
+    expect(getVariableHighlights("", env({ host: "x" }))).toEqual([])
+  })
+
+  it("returns empty highlights when no variables present", () => {
+    expect(getVariableHighlights("plain text", env({ host: "x" }))).toEqual([])
+  })
+
+  it("returns missing highlights when env is null", () => {
+    expect(getVariableHighlights("$host", null)).toEqual([
+      { start: 0, end: 5, exists: false },
+    ])
+  })
 })

--- a/tests/unit/variableHighlight.test.tsx
+++ b/tests/unit/variableHighlight.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { RGBA } from "@opentui/core"
+import { act, useState } from "react"
+import { ThemeProvider } from "../../src/ui/theme"
+import { VarInput } from "../../src/ui/VarInput"
+import type { Environment } from "../../src/schema"
+
+function env(vars: Record<string, string>): Environment {
+  return { name: "test", vars }
+}
+
+function hexToRgba(hex: string): RGBA {
+  return RGBA.fromInts(
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+  )
+}
+
+describe("variableHighlight", () => {
+  it("highlights multiple variables on different display lines", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$host\n$port"
+          env={env({ host: "localhost", port: "8080" })}
+          isEditing={false}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const hostSpan = spans.find((s) => s.text.includes("$host"))
+    const portSpan = spans.find((s) => s.text.includes("$port"))
+    expect(hostSpan).toBeDefined()
+    expect(portSpan).toBeDefined()
+  })
+
+  it("highlights resolved and missing variables correctly in same content", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$host $missing"
+          env={env({ host: "localhost" })}
+          isEditing={false}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const hostSpan = spans.find((s) => s.text.includes("$host"))
+    const missingSpan = spans.find((s) => s.text.includes("$missing"))
+    expect(hostSpan).toBeDefined()
+    expect(missingSpan).toBeDefined()
+    const t = await import("../../src/ui/theme")
+    expect(hostSpan!.fg.equals(hexToRgba(t.THEMES[0]!.primary))).toBe(true)
+    expect(missingSpan!.fg.equals(hexToRgba(t.THEMES[0]!.error))).toBe(true)
+  })
+
+  it("shows all variables as missing when env is null", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput value="$var1 $var2" env={null} isEditing={false} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const var1 = spans.find((s) => s.text.includes("$var1"))
+    const var2 = spans.find((s) => s.text.includes("$var2"))
+    expect(var1).toBeDefined()
+    expect(var2).toBeDefined()
+    const t = await import("../../src/ui/theme")
+    expect(var1!.fg.equals(hexToRgba(t.THEMES[0]!.error))).toBe(true)
+    expect(var2!.fg.equals(hexToRgba(t.THEMES[0]!.error))).toBe(true)
+  })
+
+  it("does not highlight dollar sign without following word chars", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput value="price $5 and $" env={env({})} isEditing={false} />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const resolved = spans.filter((s) => s.fg.equals(hexToRgba("#7fd88f")))
+    const error = spans.filter((s) => s.fg.equals(hexToRgba("#e06c75")))
+    expect(resolved).toHaveLength(0)
+    expect(error).toHaveLength(0)
+  })
+
+  it("highlights variables in edit mode with textarea", async () => {
+    let setValue = (_v: string) => {}
+    function Harness() {
+      const [value, setVal] = useState("$host\n$port")
+      setValue = (v: string) => setVal(v)
+      return (
+        <VarInput
+          value={value}
+          env={env({ host: "localhost", port: "8080" })}
+          isEditing
+          useTextarea
+          onChange={setVal}
+        />
+      )
+    }
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness />
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    await renderOnce()
+    await act(async () => {
+      setValue("$host\n$port")
+    })
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const hostSpan = spans.find((s) => s.text.includes("$host"))
+    const portSpan = spans.find((s) => s.text.includes("$port"))
+    expect(hostSpan).toBeDefined()
+    expect(portSpan).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Implements `$variable` autocompletion, env-aware JSON validation, and inline variable highlighting across Noodle's UI components.

## Changes

### Autocompletion
- **Completion engine** (`src/ui/variableCompletion.ts`): Token detection, prefix matching, and variable replacement logic
- **Completion popup** (`src/ui/CodeEditorCompletion.tsx`): Dropdown for the code editor
- **Shared hook** (`src/ui/useVariableCompletion.ts`): Reusable completion logic extracted for both `CodeEditorCompletion` and `VarInput`
- **Interceptor** (`src/ui/variableCompletionInterceptor.tsx`): Registers key handlers via OpenTUI's key interceptor for multiple input types
- **VarInput integration** (`src/ui/VarInput.tsx`): Full completion popup inside text inputs (env editor, URL bar, form fields)

### Env variable highlighting
- **Inline highlights** (`src/ui/variableHighlight.tsx`): Highlights `$var` tokens in editors — resolved = green, missing = red
- **VarText** (`src/ui/VarText.tsx`): Reusable inline variable rendering with color-coded segments
- Integrated into `RequestPane`, `YamlEditorOverlay`, `UrlBar`, `EnvEditorPane`

### JSON validation with env vars
- (`src/ui/jsonValidation.ts`): Validates JSON after env var substitution, catches unresolved vars before sending
- (`tests/unit/jsonValidation.test.ts`): Unit tests for validation scenarios

### Highlight offset fixes
- (`src/ui/highlightOffsets.ts`): New utility to map char offsets to display offsets (skipping newlines) for multiline highlight regions
- CRLF and carriage return handling fixed (`buildCharToDisplayOffsets`)

### Code quality
- Removed dead code: empty `onResize` override, unused `lookupContentType`, `useJsonHighlight` hook, redundant JSON parse logic in `format.ts`
- Used `Object.hasOwn` instead of `in` operator for safer prototype checks
- Simplified TreeSitter fallback — JSON highlight fallback removed (now handled by local tokenizer), YAML fallback kept
- `AppOverlays`: Fixed `ConfirmOverlay` `selectedIndex` for delete confirmations to use state instead of hardcoded `0`

### Tests
- 7 new test files, ~1400+ tests total
- Tests for completion, highlighting, offsets, validation, and VarInput

## Verification

- `bun run format` ✅
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun test` ✅ (1403 pass)