### PR TITLE
feat(ui): add timeline request and response detail overlay

### DIFF
--- a/.agents/skills/opentui/docs/bindings/solid.mdx
+++ b/.agents/skills/opentui/docs/bindings/solid.mdx
@@ -80,7 +80,7 @@ export default {
 }
 ```
 
-The current Node runtime path is still lower-level than Bun. OpenTUI's native renderer currently relies on Node's experimental FFI support, so select Node 26.3.0 before running it and pass `--experimental-ffi`, `--permission`, and the filesystem or FFI permissions your app needs. OpenTUI does not install Node automatically.
+The current Node runtime path is still lower-level than Bun. OpenTUI's native renderer currently relies on Node's experimental FFI support, so select Node 26.4.0 before running it and pass `--experimental-ffi`, `--permission`, and the filesystem or FFI permissions your app needs. OpenTUI does not install Node automatically.
 
 ### 4. Enable runtime-loaded plugin support (if needed)
 

--- a/.agents/skills/opentui/docs/components/select.mdx
+++ b/.agents/skills/opentui/docs/components/select.mdx
@@ -122,25 +122,26 @@ const styledMenu = new SelectRenderable(renderer, {
 
 ## Properties
 
-| Property                   | Type             | Default       | Description                       |
-| -------------------------- | ---------------- | ------------- | --------------------------------- |
-| `width`                    | `number`         | -             | Component width                   |
-| `height`                   | `number`         | -             | Component height                  |
-| `options`                  | `SelectOption[]` | `[]`          | Available options                 |
-| `selectedIndex`            | `number`         | `0`           | Initially selected index          |
-| `backgroundColor`          | `string \| RGBA` | `transparent` | Background color                  |
-| `textColor`                | `string \| RGBA` | `#FFFFFF`     | Normal text color                 |
-| `focusedBackgroundColor`   | `string \| RGBA` | `#1a1a1a`     | Background when focused           |
-| `focusedTextColor`         | `string \| RGBA` | `#FFFFFF`     | Text color when focused           |
-| `selectedBackgroundColor`  | `string \| RGBA` | `#334455`     | Selected item background          |
-| `selectedTextColor`        | `string \| RGBA` | `#FFFF00`     | Selected item text color          |
-| `descriptionColor`         | `string \| RGBA` | `#888888`     | Description text color            |
-| `selectedDescriptionColor` | `string \| RGBA` | `#CCCCCC`     | Selected item description color   |
-| `showDescription`          | `boolean`        | `true`        | Show option descriptions          |
-| `showScrollIndicator`      | `boolean`        | `false`       | Show scroll position indicator    |
-| `wrapSelection`            | `boolean`        | `false`       | Wrap selection at list boundaries |
-| `itemSpacing`              | `number`         | `0`           | Spacing between items             |
-| `fastScrollStep`           | `number`         | `5`           | Items to skip with Shift+Up/Down  |
+| Property                   | Type             | Default       | Description                          |
+| -------------------------- | ---------------- | ------------- | ------------------------------------ |
+| `width`                    | `number`         | -             | Component width                      |
+| `height`                   | `number`         | -             | Component height                     |
+| `options`                  | `SelectOption[]` | `[]`          | Available options                    |
+| `selectedIndex`            | `number`         | `0`           | Initially selected index             |
+| `backgroundColor`          | `string \| RGBA` | `transparent` | Background color                     |
+| `textColor`                | `string \| RGBA` | `#FFFFFF`     | Normal text color                    |
+| `focusedBackgroundColor`   | `string \| RGBA` | `#1a1a1a`     | Background when focused              |
+| `focusedTextColor`         | `string \| RGBA` | `#FFFFFF`     | Text color when focused              |
+| `selectedBackgroundColor`  | `string \| RGBA` | `#334455`     | Selected item background             |
+| `selectedTextColor`        | `string \| RGBA` | `#FFFF00`     | Selected item text color             |
+| `descriptionColor`         | `string \| RGBA` | `#888888`     | Description text color               |
+| `selectedDescriptionColor` | `string \| RGBA` | `#CCCCCC`     | Selected item description color      |
+| `showDescription`          | `boolean`        | `true`        | Show option descriptions             |
+| `showScrollIndicator`      | `boolean`        | `false`       | Show scroll position indicator       |
+| `showSelectionIndicator`   | `boolean`        | `true`        | Show the selection marker and gutter |
+| `wrapSelection`            | `boolean`        | `false`       | Wrap selection at list boundaries    |
+| `itemSpacing`              | `number`         | `0`           | Spacing between items                |
+| `fastScrollStep`           | `number`         | `5`           | Items to skip with Shift+Up/Down     |
 
 ## Example: file menu
 
