### PR TITLE
fix(timeline): mask auth header values in timeline detail overlay

### DIFF
--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -11,11 +11,11 @@ import { formatBody, formatHeaders, formatSize, statusColor } from "../format"
 import { methodColor } from "../formatRequest"
 import { JsonBodyViewer } from "../editor/JsonBodyViewer"
 import {
-  authSummary,
   entryMethod,
   entryStatus,
   entryTiming,
   formatRequestUrl,
+  maskedAuthHeader,
   shortMethod,
 } from "../timeline/formatTimeline"
 
@@ -79,10 +79,15 @@ export function TimelineDetailOverlay({
         theme.info)
       : theme.info
 
-  const requestHeaders = Object.entries(entry.request.headers)
-    .filter(([, value]) => value.enabled)
-    .map(([key, value]) => ({ key, value: value.value }))
-    .sort((a, b) => a.key.localeCompare(b.key))
+  const authHeader = entry.request.auth
+    ? maskedAuthHeader(entry.request.auth)
+    : null
+  const requestHeaders = [
+    ...(authHeader ? [authHeader] : []),
+    ...Object.entries(entry.request.headers)
+      .filter(([, value]) => value.enabled)
+      .map(([key, value]) => ({ key, value: value.value })),
+  ].sort((a, b) => a.key.localeCompare(b.key))
   const responseHeaders = entry.response ? formatHeaders(entry.response) : []
   const requestMaxKeyLen = requestHeaders.reduce(
     (max, header) => Math.max(max, header.key.length),
@@ -149,11 +154,6 @@ export function TimelineDetailOverlay({
                     {entry.request.id}
                   </text>
                 </box>
-                {authSummary(entry.request.auth) && (
-                  <text fg={theme.textMuted}>
-                    {authSummary(entry.request.auth)}
-                  </text>
-                )}
                 <box
                   border={["bottom"]}
                   borderColor={theme.borderSubtle}

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -79,9 +79,7 @@ export function TimelineDetailOverlay({
         theme.info)
       : theme.info
 
-  const authHeader = entry.request.auth
-    ? maskedAuthHeader(entry.request.auth)
-    : null
+  const authHeader = maskedAuthHeader(entry.request.auth)
   const requestHeaders = [
     ...(authHeader ? [authHeader] : []),
     ...Object.entries(entry.request.headers)

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -109,14 +109,6 @@ export function shortMethod(m: string): string {
   return m === "DELETE" ? "DEL" : m
 }
 
-export function formatRequestHeaders(entry: TimelineEntry): string[] {
-  const lines: string[] = []
-  for (const [k, v] of Object.entries(entry.request.headers)) {
-    if (v.enabled) lines.push(`${k}: ${v.value}`)
-  }
-  return lines.sort()
-}
-
 export function formatRequestUrl(entry: TimelineEntry): string {
   const u = entry.request.url
   const params = entry.request.params
@@ -129,12 +121,16 @@ export function formatRequestUrl(entry: TimelineEntry): string {
   return `${u}?${qs}`
 }
 
-export function authSummary(
+export function maskedAuthHeader(
   auth: TimelineEntry["request"]["auth"],
-): string | null {
-  if (!auth || auth.type === "none") return null
-  if (auth.type === "bearer") return "Bearer token"
-  if (auth.type === "basic") return `Basic ${auth.user}:****`
-  if (auth.type === "api_key") return `${auth.key}: ••••`
+): { key: string; value: string } | null {
+  if (!auth || auth.type === "none" || auth.type === "inherit") return null
+  if (auth.type === "bearer")
+    return { key: "Authorization", value: "Bearer ••••••••" }
+  if (auth.type === "basic")
+    return { key: "Authorization", value: "Basic ••••••••" }
+  if (auth.type === "api_key" && auth.placement === "header") {
+    return { key: auth.key, value: "••••••••" }
+  }
   return null
 }

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -10,7 +10,7 @@ import {
   buildTimelineEntry,
   shortMethod,
   formatRequestUrl,
-  authSummary,
+  maskedAuthHeader,
 } from "../src/ui/timeline/formatTimeline"
 import type { TimelineEntry } from "../src/schema"
 
@@ -289,25 +289,37 @@ describe("formatRequestUrl", () => {
   })
 })
 
-describe("authSummary", () => {
-  it("summarizes supported auth types without exposing secrets", () => {
-    expect(authSummary(undefined)).toBeNull()
-    expect(authSummary({ type: "none" })).toBeNull()
-    expect(authSummary({ type: "inherit" })).toBeNull()
-    expect(authSummary({ type: "bearer", token: "secret" })).toBe(
-      "Bearer token",
-    )
-    expect(authSummary({ type: "basic", user: "alice", pass: "secret" })).toBe(
-      "Basic alice:****",
-    )
+describe("maskedAuthHeader", () => {
+  it("returns masked header for supported auth types, null for none/inherit", () => {
+    expect(maskedAuthHeader(undefined)).toBeNull()
+    expect(maskedAuthHeader({ type: "none" })).toBeNull()
+    expect(maskedAuthHeader({ type: "inherit" })).toBeNull()
+    expect(maskedAuthHeader({ type: "bearer", token: "secret" })).toEqual({
+      key: "Authorization",
+      value: "Bearer ••••••••",
+    })
     expect(
-      authSummary({
+      maskedAuthHeader({ type: "basic", user: "alice", pass: "secret" }),
+    ).toEqual({
+      key: "Authorization",
+      value: "Basic ••••••••",
+    })
+    expect(
+      maskedAuthHeader({
         type: "api_key",
         key: "X-API-Key",
         value: "secret",
         placement: "header",
       }),
-    ).toBe("X-API-Key: ••••")
+    ).toEqual({ key: "X-API-Key", value: "••••••••" })
+    expect(
+      maskedAuthHeader({
+        type: "api_key",
+        key: "api_key",
+        value: "secret",
+        placement: "query",
+      }),
+    ).toBeNull()
   })
 })
 


### PR DESCRIPTION
## What changed

- Replaced the timeline auth summary with a masked header representation in the detail overlay.
- Bearer and basic auth now render as masked Authorization headers.
- API key auth is only shown when it is placed in a header, and its value is masked.
- Query-placement API keys are omitted from the detail header list.

## Why

The previous timeline detail view summarized auth in a way that could still expose sensitive intent or values too clearly. This change keeps the timeline useful while ensuring secret material is not displayed in the overlay.

## Impact

- Users inspecting past requests can still see which auth mechanism was used.
- Sensitive auth values are no longer surfaced in the detail overlay.
- The change is limited to the timeline UI and the supporting formatter.

## Validation

- bun test tests/timeline-format.test.ts