@@ -201,5 +202,6 @@ menu.options = [
 // Toggle display options
 menu.showDescription = false
 menu.showScrollIndicator = true
+menu.showSelectionIndicator = false
 menu.wrapSelection = true
 ```

--- a/.agents/skills/opentui/docs/components/tab-select.mdx
+++ b/.agents/skills/opentui/docs/components/tab-select.mdx
@@ -158,7 +158,7 @@ contentArea.add(currentPanel)
 tabs.on("itemSelected", (index, option) => {
   // Remove current panel
   if (currentPanel) {
-    contentArea.remove(currentPanel.id)
+    contentArea.remove(currentPanel)
   }
   // Add new panel based on selection
   switch (option.name) {

--- a/.agents/skills/opentui/docs/core-concepts/audio.mdx
+++ b/.agents/skills/opentui/docs/core-concepts/audio.mdx
@@ -1,10 +1,10 @@
 ---
 title: Native audio
-description: Load, play, mix, and inspect audio with the native miniaudio backend
+description: Load, stream, play, mix, and inspect audio with the native miniaudio backend
 order: 11
 skill:
   entry: true
-  intents: [audio, native-audio, sound, playback, pcm, fft]
+  intents: [audio, native-audio, sound, playback, streaming, radio, mp3, flac, pcm, fft]
 ---
 
 # Native audio
@@ -32,11 +32,13 @@ audio.dispose()
 
 Use `setupAudio(options?)` when you prefer a function wrapper around `Audio.create(options?)`.
 
+`Audio.create()` and `setupAudio()` initialize synchronously and throw `AudioInitializationError` if native library resolution, engine creation, or `autoStart` fails. Construction never emits events; successful `autoStart` also does not emit `started` before listeners can be attached.
+
 ## Engine options
 
 | Option             | Default  | Description                                    |
 | ------------------ | -------- | ---------------------------------------------- |
-| `autoStart`        | `false`  | Call `start()` during creation                 |
+| `autoStart`        | `false`  | Start playback during synchronous construction |
 | `sampleRate`       | `48000`  | Engine sample rate                             |
 | `playbackChannels` | `2`      | Requested playback channel count               |
 | `startOptions`     | defaults | Options passed to `start()` when auto-starting |
@@ -57,7 +59,178 @@ Create a new `Audio` instance to change `sampleRate` or `playbackChannels`.
 | `setGroupVolume(group, volume)` | Set group volume                                              |
 | `setMasterVolume(volume)`       | Set master volume                                             |
 
-`play()` accepts `{ volume, pan, loop, groupId }`. Native playback clamps `volume` to `0..4` and `pan` to `-1..1`. The engine has 32 voice slots.
+`play()` accepts `{ volume, pan, loop, groupId }`. Native playback clamps `volume` to `0..4` and `pan` to `-1..1`. The engine supports 32 active voices and streams in total.
+
+## Encoded streams
+
+Streaming supports `format: "mp3"` (the default) and `format: "flac"`. The selected format is exposed as `AudioStream.format`; unsupported formats reject before opening a source. Choose the entry point by source ownership:
+
+| Method                               | Use                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| `playStreamUrl(url, options?)`       | Fetch, ICY negotiation, HTTP retry, reconnect, and response demuxing |
+| `playStream(bytes, options?)`        | One-shot encoded `ReadableStream` or `AsyncIterable`                 |
+| `playStreamSource(connector, opts?)` | Reconnectable custom transport with per-connection demuxing          |
+
+All three resolve after the native decoder is ready, normally while buffering. Streaming begins before the source ends.
+
+### URL streams
+
+```typescript
+import { Audio, AudioStreamError, type AudioStream } from "@opentui/core"
+
+const audio = Audio.create({ autoStart: false })
+let stream: AudioStream | null = null
+const safeMetadata = (value: string | undefined) => value?.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+
+audio.on("error", (error) => {
+  console.error(error.message)
+})
+
+try {
+  if (!audio.start()) throw new Error("No playback device available")
+
+  stream = await audio.playStreamUrl("https://anomaly.fm/radio", {
+    format: "mp3",
+    reconnect: { maxRetries: 5, retryOnEnd: true },
+  })
+
+  const initialMetadata = stream.getMetadata()
+  console.log(safeMetadata(initialMetadata?.fields.StreamTitle))
+
+  stream.on("metadata", (metadata) => {
+    console.log(safeMetadata(metadata?.headers["icy-name"]), safeMetadata(metadata?.fields.StreamTitle))
+  })
+
+  stream.on("error", (error) => {
+    console.error(error.message)
+  })
+
+  // Run the application until playback should stop.
+} catch (error) {
+  if (error instanceof AudioStreamError) {
+    console.error(`${error.context.action}: ${error.message}`)
+  } else {
+    throw error
+  }
+} finally {
+  stream?.dispose()
+  await stream?.closed
+  audio.dispose()
+}
+```
+
+The default `contentTypePolicy: "validate"` accepts `audio/mpeg`, `audio/mp3`, and `application/mp3` for MP3; `audio/flac` and `audio/x-flac` for FLAC; and `application/octet-stream` or a missing type for either format. Set it to `"ignore"` to let the decoder validate mislabeled responses, or pass a callback receiving `{ format, contentType, status, url }`. Every response, including reconnect replacements, is evaluated before its bytes reach the decoder. `request` accepts `RequestInit` except `body` and `signal`; use the stream-level `signal` option for cancellation.
+
+URL streams request ICY metadata with `Icy-MetaData: 1` unless `request.headers` already contains that header. Set it to `0` explicitly to disable negotiation. Any `icy-*` response headers are exposed as an ICY metadata snapshot; a positive `icy-metaint` additionally enables in-band framing. URLs, content types, station headers, and server names are not used to infer framing. Invalid or ambiguous intervals reject the response before a native voice is allocated.
+
+ICY framing is removed in TypeScript before bytes reach the native decoder. `getMetadata()` returns the latest immutable `{ format, headers, fields }` snapshot or `null`. ICY response header names are lowercase in `headers`; in-band field names such as `StreamTitle` and `StreamUrl` retain their original case. Unknown fields are preserved. The `metadata` event emits the latest changed snapshot, and emits `null` when a replacement response no longer advertises ICY metadata. Rapid changes can coalesce into one asynchronous event; `getMetadata()` always returns the current snapshot. Zero-length and repeated equivalent metadata blocks do not emit events.
+
+ICY does not define a text encoding. OpenTUI follows Icecast's documented non-Ogg default of ISO-8859-1, represented by the Encoding Standard's `windows-1252` decoder. Set `metadataEncoding`, for example `metadataEncoding: "utf-8"`, when the station uses another encoding. Metadata is untrusted text and should be sanitized before writing it directly to a terminal or interpreting metadata URLs.
+
+Metadata events follow response ingestion, not audible playback. Native buffering means a title can arrive before its audio is heard. Metadata received during setup is retained and emitted asynchronously after `playStreamUrl()` resolves.
+
+URL reconnect is opt-in. It retries network failures, interrupted or missing response bodies, HTTP 408/425/429, and HTTP 5xx responses. Reconnects restart the decoder in the same native stream session, preserving controls, counters, the voice slot, and any decoded PCM still available after an interruption. `retryOnEnd` restarts the same session after a clean response ends and its buffered PCM drains. Initial retries happen while `playStreamUrl()` is pending and do not emit `reconnecting` because the stream has not been returned yet; `reconnect.retry` still observes and can stop them. `maxRetries` limits consecutive retries for one outage and resets after a replacement decoder becomes ready; omitting it means unlimited retries. An `AbortSignal` or `dispose()` stops them.
+
+Each replacement response creates a new demuxer and can advertise a different ICY interval. Existing metadata remains available while reconnecting, then the replacement clears prior fields. A response without ICY headers clears metadata.
+
+Reconnect options default to `initialDelayMs: 1000`, `maxDelayMs: 15000`, `backoffFactor: 2`, `retryOnEnd: false`, and unlimited `maxRetries`. Valid `Retry-After` values override exponential backoff up to `maxDelayMs`. `reconnect.retry` can override default URL response classification; `{}` keeps the transport delay, while `{ delayMs }` replaces it.
+
+### Byte streams
+
+`playStream()` accepts encoded MP3 or FLAC bytes and is one-shot. Input chunks must be `Uint8Array`; request and reconnect options belong to the other entry points. Backpressure and encoded/decoded buffering remain bounded.
+
+Pass a demuxer factory when framing or metadata is interleaved with the encoded audio. The built-in ICY demuxer accepts semantic options directly and does not require HTTP headers:
+
+```typescript
+import { Audio, createIcyStreamDemuxer } from "@opentui/core"
+
+const stream = await audio.playStream(socketBytes, {
+  format: "mp3",
+  demuxer: () =>
+    createIcyStreamDemuxer({
+      metadataInterval: negotiatedInterval,
+      metadataEncoding: "utf-8",
+    }),
+})
+
+stream.on("metadata", (metadata) => {
+  const title = metadata?.fields.StreamTitle?.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+  console.log(title)
+})
+```
+
+`createIcyStreamDemuxer()` defaults to the same ISO-8859-1/`windows-1252` decoding as URL streams. Optional `headers` are copied, lowercased, and exposed in metadata; non-HTTP transports can omit them.
+
+### Custom connectors
+
+A connector creates one transport connection at a time. It receives `{ signal, attempt }` and returns `{ body, info, close? }`. The initial connection uses attempt `0`; every reconnect gets a new connection and demuxer. Consecutive attempt numbering resets after a replacement decoder becomes ready, while `getStats().reconnectAttempts` remains cumulative.
+
+```typescript
+import { Audio, createIcyStreamDemuxer, type AudioStreamConnector } from "@opentui/core"
+
+interface RadioInfo {
+  metadataInterval: number
+}
+
+const connector: AudioStreamConnector<RadioInfo> = {
+  async connect({ signal }) {
+    const connection = await openRadioConnection({ signal })
+    return {
+      body: connection.readable,
+      info: { metadataInterval: connection.metadataInterval },
+      close: () => connection.close(),
+    }
+  },
+}
+
+const stream = await audio.playStreamSource(connector, {
+  format: "mp3",
+  reconnect: {
+    maxRetries: 5,
+    retry() {
+      return {}
+    },
+  },
+  demuxer: (info) => createIcyStreamDemuxer({ metadataInterval: info.metadataInterval }),
+})
+```
+
+`reconnect.retry(error, context)` is optional for URL and custom connectors. Custom connector and body-read failures are retryable by default. Return `false` to stop, `{}` to keep the transport hint or normal backoff, or `{ delayMs }` for a bounded finite non-negative integer delay. `context` contains the next `attempt`, `maxRetries`, and `phase`. `close()` is invoked once after EOF, failure, or cancellation; cleanup gets a bounded grace period so an uncooperative transport cannot prevent shutdown.
+
+Custom demuxers expose `initialMetadata`, `push(chunk)`, and `flush()`, with optional `abort(reason)`. `push()` and `flush()` return ordered `{ type: "audio", data }` or `{ type: "metadata", metadata }` outputs. Flush output is consumed before decoder EOF; interruption calls `abort()` instead. A `push()` exception is a terminal demuxer error. A `flush()` exception reports truncated input and follows the reconnect read policy. `AudioStream<M>` exposes the same metadata type through `getMetadata()` and `metadata` events. Custom demuxers should return immutable snapshots and suppress equivalent updates when desired.
+
+### Options and lifecycle
+
+| Shared option       | Default | Description                                               |
+| ------------------- | ------- | --------------------------------------------------------- |
+| `format`            | `"mp3"` | Encoded stream format: MP3 or FLAC                        |
+| `volume`            | `1`     | Stream volume; native playback clamps to `0..4`           |
+| `pan`               | `0`     | Stereo pan; native playback clamps to `-1..1`             |
+| `groupId`           | `0`     | Mixer group                                               |
+| `buffer.capacityMs` | `2000`  | Decoded PCM buffer capacity                               |
+| `buffer.startupMs`  | `1000`  | Initial playback threshold                                |
+| `buffer.resumeMs`   | `1000`  | Resume threshold after starvation                         |
+| `maxProbeBytes`     | `1 MiB` | Maximum encoded bytes inspected during decoder setup      |
+| `signal`            | none    | Cancels setup, retries, source reads, and active playback |
+
+Buffer values must be positive integers; startup and resume thresholds cannot exceed capacity.
+
+| `AudioStream` member                    | Description                                                                                                                             |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`                                 | Latest cached lifecycle state                                                                                                           |
+| `getStats()`                            | Refreshes state and returns sample rate, channels, buffer capacity/use, encoded bytes, decoded/played frames, underruns, and reconnects |
+| `getMetadata()`                         | Latest metadata snapshot or `null`                                                                                                      |
+| `setVolume()`, `setPan()`, `setGroup()` | Controls that remain effective across reconnects                                                                                        |
+| `dispose()`                             | Cancels transport, demuxer, retries, and native playback                                                                                |
+| `closed`                                | Resolves after bounded cleanup and delivery of the terminal `ended`, `error`, or `disposed` event                                       |
+
+Events are `metadata`, `reconnecting`, `ended`, `error`, and `disposed`. Transport, response, demuxer, native creation, and decoder setup failures reject with `AudioStreamError`; validation performed in JavaScript uses `TypeError`/`RangeError`, cancellation uses `AbortError`, and starting a stream after its owning `Audio` was disposed rejects with `Error`. Later terminal failures emit `error` with context. Disposing the owning `Audio` also disposes pending and active streams.
+
+`bytesReceived` counts only encoded audio bytes emitted by the demuxer; framing and metadata are excluded. Final stats and metadata remain readable after natural completion. Native readiness, backpressure, and EOF draining use short-lived polling; there is no persistent idle statistics loop.
+
+In browser-like Fetch environments, cross-origin ICY negotiation requires an appropriate `Access-Control-Allow-Origin`, permission for the `Icy-MetaData` request header, and exposure of `icy-metaint` through CORS. Other `icy-*` response headers must also be exposed for them to appear in `getMetadata().headers`. Legacy servers that respond with the non-HTTP `ICY 200 OK` status line can be rejected by `fetch()` before OpenTUI receives a response.
+
+Streams use the same mixer and master tap as loaded sounds. Once `enableTap()` is active, `readTapFrames()` includes streamed audio automatically. The tap is the combined master mix, not an isolated copy of one stream.
 
 ## Starting audio
 
@@ -129,4 +302,4 @@ The tap is disabled by default. When enabled, it stores the latest frames and ov
 
 ## Lifecycle and errors
 
-Use `start()`, `startMixer()`, `stop()`, `isStarted()`, `isMixerStarted()`, and `dispose()` for lifecycle. `Audio` emits `started`, `mixerStarted`, `stopped`, `disposed`, and `error`. Methods that fail return `false` or `null` and emit `error` with `{ action, status }` context.
+Use `start()`, `startMixer()`, `stop()`, `isStarted()`, `isMixerStarted()`, and `dispose()` for lifecycle. After construction, `Audio` emits `started`, `mixerStarted`, `stopped`, `disposed`, and `error`. Most non-stream operations report failure by returning `false` or `null` and emitting `Audio.error` with `{ action, status }`; stream setup rejection and `AudioStream` errors are described above.

--- a/.agents/skills/opentui/docs/core-concepts/renderables.mdx
+++ b/.agents/skills/opentui/docs/core-concepts/renderables.mdx
@@ -69,8 +69,8 @@ container.add(body)
 
 renderer.root.add(container)
 
-// Later, remove a child
-container.remove("body")
+// Later, remove a child by reference
+container.remove(body)
 ```
 
 ## Finding Renderables
@@ -80,6 +80,10 @@ Navigate the tree to find specific renderables:
 ```typescript
 // Get a direct child by ID
 const title = container.getRenderable("title")
+
+// Remove by ID lookup when needed
+const body = container.getRenderable("body")
+if (body) container.remove(body)
 
 // Recursively search all descendants
 const deepChild = container.findDescendantById("nested-input")

--- a/.agents/skills/opentui/docs/getting-started.mdx
+++ b/.agents/skills/opentui/docs/getting-started.mdx
@@ -16,7 +16,7 @@ OpenTUI is a native terminal UI core written in Zig with TypeScript bindings. Th
 
 OpenTUI's renderer examples use [Bun](https://bun.sh). You can import portable entry points such as `@opentui/keymap` and
 `@opentui/core` in Node.js without installing Bun or enabling FFI. These imports do not create a native renderer. To
-create a native renderer in Node.js, you need Node.js 26.3.0 with experimental FFI enabled.
+create a native renderer in Node.js, you need Node.js 26.4.0 with experimental FFI enabled.
 
 ```bash
 mkdir my-tui && cd my-tui
@@ -30,7 +30,7 @@ Importing packages does not require native FFI. For example, Node.js can load
 `await import("@opentui/keymap")` and `await import("@opentui/core")` without `--experimental-ffi`.
 
 Creating a native renderer requires FFI. This includes calling `createCliRenderer()` or any other API that loads and calls
-OpenTUI's native Zig renderer. In Node.js, use Node.js 26.3.0 with `--experimental-ffi`. If you use Node.js permissions,
+OpenTUI's native Zig renderer. In Node.js, use Node.js 26.4.0 with `--experimental-ffi`. If you use Node.js permissions,
 you must also add `--allow-ffi` and the filesystem permissions your app needs. OpenTUI does not install Node.js, so select
 the required version before you run Node.js-specific examples or scripts.
 

--- a/.agents/skills/opentui/docs/keymap/overview.mdx
+++ b/.agents/skills/opentui/docs/keymap/overview.mdx
@@ -19,7 +19,7 @@ bun add @opentui/keymap
 ```
 
 The keymap package contains only JavaScript. You can import it in Node.js without installing Bun or enabling native FFI.
-You can also import the OpenTUI host helpers. However, creating a native renderer in Node.js requires Node.js 26.3.0 with
+You can also import the OpenTUI host helpers. However, creating a native renderer in Node.js requires Node.js 26.4.0 with
 experimental FFI. For details, see [Getting started](/docs/getting-started#runtime-support).
 
 Live demo: [HTML keymap demo](/demos/keymap-html/)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,13 +5,7 @@
       "source": "anomalyco/opentui",
       "sourceType": "github",
       "skillPath": "packages/web/src/content/SKILL.md",
-      "computedHash": "1bdc3b78601e9a38acea372ad0ca6173b1fbe9fde315e5f13c7c52bf99789205"
-    },
-    "vercel-react-best-practices": {
-      "source": "vercel-labs/agent-skills",
-      "sourceType": "github",
-      "skillPath": "skills/react-best-practices/SKILL.md",
-      "computedHash": "ca7b0c0c6e5f2750043f7f0cd72d16ac4e2abc48f9b5500d047a4b77a2506212"
+      "computedHash": "91564dd09a740dde98c81e0668664d32c2ed77551c3139e3552d4906b8e3ecba"
     }
   }
 }

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -54,7 +54,12 @@ export async function loadTimeline(
     return (data as Record<string, unknown>[]).map(migrateEntry)
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") return []
-    return []
+    throw new Error(
+      `filestore.loadTimeline: failed to load timeline for ${reqId}`,
+      {
+        cause: e,
+      },
+    )
   }
 }
 

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -43,15 +43,31 @@ function migrateEntry(entry: Record<string, unknown>): TimelineEntry {
   } as TimelineEntry
 }
 
+function parseTimeline(raw: string): TimelineEntry[] {
+  const data = yaml.load(raw)
+  if (!Array.isArray(data)) return []
+  return (data as Record<string, unknown>[]).map(migrateEntry)
+}
+
+async function readTimelineEntries(
+  colDir: string,
+  reqId: string,
+): Promise<TimelineEntry[]> {
+  try {
+    const raw = await readFile(timelinePath(colDir, reqId), "utf8")
+    return parseTimeline(raw)
+  } catch {
+    return []
+  }
+}
+
 export async function loadTimeline(
   colDir: string,
   reqId: string,
 ): Promise<TimelineEntry[]> {
   try {
     const raw = await readFile(timelinePath(colDir, reqId), "utf8")
-    const data = yaml.load(raw)
-    if (!Array.isArray(data)) return []
-    return (data as Record<string, unknown>[]).map(migrateEntry)
+    return parseTimeline(raw)
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") return []
     throw new Error(
@@ -72,7 +88,7 @@ export async function saveTimelineEntry(
   const filePath = timelinePath(colDir, reqId)
   await mkdir(dirname(filePath), { recursive: true })
 
-  const current = await loadTimeline(colDir, reqId)
+  const current = await readTimelineEntries(colDir, reqId)
   current.unshift(entry)
 
   if (current.length > maxEntries) {

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -682,6 +682,7 @@ export function useRequestDraft(
     authTypeCache.clear()
     bodyCache.clear()
     setMap(new Map())
+    setOriginalMap(new Map())
   }, [])
 
   const mapRef = useRef(map)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,6 +35,7 @@ export function App({
   )
   const [activeCollectionDir, setActiveCollectionDir] =
     useState(initialCollectionDir)
+  const [reloadKey, setReloadKey] = useState(0)
   const [settingsEnv, setSettingsEnv] = useState<string | undefined>(
     initialSettingsEnv,
   )
@@ -116,6 +117,10 @@ export function App({
     [activeCollectionDir],
   )
 
+  const handleReloadCollection = useCallback(() => {
+    setReloadKey((k) => k + 1)
+  }, [])
+
   const handleCollectionChange = useCallback(
     async (nextDir: string) => {
       if (switchingRef.current) return
@@ -189,7 +194,7 @@ export function App({
     <ThemeProvider activeIndex={activeIndex} previewIndex={previewIndex}>
       <Toast />
       <AppInner
-        key={activeCollectionDir}
+        key={`${activeCollectionDir}__${reloadKey}`}
         collectionDir={activeCollectionDir}
         environmentsDir={activeEnvironmentsDir}
         envNames={envNames}
@@ -209,6 +214,7 @@ export function App({
         initialLastRequestId={lastRequestId}
         collectionPaths={collectionPaths}
         onCollectionChange={handleCollectionChange}
+        onReloadCollection={handleReloadCollection}
       />
     </ThemeProvider>
   )

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -100,6 +100,7 @@ export function AppInner({
   const viewRef = useRef(view)
   viewRef.current = view
   const [helpVisible, setHelpVisible] = useState(false)
+  const [aboutVisible, setAboutVisible] = useState(false)
   const [layout, setLayout] = useState<"stacked" | "side-by-side">(
     initialLayout,
   )
@@ -378,35 +379,38 @@ export function AppInner({
       ? "command-palette"
       : helpVisible
         ? "help"
-        : previewIndex !== null
-          ? "theme"
-          : saveState.kind === "confirming"
-            ? "confirm"
-            : undoAllPending
-              ? "undo-all"
-              : collectionSwitchPending !== null
-                ? "collection-switch-confirm"
-                : collectionSwitcherVisible
-                  ? "collection-switcher"
-                  : yamlEditor.visible
-                    ? "yaml-editor"
-                    : newRequestVisible
-                      ? "new-request"
-                      : editRequestVisible
-                        ? "edit-request"
-                        : cloneRequestVisible
-                          ? "clone-request"
-                          : newFolderVisible
-                            ? "new-folder"
-                            : folderDeletePending !== null
-                              ? "delete-folder"
-                              : requestDeletePending !== null
-                                ? "request-delete"
-                                : "none"
+        : aboutVisible
+          ? "about"
+          : previewIndex !== null
+            ? "theme"
+            : saveState.kind === "confirming"
+              ? "confirm"
+              : undoAllPending
+                ? "undo-all"
+                : collectionSwitchPending !== null
+                  ? "collection-switch-confirm"
+                  : collectionSwitcherVisible
+                    ? "collection-switcher"
+                    : yamlEditor.visible
+                      ? "yaml-editor"
+                      : newRequestVisible
+                        ? "new-request"
+                        : editRequestVisible
+                          ? "edit-request"
+                          : cloneRequestVisible
+                            ? "clone-request"
+                            : newFolderVisible
+                              ? "new-folder"
+                              : folderDeletePending !== null
+                                ? "delete-folder"
+                                : requestDeletePending !== null
+                                  ? "request-delete"
+                                  : "none"
     keymap.setData("app.overlay", overlay)
   }, [
     commandPaletteVisible,
     helpVisible,
+    aboutVisible,
     previewIndex,
     saveState.kind,
     yamlEditor.visible,
@@ -693,6 +697,8 @@ export function AppInner({
     saveTimerRef,
     helpVisible,
     setHelpVisible,
+    aboutVisible,
+    setAboutVisible,
     view,
     setView,
     focusRef,
@@ -776,6 +782,7 @@ export function AppInner({
         setLayout,
         onLayoutChange,
         setHelpVisible,
+        setAboutVisible,
         setNewRequestVisible,
         setNewFolderVisible,
         setCloneRequestVisible,
@@ -866,6 +873,7 @@ export function AppInner({
         <AppOverlays
           keybinds={keybinds}
           helpVisible={helpVisible}
+          aboutVisible={aboutVisible}
           saveState={saveState}
           confirmSelection={confirmSelection}
           envDeletePending={envDeletePending}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -68,6 +68,7 @@ export function AppInner({
   initialLastRequestId,
   collectionPaths,
   onCollectionChange,
+  onReloadCollection,
 }: {
   collectionDir: string
   environmentsDir: string
@@ -88,6 +89,7 @@ export function AppInner({
   initialLastRequestId?: string
   collectionPaths: string[]
   onCollectionChange: (collectionDir: string) => void
+  onReloadCollection: () => void
 }) {
   const keymap = useKeymap()
   const theme = useTheme()
@@ -798,6 +800,8 @@ export function AppInner({
         setPreviewIndexProp,
         setEnvDeletePending,
         setDeleteConfirmSelection,
+        setCollectionReloadToken,
+        onReloadCollection,
       }),
     [
       keybinds,
@@ -805,6 +809,8 @@ export function AppInner({
       confirmUndoAll,
       onLayoutChange,
       setCollectionSwitcherVisible,
+      setCollectionReloadToken,
+      onReloadCollection,
       view,
     ],
   )

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -805,7 +805,6 @@ export function AppInner({
         setPreviewIndexProp,
         setEnvDeletePending,
         setDeleteConfirmSelection,
-        setCollectionReloadToken,
         onReloadCollection,
       }),
     [
@@ -814,7 +813,6 @@ export function AppInner({
       confirmUndoAll,
       onLayoutChange,
       setCollectionSwitcherVisible,
-      setCollectionReloadToken,
       onReloadCollection,
       view,
     ],

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -10,7 +10,7 @@ import { useTreeNavigation } from "../hooks/useTreeNavigation"
 import { deriveRequestParentFolder, getFolderPaths } from "./tree"
 import { useResponse } from "../hooks/useResponse"
 import type { SendCompleteResult } from "../hooks/useResponse"
-import type { Request as NoodleRequest, Method } from "../schema"
+import type { Request as NoodleRequest, Method, TimelineEntry } from "../schema"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
 import { useFolderDraft } from "../hooks/useFolderDraft"
@@ -153,6 +153,8 @@ export function AppInner({
   const folderDeletePathRef = useRef<string | null>(null)
   const [undoAllPending, setUndoAllPending] = useState(false)
   const [commandPaletteVisible, setCommandPaletteVisible] = useState(false)
+  const [timelineDetailEntry, setTimelineDetailEntry] =
+    useState<TimelineEntry | null>(null)
   const [collectionSwitcherVisible, setCollectionSwitcherVisible] =
     useState(false)
   const [collectionSwitchPending, setCollectionSwitchPending] = useState<
@@ -407,7 +409,9 @@ export function AppInner({
                                 ? "delete-folder"
                                 : requestDeletePending !== null
                                   ? "request-delete"
-                                  : "none"
+                                  : timelineDetailEntry !== null
+                                    ? "timeline-detail"
+                                    : "none"
     keymap.setData("app.overlay", overlay)
   }, [
     commandPaletteVisible,
@@ -425,6 +429,7 @@ export function AppInner({
     undoAllPending,
     collectionSwitchPending,
     collectionSwitcherVisible,
+    timelineDetailEntry,
     keymap,
   ])
 
@@ -861,6 +866,7 @@ export function AppInner({
             timelineEntries={timeline.entries}
             initialResponseTab={initialResponseTab}
             onResponseTabChange={onResponseTabChange}
+            onOpenTimelineEntry={(entry) => setTimelineDetailEntry(entry)}
             setSelectOpen={setSelectOpen}
             expandHint={expandHint}
           />
@@ -922,6 +928,9 @@ export function AppInner({
           newFolderRef={newFolderRef}
           folderDeletePending={folderDeletePending}
           requestDeletePending={requestDeletePending}
+          timelineDetailEntry={timelineDetailEntry}
+          setTimelineDetailEntry={setTimelineDetailEntry}
+          envColors={envColors}
         />
       </box>
       <StatusBar

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -21,7 +21,12 @@ import {
   NewFolderOverlay,
   type NewFolderOverlayHandle,
 } from "./overlays/NewFolderOverlay"
-import type { Environment, Request as NoodleRequest } from "../schema"
+import type {
+  Environment,
+  Request as NoodleRequest,
+  TimelineEntry,
+} from "../schema"
+import { TimelineDetailOverlay } from "./overlays/TimelineDetailOverlay"
 import type { Keybinds } from "./keybind"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
@@ -87,6 +92,9 @@ interface AppOverlaysProps {
   newFolderRef: RefObject<NewFolderOverlayHandle | null>
   folderDeletePending: string | null
   requestDeletePending: string | null
+  timelineDetailEntry: TimelineEntry | null
+  setTimelineDetailEntry: (entry: TimelineEntry | null) => void
+  envColors: Record<string, string | undefined>
 }
 
 export function AppOverlays({
@@ -135,6 +143,9 @@ export function AppOverlays({
   newFolderRef,
   folderDeletePending,
   requestDeletePending,
+  timelineDetailEntry,
+  setTimelineDetailEntry,
+  envColors,
 }: AppOverlaysProps) {
   return (
     <>
@@ -276,6 +287,14 @@ export function AppOverlays({
           visible
           message={`Delete "${requestDeletePending}"?`}
           selectedIndex={deleteConfirmSelection}
+        />
+      )}
+      {timelineDetailEntry !== null && (
+        <TimelineDetailOverlay
+          visible
+          entry={timelineDetailEntry}
+          onClose={() => setTimelineDetailEntry(null)}
+          envColors={envColors}
         />
       )}
     </>

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -1,5 +1,6 @@
 import type { RefObject } from "react"
 import { HelpOverlay } from "./overlays/HelpOverlay"
+import { AboutOverlay } from "./overlays/AboutOverlay"
 import { ConfirmOverlay } from "./overlays/ConfirmOverlay"
 import {
   CommandPaletteOverlay,
@@ -43,6 +44,7 @@ interface YamlEditorState {
 interface AppOverlaysProps {
   keybinds: Keybinds
   helpVisible: boolean
+  aboutVisible: boolean
   saveState: SaveState
   confirmSelection: number
   envDeletePending: string | null
@@ -90,6 +92,7 @@ interface AppOverlaysProps {
 export function AppOverlays({
   keybinds,
   helpVisible,
+  aboutVisible,
   saveState,
   confirmSelection,
   envDeletePending,
@@ -136,6 +139,7 @@ export function AppOverlays({
   return (
     <>
       {helpVisible && <HelpOverlay visible keybinds={keybinds} />}
+      {aboutVisible && <AboutOverlay visible />}
       {saveState.kind === "confirming" && (
         <ConfirmOverlay
           visible

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -16,6 +16,7 @@ export function Badge({
         paddingLeft: 1,
         paddingRight: 1,
         flexShrink: 0,
+        alignSelf: "flex-start",
       }}
     >
       <text fg={fg}>{children}</text>

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -34,6 +34,7 @@ interface MainViewProps {
   timelineEntries: import("../schema").TimelineEntry[]
   initialResponseTab?: import("./tabs/uiState").ResponseTabKind
   onResponseTabChange: (tab: import("./tabs/uiState").ResponseTabKind) => void
+  onOpenTimelineEntry?: (entry: import("../schema").TimelineEntry) => void
   setSelectOpen: (open: boolean) => void
   expandHint: string
 }
@@ -61,6 +62,7 @@ export function MainView({
   timelineEntries,
   initialResponseTab,
   onResponseTabChange,
+  onOpenTimelineEntry,
   setSelectOpen,
   expandHint,
 }: MainViewProps) {
@@ -119,6 +121,7 @@ export function MainView({
             timelineEntries={timelineEntries}
             initialResponseTab={initialResponseTab}
             onResponseTabChange={onResponseTabChange}
+            onOpenTimelineEntry={onOpenTimelineEntry}
             setSelectOpen={setSelectOpen}
             expandHint={expandHint}
           />

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -20,6 +20,7 @@ interface RequestResponseViewProps {
   timelineEntries: TimelineEntry[]
   initialResponseTab?: ResponseTabKind
   onResponseTabChange: (tab: ResponseTabKind) => void
+  onOpenTimelineEntry?: (entry: TimelineEntry) => void
   setSelectOpen: (open: boolean) => void
   expandHint: string
 }
@@ -36,6 +37,7 @@ export function RequestResponseView({
   timelineEntries,
   initialResponseTab,
   onResponseTabChange,
+  onOpenTimelineEntry,
   setSelectOpen,
   expandHint,
 }: RequestResponseViewProps) {
@@ -67,6 +69,7 @@ export function RequestResponseView({
           timelineEntries={timelineEntries}
           initialTab={initialResponseTab}
           onTabChange={onResponseTabChange}
+          onOpenTimelineEntry={onOpenTimelineEntry}
           expandHint={expandHint}
         />
       )}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -28,6 +28,7 @@ export function ResponsePane({
   timelineEntries,
   initialTab,
   onTabChange,
+  onOpenTimelineEntry,
   expandHint,
 }: {
   state: SendState
@@ -35,6 +36,7 @@ export function ResponsePane({
   timelineEntries?: TimelineEntry[]
   initialTab?: "body" | "headers" | "timeline"
   onTabChange?: (tab: "body" | "headers" | "timeline") => void
+  onOpenTimelineEntry?: (entry: TimelineEntry) => void
   expandHint?: string
 }) {
   const theme = useTheme()
@@ -187,7 +189,11 @@ export function ResponsePane({
         <box style={{ flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
           <Tabs tabs={TAB_DEFS} activeId={activeTab}>
             {activeTab === "timeline" ? (
-              <TimelineTab entries={timelineEntries ?? []} focused={focused} />
+              <TimelineTab
+                entries={timelineEntries ?? []}
+                focused={focused}
+                onOpenEntry={onOpenTimelineEntry}
+              />
             ) : (
               <scrollbox
                 ref={scrollRef}

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -250,6 +250,10 @@ export function openThemePicker(): boolean {
   return true
 }
 
+export function openAbout(): boolean {
+  return true
+}
+
 export function openCollectionSwitcher(view: string): boolean {
   if (view === "env-editor") {
     showToast("Cannot switch collections from environment editor", "warning")

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -131,7 +131,6 @@ export interface CommandBuilderContext {
     s: string | null | ((prev: string | null) => string | null),
   ) => void
   setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
-  setCollectionReloadToken: (fn: (n: number) => number) => void
   onReloadCollection: () => void
 }
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -131,6 +131,8 @@ export interface CommandBuilderContext {
     s: string | null | ((prev: string | null) => string | null),
   ) => void
   setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
+  setCollectionReloadToken: (fn: (n: number) => number) => void
+  onReloadCollection: () => void
 }
 
 function toConfig(ctx: CommandBuilderContext): CommandActionsConfig {
@@ -464,6 +466,15 @@ export function buildCommandPaletteCommands(
       run: () => {
         if (!openCollectionSwitcher(view)) return false
         setCollectionSwitcherVisible(true)
+        return true
+      },
+    },
+    {
+      id: "collection.reload",
+      label: "Reload Collection",
+      section: "System",
+      run: () => {
+        ctx.onReloadCollection()
         return true
       },
     },

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -29,6 +29,7 @@ import {
   togglePaneExpand,
   undoAll,
   openThemePicker,
+  openAbout,
   openCollectionSwitcher,
   type CommandActionsConfig,
 } from "./commandActions"
@@ -63,6 +64,7 @@ export interface CommandBuilderContext {
   ) => void
   onLayoutChange: (layout: "stacked" | "side-by-side") => void
   setHelpVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setAboutVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setNewRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setNewFolderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setCloneRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
@@ -176,6 +178,7 @@ export function buildCommandPaletteCommands(
     getKeymapFocus,
     getView,
     setHelpVisible,
+    setAboutVisible,
     setPreviewIndexProp,
     setCollectionSwitcherVisible,
     setEnvDeletePending,
@@ -432,6 +435,15 @@ export function buildCommandPaletteCommands(
       run: () => {
         setHelpVisible((prev: boolean) => !prev)
         return true
+      },
+    },
+    {
+      id: "app.about",
+      label: "About Noodle",
+      section: "System",
+      run: () => {
+        setAboutVisible(true)
+        return openAbout()
       },
     },
     {

--- a/src/ui/overlays/AboutOverlay.tsx
+++ b/src/ui/overlays/AboutOverlay.tsx
@@ -1,0 +1,44 @@
+import { TextAttributes } from "@opentui/core"
+import pkg from "../../../package.json" with { type: "json" }
+import { useTheme } from "../theme"
+import { Overlay } from "./Overlay"
+
+export function AboutOverlay({ visible }: { visible: boolean }) {
+  const theme = useTheme()
+
+  return (
+    <Overlay visible={visible} width={60} gap={1} padding={1}>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingLeft: 4,
+          paddingRight: 4,
+        }}
+      >
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          About
+        </text>
+        <text fg={theme.textMuted}>esc</text>
+      </box>
+      <box style={{ flexDirection: "column", gap: 1, paddingX: 4 }}>
+        <text fg={theme.text}>Noodle v{pkg.version}</text>
+        <text fg={theme.textMuted}>
+          Free, open-source REST client that runs entirely in your terminal.
+        </text>
+        <text>
+          <a href="https://github.com/wilfredinni/noodle" fg={theme.primary}>
+            GitHub
+          </a>
+          <span fg={theme.textMuted}> · </span>
+          <a
+            href="https://github.com/wilfredinni/noodle/releases"
+            fg={theme.primary}
+          >
+            Releases
+          </a>
+        </text>
+      </box>
+    </Overlay>
+  )
+}

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -49,7 +49,7 @@ export function TimelineDetailOverlay({
 
   useEffect(() => {
     if (visible) setActiveTab("response")
-  }, [visible, entry?.timestamp])
+  }, [visible])
 
   useKeyboard((key) => {
     if (!visible || !entry) return

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useRef, useState } from "react"
+import { useKeyboard } from "@opentui/react"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import type { TimelineEntry } from "../../schema"
+import { VALID_COLORS } from "../../env/constants"
+import { useTheme } from "../theme"
+import { Overlay } from "./Overlay"
+import { Tabs, type TabDef } from "../Tabs"
+import { Badge } from "../Badge"
+import { formatBody, formatHeaders, formatSize, statusColor } from "../format"
+import { methodColor } from "../formatRequest"
+import { JsonBodyViewer } from "../editor/JsonBodyViewer"
+import {
+  authSummary,
+  entryMethod,
+  entryStatus,
+  entryTiming,
+  formatRequestUrl,
+  shortMethod,
+} from "../timeline/formatTimeline"
+
+const TAB_DEFS: TabDef[] = [
+  { id: "response", label: "Response" },
+  { id: "request", label: "Request" },
+]
+
+function formatRequestBody(body: string): string {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2)
+  } catch {
+    return body
+  }
+}
+
+export function TimelineDetailOverlay({
+  visible,
+  entry,
+  onClose,
+  envColors,
+}: {
+  visible: boolean
+  entry: TimelineEntry | null
+  onClose: () => void
+  envColors?: Record<string, string | undefined>
+}) {
+  const theme = useTheme()
+  const [activeTab, setActiveTab] = useState<"request" | "response">("response")
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+
+  useEffect(() => {
+    if (visible) setActiveTab("response")
+  }, [visible, entry?.timestamp])
+
+  useKeyboard((key) => {
+    if (!visible || !entry) return
+    if (key.name === "escape") {
+      onClose()
+    } else if (key.name === "left" || key.name === "right") {
+      setActiveTab((prev) => (prev === "request" ? "response" : "request"))
+    } else if (key.name === "up") {
+      scrollRef.current?.scrollBy(-1)
+    } else if (key.name === "down") {
+      scrollRef.current?.scrollBy(1)
+    } else if (key.name === "pageup") {
+      scrollRef.current?.scrollBy(-1, "viewport")
+    } else if (key.name === "pagedown") {
+      scrollRef.current?.scrollBy(1, "viewport")
+    }
+  })
+
+  if (!visible || !entry) return null
+
+  const method = entryMethod(entry)
+  const status = entryStatus(entry)
+  const envColorKey = entry.envName ? envColors?.[entry.envName] : undefined
+  const envBadgeBg =
+    envColorKey && VALID_COLORS.has(envColorKey)
+      ? ((theme as unknown as Record<string, string>)[envColorKey] ??
+        theme.info)
+      : theme.info
+
+  const requestHeaders = Object.entries(entry.request.headers)
+    .filter(([, value]) => value.enabled)
+    .map(([key, value]) => ({ key, value: value.value }))
+    .sort((a, b) => a.key.localeCompare(b.key))
+  const responseHeaders = entry.response ? formatHeaders(entry.response) : []
+  const requestMaxKeyLen = requestHeaders.reduce(
+    (max, header) => Math.max(max, header.key.length),
+    0,
+  )
+  const responseMaxKeyLen = responseHeaders.reduce(
+    (max, header) => Math.max(max, header.key.length),
+    0,
+  )
+  const requestBody = entry.request.body
+    ? formatRequestBody(entry.request.body)
+    : ""
+  const responseBody = entry.response?.body ? formatBody(entry.response) : ""
+
+  return (
+    <Overlay visible width={70} gap={1} padding={1}>
+      <box
+        style={{
+          paddingLeft: 4,
+          paddingRight: 4,
+          flexDirection: "column",
+          flexGrow: 1,
+          minHeight: 0,
+        }}
+      >
+        <Tabs
+          tabs={TAB_DEFS}
+          activeId={activeTab}
+          rightChildren={<text fg={theme.textMuted}>esc</text>}
+        >
+          <scrollbox
+            ref={scrollRef}
+            scrollY
+            maxHeight={24}
+            scrollbarOptions={{ visible: false }}
+            style={{ flexGrow: 1, minHeight: 0 }}
+          >
+            {activeTab === "request" && (
+              <box style={{ flexDirection: "column", gap: 0, paddingTop: 1 }}>
+                <box style={{ flexDirection: "row" }}>
+                  <text fg={methodColor(method, theme)}>
+                    {shortMethod(method)}
+                  </text>
+                  <text
+                    fg={theme.primary}
+                    wrapMode="none"
+                    style={{ flexShrink: 1, minWidth: 10 }}
+                  >
+                    {" "}
+                    {formatRequestUrl(entry)}
+                  </text>
+                </box>
+                <box
+                  style={{
+                    flexDirection: "row",
+                    minWidth: 0,
+                  }}
+                >
+                  <text
+                    fg={theme.textMuted}
+                    wrapMode="none"
+                    style={{ flexShrink: 1, minWidth: 10 }}
+                  >
+                    {entry.request.id}
+                  </text>
+                </box>
+                {authSummary(entry.request.auth) && (
+                  <text fg={theme.textMuted}>
+                    {authSummary(entry.request.auth)}
+                  </text>
+                )}
+                <box
+                  border={["bottom"]}
+                  borderColor={theme.borderSubtle}
+                  style={{ marginTop: 1 }}
+                >
+                  <text fg={theme.text}>Headers</text>
+                </box>
+                {requestHeaders.length === 0 ? (
+                  <text fg={theme.textMuted}>(no headers)</text>
+                ) : (
+                  requestHeaders.map(({ key, value }, index) => (
+                    <box
+                      key={key}
+                      border={
+                        index < requestHeaders.length - 1 ? ["bottom"] : []
+                      }
+                      borderColor={theme.borderDimmest}
+                      style={{ flexDirection: "row" }}
+                    >
+                      <text
+                        fg={theme.textMuted}
+                        style={{ minWidth: requestMaxKeyLen + 1 }}
+                      >
+                        {key.padEnd(requestMaxKeyLen)}
+                      </text>
+                      <text fg={theme.textMuted} wrapMode="none">
+                        : {value}
+                      </text>
+                    </box>
+                  ))
+                )}
+                <box
+                  border={["bottom"]}
+                  borderColor={theme.borderSubtle}
+                  style={{ marginTop: 1 }}
+                >
+                  <text fg={theme.text}>Body</text>
+                </box>
+                {requestBody ? (
+                  <JsonBodyViewer
+                    key={requestBody}
+                    body={requestBody}
+                    theme={theme}
+                    readOnly
+                  />
+                ) : (
+                  <text fg={theme.textMuted}>(no body)</text>
+                )}
+              </box>
+            )}
+            {activeTab === "response" && (
+              <box style={{ flexDirection: "column", gap: 0, paddingTop: 1 }}>
+                {entry.error ? (
+                  <box
+                    border={["left", "right", "top", "bottom"]}
+                    borderColor={theme.error}
+                    style={{ padding: 1, marginBottom: 1 }}
+                  >
+                    <text fg={theme.error}>{entry.error.message}</text>
+                  </box>
+                ) : entry.response ? (
+                  <box
+                    style={{
+                      flexDirection: "row",
+                      marginBottom: 1,
+                      minWidth: 0,
+                    }}
+                  >
+                    <box style={{ flexDirection: "row", flexShrink: 0 }}>
+                      <Badge
+                        bg={statusColor(status!, theme)}
+                        fg={theme.background}
+                      >
+                        {status}
+                        {entry.response.statusText
+                          ? ` ${entry.response.statusText}`
+                          : ""}
+                      </Badge>
+                      {entry.envName && (
+                        <box style={{ marginLeft: 1 }}>
+                          <Badge bg={envBadgeBg} fg={theme.background}>
+                            {entry.envName}
+                          </Badge>
+                        </box>
+                      )}
+                    </box>
+                    <box style={{ flexGrow: 1 }} />
+                    <text fg={theme.textMuted} wrapMode="none">
+                      {formatSize(entry.response.size)} in {entryTiming(entry)}
+                    </text>
+                  </box>
+                ) : (
+                  <text fg={theme.textMuted}>No response</text>
+                )}
+                <box border={["bottom"]} borderColor={theme.borderSubtle}>
+                  <text fg={theme.text}>Headers</text>
+                </box>
+                {responseHeaders.length === 0 ? (
+                  <text fg={theme.textMuted}>(no headers)</text>
+                ) : (
+                  responseHeaders.map(({ key, value }, index) => (
+                    <box
+                      key={key}
+                      border={
+                        index < responseHeaders.length - 1 ? ["bottom"] : []
+                      }
+                      borderColor={theme.borderDimmest}
+                      style={{ flexDirection: "row" }}
+                    >
+                      <text
+                        fg={theme.textMuted}
+                        style={{ minWidth: responseMaxKeyLen + 1 }}
+                      >
+                        {key.padEnd(responseMaxKeyLen)}
+                      </text>
+                      <text fg={theme.textMuted} wrapMode="none">
+                        : {value}
+                      </text>
+                    </box>
+                  ))
+                )}
+                <box
+                  border={["bottom"]}
+                  borderColor={theme.borderSubtle}
+                  style={{ marginTop: 1 }}
+                >
+                  <text fg={theme.text}>Body</text>
+                </box>
+                {entry.response ? (
+                  responseBody ? (
+                    <JsonBodyViewer
+                      key={responseBody}
+                      body={responseBody}
+                      theme={theme}
+                      readOnly
+                    />
+                  ) : (
+                    <text fg={theme.textMuted}>(empty body)</text>
+                  )
+                ) : (
+                  <text fg={theme.textMuted}>No response</text>
+                )}
+              </box>
+            )}
+          </scrollbox>
+        </Tabs>
+      </box>
+    </Overlay>
+  )
+}

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -1,72 +1,32 @@
 import type { TimelineEntry as TimelineEntryType } from "../../schema"
 import { useTheme } from "../theme"
-import {
-  formatHeaders,
-  formatStatusLine,
-  statusColor,
-  formatSize,
-} from "../format"
+import { statusColor } from "../format"
 import {
   entryMethod,
   entryStatus,
   entryTiming,
   relativeTime,
   truncateUrl,
+  shortMethod,
+  formatRequestUrl,
 } from "./formatTimeline"
 import { methodColor } from "../formatRequest"
-
-function shortMethod(m: string): string {
-  return m === "DELETE" ? "DEL" : m
-}
-
-function formatRequestHeaders(entry: TimelineEntryType): string[] {
-  const lines: string[] = []
-  for (const [k, v] of Object.entries(entry.request.headers)) {
-    if (v.enabled) lines.push(`${k}: ${v.value}`)
-  }
-  return lines.sort()
-}
-
-function formatRequestUrl(entry: TimelineEntryType): string {
-  const u = entry.request.url
-  const params = entry.request.params
-  const enabled = params.filter((p) => p.enabled)
-  if (enabled.length === 0) return u
-  const qs = enabled
-    .map((p) => `${encodeURIComponent(p.name)}=${encodeURIComponent(p.value)}`)
-    .join("&")
-  if (u.includes("?")) return `${u}&${qs}`
-  return `${u}?${qs}`
-}
-
-function authSummary(
-  auth: TimelineEntryType["request"]["auth"],
-): string | null {
-  if (!auth || auth.type === "none") return null
-  if (auth.type === "bearer") return "Bearer token"
-  if (auth.type === "basic") return `Basic ${auth.user}:****`
-  if (auth.type === "api_key") return `${auth.key}: ${auth.value}`
-  return null
-}
 
 export function TimelineEntry({
   id,
   entry,
   isSelected,
-  isExpanded,
   containerWidth,
 }: {
   id?: string
   entry: TimelineEntryType
   isSelected: boolean
-  isExpanded: boolean
   containerWidth: number
 }) {
   const theme = useTheme()
   const status = entryStatus(entry)
   const hasError = entry.error !== undefined
 
-  const prefix = isExpanded ? "▾" : "▸"
   const rowBg = isSelected ? theme.backgroundElement : undefined
   const rowFg = isSelected ? theme.text : theme.textMuted
 
@@ -114,7 +74,7 @@ export function TimelineEntry({
             overflow: "hidden",
           }}
         >
-          <text fg={rowFg}>{prefix} </text>
+          <text fg={rowFg}>⏎ </text>
           <text fg={methodColor(method, theme)}>{methodStr}</text>
           {status !== null ? (
             <text fg={statusColor(status, theme)}>{statusStr}</text>
@@ -133,89 +93,6 @@ export function TimelineEntry({
           {timingStr + " " + reltimeStr}
         </text>
       </box>
-
-      {isExpanded && (
-        <box
-          style={{
-            flexDirection: "column",
-            paddingLeft: 2,
-            paddingRight: 1,
-            gap: 0,
-          }}
-        >
-          <box
-            border={["bottom"]}
-            borderColor={theme.borderSubtle}
-            style={{ paddingLeft: 1 }}
-          >
-            <text fg={theme.text}>Request</text>
-          </box>
-          <box style={{ flexDirection: "column", gap: 0, paddingLeft: 2 }}>
-            <text fg={theme.text}>
-              {" "}
-              {shortMethod(entryMethod(entry))} {formatRequestUrl(entry)}
-            </text>
-            {authSummary(entry.request.auth) && (
-              <text fg={theme.textMuted}>
-                {" "}
-                {authSummary(entry.request.auth)}
-              </text>
-            )}
-            {formatRequestHeaders(entry).map((h) => (
-              <text key={h} fg={theme.textMuted}>
-                {" "}
-                {h}
-              </text>
-            ))}
-            {entry.request.body && (
-              <text fg={theme.text}> {entry.request.body}</text>
-            )}
-            {entry.envName && (
-              <text fg={theme.info}> env: {entry.envName}</text>
-            )}
-          </box>
-          <box
-            border={["bottom"]}
-            borderColor={theme.borderSubtle}
-            style={{ paddingLeft: 1 }}
-          >
-            <text fg={theme.text}>Response</text>
-          </box>
-          <box style={{ flexDirection: "column", gap: 0, paddingLeft: 2 }}>
-            {(() => {
-              const r = entry.response
-              if (r) {
-                return (
-                  <>
-                    <text fg={theme.text}>
-                      {" "}
-                      {formatStatusLine(r) + " · " + formatSize(r.size)}
-                    </text>
-                    {formatHeaders(r).map(({ key, value }) => (
-                      <text key={key} fg={theme.textMuted}>
-                        {" "}
-                        {key}: {value}
-                      </text>
-                    ))}
-                    {r.body && (
-                      <text fg={theme.text}>
-                        {" "}
-                        {r.body.length > 1000
-                          ? r.body.slice(0, 1000) + "..."
-                          : r.body}
-                      </text>
-                    )}
-                  </>
-                )
-              }
-              if (entry.error) {
-                return <text fg={theme.error}> {entry.error.message}</text>
-              }
-              return <text fg={theme.textMuted}> No response</text>
-            })()}
-          </box>
-        </box>
-      )}
     </box>
   )
 }

--- a/src/ui/timeline/TimelineTab.tsx
+++ b/src/ui/timeline/TimelineTab.tsx
@@ -8,9 +8,11 @@ import { TimelineEntry } from "./TimelineEntry"
 export function TimelineTab({
   entries,
   focused,
+  onOpenEntry,
 }: {
   entries: TimelineEntryType[]
   focused: boolean
+  onOpenEntry?: (entry: TimelineEntryType) => void
 }) {
   const theme = useTheme()
   const keymap = useKeymap()
@@ -22,7 +24,6 @@ export function TimelineTab({
   )
 
   const [selectedIdx, setSelectedIdx] = useState(0)
-  const [expandedIdx, setExpandedIdx] = useState<number | null>(null)
   const [containerWidth, setContainerWidth] = useState(0)
   const containerWidthRef = useRef(0)
 
@@ -49,7 +50,6 @@ export function TimelineTab({
 
   useEffect(() => {
     setSelectedIdx(0)
-    setExpandedIdx(null)
   }, [entries.length])
 
   useKeyboard((key) => {
@@ -57,29 +57,20 @@ export function TimelineTab({
     if (entries.length === 0) return
     if (keymap.getData("app.overlay") !== "none") return
 
-    if (expandedIdx === selectedIdx && expandedIdx !== null) {
-      if (key.name === "up") {
-        scrollRef.current?.scrollBy(-1)
-      } else if (key.name === "down") {
-        scrollRef.current?.scrollBy(1)
-      }
-    } else {
-      if (key.name === "up") {
-        setSelectedIdx((prev) => {
-          const next = prev <= 0 ? entries.length - 1 : prev - 1
-          scrollRef.current?.scrollChildIntoView(`tl-${next}`)
-          return next
-        })
-      } else if (key.name === "down") {
-        setSelectedIdx((prev) => {
-          const next = prev >= entries.length - 1 ? 0 : prev + 1
-          scrollRef.current?.scrollChildIntoView(`tl-${next}`)
-          return next
-        })
-      }
-    }
-    if (key.name === "return") {
-      setExpandedIdx((prev) => (prev === selectedIdx ? null : selectedIdx))
+    if (key.name === "up") {
+      setSelectedIdx((prev) => {
+        const next = prev <= 0 ? entries.length - 1 : prev - 1
+        scrollRef.current?.scrollChildIntoView(`tl-${next}`)
+        return next
+      })
+    } else if (key.name === "down") {
+      setSelectedIdx((prev) => {
+        const next = prev >= entries.length - 1 ? 0 : prev + 1
+        scrollRef.current?.scrollChildIntoView(`tl-${next}`)
+        return next
+      })
+    } else if (key.name === "return") {
+      onOpenEntry?.(entries[selectedIdx])
     }
   })
 
@@ -107,7 +98,6 @@ export function TimelineTab({
           id={`tl-${idx}`}
           entry={entry}
           isSelected={idx === selectedIdx}
-          isExpanded={idx === expandedIdx}
           containerWidth={containerWidth}
         />
       ))}

--- a/src/ui/timeline/TimelineTab.tsx
+++ b/src/ui/timeline/TimelineTab.tsx
@@ -70,7 +70,10 @@ export function TimelineTab({
         return next
       })
     } else if (key.name === "return") {
-      onOpenEntry?.(entries[selectedIdx])
+      setSelectedIdx((prev) => {
+        onOpenEntry?.(entries[prev])
+        return prev
+      })
     }
   })
 

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -104,3 +104,37 @@ export function entryTiming(entry: TimelineEntry): string {
 export function entryIsError(entry: TimelineEntry): boolean {
   return entry.error !== undefined
 }
+
+export function shortMethod(m: string): string {
+  return m === "DELETE" ? "DEL" : m
+}
+
+export function formatRequestHeaders(entry: TimelineEntry): string[] {
+  const lines: string[] = []
+  for (const [k, v] of Object.entries(entry.request.headers)) {
+    if (v.enabled) lines.push(`${k}: ${v.value}`)
+  }
+  return lines.sort()
+}
+
+export function formatRequestUrl(entry: TimelineEntry): string {
+  const u = entry.request.url
+  const params = entry.request.params
+  const enabled = params.filter((p) => p.enabled)
+  if (enabled.length === 0) return u
+  const qs = enabled
+    .map((p) => `${encodeURIComponent(p.name)}=${encodeURIComponent(p.value)}`)
+    .join("&")
+  if (u.includes("?")) return `${u}&${qs}`
+  return `${u}?${qs}`
+}
+
+export function authSummary(
+  auth: TimelineEntry["request"]["auth"],
+): string | null {
+  if (!auth || auth.type === "none") return null
+  if (auth.type === "bearer") return "Bearer token"
+  if (auth.type === "basic") return `Basic ${auth.user}:****`
+  if (auth.type === "api_key") return `${auth.key}: ${auth.value}`
+  return null
+}

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -135,6 +135,6 @@ export function authSummary(
   if (!auth || auth.type === "none") return null
   if (auth.type === "bearer") return "Bearer token"
   if (auth.type === "basic") return `Basic ${auth.user}:****`
-  if (auth.type === "api_key") return `${auth.key}: ${auth.value}`
+  if (auth.type === "api_key") return `${auth.key}: ••••`
   return null
 }

--- a/src/ui/timeline/useTimeline.ts
+++ b/src/ui/timeline/useTimeline.ts
@@ -16,8 +16,9 @@ export function useTimeline(
 ): UseTimelineResult {
   const [entries, setEntries] = useState<TimelineEntry[]>([])
   const [loading, setLoading] = useState(false)
-  const lastReqIdRef = useRef<string | undefined>(undefined)
+  const lastKeyRef = useRef("")
   const mountedRef = useRef(true)
+  const saveChainRef = useRef<Promise<void>>(Promise.resolve())
 
   useEffect(() => {
     mountedRef.current = true
@@ -45,16 +46,21 @@ export function useTimeline(
   }, [collectionDir, requestId])
 
   useEffect(() => {
-    if (requestId !== lastReqIdRef.current) {
-      lastReqIdRef.current = requestId
+    const key = `${collectionDir ?? ""}||${requestId ?? ""}`
+    if (key !== lastKeyRef.current) {
+      lastKeyRef.current = key
       doLoad()
     }
-  }, [requestId, doLoad])
+  }, [collectionDir, requestId, doLoad])
 
   const appendEntry = useCallback(
     async (entry: TimelineEntry) => {
       if (!collectionDir || !requestId) return
-      await saveTimelineEntry(collectionDir, requestId, entry, maxEntries)
+      const save = saveChainRef.current.then(() =>
+        saveTimelineEntry(collectionDir, requestId, entry, maxEntries),
+      )
+      saveChainRef.current = save.catch(() => {})
+      await save
       setEntries((prev) => {
         const next = [entry, ...prev]
         return next.length > maxEntries ? next.slice(0, maxEntries) : next

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -28,6 +28,8 @@ export function useOverlayIntercepts(opts: {
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
   helpVisible: boolean
   setHelpVisible: (v: boolean) => void
+  aboutVisible: boolean
+  setAboutVisible: (v: boolean) => void
   view: "main" | "env-editor"
   setView: (v: "main" | "env-editor") => void
   focusRef: RefObject<Focus>
@@ -93,6 +95,8 @@ export function useOverlayIntercepts(opts: {
     saveTimerRef,
     helpVisible,
     setHelpVisible,
+    aboutVisible,
+    setAboutVisible,
     view,
     setView,
     focusRef,
@@ -319,6 +323,23 @@ export function useOverlayIntercepts(opts: {
     )
     return dispose
   }, [helpVisible, keymap, setHelpVisible])
+
+  // ── Overlay: About ─────────────────────────────────────────────────
+  useEffect(() => {
+    if (!aboutVisible) return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        if (ctx.event.name === "escape") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          setAboutVisible(false)
+        }
+      },
+      { priority: 100 },
+    )
+    return dispose
+  }, [aboutVisible, keymap, setAboutVisible])
 
   // ── Overlay: New Request ──────────────────────────────────────────
   useEffect(() => {

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -63,8 +63,38 @@ describe("loadTimeline", () => {
     const { join } = await import("node:path")
     await mkdir(join(dir, ".timeline"), { recursive: true })
     await writeFile(join(dir, ".timeline", "bad.yml"), "{: invalid", "utf8")
-    const result = await loadTimeline(dir, "bad")
-    expect(result).toEqual([])
+    expect(loadTimeline(dir, "bad")).rejects.toThrow(
+      "filestore.loadTimeline: failed to load timeline",
+    )
+  })
+
+  it("migrates legacy object-form params", async () => {
+    const { mkdir, writeFile } = await import("node:fs/promises")
+    await mkdir(join(dir, ".timeline"), { recursive: true })
+    await writeFile(
+      join(dir, ".timeline", "legacy.yml"),
+      `- timestamp: 1\n  request:\n    id: legacy\n    name: Legacy\n    method: GET\n    url: https://example.com\n    headers: {}\n    params:\n      q: hello\n      disabled:\n        value: no\n        enabled: false\n      count: 42\n`,
+      "utf8",
+    )
+
+    const result = await loadTimeline(dir, "legacy")
+    expect(result[0]?.request.params).toEqual([
+      { name: "q", value: "hello", enabled: true },
+      { name: "disabled", value: "no", enabled: false },
+    ])
+  })
+
+  it("preserves array-form params during migration", async () => {
+    const entry = makeEntry({
+      request: {
+        ...makeEntry().request,
+        params: [{ name: "q", value: "hello", enabled: true }],
+      },
+    })
+    await saveTimelineEntry(dir, "array", entry)
+
+    const result = await loadTimeline(dir, "array")
+    expect(result[0]?.request.params).toEqual(entry.request.params)
   })
 })
 

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -108,6 +108,18 @@ describe("saveTimelineEntry", () => {
     expect(content).toContain("method: GET")
   })
 
+  it("self-heals a corrupt timeline file on save", async () => {
+    const { mkdir, writeFile } = await import("node:fs/promises")
+    await mkdir(join(dir, ".timeline"), { recursive: true })
+    await writeFile(join(dir, ".timeline", "corrupt.yml"), "{: invalid", "utf8")
+
+    await saveTimelineEntry(dir, "corrupt", makeEntry({ timestamp: 42 }))
+
+    const result = await loadTimeline(dir, "corrupt")
+    expect(result).toHaveLength(1)
+    expect(result[0]?.timestamp).toBe(42)
+  })
+
   it("appends new entry as first in list (newest first)", async () => {
     await saveTimelineEntry(dir, "req-1", makeEntry({ timestamp: 1 }))
     await saveTimelineEntry(dir, "req-1", makeEntry({ timestamp: 2 }))

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -8,6 +8,9 @@ import {
   entrySize,
   entryIsError,
   buildTimelineEntry,
+  shortMethod,
+  formatRequestUrl,
+  authSummary,
 } from "../src/ui/timeline/formatTimeline"
 import type { TimelineEntry } from "../src/schema"
 
@@ -231,6 +234,80 @@ describe("entrySize", () => {
 
   it("returns null for error entries", () => {
     expect(entrySize(makeEntry({ error: { message: "fail" } }))).toBeNull()
+  })
+})
+
+describe("shortMethod", () => {
+  it("shortens DELETE and preserves other methods", () => {
+    expect(shortMethod("DELETE")).toBe("DEL")
+    expect(shortMethod("GET")).toBe("GET")
+    expect(shortMethod("PATCH")).toBe("PATCH")
+    expect(shortMethod("POST")).toBe("POST")
+  })
+})
+
+describe("formatRequestUrl", () => {
+  it("returns URL when no params are enabled", () => {
+    expect(
+      formatRequestUrl({
+        ...makeEntry(),
+        request: {
+          ...makeEntry().request,
+          params: [{ name: "skip", value: "x", enabled: false }],
+        },
+      }),
+    ).toBe("https://example.com")
+  })
+
+  it("appends enabled params and encodes values", () => {
+    expect(
+      formatRequestUrl({
+        ...makeEntry(),
+        request: {
+          ...makeEntry().request,
+          params: [
+            { name: "q", value: "hello world", enabled: true },
+            { name: "skip", value: "x", enabled: false },
+            { name: "tag", value: "a&b", enabled: true },
+          ],
+        },
+      }),
+    ).toBe("https://example.com?q=hello%20world&tag=a%26b")
+  })
+
+  it("uses ampersand when URL already has a query", () => {
+    expect(
+      formatRequestUrl({
+        ...makeEntry(),
+        request: {
+          ...makeEntry().request,
+          url: "https://example.com?existing=1",
+          params: [{ name: "next", value: "2", enabled: true }],
+        },
+      }),
+    ).toBe("https://example.com?existing=1&next=2")
+  })
+})
+
+describe("authSummary", () => {
+  it("summarizes supported auth types without exposing secrets", () => {
+    expect(authSummary(undefined)).toBeNull()
+    expect(authSummary({ type: "none" })).toBeNull()
+    expect(authSummary({ type: "inherit" })).toBeNull()
+    expect(authSummary({ type: "bearer", token: "secret" })).toBe(
+      "Bearer token",
+    )
+    expect(authSummary({ type: "basic", user: "alice", pass: "secret" })).toBe(
+      "Basic alice:****",
+    )
+    expect(
+      authSummary({
+        type: "api_key",
+        key: "X-API-Key",
+        value: "secret",
+        placement: "header",
+      }),
+    ).toBe("X-API-Key: ••••")
   })
 })
 

--- a/tests/unit/AboutOverlay.test.tsx
+++ b/tests/unit/AboutOverlay.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { AboutOverlay } from "../../src/ui/overlays/AboutOverlay"
+import pkg from "../../package.json" with { type: "json" }
+
+describe("AboutOverlay", () => {
+  it("renders Noodle information and links", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <AboutOverlay visible />
+      </ThemeProvider>,
+      { width: 80, height: 20 },
+    )
+
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    expect(frame).toContain(`Noodle v${pkg.version}`)
+    expect(frame).toContain("Free, open-source REST client")
+    expect(frame).toContain("GitHub · Releases")
+  })
+})

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test"
+import { act, useState } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { ThemeProvider } from "../../src/ui/theme"
+import { TimelineDetailOverlay } from "../../src/ui/overlays/TimelineDetailOverlay"
+import type { TimelineEntry } from "../../src/schema"
+import { setupKeymap } from "./_helpers"
+
+function makeEntry(over: Partial<TimelineEntry> = {}): TimelineEntry {
+  return {
+    timestamp: 1,
+    request: {
+      id: "request-1",
+      name: "Test request",
+      method: "GET",
+      url: "https://example.com",
+      headers: {},
+      params: [],
+    },
+    ...over,
+  }
+}
+
+async function renderOverlay(
+  entry: TimelineEntry,
+  onClose: () => void,
+  visible = true,
+) {
+  const { keymap, cleanup } = setupKeymap()
+  ;(
+    keymap as unknown as { setData: (key: string, value: string) => void }
+  ).setData("app.overlay", "none")
+  const render = await testRender(
+    <KeymapProvider keymap={keymap}>
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <TimelineDetailOverlay
+          visible={visible}
+          entry={entry}
+          onClose={onClose}
+        />
+      </ThemeProvider>
+    </KeymapProvider>,
+    { width: 80, height: 30 },
+  )
+  return { ...render, cleanup, keymap }
+}
+
+describe("TimelineDetailOverlay", () => {
+  it("renders response details", async () => {
+    const { renderOnce, captureCharFrame, cleanup } = await renderOverlay(
+      makeEntry({
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: '{"ok":true}',
+          timeMs: 12,
+          size: 11,
+        },
+      }),
+      () => {},
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("200 OK")
+    expect(frame).toContain("ok")
+    cleanup()
+  })
+
+  it("renders error details", async () => {
+    const { renderOnce, captureCharFrame, cleanup } = await renderOverlay(
+      makeEntry({ error: { message: "Connection refused" } }),
+      () => {},
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Connection refused")
+    expect(frame).toContain("No response")
+    cleanup()
+  })
+
+  it("switches to request tab with left arrow", async () => {
+    const { renderOnce, captureCharFrame, mockInput, cleanup } =
+      await renderOverlay(makeEntry(), () => {})
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_LEFT"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("request-1")
+    cleanup()
+  })
+
+  it("resets to response when reopened", async () => {
+    const entry = makeEntry({
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "response",
+        timeMs: 1,
+        size: 8,
+      },
+    })
+    const { keymap, cleanup } = setupKeymap()
+    ;(
+      keymap as unknown as { setData: (key: string, value: string) => void }
+    ).setData("app.overlay", "none")
+    let setVisible: ((visible: boolean) => void) | undefined
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <TimelineDetailHarness
+            entry={entry}
+            setVisibleRef={(set) => (setVisible = set)}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 30 },
+    )
+    const { renderOnce, captureCharFrame, mockInput } = render
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_LEFT"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("request-1")
+
+    await act(async () => setVisible?.(false))
+    await renderOnce()
+    await act(async () => setVisible?.(true))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("response")
+    cleanup()
+  })
+})
+
+function TimelineDetailHarness({
+  entry,
+  setVisibleRef,
+}: {
+  entry: TimelineEntry
+  setVisibleRef: (setVisible: (visible: boolean) => void) => void
+}) {
+  const [visible, setVisible] = useState(true)
+  setVisibleRef(setVisible)
+  return (
+    <TimelineDetailOverlay visible={visible} entry={entry} onClose={() => {}} />
+  )
+}

--- a/tests/unit/TimelineTab.test.tsx
+++ b/tests/unit/TimelineTab.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { ThemeProvider } from "../../src/ui/theme"
+import { TimelineTab } from "../../src/ui/timeline/TimelineTab"
+import type { TimelineEntry } from "../../src/schema"
+import { setupKeymap } from "./_helpers"
+
+function makeEntry(id: string): TimelineEntry {
+  return {
+    timestamp: Number(id),
+    request: {
+      id,
+      name: id,
+      method: "GET",
+      url: `https://example.com/${id}`,
+      headers: {},
+      params: [],
+    },
+  }
+}
+
+function renderTimeline(
+  entries: TimelineEntry[],
+  focused: boolean,
+  onOpenEntry: (entry: TimelineEntry) => void,
+) {
+  const { keymap, cleanup } = setupKeymap()
+  ;(
+    keymap as unknown as { setData: (key: string, value: string) => void }
+  ).setData("app.overlay", "none")
+  return testRender(
+    <KeymapProvider keymap={keymap}>
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <TimelineTab
+          entries={entries}
+          focused={focused}
+          onOpenEntry={onOpenEntry}
+        />
+      </ThemeProvider>
+    </KeymapProvider>,
+    { width: 80, height: 20 },
+  ).then((render) => ({ ...render, cleanup }))
+}
+
+describe("TimelineTab", () => {
+  it("renders empty state", async () => {
+    const { renderOnce, captureCharFrame, cleanup } = await renderTimeline(
+      [],
+      true,
+      () => {},
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("No timeline entries yet")
+    cleanup()
+  })
+
+  it("opens entry selected after navigation", async () => {
+    const entries = [makeEntry("1"), makeEntry("2"), makeEntry("3")]
+    let opened: TimelineEntry | undefined
+    const { renderOnce, mockInput, cleanup } = await renderTimeline(
+      entries,
+      true,
+      (entry) => {
+        opened = entry
+      },
+    )
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_DOWN"))
+    await renderOnce()
+    await act(async () => mockInput.pressKey("RETURN"))
+    await renderOnce()
+    expect(opened?.request.id).toBe("2")
+    cleanup()
+  })
+
+  it("wraps upward from first entry to last", async () => {
+    const entries = [makeEntry("1"), makeEntry("2"), makeEntry("3")]
+    let opened: TimelineEntry | undefined
+    const { renderOnce, mockInput, cleanup } = await renderTimeline(
+      entries,
+      true,
+      (entry) => {
+        opened = entry
+      },
+    )
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_UP"))
+    await renderOnce()
+    await act(async () => mockInput.pressKey("RETURN"))
+    await renderOnce()
+    expect(opened?.request.id).toBe("3")
+    cleanup()
+  })
+
+  it("ignores navigation when unfocused", async () => {
+    const entries = [makeEntry("1"), makeEntry("2")]
+    let opened: TimelineEntry | undefined
+    const { renderOnce, mockInput, cleanup } = await renderTimeline(
+      entries,
+      false,
+      (entry) => {
+        opened = entry
+      },
+    )
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_DOWN"))
+    await renderOnce()
+    await act(async () => mockInput.pressKey("RETURN"))
+    await renderOnce()
+    expect(opened).toBeUndefined()
+    cleanup()
+  })
+})

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -49,13 +49,15 @@ function minimalContext(): CommandBuilderContext {
     setPreviewIndexProp: () => {},
     setEnvDeletePending: () => {},
     setDeleteConfirmSelection: () => {},
+    setCollectionReloadToken: () => {},
+    onReloadCollection: () => {},
   }
 }
 
 describe("buildCommandPaletteCommands", () => {
   it("returns all commands with required fields", () => {
     const commands = buildCommandPaletteCommands(minimalContext())
-    expect(commands.length).toBe(19)
+    expect(commands.length).toBe(20)
     for (const cmd of commands) {
       expect(cmd.id).toBeTruthy()
       expect(cmd.label).toBeTruthy()
@@ -241,5 +243,18 @@ describe("buildCommandPaletteCommands", () => {
     const file = getEditRequestYamlFile(ctx)
     expect(file?.filePath).toBe("/tmp/collections/users/login.yml")
     expect(file?.requestName).toBe("Login")
+  })
+
+  it("collection.reload calls onReloadCollection", () => {
+    const ctx = minimalContext()
+    let reloaded = false
+    ctx.onReloadCollection = () => {
+      reloaded = true
+    }
+    const commands = buildCommandPaletteCommands(ctx)
+    const cmd = commands.find((c) => c.id === "collection.reload")!
+    const result = cmd.run()
+    expect(result).toBe(true)
+    expect(reloaded).toBe(true)
   })
 })

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -49,7 +49,6 @@ function minimalContext(): CommandBuilderContext {
     setPreviewIndexProp: () => {},
     setEnvDeletePending: () => {},
     setDeleteConfirmSelection: () => {},
-    setCollectionReloadToken: () => {},
     onReloadCollection: () => {},
   }
 }

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -33,6 +33,7 @@ function minimalContext(): CommandBuilderContext {
     setLayout: () => {},
     onLayoutChange: () => {},
     setHelpVisible: () => {},
+    setAboutVisible: () => {},
     setNewRequestVisible: () => {},
     setNewFolderVisible: () => {},
     setCloneRequestVisible: () => {},
@@ -54,7 +55,7 @@ function minimalContext(): CommandBuilderContext {
 describe("buildCommandPaletteCommands", () => {
   it("returns all commands with required fields", () => {
     const commands = buildCommandPaletteCommands(minimalContext())
-    expect(commands.length).toBe(18)
+    expect(commands.length).toBe(19)
     for (const cmd of commands) {
       expect(cmd.id).toBeTruthy()
       expect(cmd.label).toBeTruthy()
@@ -113,6 +114,18 @@ describe("buildCommandPaletteCommands", () => {
     const commands = buildCommandPaletteCommands(ctx)
     const cmd = commands.find((c) => c.id === "collection.switcher")!
     cmd.run()
+    expect(opened).toBe(true)
+  })
+
+  it("app.about opens the about overlay", () => {
+    const ctx = minimalContext()
+    let opened = false
+    ctx.setAboutVisible = () => {
+      opened = true
+    }
+    const commands = buildCommandPaletteCommands(ctx)
+    const cmd = commands.find((c) => c.id === "app.about")!
+    expect(cmd.run()).toBe(true)
     expect(opened).toBe(true)
   })
 


### PR DESCRIPTION
## Summary

- Add a timeline detail overlay for inspecting recorded requests and responses
- Support request/response tabs, headers, bodies, status, timing, environment badges, and error details
- Fix timeline selection, persistence races, collection reloads, corrupted-file handling, and API-key masking
- Add About overlay and collection reload command included in this branch

## Tests

- `bun test` (1459 passed)
- `bun run lint`
- `bun run typecheck`
- `bunx prettier --check ./src ./tests`
- `git diff --check`

OpenTUI test runs emit existing React `act(...)` warnings, but all tests pass.