### PR TITLE
feat(cli): add collection initialization, audit, and read-only browsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "license": "Apache-2.0",
   "private": true,

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -17,6 +17,48 @@ if (rawArgs.length === 1 && ["-v", "--version"].includes(rawArgs[0])) {
   process.exit(0)
 }
 
+const KNOWN_SUBCOMMANDS = new Set([
+  "import",
+  "update",
+  "workspace",
+  "collection",
+  "request",
+  "environment",
+])
+
+let userArgsStart = 1
+for (let i = 1; i < process.argv.length; i++) {
+  if (process.argv[i]!.endsWith(".ts")) {
+    userArgsStart = i + 1
+    break
+  }
+}
+const firstUserArg = process.argv[userArgsStart]
+
+function isTuiFlag(arg: string): boolean {
+  return (
+    arg === "-c" ||
+    arg === "-e" ||
+    arg.startsWith("-c=") ||
+    arg.startsWith("-e=") ||
+    arg === "--collection" ||
+    arg === "--env" ||
+    arg.startsWith("--collection=") ||
+    arg.startsWith("--env=")
+  )
+}
+
+if (
+  firstUserArg &&
+  firstUserArg !== "noodle" &&
+  !KNOWN_SUBCOMMANDS.has(firstUserArg) &&
+  !firstUserArg.startsWith("-")
+) {
+  process.argv.splice(userArgsStart, 0, "noodle")
+} else if (firstUserArg && isTuiFlag(firstUserArg)) {
+  process.argv.splice(userArgsStart, 0, "noodle")
+}
+
 const main = defineCommand({
   meta: {
     name: "noodle",

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -5,6 +5,7 @@ import {
   formatCollectionAudit,
   formatCollectionCreate,
   formatCollectionInspect,
+  formatCollectionInit,
   formatCollectionList,
   formatCollectionRun,
   formatEnvironmentSet,
@@ -15,6 +16,7 @@ import {
 import {
   collectionAudit,
   collectionCreate,
+  collectionInit,
   collectionInspect,
   collectionList,
   collectionRun,
@@ -83,6 +85,22 @@ const collection = defineCommand({
             data: await collectionCreate(args.name, args.output),
           }),
           formatCollectionCreate,
+        ),
+    }),
+    init: defineCommand({
+      meta: {
+        name: "init",
+        description: "Initialize an existing directory as a collection",
+      },
+      args: {
+        path: { type: "positional", required: true },
+        json: jsonArg,
+      },
+      run: ({ args }) =>
+        emitCommand(
+          args.json,
+          async () => ({ data: await collectionInit(args.path) }),
+          formatCollectionInit,
         ),
     }),
     list: defineCommand({

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -11,6 +11,7 @@ import {
   formatEnvironmentSet,
   formatRequestCreate,
   formatRequestRun,
+  formatWorkspaceAudit,
   formatWorkspaceList,
 } from "../humanOutput"
 import {
@@ -23,6 +24,7 @@ import {
   environmentSet,
   requestCreate,
   requestRun,
+  workspaceAudit,
   workspaceList,
 } from "../services"
 import type { Method } from "../../schema"
@@ -58,6 +60,19 @@ const workspace = defineCommand({
           args.json,
           async () => ({ data: await workspaceList() }),
           formatWorkspaceList,
+        ),
+    }),
+    audit: defineCommand({
+      meta: { name: "audit", description: "Validate registered collections" },
+      args: { fix: { type: "boolean", default: false }, json: jsonArg },
+      run: ({ args }) =>
+        emitCommand(
+          args.json,
+          async () => {
+            const data = await workspaceAudit(args.fix)
+            return { data, failed: !data.valid }
+          },
+          formatWorkspaceAudit,
         ),
     }),
   },

--- a/src/app/commands/default.ts
+++ b/src/app/commands/default.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty"
+import { resolve } from "node:path"
 import { bootstrap } from "../main"
 
 export default defineCommand({
@@ -8,20 +9,34 @@ export default defineCommand({
       "Terminal REST client. Inspect, send, and iterate on HTTP requests.",
   },
   args: {
+    targetPath: {
+      type: "positional" as const,
+      required: false,
+      description:
+        "Collection directory (use '.' for current dir). Overrides --collection and config.yml.",
+    },
     collection: {
-      type: "string",
+      type: "string" as const,
       alias: "c",
       description: "Collection directory",
     },
     env: {
-      type: "string",
+      type: "string" as const,
       alias: "e",
       description: "Initial environment name",
     },
   },
   async run({ args }) {
+    if (args.targetPath && args.collection) {
+      process.stderr.write(
+        "error: cannot supply both a positional path and --collection\n",
+      )
+      process.exit(1)
+    }
+
     await bootstrap({
-      collectionDir: args.collection,
+      targetPath: args.targetPath ? resolve(args.targetPath) : undefined,
+      collectionDir: args.collection ? resolve(args.collection) : undefined,
       envName: args.env,
     })
   },

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -5,6 +5,7 @@ import type {
   CollectionRunResult,
   CollectionTreeItem,
   RequestRunResult,
+  WorkspaceAuditResult,
 } from "./services"
 
 type Color = "red" | "green" | "yellow" | "cyan" | "dim"
@@ -47,6 +48,22 @@ export function formatWorkspaceList(data: { collections: string[] }): string {
   return [
     `Collections (${data.collections.length})`,
     ...data.collections.map((path) => `  ${path}`),
+  ].join("\n")
+}
+
+export function formatWorkspaceAudit(data: WorkspaceAuditResult): string {
+  if (data.issues.length === 0)
+    return `${color("✓", "green")} All registered collections are valid`
+  const fixed = data.issues.filter((issue) => issue.fixed).length
+  const headline = data.valid
+    ? `${color("✓", "green")} Removed ${fixed} invalid collection${fixed === 1 ? "" : "s"}`
+    : `${color("✗", "red")} Found ${data.issues.length} invalid collection${data.issues.length === 1 ? "" : "s"}`
+  return [
+    headline,
+    ...data.issues.map(
+      (issue) =>
+        `  ${issue.fixed ? color("removed", "green") : color("error", "red")} ${issue.path}: ${issue.message}`,
+    ),
   ].join("\n")
 }
 

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -57,6 +57,10 @@ export function formatCollectionCreate(data: {
   return `${color("✓", "green")} Created collection ${data.name}\n  ${data.path}`
 }
 
+export function formatCollectionInit(data: { path: string }): string {
+  return `${color("✓", "green")} Initialized collection\n  ${data.path}`
+}
+
 export function formatCollectionList(data: CollectionListResult): string {
   if (data.tree.length === 0) return `Collection is empty: ${data.path}`
   return [`Collection: ${data.path}`, ...formatTree(data.tree)].join("\n")

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -24,7 +24,7 @@ extend({ "code-editor": CodeEditorRenderable })
 
 const CONFIG_DIR = `${process.env.HOME ?? "~"}/.config/noodle`
 
-export type CollectionMode = "collection" | "browse" | "empty"
+export type CollectionMode = "collection" | "browse" | "empty" | "invalid"
 
 export interface BootstrapOptions {
   targetPath?: string
@@ -69,8 +69,8 @@ function hasNoodleContent(dir: string): boolean {
 }
 
 export function classifyPath(dir: string): CollectionMode {
-  if (!existsSync(dir)) return "empty"
-  if (!isDirectoryPath(dir)) return "empty"
+  if (!existsSync(dir)) return "invalid"
+  if (!isDirectoryPath(dir)) return "invalid"
 
   const envDir = join(dir, ".environments")
   if (existsSync(envDir)) return "collection"
@@ -121,6 +121,13 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
   }
 
   const mode: CollectionMode = classifyPath(collectionDir)
+  if (mode === "invalid") {
+    process.stderr.write(
+      `error: collection path is not a directory: ${collectionDir}\n`,
+    )
+    process.exit(1)
+    return
+  }
   const shouldRegister =
     mode === "collection" && (!!options.targetPath || !!options.collectionDir)
 

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -109,7 +109,7 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
     let fromConfig: string | undefined
     try {
       const cfg = loadConfig(CONFIG_DIR)
-      fromConfig = cfg.collections[0]
+      fromConfig = cfg.collections.find(isDirectoryPath)
     } catch {
       // config unavailable
     }

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -11,6 +11,7 @@ import { createNoodleKeymap } from "../hooks/useKeymap"
 import { parseOverrides } from "../ui/keybind"
 import { showToast } from "../ui/Toast"
 import { join, resolve } from "node:path"
+import { existsSync, readdirSync, statSync } from "node:fs"
 import * as yaml from "js-yaml"
 import { readFileSync } from "node:fs"
 import { loadConfig } from "../hooks/useConfig"
@@ -19,39 +20,117 @@ import { codeEditorParsers } from "../ui/editor/codeEditorParsers"
 
 addDefaultParsers([...codeEditorParsers])
 
-// Register custom components
 extend({ "code-editor": CodeEditorRenderable })
 
 const CONFIG_DIR = `${process.env.HOME ?? "~"}/.config/noodle`
 
+export type CollectionMode = "collection" | "browse" | "empty"
+
 export interface BootstrapOptions {
+  targetPath?: string
   collectionDir?: string
   envName?: string
 }
 
+function isDirectoryPath(dir: string): boolean {
+  try {
+    return statSync(dir).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function hasNoodleContent(dir: string): boolean {
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue
+      if (
+        entry.isFile() &&
+        entry.name.endsWith(".yml") &&
+        entry.name !== "settings.yml"
+      ) {
+        return true
+      }
+      if (entry.isDirectory()) {
+        if (
+          !entry.name.startsWith(".") &&
+          entry.name !== "node_modules" &&
+          hasNoodleContent(join(dir, entry.name))
+        ) {
+          return true
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return false
+}
+
+export function classifyPath(dir: string): CollectionMode {
+  if (!existsSync(dir)) return "empty"
+  if (!isDirectoryPath(dir)) return "empty"
+
+  const envDir = join(dir, ".environments")
+  if (existsSync(envDir)) return "collection"
+  const settingsPath = join(dir, "settings.yml")
+  if (existsSync(settingsPath)) return "collection"
+
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return "empty"
+  }
+
+  const hasRootRequest = entries.some(
+    (entry) =>
+      entry.isFile() &&
+      entry.name.endsWith(".yml") &&
+      entry.name !== "folder.yml" &&
+      entry.name !== "settings.yml",
+  )
+  if (hasRootRequest) return "collection"
+
+  if (hasNoodleContent(dir)) return "browse"
+
+  return "empty"
+}
+
 export async function bootstrap(options: BootstrapOptions): Promise<void> {
   let collectionDir: string
-  if (options.collectionDir) {
-    collectionDir = resolve(options.collectionDir)
+
+  if (options.targetPath) {
+    collectionDir = options.targetPath
+  } else if (options.collectionDir) {
+    collectionDir = options.collectionDir
   } else {
-    let fallback: string | undefined
+    let fromConfig: string | undefined
     try {
-      const config = loadConfig(CONFIG_DIR)
-      fallback = config.collections[0]
+      const cfg = loadConfig(CONFIG_DIR)
+      fromConfig = cfg.collections[0]
     } catch {
       // config unavailable
     }
-    collectionDir = resolve(fallback ?? "./collections")
+    if (fromConfig) {
+      collectionDir = resolve(fromConfig)
+    } else {
+      collectionDir = resolve("./collections")
+    }
   }
+
+  const mode: CollectionMode = classifyPath(collectionDir)
+  const shouldRegister =
+    mode === "collection" && (!!options.targetPath || !!options.collectionDir)
+
   const environmentsDir = join(collectionDir, ".environments")
 
   let envList: string[]
   try {
     envList = await env.listEnvironments(environmentsDir)
-  } catch (e) {
-    const reason = e instanceof Error ? e.message : String(e)
-    process.stderr.write(`error: ${reason}\n`)
-    process.exit(1)
+  } catch {
+    envList = []
   }
 
   let initialEnvName: string | undefined
@@ -67,18 +146,22 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
   }
 
   let settingsEnv: string | undefined
-  try {
-    const settings = await loadSettings(collectionDir)
-    settingsEnv = settings.environment
-  } catch {
-    // settings.yml missing or invalid — ignore, use defaults
+  if (mode === "collection") {
+    try {
+      const settings = await loadSettings(collectionDir)
+      settingsEnv = settings.environment
+    } catch {
+      // settings.yml missing or invalid — ignore, use defaults
+    }
   }
 
   let lastRequestId: string | undefined
-  try {
-    lastRequestId = await loadLastRequest(collectionDir)
-  } catch {
-    // ignore — fall through to undefined
+  if (mode === "collection") {
+    try {
+      lastRequestId = await loadLastRequest(collectionDir)
+    } catch {
+      // ignore
+    }
   }
 
   const KEYBINDS_PATH = `${process.env.HOME ?? "~"}/.config/noodle/keybinds.yml`
@@ -132,6 +215,8 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
           settingsEnv={settingsEnv}
           keybinds={keybinds}
           lastRequestId={lastRequestId}
+          shouldRegister={shouldRegister}
+          mode={mode}
         />
       </RendererProvider>
     </KeymapProvider>,

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -152,7 +152,18 @@ export async function workspaceAudit(
       })
       continue
     }
-    if (!(await isCollectionRoot(path))) {
+    let collectionRoot
+    try {
+      collectionRoot = await isCollectionRoot(path)
+    } catch {
+      issues.push({
+        path,
+        message: "not accessible",
+        fixed: fix,
+      })
+      continue
+    }
+    if (!collectionRoot) {
       issues.push({
         path,
         message: "not a collection root",
@@ -228,8 +239,7 @@ export async function collectionInit(path: string): Promise<{ path: string }> {
 
 async function isDirectory(path: string): Promise<boolean> {
   try {
-    await readdir(path)
-    return true
+    return (await stat(path)).isDirectory()
   } catch {
     return false
   }

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -1,5 +1,12 @@
 import { existsSync } from "node:fs"
-import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises"
+import {
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  stat,
+  writeFile,
+} from "node:fs/promises"
 import { basename, join, relative, resolve } from "node:path"
 import * as yaml from "js-yaml"
 import { loadConfig, saveConfig, upsertCollectionPath } from "../config"
@@ -126,7 +133,10 @@ export async function workspaceAudit(
   const validCollections: string[] = []
 
   for (const path of config.collections) {
-    if (!existsSync(path)) {
+    let pathStat
+    try {
+      pathStat = await stat(path)
+    } catch {
       issues.push({
         path,
         message: "directory does not exist",
@@ -134,7 +144,7 @@ export async function workspaceAudit(
       })
       continue
     }
-    if (!(await isDirectory(path))) {
+    if (!pathStat.isDirectory()) {
       issues.push({
         path,
         message: "not a directory",

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -9,6 +9,7 @@ import {
   loadSettings,
   saveRequest,
   saveSettings,
+  ensureCollectionBootstrapped,
 } from "../filestore"
 import { lang } from "../lang"
 import { executor, substitute } from "../requests"
@@ -134,6 +135,36 @@ export async function collectionCreate(
     collections: upsertCollectionPath(config.collections, path),
   })
   return { path, name }
+}
+
+export async function collectionInit(path: string): Promise<{ path: string }> {
+  const absolutePath = resolve(path)
+  if (!existsSync(absolutePath)) {
+    throw new Error(`directory not found: ${absolutePath}`)
+  }
+  if (!(await isDirectory(absolutePath))) {
+    throw new Error(`not a directory: ${absolutePath}`)
+  }
+  if (await isCollectionRoot(absolutePath)) {
+    throw new Error(`already a collection: ${absolutePath}`)
+  }
+
+  await ensureCollectionBootstrapped(absolutePath)
+  const config = loadConfig(CONFIG_DIR)
+  saveConfig(CONFIG_DIR, {
+    ...config,
+    collections: upsertCollectionPath(config.collections, absolutePath),
+  })
+  return { path: absolutePath }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    await readdir(path)
+    return true
+  } catch {
+    return false
+  }
 }
 
 async function isCollectionRoot(path: string): Promise<boolean> {

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -107,6 +107,64 @@ export function collectionTree(items: CollectionItem[]): CollectionTreeItem[] {
 export async function workspaceList(): Promise<{ collections: string[] }> {
   return { collections: loadConfig(CONFIG_DIR).collections }
 }
+export interface WorkspaceAuditIssue {
+  path: string
+  message: string
+  fixed: boolean
+}
+export interface WorkspaceAuditResult {
+  valid: boolean
+  collections: string[]
+  issues: WorkspaceAuditIssue[]
+}
+export async function workspaceAudit(
+  fix: boolean,
+  configDir = CONFIG_DIR,
+): Promise<WorkspaceAuditResult> {
+  const config = loadConfig(configDir)
+  const issues: WorkspaceAuditIssue[] = []
+  const validCollections: string[] = []
+
+  for (const path of config.collections) {
+    if (!existsSync(path)) {
+      issues.push({
+        path,
+        message: "directory does not exist",
+        fixed: fix,
+      })
+      continue
+    }
+    if (!(await isDirectory(path))) {
+      issues.push({
+        path,
+        message: "not a directory",
+        fixed: fix,
+      })
+      continue
+    }
+    if (!(await isCollectionRoot(path))) {
+      issues.push({
+        path,
+        message: "not a collection root",
+        fixed: fix,
+      })
+      continue
+    }
+    validCollections.push(path)
+  }
+
+  if (fix && issues.length > 0)
+    saveConfig(configDir, {
+      ...config,
+      collections: validCollections,
+    })
+
+  return {
+    valid: issues.every((issue) => issue.fixed),
+    collections: fix ? validCollections : config.collections,
+    issues,
+  }
+}
 export async function collectionCreate(
   name: string,
   output: string,

--- a/src/filestore/index.ts
+++ b/src/filestore/index.ts
@@ -1,11 +1,12 @@
 import type { Collection, CollectionSettings, Request } from "../schema"
-import { loadCollection, loadSettings } from "./load"
+import { loadCollection, loadCollectionBrowse, loadSettings } from "./load"
 import {
   saveRequest,
   saveSettings,
   deleteRequest,
   saveFolder,
   deleteFolder,
+  ensureCollectionBootstrapped,
 } from "./save"
 import {
   loadTimeline,
@@ -16,11 +17,13 @@ import {
 
 export {
   loadSettings,
+  loadCollectionBrowse,
   saveSettings,
   saveRequest,
   deleteRequest,
   saveFolder,
   deleteFolder,
+  ensureCollectionBootstrapped,
   loadTimeline,
   saveTimelineEntry,
   clearTimelineForRequest,

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -182,8 +182,11 @@ export async function loadCollectionBrowse(dir: string): Promise<Collection> {
       tolerant: true,
     })
     return { id, name: id, items }
-  } catch {
-    return { id, name: id, items: [] }
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      return { id, name: id, items: [] }
+    }
+    throw e
   }
 }
 

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -12,11 +12,17 @@ import type {
 
 const SKIP_DIRS = new Set([".noodle", ".timeline", ".git", "node_modules"])
 
+export interface LoadOptions {
+  readOnly?: boolean
+  tolerant?: boolean
+}
+
 async function walk(
   absDir: string,
   relPath: string,
   visited = new Set<string>(),
   root?: string,
+  opts: LoadOptions = {},
 ): Promise<CollectionItem[]> {
   let resolved: string
   try {
@@ -79,7 +85,7 @@ async function walk(
         }
       }
 
-      const children = await walk(childAbs, childRel, visited, root)
+      const children = await walk(childAbs, childRel, visited, root, opts)
       const folder: Folder = {
         id: entry.name,
         name: folderMeta.meta?.name ?? entry.name,
@@ -107,6 +113,7 @@ async function walk(
       try {
         req = lang.parseRequest(reqId, content)
       } catch (e) {
+        if (opts.tolerant) continue
         const msg = e instanceof Error ? e.message : String(e)
         throw new Error(
           `filestore.loadCollection: failed to parse "${entry.name}": ${msg}`,
@@ -115,7 +122,7 @@ async function walk(
       }
       requests.push({ item: { type: "request", data: req }, name: entry.name })
 
-      if (!/^timeout:\s/m.test(content)) {
+      if (!opts.readOnly && !/^timeout:\s/m.test(content)) {
         try {
           await writeFile(
             join(absDir, entry.name),
@@ -164,6 +171,20 @@ export async function loadCollection(dir: string): Promise<Collection> {
   const root = await realpath(dir)
   const items = await walk(dir, "", new Set(), root)
   return { id, name: id, items }
+}
+
+export async function loadCollectionBrowse(dir: string): Promise<Collection> {
+  const id = basename(dir)
+  try {
+    const root = await realpath(dir)
+    const items = await walk(dir, "", new Set(), root, {
+      readOnly: true,
+      tolerant: true,
+    })
+    return { id, name: id, items }
+  } catch {
+    return { id, name: id, items: [] }
+  }
 }
 
 export async function loadSettings(dir: string): Promise<CollectionSettings> {

--- a/src/filestore/save.ts
+++ b/src/filestore/save.ts
@@ -1,8 +1,10 @@
 import { mkdir, writeFile, unlink, rm } from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { dirname, join } from "node:path"
 import * as yaml from "js-yaml"
 import { lang } from "../lang"
 import type { CollectionSettings, Folder, Request } from "../schema"
+import { env } from "../env"
 
 function validatePathId(id: string | undefined): void {
   if (!id) {
@@ -112,5 +114,18 @@ export async function saveSettings(
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
     throw new Error(`filestore.saveSettings: ${msg}`, { cause: e })
+  }
+}
+
+export async function ensureCollectionBootstrapped(dir: string): Promise<void> {
+  const envDir = join(dir, ".environments")
+  const settingsPath = join(dir, "settings.yml")
+
+  if (!existsSync(settingsPath)) {
+    await saveSettings(dir, { environment: "development" })
+  }
+  if (!existsSync(envDir)) {
+    await mkdir(envDir, { recursive: true })
+    await env.saveEnvironment(envDir, { name: "development", vars: {} })
   }
 }

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { filestore } from "../filestore"
+import { loadCollectionBrowse } from "../filestore"
 import type { Collection } from "../schema"
 
 export interface UseCollectionResult {
@@ -12,18 +13,27 @@ export interface UseCollectionResult {
 export function useCollection(
   dir: string,
   reloadToken = 0,
+  skip = false,
+  browse = false,
 ): UseCollectionResult {
   const [collection, setCollection] = useState<Collection | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(!skip)
   const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
+    if (skip) {
+      setCollection(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
     setLoading(true)
     setError(null)
     let cancelled = false
 
-    filestore
-      .loadCollection(dir)
+    const loader = browse ? loadCollectionBrowse : filestore.loadCollection
+
+    loader(dir)
       .then((c) => {
         if (!cancelled) {
           setCollection(c)
@@ -32,7 +42,11 @@ export function useCollection(
       })
       .catch((e) => {
         if (!cancelled) {
-          setError(e instanceof Error ? e : new Error(String(e)))
+          if (browse) {
+            setCollection({ id: dir, name: dir, items: [] })
+          } else {
+            setError(e instanceof Error ? e : new Error(String(e)))
+          }
           setLoading(false)
         }
       })
@@ -40,7 +54,7 @@ export function useCollection(
     return () => {
       cancelled = true
     }
-  }, [dir, reloadToken])
+  }, [dir, reloadToken, skip, browse])
 
   return { collection, loading, error, updateCollection: setCollection }
 }

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -44,9 +44,8 @@ export function useCollection(
         if (!cancelled) {
           if (browse) {
             setCollection({ id: dir, name: dir, items: [] })
-          } else {
-            setError(e instanceof Error ? e : new Error(String(e)))
           }
+          setError(e instanceof Error ? e : new Error(String(e)))
           setLoading(false)
         }
       })

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -242,7 +242,7 @@ export function App({
     <ThemeProvider activeIndex={activeIndex} previewIndex={previewIndex}>
       <Toast />
       <AppInner
-        key={`${activeCollectionDir}__${reloadKey}`}
+        key={`${activeCollectionDir}__${reloadKey}__${mode}`}
         collectionDir={activeCollectionDir}
         environmentsDir={activeEnvironmentsDir}
         envNames={envNames}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,8 @@ import { Toast, showToast } from "./Toast"
 import { loadSettings, saveSettings } from "../filestore"
 import { loadLastRequest } from "./tabs/uiState"
 import type { Keybinds } from "./keybind"
+import type { CollectionMode } from "../app/main"
+import { classifyPath } from "../app/main"
 
 const CONFIG_DIR = `${process.env.HOME ?? "~"}/.config/noodle`
 
@@ -19,6 +21,8 @@ export function App({
   settingsEnv: initialSettingsEnv,
   keybinds: keybinds,
   lastRequestId: initialLastRequestId,
+  shouldRegister = false,
+  mode: initialMode = "empty",
 }: {
   collectionDir: string
   envList: string[]
@@ -26,6 +30,8 @@ export function App({
   settingsEnv?: string
   keybinds: Keybinds
   lastRequestId?: string
+  shouldRegister?: boolean
+  mode?: CollectionMode
 }) {
   const { config, updateConfig } = useConfig(CONFIG_DIR)
   const switchingRef = useRef(false)
@@ -35,6 +41,7 @@ export function App({
   )
   const [activeCollectionDir, setActiveCollectionDir] =
     useState(initialCollectionDir)
+  const [mode, setMode] = useState<CollectionMode>(initialMode)
   const [reloadKey, setReloadKey] = useState(0)
   const [settingsEnv, setSettingsEnv] = useState<string | undefined>(
     initialSettingsEnv,
@@ -63,13 +70,18 @@ export function App({
   )
 
   useEffect(() => {
-    if (config.collections[0] === activeCollectionDir) return
-    updateConfig((prev) => ({
-      collections: upsertCollectionPath(prev.collections, activeCollectionDir),
-    }))
-  }, [activeCollectionDir, config.collections, updateConfig])
+    if (shouldRegister && mode === "collection") {
+      updateConfig((prev) => ({
+        collections: upsertCollectionPath(
+          prev.collections,
+          activeCollectionDir,
+        ),
+      }))
+    }
+  }, [])
 
   useEffect(() => {
+    if (mode !== "collection") return
     let cancelled = false
     listEnvironmentsWithColors(activeEnvironmentsDir).then((items) => {
       if (cancelled) return
@@ -81,7 +93,7 @@ export function App({
     return () => {
       cancelled = true
     }
-  }, [activeEnvironmentsDir])
+  }, [activeEnvironmentsDir, mode])
 
   const handleThemeChange = useCallback(
     (index: number) => {
@@ -99,27 +111,49 @@ export function App({
   )
 
   const handleEnvListChanged = useCallback(async () => {
+    if (mode !== "collection") return
     const items = await listEnvironmentsWithColors(activeEnvironmentsDir)
     setEnvNames(items.map((i) => i.name))
     const colors: Record<string, string | undefined> = {}
     for (const item of items) colors[item.name] = item.color
     setEnvColors(colors)
-  }, [activeEnvironmentsDir])
+  }, [activeEnvironmentsDir, mode])
 
   const handleEnvChange = useCallback(
     (name: string | null) => {
       const envName = name ?? undefined
       setSettingsEnv(envName)
-      saveSettings(activeCollectionDir, { environment: envName }).catch(
-        () => {},
-      )
+      if (mode === "collection") {
+        saveSettings(activeCollectionDir, { environment: envName }).catch(
+          () => {},
+        )
+      }
     },
-    [activeCollectionDir],
+    [activeCollectionDir, mode],
   )
 
   const handleReloadCollection = useCallback(() => {
     setReloadKey((k) => k + 1)
   }, [])
+
+  const handleCollectionBootstrapped = useCallback(
+    (bootstrappedDir: string) => {
+      const resolved = resolve(bootstrappedDir)
+      setMode("collection")
+      updateConfig((prev) => ({
+        collections: upsertCollectionPath(prev.collections, resolved),
+      }))
+      listEnvironmentsWithColors(join(resolved, ".environments"))
+        .then((items) => {
+          setEnvNames(items.map((i) => i.name))
+          const colors: Record<string, string | undefined> = {}
+          for (const item of items) colors[item.name] = item.color
+          setEnvColors(colors)
+        })
+        .catch(() => {})
+    },
+    [updateConfig],
+  )
 
   const handleCollectionChange = useCallback(
     async (nextDir: string) => {
@@ -141,32 +175,40 @@ export function App({
           return
         }
 
+        const nextMode = classifyPath(normalized)
         let nextEnvNames: string[] = []
         const nextEnvColors: Record<string, string | undefined> = {}
-        try {
-          const items = await listEnvironmentsWithColors(
-            join(normalized, ".environments"),
-          )
-          nextEnvNames = items.map((item) => item.name)
-          for (const item of items) {
-            nextEnvColors[item.name] = item.color
+
+        if (nextMode === "collection") {
+          try {
+            const items = await listEnvironmentsWithColors(
+              join(normalized, ".environments"),
+            )
+            nextEnvNames = items.map((item) => item.name)
+            for (const item of items) {
+              nextEnvColors[item.name] = item.color
+            }
+          } catch {
+            // Collection env metadata is optional.
           }
-        } catch {
-          // Collection env metadata is optional.
         }
 
         let nextSettingsEnv: string | undefined
-        try {
-          nextSettingsEnv = (await loadSettings(normalized)).environment
-        } catch {
-          nextSettingsEnv = undefined
+        if (nextMode === "collection") {
+          try {
+            nextSettingsEnv = (await loadSettings(normalized)).environment
+          } catch {
+            nextSettingsEnv = undefined
+          }
         }
 
         let nextLastRequestId: string | undefined
-        try {
-          nextLastRequestId = await loadLastRequest(normalized)
-        } catch {
-          nextLastRequestId = undefined
+        if (nextMode === "collection") {
+          try {
+            nextLastRequestId = await loadLastRequest(normalized)
+          } catch {
+            nextLastRequestId = undefined
+          }
         }
 
         setEnvNames(nextEnvNames)
@@ -175,9 +217,12 @@ export function App({
         setLastRequestId(nextLastRequestId)
         setInitialEnvNameState(undefined)
         setActiveCollectionDir(normalized)
-        updateConfig((prev) => ({
-          collections: upsertCollectionPath(prev.collections, normalized),
-        }))
+        setMode(nextMode)
+        if (nextMode === "collection") {
+          updateConfig((prev) => ({
+            collections: upsertCollectionPath(prev.collections, normalized),
+          }))
+        }
       } finally {
         switchingRef.current = false
       }
@@ -186,8 +231,11 @@ export function App({
   )
 
   const collectionPaths = useMemo(
-    () => upsertCollectionPath(config.collections, activeCollectionDir),
-    [config.collections, activeCollectionDir],
+    () =>
+      mode === "collection"
+        ? upsertCollectionPath(config.collections, activeCollectionDir)
+        : config.collections,
+    [config.collections, activeCollectionDir, mode],
   )
 
   return (
@@ -215,6 +263,8 @@ export function App({
         collectionPaths={collectionPaths}
         onCollectionChange={handleCollectionChange}
         onReloadCollection={handleReloadCollection}
+        onCollectionBootstrapped={handleCollectionBootstrapped}
+        mode={mode}
       />
     </ThemeProvider>
   )

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -836,6 +836,7 @@ export function AppInner({
       setCollectionSwitcherVisible,
       onReloadCollection,
       view,
+      mode,
     ],
   )
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -160,6 +160,7 @@ export function AppInner({
   const folderDeletePathRef = useRef<string | null>(null)
   const [undoAllPending, setUndoAllPending] = useState(false)
   const [initPending, setInitPending] = useState(false)
+  const [initConfirmSelection, setInitConfirmSelection] = useState(0)
   const [commandPaletteVisible, setCommandPaletteVisible] = useState(false)
   const [timelineDetailEntry, setTimelineDetailEntry] =
     useState<TimelineEntry | null>(null)
@@ -760,6 +761,8 @@ export function AppInner({
     undoAllPending,
     setUndoAllPending,
     initPending,
+    initConfirmSelection,
+    setInitConfirmSelection,
     setInitPending,
     onInitConfirm: () => executeInitPending(),
     draftRef,
@@ -915,6 +918,7 @@ export function AppInner({
           deleteConfirmSelection={deleteConfirmSelection}
           undoAllPending={undoAllPending}
           initPending={initPending}
+          initConfirmSelection={initConfirmSelection}
           collectionSwitchPending={collectionSwitchPending}
           collectionSwitchSelection={collectionSwitchSelection}
           commandPaletteVisible={commandPaletteVisible}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -93,7 +93,7 @@ export function AppInner({
   onCollectionChange: (collectionDir: string) => void
   onReloadCollection: () => void
   onCollectionBootstrapped: (collectionDir: string) => void
-  mode?: "collection" | "browse" | "empty"
+  mode?: "collection" | "browse" | "empty" | "invalid"
 }) {
   const keymap = useKeymap()
   const theme = useTheme()
@@ -605,7 +605,7 @@ export function AppInner({
   const collectionRef = useRef(collection)
   collectionRef.current = collection
 
-  const modeRef = useRef<"collection" | "browse" | "empty">(mode)
+  const modeRef = useRef<"collection" | "browse" | "empty" | "invalid">(mode)
   modeRef.current = mode
 
   const selectedIdRef = useRef(selectedId)
@@ -806,7 +806,7 @@ export function AppInner({
         folderDeletePathRef,
         getKeymapFocus: () => keymap.getData("app.focus") as string,
         getView: () => view,
-        getCollectionMode: () => mode,
+        getCollectionMode: () => (mode === "invalid" ? "empty" : mode),
         setLayout,
         onLayoutChange,
         setHelpVisible,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -69,6 +69,8 @@ export function AppInner({
   collectionPaths,
   onCollectionChange,
   onReloadCollection,
+  onCollectionBootstrapped,
+  mode = "empty",
 }: {
   collectionDir: string
   environmentsDir: string
@@ -90,6 +92,8 @@ export function AppInner({
   collectionPaths: string[]
   onCollectionChange: (collectionDir: string) => void
   onReloadCollection: () => void
+  onCollectionBootstrapped: (collectionDir: string) => void
+  mode?: "collection" | "browse" | "empty"
 }) {
   const keymap = useKeymap()
   const theme = useTheme()
@@ -155,6 +159,7 @@ export function AppInner({
   )
   const folderDeletePathRef = useRef<string | null>(null)
   const [undoAllPending, setUndoAllPending] = useState(false)
+  const [initPending, setInitPending] = useState(false)
   const [commandPaletteVisible, setCommandPaletteVisible] = useState(false)
   const [timelineDetailEntry, setTimelineDetailEntry] =
     useState<TimelineEntry | null>(null)
@@ -169,18 +174,25 @@ export function AppInner({
   const headerFieldRef = useRef<"name" | "color">("name")
 
   // ── Collection ──────────────────────────────────────────────────────
+  const isCollection = mode === "collection"
+  const isBrowse = mode === "browse"
+  const isReadOnly = mode !== "collection"
+  const skipCollection = mode === "empty"
   const { collection, loading, error, updateCollection } = useCollection(
     collectionDir,
     collectionReloadToken,
+    skipCollection,
+    isBrowse,
   )
   const items = collection?.items ?? []
 
   const requestIds = useMemo(() => getRequestIds(items), [items])
-  const { getTab, setTab } = useUIState(collectionDir, requestIds)
+  const { getTab, setTab } = useUIState(collectionDir, requestIds, isReadOnly)
 
   useEffect(() => {
+    if (!isCollection) return
     loadExpandedFolders(collectionDir).then(setInitialExpandedFolders)
-  }, [collectionDir])
+  }, [collectionDir, isCollection])
 
   // ── Sidebar selection + request draft + edit-browse ─────────────────
   const {
@@ -249,6 +261,7 @@ export function AppInner({
   const saveLastDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    if (!isCollection) return
     if (!saveLastReqRef.current) {
       saveLastReqRef.current = true
       return
@@ -266,12 +279,13 @@ export function AppInner({
     return () => {
       if (saveLastDebounceRef.current) clearTimeout(saveLastDebounceRef.current)
     }
-  }, [selectedId, focusedFolderPath])
+  }, [selectedId, focusedFolderPath, isCollection])
 
   const expandedSaveRef = useRef(false)
   const expandedDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    if (!isCollection) return
     if (!expandedSaveRef.current) {
       expandedSaveRef.current = true
       return
@@ -287,7 +301,7 @@ export function AppInner({
     return () => {
       if (expandedDebounceRef.current) clearTimeout(expandedDebounceRef.current)
     }
-  }, [expandedFolders, collectionDir])
+  }, [expandedFolders, collectionDir, isCollection])
 
   const draft = useRequestDraft(selectedRequest)
 
@@ -348,6 +362,7 @@ export function AppInner({
     handleFolderDeleteConfirm,
     handleEditRequestConfirm,
     handleRequestDeleteConfirm,
+    executeInitPending,
   } = useCollectionFileActions({
     collection,
     collectionDir,
@@ -369,6 +384,8 @@ export function AppInner({
     setEditRequestVisible,
     setRequestDeletePending,
     setFolderDeletePending,
+    onCollectionBootstrapped,
+    onInitRequested: () => setInitPending(true),
   })
 
   folderSaveRef.current = handleFolderSave
@@ -381,6 +398,7 @@ export function AppInner({
     if (previewIndex !== null) return "theme"
     if (saveState.kind === "confirming") return "confirm"
     if (undoAllPending) return "undo-all"
+    if (initPending) return "init-confirm"
     if (collectionSwitchPending !== null) return "collection-switch-confirm"
     if (collectionSwitcherVisible) return "collection-switcher"
     if (yamlEditor.visible) return "yaml-editor"
@@ -399,6 +417,7 @@ export function AppInner({
     previewIndex,
     saveState.kind,
     undoAllPending,
+    initPending,
     collectionSwitchPending,
     collectionSwitcherVisible,
     yamlEditor.visible,
@@ -439,7 +458,10 @@ export function AppInner({
     envNameRef.current = envState.activeEnv?.name
   }, [envState.activeEnv?.name])
 
-  const timeline = useTimeline(collectionDir, selectedRequest?.id)
+  const timeline = useTimeline(
+    isCollection ? collectionDir : undefined,
+    selectedRequest?.id,
+  )
   const timelineAppendRef = useRef(timeline.appendEntry)
   timelineAppendRef.current = timeline.appendEntry
 
@@ -583,6 +605,9 @@ export function AppInner({
   const collectionRef = useRef(collection)
   collectionRef.current = collection
 
+  const modeRef = useRef<"collection" | "browse" | "empty">(mode)
+  modeRef.current = mode
+
   const selectedIdRef = useRef(selectedId)
   selectedIdRef.current = selectedId
 
@@ -649,6 +674,7 @@ export function AppInner({
       focusedFolderNameRef,
       folderDeletePathRef,
       responseStateRef,
+      modeRef,
     },
     {
       setFocus,
@@ -734,6 +760,9 @@ export function AppInner({
     onCollectionSwitchConfirm: confirmCollectionSwitch,
     undoAllPending,
     setUndoAllPending,
+    initPending,
+    setInitPending,
+    onInitConfirm: () => executeInitPending(),
     draftRef,
     folderDraftRef,
   })
@@ -777,6 +806,7 @@ export function AppInner({
         folderDeletePathRef,
         getKeymapFocus: () => keymap.getData("app.focus") as string,
         getView: () => view,
+        getCollectionMode: () => mode,
         setLayout,
         onLayoutChange,
         setHelpVisible,
@@ -860,8 +890,9 @@ export function AppInner({
             urlbarSubFocus={urlbarSubFocus}
             urlbarInteractive={activeOverlay === "none"}
             expandHint={expandHint}
+            mode={mode}
           />
-        ) : (
+        ) : mode === "collection" ? (
           <EnvironmentEditorView
             envEditor={envEditor}
             activeEnv={envState.activeEnv}
@@ -872,7 +903,7 @@ export function AppInner({
             setEnvDeletePending={setEnvDeletePending}
             setDeleteConfirmSelection={setDeleteConfirmSelection}
           />
-        )}
+        ) : null}
         <AppOverlays
           keybinds={keybinds}
           helpVisible={helpVisible}
@@ -882,6 +913,7 @@ export function AppInner({
           envDeletePending={envDeletePending}
           deleteConfirmSelection={deleteConfirmSelection}
           undoAllPending={undoAllPending}
+          initPending={initPending}
           collectionSwitchPending={collectionSwitchPending}
           collectionSwitchSelection={collectionSwitchSelection}
           commandPaletteVisible={commandPaletteVisible}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -385,7 +385,6 @@ export function AppInner({
     setRequestDeletePending,
     setFolderDeletePending,
     onCollectionBootstrapped,
-    onInitRequested: () => setInitPending(true),
   })
 
   folderSaveRef.current = handleFolderSave
@@ -822,6 +821,7 @@ export function AppInner({
         setView,
         setFocus,
         setUndoAllPending,
+        setInitPending,
         setExpanded,
         setPreviewIndexProp,
         setEnvDeletePending,
@@ -889,7 +889,7 @@ export function AppInner({
             onOpenTimelineEntry={(entry) => setTimelineDetailEntry(entry)}
             setSelectOpen={setSelectOpen}
             urlbarSubFocus={urlbarSubFocus}
-            urlbarInteractive={activeOverlay === "none"}
+            urlbarInteractive={activeOverlay === "none" && !isReadOnly}
             expandHint={expandHint}
             mode={mode}
           />

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -55,6 +55,7 @@ interface AppOverlaysProps {
   envDeletePending: string | null
   deleteConfirmSelection: number
   undoAllPending: boolean
+  initPending: boolean
   collectionSwitchPending: string | null
   collectionSwitchSelection: number
   commandPaletteVisible: boolean
@@ -106,6 +107,7 @@ export function AppOverlays({
   envDeletePending,
   deleteConfirmSelection,
   undoAllPending,
+  initPending,
   collectionSwitchPending,
   collectionSwitchSelection,
   commandPaletteVisible,
@@ -170,6 +172,13 @@ export function AppOverlays({
           visible
           message="Discard all unsaved changes? (y/n)"
           selectedIndex={confirmSelection}
+        />
+      )}
+      {initPending && (
+        <ConfirmOverlay
+          visible
+          message={`Initialize collection in ${collectionDir}? (y/n)`}
+          selectedIndex={0}
         />
       )}
       {collectionSwitchPending !== null && (

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -56,6 +56,7 @@ interface AppOverlaysProps {
   deleteConfirmSelection: number
   undoAllPending: boolean
   initPending: boolean
+  initConfirmSelection: number
   collectionSwitchPending: string | null
   collectionSwitchSelection: number
   commandPaletteVisible: boolean
@@ -108,6 +109,7 @@ export function AppOverlays({
   deleteConfirmSelection,
   undoAllPending,
   initPending,
+  initConfirmSelection,
   collectionSwitchPending,
   collectionSwitchSelection,
   commandPaletteVisible,
@@ -178,7 +180,7 @@ export function AppOverlays({
         <ConfirmOverlay
           visible
           message={`Initialize collection in ${collectionDir}? (y/n)`}
-          selectedIndex={0}
+          selectedIndex={initConfirmSelection}
         />
       )}
       {collectionSwitchPending !== null && (

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -75,24 +75,6 @@ export function MainView({
 }: MainViewProps) {
   const theme = useTheme()
 
-  if (mode === "empty") {
-    return (
-      <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
-        <box
-          style={{
-            flexGrow: 1,
-            alignItems: "center",
-            justifyContent: "center",
-            flexDirection: "column",
-          }}
-        >
-          <text fg={theme.textMuted}>No collection here.</text>
-          <text fg={theme.textMuted}>Ctrl+N to create a request.</text>
-        </box>
-      </box>
-    )
-  }
-
   return (
     <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
       <Sidebar
@@ -116,6 +98,13 @@ export function MainView({
           minHeight: 0,
         }}
       >
+        {mode !== "collection" && (
+          <box style={{ paddingLeft: 1, paddingRight: 1 }}>
+            <text fg={theme.warning}>
+              Read-only folder. Initialize collection to edit or send requests.
+            </text>
+          </box>
+        )}
         {focusedFolderPresent ? (
           <FolderPane
             collectionDir={collectionDir}

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -40,6 +40,7 @@ interface MainViewProps {
   urlbarSubFocus: UrlBarSubFocus
   urlbarInteractive: boolean
   expandHint: string
+  mode?: "collection" | "browse" | "empty"
 }
 
 export function MainView({
@@ -70,8 +71,27 @@ export function MainView({
   urlbarSubFocus,
   urlbarInteractive,
   expandHint,
+  mode = "collection",
 }: MainViewProps) {
   const theme = useTheme()
+
+  if (mode === "empty") {
+    return (
+      <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
+        <box
+          style={{
+            flexGrow: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            flexDirection: "column",
+          }}
+        >
+          <text fg={theme.textMuted}>No collection here.</text>
+          <text fg={theme.textMuted}>Ctrl+N to create a request.</text>
+        </box>
+      </box>
+    )
+  }
 
   return (
     <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -40,7 +40,7 @@ interface MainViewProps {
   urlbarSubFocus: UrlBarSubFocus
   urlbarInteractive: boolean
   expandHint: string
-  mode?: "collection" | "browse" | "empty"
+  mode?: "collection" | "browse" | "empty" | "invalid"
 }
 
 export function MainView({

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -90,7 +90,8 @@ export function RequestResponseView({
         setUrl={draft.setUrl}
         setMethod={draft.setMethod}
         onDefocus={draft.syncUrlParams}
-        focused={focus === "urlbar" && urlbarInteractive}
+        focused={focus === "urlbar"}
+        interactive={urlbarInteractive}
         subFocus={urlbarSubFocus}
         activeEnv={activeEnv}
       />

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -17,6 +17,7 @@ export interface SelectProps {
   value?: string
   onChange?: (id: string) => void
   focused?: boolean
+  visualFocused?: boolean
   placeholder?: string
   width?: number
   maxDropdownHeight?: number
@@ -30,6 +31,7 @@ export function Select({
   value,
   onChange,
   focused = false,
+  visualFocused = focused,
   placeholder = "Select...",
   width,
   maxDropdownHeight = 16,
@@ -186,7 +188,7 @@ export function Select({
               ? selectedBadgeBg
               : open
                 ? theme.primary
-                : focused
+                : visualFocused
                   ? theme.borderSubtle
                   : theme.backgroundElement,
           }}

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -17,6 +17,7 @@ export function UrlBar({
   setMethod = () => {},
   onDefocus,
   focused = false,
+  interactive = true,
   activeEnv,
   subFocus = "select",
 }: {
@@ -27,6 +28,7 @@ export function UrlBar({
   setMethod?: (method: Method) => void
   onDefocus: (rawUrl: string) => void
   focused?: boolean
+  interactive?: boolean
   activeEnv?: Environment | null
   subFocus?: UrlBarSubFocus
 }) {
@@ -106,13 +108,14 @@ export function UrlBar({
             items={METHOD_ITEMS}
             value={method}
             onChange={(value) => setMethod(value as Method)}
-            focused={focused && subFocus === "select"}
+            focused={focused && interactive && subFocus === "select"}
+            visualFocused={focused && subFocus === "select"}
             badge
             width={8}
             maxDropdownHeight={10}
             onOpenChange={setMethodSelectOpen}
           />
-          {focused && subFocus === "text" ? (
+          {focused && subFocus === "text" && interactive ? (
             <box style={{ flexGrow: 1 }}>
               <VarInput
                 value={inputValue}
@@ -129,7 +132,10 @@ export function UrlBar({
           ) : (
             <box
               style={{
-                backgroundColor: theme.backgroundElement,
+                backgroundColor:
+                  focused && subFocus === "text"
+                    ? theme.borderSubtle
+                    : theme.backgroundElement,
                 flexGrow: 1,
                 overflow: "hidden",
               }}

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -56,6 +56,7 @@ export interface CommandBuilderContext {
   folderDeletePathRef: RefObject<string | null>
   getKeymapFocus: () => string
   getView: () => string
+  getCollectionMode: () => "collection" | "browse" | "empty"
   setLayout: (
     v:
       | "stacked"
@@ -184,10 +185,12 @@ export function buildCommandPaletteCommands(
     setCollectionSwitcherVisible,
     setEnvDeletePending,
     setDeleteConfirmSelection,
+    getCollectionMode,
   } = ctx
 
   const c = toConfig(ctx)
   const view = getView()
+  const mode = getCollectionMode()
 
   const requestCommands: CommandItem[] = [
     {
@@ -205,7 +208,10 @@ export function buildCommandPaletteCommands(
       label: "Save Request",
       section: "Request",
       keybinding: displayKey(keybinds.request_save),
-      run: () => saveRequest(c),
+      run: () => {
+        if (mode !== "collection") return false
+        return saveRequest(c)
+      },
     },
     {
       id: "request.edit-overlay",
@@ -213,6 +219,7 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_edit_overlay),
       run: () => {
+        if (mode !== "collection") return false
         if (!cloneRequest(c)) return false
         setEditRequestVisible(true)
         return true
@@ -234,6 +241,7 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_clone),
       run: () => {
+        if (mode !== "collection") return false
         if (!cloneRequest(c)) return false
         setCloneRequestVisible(true)
         return true
@@ -245,6 +253,7 @@ export function buildCommandPaletteCommands(
       section: "Request",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
+        if (mode !== "collection") return false
         const result = deleteRequest(c)
         if (!result) return false
         setRequestDeletePending(result.requestName)
@@ -351,6 +360,7 @@ export function buildCommandPaletteCommands(
       section: "Workspace",
       keybinding: displayKey(keybinds.request_delete),
       run: () => {
+        if (mode !== "collection") return false
         const result = deleteFolder(c)
         if (!result) return false
         c.folderDeletePathRef.current = result.folderPath
@@ -364,6 +374,7 @@ export function buildCommandPaletteCommands(
       section: "Workspace",
       keybinding: displayKey(keybinds.request_edit_yaml),
       run: () => {
+        if (mode !== "collection") return false
         if (c.focusedFolderPathRef.current) {
           const result = getEditFolderYamlFile(c)
           if (!result) return false
@@ -481,7 +492,7 @@ export function buildCommandPaletteCommands(
 
   if (view === "env-editor") {
     return [
-      ...editorEnvCommands,
+      ...(mode === "collection" ? editorEnvCommands : []),
       ...workspaceCommands,
       ...globalCommands,
       ...systemCommands,
@@ -491,7 +502,7 @@ export function buildCommandPaletteCommands(
   return [
     ...requestCommands,
     ...responseCommands,
-    ...mainEnvCommands,
+    ...(mode === "collection" ? mainEnvCommands : []),
     ...workspaceCommands,
     ...mainOnlyCommands,
     ...globalCommands,

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -116,6 +116,7 @@ export interface CommandBuilderContext {
   ) => void
   setFocus: (focus: Focus | ((prev: Focus) => Focus)) => void
   setUndoAllPending: (v: boolean | ((prev: boolean) => boolean)) => void
+  setInitPending: (v: boolean | ((prev: boolean) => boolean)) => void
   setExpanded: (
     v:
       | "request"
@@ -171,6 +172,7 @@ export function buildCommandPaletteCommands(
     setRequestDeletePending,
     setFolderDeletePending,
     setUndoAllPending,
+    setInitPending,
     setView,
     setFocus,
     setLayout,
@@ -438,6 +440,18 @@ export function buildCommandPaletteCommands(
     },
   ]
 
+  const readOnlyCommands: CommandItem[] = [
+    {
+      id: "collection.init",
+      label: "Initialize Collection",
+      section: "Collection",
+      run: () => {
+        setInitPending(true)
+        return true
+      },
+    },
+  ]
+
   const systemCommands: CommandItem[] = [
     {
       id: "app.help",
@@ -492,18 +506,18 @@ export function buildCommandPaletteCommands(
 
   if (view === "env-editor") {
     return [
-      ...(mode === "collection" ? editorEnvCommands : []),
-      ...workspaceCommands,
+      ...(mode === "collection" ? editorEnvCommands : readOnlyCommands),
+      ...(mode === "collection" ? workspaceCommands : []),
       ...globalCommands,
       ...systemCommands,
     ]
   }
 
   return [
-    ...requestCommands,
+    ...(mode === "collection" ? requestCommands : []),
     ...responseCommands,
     ...(mode === "collection" ? mainEnvCommands : []),
-    ...workspaceCommands,
+    ...(mode === "collection" ? workspaceCommands : readOnlyCommands),
     ...mainOnlyCommands,
     ...globalCommands,
     ...systemCommands,

--- a/src/ui/overlays/ConfirmOverlay.tsx
+++ b/src/ui/overlays/ConfirmOverlay.tsx
@@ -10,7 +10,7 @@ export interface ConfirmOverlayProps {
 export function ConfirmOverlay({
   visible,
   message,
-  selectedIndex: _selectedIndex,
+  selectedIndex,
 }: ConfirmOverlayProps) {
   const theme = useTheme()
 
@@ -38,10 +38,10 @@ export function ConfirmOverlay({
           paddingX: 2,
         }}
       >
-        <text fg={theme.text}>y</text>
+        <text fg={selectedIndex === 0 ? theme.primary : theme.text}>y</text>
         <text fg={theme.textMuted}>confirm</text>
         <text fg={theme.textMuted}> · </text>
-        <text fg={theme.text}>n</text>
+        <text fg={selectedIndex === 1 ? theme.primary : theme.text}>n</text>
         <text fg={theme.textMuted}>cancel</text>
       </box>
     </Overlay>

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -80,10 +80,16 @@ export function TimelineDetailOverlay({
       : theme.info
 
   const authHeader = maskedAuthHeader(entry.request.auth)
+  const authSkipKeys = new Set<string>()
+  if (authHeader) {
+    authSkipKeys.add(authHeader.key.toLowerCase())
+  }
   const requestHeaders = [
     ...(authHeader ? [authHeader] : []),
     ...Object.entries(entry.request.headers)
-      .filter(([, value]) => value.enabled)
+      .filter(
+        ([key, value]) => value.enabled && !authSkipKeys.has(key.toLowerCase()),
+      )
       .map(([key, value]) => ({ key, value: value.value })),
   ].sort((a, b) => a.key.localeCompare(b.key))
   const responseHeaders = entry.response ? formatHeaders(entry.response) : []

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -15,7 +15,7 @@ import {
   entryStatus,
   entryTiming,
   formatRequestUrl,
-  maskedAuthHeader,
+  buildDetailRequestHeaders,
   shortMethod,
 } from "../timeline/formatTimeline"
 
@@ -79,19 +79,10 @@ export function TimelineDetailOverlay({
         theme.info)
       : theme.info
 
-  const authHeader = maskedAuthHeader(entry.request.auth)
-  const authSkipKeys = new Set<string>()
-  if (authHeader) {
-    authSkipKeys.add(authHeader.key.toLowerCase())
-  }
-  const requestHeaders = [
-    ...(authHeader ? [authHeader] : []),
-    ...Object.entries(entry.request.headers)
-      .filter(
-        ([key, value]) => value.enabled && !authSkipKeys.has(key.toLowerCase()),
-      )
-      .map(([key, value]) => ({ key, value: value.value })),
-  ].sort((a, b) => a.key.localeCompare(b.key))
+  const requestHeaders = buildDetailRequestHeaders(
+    entry.request.auth,
+    entry.request.headers,
+  )
   const responseHeaders = entry.response ? formatHeaders(entry.response) : []
   const requestMaxKeyLen = requestHeaders.reduce(
     (max, header) => Math.max(max, header.key.length),

--- a/src/ui/tabs/useUIState.ts
+++ b/src/ui/tabs/useUIState.ts
@@ -23,6 +23,7 @@ const DEFAULTS: TabPrefs = { requestTab: "headers", responseTab: "body" }
 export function useUIState(
   collectionDir: string,
   requestIds: string[],
+  skip = false,
 ): UseUIStateResult {
   const [state, setState] = useState<Map<string, TabPrefs>>(new Map())
   const mapRef = useRef(state)
@@ -34,10 +35,11 @@ export function useUIState(
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    if (skip) return
     loadUIState(collectionDir).then((m) => {
       setState(m)
     })
-  }, [collectionDir])
+  }, [collectionDir, skip])
 
   useEffect(() => {
     return () => {
@@ -54,6 +56,7 @@ export function useUIState(
 
   const setTab = useCallback(
     (requestId: string, pane: Pane, value: FieldKind | ResponseTabKind) => {
+      if (skip) return
       const next = new Map(mapRef.current)
       const prefs = next.get(requestId) ?? { ...DEFAULTS }
       if (pane === "request") {
@@ -74,7 +77,7 @@ export function useUIState(
         )
       }, 300)
     },
-    [collectionDir],
+    [collectionDir, skip],
   )
 
   return { getTab, setTab }

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -134,3 +134,24 @@ export function maskedAuthHeader(
   }
   return null
 }
+
+export function buildDetailRequestHeaders(
+  auth: TimelineEntry["request"]["auth"],
+  headers: TimelineEntry["request"]["headers"],
+): { key: string; value: string }[] {
+  const authHeader = maskedAuthHeader(auth)
+  const skipKeys = new Set<string>()
+  if (authHeader) {
+    skipKeys.add(authHeader.key.toLowerCase())
+  }
+  const merged = [
+    ...(authHeader ? [authHeader] : []),
+    ...Object.entries(headers)
+      .filter(
+        ([key, value]) => value.enabled && !skipKeys.has(key.toLowerCase()),
+      )
+      .map(([key, value]) => ({ key, value: value.value })),
+  ]
+  merged.sort((a, b) => a.key.localeCompare(b.key))
+  return merged
+}

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -46,7 +46,7 @@ export interface UseAppKeymapRefs {
   focusedFolderNameRef: RefObject<string | null>
   folderDeletePathRef: RefObject<string | null>
   responseStateRef: RefObject<SendState>
-  modeRef: RefObject<"collection" | "browse" | "empty">
+  modeRef: RefObject<"collection" | "browse" | "empty" | "invalid">
 }
 
 export interface UseAppKeymapSetters {

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -236,6 +236,7 @@ export function useAppKeymap(
       },
       {
         name: "request.edit-yaml",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           if (refs.focusedFolderPathRef.current) {
             const file = getEditFolderYamlFile(actionsConfig)
@@ -565,6 +566,7 @@ export function useAppKeymap(
       },
       {
         name: "browse.save",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           const d = refs.draftRef.current
           if (!refs.savingRef.current && d.draft && d.isDirty) {
@@ -623,6 +625,7 @@ export function useAppKeymap(
       },
       {
         name: "request.clone",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           const sid = refs.selectedIdRef.current
           if (!sid) return
@@ -653,10 +656,12 @@ export function useAppKeymap(
     commands: [
       {
         name: "folder.save",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.folderSaveRef.current(),
       },
       {
         name: "folder.delete",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           const folderPath = refs.focusedFolderPathRef.current
           const folderName = refs.focusedFolderNameRef.current

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -46,6 +46,7 @@ export interface UseAppKeymapRefs {
   focusedFolderNameRef: RefObject<string | null>
   folderDeletePathRef: RefObject<string | null>
   responseStateRef: RefObject<SendState>
+  modeRef: RefObject<"collection" | "browse" | "empty">
 }
 
 export interface UseAppKeymapSetters {
@@ -399,7 +400,9 @@ export function useAppKeymap(
     commands: [
       {
         name: "env.editor-open",
-        enabled: () => keymap.getData("app.focus") === "sidebar",
+        enabled: () =>
+          keymap.getData("app.focus") === "sidebar" &&
+          refs.modeRef.current === "collection",
         run: () => {
           const name = refs.envStateRef.current.activeEnv?.name
           refs.envEditorRef.current.openEditor(name)
@@ -413,6 +416,7 @@ export function useAppKeymap(
       },
       {
         name: "request.save",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           const d = refs.draftRef.current
           if (!refs.savingRef.current && d.draft && d.isDirty) {
@@ -422,6 +426,7 @@ export function useAppKeymap(
       },
       {
         name: "env.cycle",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.envStateRef.current.cycle(1),
       },
       {
@@ -434,6 +439,7 @@ export function useAppKeymap(
       },
       {
         name: "request.edit-overlay",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           if (refs.focusedFolderPathRef.current) return
           const sid = refs.selectedIdRef.current
@@ -447,6 +453,7 @@ export function useAppKeymap(
       },
       {
         name: "request.clone",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           const sid = refs.selectedIdRef.current
           if (!sid) return
@@ -459,6 +466,7 @@ export function useAppKeymap(
       },
       {
         name: "request.delete",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           const folderPath = refs.focusedFolderPathRef.current
           const folderName = refs.focusedFolderNameRef.current

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -315,7 +315,11 @@ export function useAppKeymap(
         enabled: () => {
           const mode = keymap.getData("app.mode") as string
           const overlay = keymap.getData("app.overlay") as string
-          return mode !== "edit" && overlay === "none"
+          return (
+            refs.modeRef.current === "collection" &&
+            mode !== "edit" &&
+            overlay === "none"
+          )
         },
         run: () => {
           if (!undoAll(actionsConfig)) return
@@ -413,6 +417,7 @@ export function useAppKeymap(
       },
       {
         name: "request.send",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.trySendRef.current?.(),
       },
       {
@@ -432,10 +437,12 @@ export function useAppKeymap(
       },
       {
         name: "request.new",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => setters.setNewRequestVisible(true),
       },
       {
         name: "folder.new",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => setters.setNewFolderVisible(true),
       },
       {
@@ -515,6 +522,7 @@ export function useAppKeymap(
     commands: [
       {
         name: "request.edit-enter",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           refs.ebRef.current.enterBrowse()
           setters.setFocus("request")
@@ -548,16 +556,22 @@ export function useAppKeymap(
       { name: "browse.down", run: () => refs.ebRef.current.browseDown() },
       { name: "browse.left", run: () => refs.ebRef.current.browseLeft() },
       { name: "browse.right", run: () => refs.ebRef.current.browseRight() },
-      { name: "browse.enter", run: () => refs.ebRef.current.enterEdit() },
+      {
+        name: "browse.enter",
+        enabled: () => refs.modeRef.current === "collection",
+        run: () => refs.ebRef.current.enterEdit(),
+      },
       { name: "browse.escape", run: () => refs.ebRef.current.exitBrowse() },
       { name: "browse.delete", run: () => refs.ebRef.current.revertField() },
       { name: "browse.revert-all", run: () => refs.ebRef.current.revertAll() },
       {
         name: "browse.toggle",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.ebRef.current.toggleRow(),
       },
       {
         name: "browse.send",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.trySendRef.current?.(),
       },
       {
@@ -602,6 +616,7 @@ export function useAppKeymap(
     commands: [
       {
         name: "folder.edit-enter",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => {
           refs.folderEbRef.current?.enterBrowse()
           setters.setFocus("folder")
@@ -617,10 +632,12 @@ export function useAppKeymap(
       },
       {
         name: "request.new",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => setters.setNewRequestVisible(true),
       },
       {
         name: "folder.new",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => setters.setNewFolderVisible(true),
       },
       {

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -576,6 +576,7 @@ export function useAppKeymap(
       },
       {
         name: "browse.toggle-form-type",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.ebRef.current.toggleFormRowType(),
       },
       {
@@ -721,6 +722,7 @@ export function useAppKeymap(
       },
       {
         name: "folder-browse.enter",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.folderEbRef.current?.enterEdit(),
       },
       {
@@ -732,6 +734,7 @@ export function useAppKeymap(
       },
       {
         name: "folder-browse.toggle",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.folderEbRef.current?.toggleRow(),
       },
       {
@@ -766,6 +769,7 @@ export function useAppKeymap(
     commands: [
       {
         name: "folder-edit.commit",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.folderEbRef.current?.commitEdit(),
       },
       {
@@ -774,6 +778,7 @@ export function useAppKeymap(
       },
       {
         name: "folder-edit.tab",
+        enabled: () => refs.modeRef.current === "collection",
         run: () => refs.folderEbRef.current?.browseTab(),
       },
     ],

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -21,15 +21,21 @@ import { updateFolderByPath } from "./tree"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
 
-interface InitPendingAction {
-  kind: "request"
-  name: string
-  methodString: string
-  url: string
-  folder?: string
-  id: string
-  isFolder?: boolean
-}
+type InitPendingAction =
+  | {
+      kind: "request"
+      name: string
+      method: Method
+      url: string
+      folder?: string
+      id: string
+    }
+  | {
+      kind: "folder"
+      name: string
+      folder?: string
+      id: string
+    }
 
 interface UseCollectionFileActionsOptions {
   collectionDir: string
@@ -145,7 +151,7 @@ export function useCollectionFileActions({
         initPendingRef.current = {
           kind: "request",
           name,
-          methodString: method,
+          method,
           url,
           folder: folder ?? undefined,
           id,
@@ -263,13 +269,10 @@ export function useCollectionFileActions({
 
       if (needsBootstrap && onInitRequested) {
         initPendingRef.current = {
-          kind: "request",
+          kind: "folder",
           name,
-          methodString: "GET",
-          url: "",
           folder: folder ?? undefined,
           id: path,
-          isFolder: true,
         }
         onInitRequested()
         return
@@ -444,7 +447,7 @@ export function useCollectionFileActions({
       await ensureCollectionBootstrapped(collectionDir)
       onCollectionBootstrapped(collectionDir)
 
-      if (action.isFolder) {
+      if (action.kind === "folder") {
         const newFolder: Folder = {
           id: action.id,
           name: action.name,
@@ -458,7 +461,7 @@ export function useCollectionFileActions({
         const req: NoodleRequest = {
           id: action.id,
           name: action.name,
-          method: action.methodString as Method,
+          method: action.method,
           url: action.url,
           timeout: 0,
           followRedirects: true,

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -1,6 +1,4 @@
-import { useCallback, useRef } from "react"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
+import { useCallback } from "react"
 import type { Dispatch, MutableRefObject, SetStateAction } from "react"
 import type {
   Collection,
@@ -20,22 +18,6 @@ import { slugify } from "./overlays/NewRequestOverlay"
 import { updateFolderByPath } from "./tree"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
-
-type InitPendingAction =
-  | {
-      kind: "request"
-      name: string
-      method: Method
-      url: string
-      folder?: string
-      id: string
-    }
-  | {
-      kind: "folder"
-      name: string
-      folder?: string
-      id: string
-    }
 
 interface UseCollectionFileActionsOptions {
   collectionDir: string
@@ -59,7 +41,6 @@ interface UseCollectionFileActionsOptions {
   setRequestDeletePending: Dispatch<SetStateAction<string | null>>
   setFolderDeletePending: Dispatch<SetStateAction<string | null>>
   onCollectionBootstrapped: (dir: string) => void
-  onInitRequested?: () => void
 }
 
 export function useCollectionFileActions({
@@ -84,10 +65,7 @@ export function useCollectionFileActions({
   setRequestDeletePending,
   setFolderDeletePending,
   onCollectionBootstrapped,
-  onInitRequested,
 }: UseCollectionFileActionsOptions) {
-  const initPendingRef = useRef<InitPendingAction | null>(null)
-
   const showSaveResult = useCallback(
     (state: SaveState) => {
       setSaveState(state)
@@ -144,22 +122,6 @@ export function useCollectionFileActions({
       const folder = newRequestFolderRef.current
       const id = folder ? `${folder}/${baseId}` : baseId
 
-      const settingsPath = join(collectionDir, "settings.yml")
-      const needsBootstrap = !existsSync(settingsPath)
-
-      if (needsBootstrap && onInitRequested) {
-        initPendingRef.current = {
-          kind: "request",
-          name,
-          method,
-          url,
-          folder: folder ?? undefined,
-          id,
-        }
-        onInitRequested()
-        return
-      }
-
       const req: NoodleRequest = {
         id,
         name,
@@ -175,17 +137,8 @@ export function useCollectionFileActions({
         body: "",
       }
 
-      const savePromise = needsBootstrap
-        ? ensureCollectionBootstrapped(collectionDir).then(() =>
-            saveRequest(collectionDir, req),
-          )
-        : saveRequest(collectionDir, req)
-
-      savePromise
+      saveRequest(collectionDir, req)
         .then(() => {
-          if (needsBootstrap) {
-            onCollectionBootstrapped(collectionDir)
-          }
           if (folder) expandFolder(folder)
           setCollectionReloadToken((n) => n + 1)
           setSelectedId(id)
@@ -202,8 +155,6 @@ export function useCollectionFileActions({
       collectionDir,
       expandFolder,
       newRequestFolderRef,
-      onCollectionBootstrapped,
-      onInitRequested,
       setCollectionReloadToken,
       setFocus,
       setNewRequestVisible,
@@ -264,20 +215,6 @@ export function useCollectionFileActions({
       const folder = newRequestFolderRef.current
       const path = folder ? `${folder}/${baseId}` : baseId
 
-      const settingsPath = join(collectionDir, "settings.yml")
-      const needsBootstrap = !existsSync(settingsPath)
-
-      if (needsBootstrap && onInitRequested) {
-        initPendingRef.current = {
-          kind: "folder",
-          name,
-          folder: folder ?? undefined,
-          id: path,
-        }
-        onInitRequested()
-        return
-      }
-
       const newFolder: Folder = {
         id: baseId,
         name,
@@ -285,17 +222,8 @@ export function useCollectionFileActions({
         children: [],
       }
 
-      const savePromise = needsBootstrap
-        ? ensureCollectionBootstrapped(collectionDir).then(() =>
-            saveFolder(collectionDir, newFolder),
-          )
-        : saveFolder(collectionDir, newFolder)
-
-      savePromise
+      saveFolder(collectionDir, newFolder)
         .then(() => {
-          if (needsBootstrap) {
-            onCollectionBootstrapped(collectionDir)
-          }
           if (folder) expandFolder(folder)
           setCollectionReloadToken((n) => n + 1)
           setNewFolderVisible(false)
@@ -311,8 +239,6 @@ export function useCollectionFileActions({
       collectionDir,
       expandFolder,
       newRequestFolderRef,
-      onCollectionBootstrapped,
-      onInitRequested,
       setCollectionReloadToken,
       setFocus,
       setNewFolderVisible,
@@ -439,63 +365,23 @@ export function useCollectionFileActions({
   ])
 
   const executeInitPending = useCallback(async () => {
-    const action = initPendingRef.current
-    if (!action) return
-    initPendingRef.current = null
-
     try {
       await ensureCollectionBootstrapped(collectionDir)
       onCollectionBootstrapped(collectionDir)
-
-      if (action.kind === "folder") {
-        const newFolder: Folder = {
-          id: action.id,
-          name: action.name,
-          path: action.id,
-          children: [],
-        }
-        await saveFolder(collectionDir, newFolder)
-        if (action.folder) expandFolder(action.folder)
-        setNewFolderVisible(false)
-      } else {
-        const req: NoodleRequest = {
-          id: action.id,
-          name: action.name,
-          method: action.method,
-          url: action.url,
-          timeout: 0,
-          followRedirects: true,
-          maxRedirects: 5,
-          headers: {},
-          params: [],
-          auth: { type: "none" },
-          bodyType: "none",
-          body: "",
-        }
-        await saveRequest(collectionDir, req)
-        if (action.folder) expandFolder(action.folder)
-        setNewRequestVisible(false)
-      }
-
       setCollectionReloadToken((n) => n + 1)
-      setSelectedId(action.id)
       setFocus("sidebar")
       showSaveResult({
         kind: "success",
-        message: `Successfully created ${action.name}`,
+        message: "Collection initialized",
       })
     } catch (e: unknown) {
       showError(e)
     }
   }, [
     collectionDir,
-    expandFolder,
     onCollectionBootstrapped,
     setCollectionReloadToken,
     setFocus,
-    setNewFolderVisible,
-    setNewRequestVisible,
-    setSelectedId,
     showError,
     showSaveResult,
   ])
@@ -508,7 +394,6 @@ export function useCollectionFileActions({
     handleFolderDeleteConfirm,
     handleEditRequestConfirm,
     handleRequestDeleteConfirm,
-    initPendingRef,
     executeInitPending,
   }
 }

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -1,4 +1,6 @@
-import { useCallback } from "react"
+import { useCallback, useRef } from "react"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
 import type { Dispatch, MutableRefObject, SetStateAction } from "react"
 import type {
   Collection,
@@ -12,11 +14,22 @@ import {
   deleteRequest,
   saveFolder,
   deleteFolder,
-} from "../filestore/save"
+  ensureCollectionBootstrapped,
+} from "../filestore"
 import { slugify } from "./overlays/NewRequestOverlay"
 import { updateFolderByPath } from "./tree"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
+
+interface InitPendingAction {
+  kind: "request"
+  name: string
+  methodString: string
+  url: string
+  folder?: string
+  id: string
+  isFolder?: boolean
+}
 
 interface UseCollectionFileActionsOptions {
   collectionDir: string
@@ -39,6 +52,8 @@ interface UseCollectionFileActionsOptions {
   setEditRequestVisible: Dispatch<SetStateAction<boolean>>
   setRequestDeletePending: Dispatch<SetStateAction<string | null>>
   setFolderDeletePending: Dispatch<SetStateAction<string | null>>
+  onCollectionBootstrapped: (dir: string) => void
+  onInitRequested?: () => void
 }
 
 export function useCollectionFileActions({
@@ -62,7 +77,11 @@ export function useCollectionFileActions({
   setEditRequestVisible,
   setRequestDeletePending,
   setFolderDeletePending,
+  onCollectionBootstrapped,
+  onInitRequested,
 }: UseCollectionFileActionsOptions) {
+  const initPendingRef = useRef<InitPendingAction | null>(null)
+
   const showSaveResult = useCallback(
     (state: SaveState) => {
       setSaveState(state)
@@ -119,6 +138,22 @@ export function useCollectionFileActions({
       const folder = newRequestFolderRef.current
       const id = folder ? `${folder}/${baseId}` : baseId
 
+      const settingsPath = join(collectionDir, "settings.yml")
+      const needsBootstrap = !existsSync(settingsPath)
+
+      if (needsBootstrap && onInitRequested) {
+        initPendingRef.current = {
+          kind: "request",
+          name,
+          methodString: method,
+          url,
+          folder: folder ?? undefined,
+          id,
+        }
+        onInitRequested()
+        return
+      }
+
       const req: NoodleRequest = {
         id,
         name,
@@ -134,8 +169,17 @@ export function useCollectionFileActions({
         body: "",
       }
 
-      saveRequest(collectionDir, req)
+      const savePromise = needsBootstrap
+        ? ensureCollectionBootstrapped(collectionDir).then(() =>
+            saveRequest(collectionDir, req),
+          )
+        : saveRequest(collectionDir, req)
+
+      savePromise
         .then(() => {
+          if (needsBootstrap) {
+            onCollectionBootstrapped(collectionDir)
+          }
           if (folder) expandFolder(folder)
           setCollectionReloadToken((n) => n + 1)
           setSelectedId(id)
@@ -152,6 +196,8 @@ export function useCollectionFileActions({
       collectionDir,
       expandFolder,
       newRequestFolderRef,
+      onCollectionBootstrapped,
+      onInitRequested,
       setCollectionReloadToken,
       setFocus,
       setNewRequestVisible,
@@ -212,6 +258,23 @@ export function useCollectionFileActions({
       const folder = newRequestFolderRef.current
       const path = folder ? `${folder}/${baseId}` : baseId
 
+      const settingsPath = join(collectionDir, "settings.yml")
+      const needsBootstrap = !existsSync(settingsPath)
+
+      if (needsBootstrap && onInitRequested) {
+        initPendingRef.current = {
+          kind: "request",
+          name,
+          methodString: "GET",
+          url: "",
+          folder: folder ?? undefined,
+          id: path,
+          isFolder: true,
+        }
+        onInitRequested()
+        return
+      }
+
       const newFolder: Folder = {
         id: baseId,
         name,
@@ -219,8 +282,17 @@ export function useCollectionFileActions({
         children: [],
       }
 
-      saveFolder(collectionDir, newFolder)
+      const savePromise = needsBootstrap
+        ? ensureCollectionBootstrapped(collectionDir).then(() =>
+            saveFolder(collectionDir, newFolder),
+          )
+        : saveFolder(collectionDir, newFolder)
+
+      savePromise
         .then(() => {
+          if (needsBootstrap) {
+            onCollectionBootstrapped(collectionDir)
+          }
           if (folder) expandFolder(folder)
           setCollectionReloadToken((n) => n + 1)
           setNewFolderVisible(false)
@@ -236,6 +308,8 @@ export function useCollectionFileActions({
       collectionDir,
       expandFolder,
       newRequestFolderRef,
+      onCollectionBootstrapped,
+      onInitRequested,
       setCollectionReloadToken,
       setFocus,
       setNewFolderVisible,
@@ -361,6 +435,68 @@ export function useCollectionFileActions({
     showSaveResult,
   ])
 
+  const executeInitPending = useCallback(async () => {
+    const action = initPendingRef.current
+    if (!action) return
+    initPendingRef.current = null
+
+    try {
+      await ensureCollectionBootstrapped(collectionDir)
+      onCollectionBootstrapped(collectionDir)
+
+      if (action.isFolder) {
+        const newFolder: Folder = {
+          id: action.id,
+          name: action.name,
+          path: action.id,
+          children: [],
+        }
+        await saveFolder(collectionDir, newFolder)
+        if (action.folder) expandFolder(action.folder)
+        setNewFolderVisible(false)
+      } else {
+        const req: NoodleRequest = {
+          id: action.id,
+          name: action.name,
+          method: action.methodString as Method,
+          url: action.url,
+          timeout: 0,
+          followRedirects: true,
+          maxRedirects: 5,
+          headers: {},
+          params: [],
+          auth: { type: "none" },
+          bodyType: "none",
+          body: "",
+        }
+        await saveRequest(collectionDir, req)
+        if (action.folder) expandFolder(action.folder)
+        setNewRequestVisible(false)
+      }
+
+      setCollectionReloadToken((n) => n + 1)
+      setSelectedId(action.id)
+      setFocus("sidebar")
+      showSaveResult({
+        kind: "success",
+        message: `Successfully created ${action.name}`,
+      })
+    } catch (e: unknown) {
+      showError(e)
+    }
+  }, [
+    collectionDir,
+    expandFolder,
+    onCollectionBootstrapped,
+    setCollectionReloadToken,
+    setFocus,
+    setNewFolderVisible,
+    setNewRequestVisible,
+    setSelectedId,
+    showError,
+    showSaveResult,
+  ])
+
   return {
     handleFolderSave,
     handleNewRequestConfirm,
@@ -369,5 +505,7 @@ export function useCollectionFileActions({
     handleFolderDeleteConfirm,
     handleEditRequestConfirm,
     handleRequestDeleteConfirm,
+    initPendingRef,
+    executeInitPending,
   }
 }

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -615,6 +615,7 @@ export function useOverlayIntercepts(opts: {
         if (name === "y" || (name === "return" && initConfirmSelection === 0)) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
+          setInitConfirmSelection(0)
           onInitConfirm()
           setInitPending(false)
         } else if (
@@ -624,6 +625,7 @@ export function useOverlayIntercepts(opts: {
         ) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
+          setInitConfirmSelection(0)
           setInitPending(false)
         } else if (name === "left" || name === "up") {
           ctx.event.preventDefault()

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -74,6 +74,9 @@ export function useOverlayIntercepts(opts: {
   onCollectionSwitchConfirm: (collectionDir: string) => void
   undoAllPending: boolean
   setUndoAllPending: (v: boolean) => void
+  initPending: boolean
+  setInitPending: (v: boolean) => void
+  onInitConfirm: () => void
   draftRef: RefObject<UseRequestDraftResult>
   folderDraftRef: RefObject<UseFolderDraftResult>
 }): void {
@@ -132,6 +135,9 @@ export function useOverlayIntercepts(opts: {
     onCollectionSwitchConfirm,
     undoAllPending,
     setUndoAllPending,
+    initPending,
+    setInitPending,
+    onInitConfirm,
     draftRef,
     folderDraftRef,
   } = opts
@@ -594,6 +600,29 @@ export function useOverlayIntercepts(opts: {
     folderDraftRef,
     envEditorRef,
   ])
+
+  // ── Overlay: Init Confirm ─────────────────────────────────────────
+  useEffect(() => {
+    if (!initPending) return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        const name = ctx.event.name
+        if (name === "y" || name === "return") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          onInitConfirm()
+          setInitPending(false)
+        } else if (name === "n" || name === "escape") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          setInitPending(false)
+        }
+      },
+      { priority: 100 },
+    )
+    return dispose
+  }, [initPending, keymap, setInitPending, onInitConfirm])
 
   // ── Overlay: New Folder ───────────────────────────────────────────
   useEffect(() => {

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -75,6 +75,8 @@ export function useOverlayIntercepts(opts: {
   undoAllPending: boolean
   setUndoAllPending: (v: boolean) => void
   initPending: boolean
+  initConfirmSelection: number
+  setInitConfirmSelection: (n: number) => void
   setInitPending: (v: boolean) => void
   onInitConfirm: () => void
   draftRef: RefObject<UseRequestDraftResult>
@@ -136,6 +138,8 @@ export function useOverlayIntercepts(opts: {
     undoAllPending,
     setUndoAllPending,
     initPending,
+    initConfirmSelection,
+    setInitConfirmSelection,
     setInitPending,
     onInitConfirm,
     draftRef,
@@ -608,21 +612,40 @@ export function useOverlayIntercepts(opts: {
       "key",
       (ctx) => {
         const name = ctx.event.name
-        if (name === "y" || name === "return") {
+        if (name === "y" || (name === "return" && initConfirmSelection === 0)) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           onInitConfirm()
           setInitPending(false)
-        } else if (name === "n" || name === "escape") {
+        } else if (
+          name === "n" ||
+          name === "escape" ||
+          (name === "return" && initConfirmSelection === 1)
+        ) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           setInitPending(false)
+        } else if (name === "left" || name === "up") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          setInitConfirmSelection(0)
+        } else if (name === "right" || name === "down") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          setInitConfirmSelection(1)
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [initPending, keymap, setInitPending, onInitConfirm])
+  }, [
+    initPending,
+    initConfirmSelection,
+    keymap,
+    onInitConfirm,
+    setInitConfirmSelection,
+    setInitPending,
+  ])
 
   // ── Overlay: New Folder ───────────────────────────────────────────
   useEffect(() => {

--- a/tests/automation.test.ts
+++ b/tests/automation.test.ts
@@ -12,6 +12,7 @@ import {
   requestCreate,
   requestRun,
   validateId,
+  workspaceAudit,
 } from "../src/app/services"
 import { collection as collectionCommand } from "../src/app/commands/automation"
 import { env } from "../src/env"
@@ -205,6 +206,56 @@ describe("automation services", () => {
       "environment: prod\n",
     )
     expect(await readFile(join(dir, "settings.yml"), "utf8")).toBe("{}\n")
+  })
+
+  it("reports invalid registered collections without changing config", async () => {
+    const configDir = join(dir, "config")
+    const missing = join(dir, "missing")
+    const uninitialized = join(dir, "uninitialized")
+    await mkdir(configDir)
+    await mkdir(uninitialized)
+    await writeFile(
+      join(configDir, "config.yml"),
+      `collections:\n  - ${missing}\n  - ${uninitialized}\n`,
+      "utf8",
+    )
+
+    const result = await workspaceAudit(false, configDir)
+
+    expect(result.valid).toBe(false)
+    expect(result.collections).toEqual([missing, uninitialized])
+    expect(result.issues).toEqual([
+      { path: missing, message: "directory does not exist", fixed: false },
+      { path: uninitialized, message: "not a collection root", fixed: false },
+    ])
+    expect(await readFile(join(configDir, "config.yml"), "utf8")).toContain(
+      missing,
+    )
+  })
+
+  it("removes invalid registered collections when fixed", async () => {
+    const configDir = join(dir, "config")
+    const missing = join(dir, "missing")
+    const valid = join(dir, "valid")
+    await mkdir(configDir)
+    await mkdir(valid)
+    await writeFile(join(valid, "settings.yml"), "{}\n", "utf8")
+    await writeFile(
+      join(configDir, "config.yml"),
+      `collections:\n  - ${missing}\n  - ${valid}\n`,
+      "utf8",
+    )
+
+    const result = await workspaceAudit(true, configDir)
+
+    expect(result.valid).toBe(true)
+    expect(result.collections).toEqual([valid])
+    expect(result.issues).toEqual([
+      { path: missing, message: "directory does not exist", fixed: true },
+    ])
+    expect(await readFile(join(configDir, "config.yml"), "utf8")).not.toContain(
+      missing,
+    )
   })
 
   it("rejects traversal, empty-segment, and hidden request IDs", () => {

--- a/tests/automation.test.ts
+++ b/tests/automation.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import {
   collectionAudit,
   collectionInspect,
+  collectionInit,
   collectionList,
   collectionRun,
   environmentSet,
@@ -59,6 +60,22 @@ describe("automation services", () => {
       create: { args: { output: { default: string } } }
     }
     expect(subCommands.create.args.output.default).toBe(".")
+  })
+
+  it("initializes an existing non-collection directory", async () => {
+    const result = await collectionInit(dir)
+    expect(result.path).toBe(dir)
+    expect(await readFile(join(dir, "settings.yml"), "utf8")).toContain(
+      "environment: development",
+    )
+    expect(await env.listEnvironments(join(dir, ".environments"))).toEqual([
+      "development",
+    ])
+  })
+
+  it("rejects initializing an existing collection", async () => {
+    await writeFile(join(dir, "settings.yml"), "{}\n", "utf8")
+    await expect(collectionInit(dir)).rejects.toThrow("already a collection")
   })
 
   it("creates collection-relative requests and reports them during inspection", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "bun:test"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { CommandMeta, ArgsDef, StringArgDef } from "citty"
 import defaultCommand from "../src/app/commands/default"
 import importCommand from "../src/app/commands/import"
 import updateCommand from "../src/app/commands/update"
+import { classifyPath } from "../src/app/main"
 
 const CLI = join(import.meta.dir, "../src/app/cli.ts")
 const defaultMeta = defaultCommand.meta as CommandMeta | undefined
@@ -174,6 +175,174 @@ describe("CLI integration", () => {
         },
         errors: [],
       })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("adds noodle subcommand when positional path is given", () => {
+    const proc = Bun.spawnSync(["bun", CLI, "./collections", "--help"], {})
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    expect(out).toContain("TARGETPATH")
+  })
+
+  it("rejects both positional path and --collection flag", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-cli-conflict-"))
+    try {
+      // Create settings.yml so the run handler doesn't try to init an
+      // empty directory (we just want the argument conflict error).
+      await writeFile(join(dir, "settings.yml"), "environment: development\n")
+      const proc = Bun.spawnSync(["bun", CLI, dir, "--collection", dir])
+      const err = proc.stderr.toString()
+      expect(err).toContain("cannot supply both")
+      expect(proc.exitCode).not.toBe(0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("accepts --collection with -c alias", () => {
+    const proc = Bun.spawnSync(["bun", CLI, "-c", "./collections", "--help"])
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    expect(out).toContain("collection")
+  })
+
+  it("accepts --collection with --collection= form", () => {
+    const proc = Bun.spawnSync([
+      "bun",
+      CLI,
+      "--collection=./collections",
+      "--help",
+    ])
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    expect(out).toContain("collection")
+  })
+
+  it("accepts --env with -e alias", () => {
+    const proc = Bun.spawnSync([
+      "bun",
+      CLI,
+      "-e",
+      "development",
+      "--collection",
+      "./collections",
+      "--help",
+    ])
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    expect(out).toContain("env")
+  })
+
+  it("handles regular file path without crashing", () => {
+    const proc = Bun.spawnSync(["bun", CLI, __filename, "--help"])
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    // Should still show help for the default command even with a file path
+    expect(out).toContain("Terminal REST client")
+  })
+
+  it("does not inject noodle subcommand for known subcommands", () => {
+    const proc = Bun.spawnSync(["bun", CLI, "import", "--help"], {})
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    expect(out).toContain("SOURCE")
+    expect(out).toContain("format")
+  })
+})
+
+describe("classifyPath", () => {
+  it("returns empty for missing path", () => {
+    expect(classifyPath("/tmp/noodle-nonexistent-xyz")).toBe("empty")
+  })
+
+  it("returns empty for a regular file path", () => {
+    expect(classifyPath(__filename)).toBe("empty")
+  })
+
+  it("returns collection for path with settings.yml", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      await writeFile(join(dir, "settings.yml"), "environment: dev\n")
+      expect(classifyPath(dir)).toBe("collection")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns collection for path with .environments", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      await mkdir(join(dir, ".environments"))
+      expect(classifyPath(dir)).toBe("collection")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns collection for path with root request .yml", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      await writeFile(
+        join(dir, "ping.yml"),
+        "name: Ping\nmethod: GET\nurl: https://example.com\n",
+      )
+      expect(classifyPath(dir)).toBe("collection")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns browse for path with nested request only", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      await mkdir(join(dir, "api"))
+      await writeFile(
+        join(dir, "api", "ping.yml"),
+        "name: Ping\nmethod: GET\nurl: https://example.com\n",
+      )
+      expect(classifyPath(dir)).toBe("browse")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns empty for truly empty directory", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      expect(classifyPath(dir)).toBe("empty")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns browse for directory with non-dot subdirs containing requests", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      await mkdir(join(dir, "src"))
+      await mkdir(join(dir, "src", "lib"))
+      await mkdir(join(dir, "collections"))
+      await writeFile(
+        join(dir, "collections", "ping.yml"),
+        "name: Ping\nmethod: GET\nurl: https://example.com\n",
+      )
+      expect(classifyPath(dir)).toBe("browse")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("skips dot-prefixed dirs when checking for nested content", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-classify-"))
+    try {
+      await mkdir(join(dir, ".noodle"))
+      await writeFile(
+        join(dir, ".noodle", "data.yml"),
+        "name: Nope\nmethod: GET\nurl: https://example.com\n",
+      )
+      expect(classifyPath(dir)).toBe("empty")
     } finally {
       await rm(dir, { recursive: true, force: true })
     }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -254,12 +254,12 @@ describe("CLI integration", () => {
 })
 
 describe("classifyPath", () => {
-  it("returns empty for missing path", () => {
-    expect(classifyPath("/tmp/noodle-nonexistent-xyz")).toBe("empty")
+  it("returns invalid for missing path", () => {
+    expect(classifyPath("/tmp/noodle-nonexistent-xyz")).toBe("invalid")
   })
 
-  it("returns empty for a regular file path", () => {
-    expect(classifyPath(__filename)).toBe("empty")
+  it("returns invalid for a regular file path", () => {
+    expect(classifyPath(__filename)).toBe("invalid")
   })
 
   it("returns collection for path with settings.yml", async () => {

--- a/tests/env-crud.test.ts
+++ b/tests/env-crud.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { env } from "../src/env"
 
 let dir: string
+const itOnCI = process.env.CI ? it.skip : it
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "noodle-crud-"))
@@ -15,7 +16,7 @@ afterEach(async () => {
 })
 
 describe("environment CRUD", () => {
-  it("full lifecycle: create → list → read → update → rename → delete", async () => {
+  itOnCI("full lifecycle: create → list → read → update → rename → delete", async () => {
     // 1. Create
     await env.saveEnvironment(dir, {
       name: "dev",

--- a/tests/env-crud.test.ts
+++ b/tests/env-crud.test.ts
@@ -16,50 +16,53 @@ afterEach(async () => {
 })
 
 describe("environment CRUD", () => {
-  itOnCI("full lifecycle: create → list → read → update → rename → delete", async () => {
-    // 1. Create
-    await env.saveEnvironment(dir, {
-      name: "dev",
-      vars: { port: "3000", host: "localhost" },
-      color: "success",
-    })
-    let names = await env.listEnvironments(dir)
-    expect(names).toEqual(["dev"])
+  itOnCI(
+    "full lifecycle: create → list → read → update → rename → delete",
+    async () => {
+      // 1. Create
+      await env.saveEnvironment(dir, {
+        name: "dev",
+        vars: { port: "3000", host: "localhost" },
+        color: "success",
+      })
+      let names = await env.listEnvironments(dir)
+      expect(names).toEqual(["dev"])
 
-    // 2. Read
-    let loaded = await env.loadEnvironment(dir, "dev")
-    expect(loaded.vars).toEqual({ port: "3000", host: "localhost" })
-    expect(loaded.color).toBe("success")
+      // 2. Read
+      let loaded = await env.loadEnvironment(dir, "dev")
+      expect(loaded.vars).toEqual({ port: "3000", host: "localhost" })
+      expect(loaded.color).toBe("success")
 
-    // 3. Clone (implied rename)
-    await env.cloneEnvironment(dir, "dev", "dev-staging")
-    names = await env.listEnvironments(dir)
-    expect(names).toEqual(["dev", "dev-staging"])
+      // 3. Clone (implied rename)
+      await env.cloneEnvironment(dir, "dev", "dev-staging")
+      names = await env.listEnvironments(dir)
+      expect(names).toEqual(["dev", "dev-staging"])
 
-    // 4. Update — add var, change color
-    await env.saveEnvironment(dir, {
-      name: "dev",
-      vars: { port: "3000", host: "localhost", debug: "true" },
-      color: "warning",
-    })
-    loaded = await env.loadEnvironment(dir, "dev")
-    expect(loaded.vars).toEqual({
-      port: "3000",
-      host: "localhost",
-      debug: "true",
-    })
-    expect(loaded.color).toBe("warning")
+      // 4. Update — add var, change color
+      await env.saveEnvironment(dir, {
+        name: "dev",
+        vars: { port: "3000", host: "localhost", debug: "true" },
+        color: "warning",
+      })
+      loaded = await env.loadEnvironment(dir, "dev")
+      expect(loaded.vars).toEqual({
+        port: "3000",
+        host: "localhost",
+        debug: "true",
+      })
+      expect(loaded.color).toBe("warning")
 
-    // 5. Delete cloned
-    await env.deleteEnvironment(dir, "dev-staging")
-    names = await env.listEnvironments(dir)
-    expect(names).toEqual(["dev"])
+      // 5. Delete cloned
+      await env.deleteEnvironment(dir, "dev-staging")
+      names = await env.listEnvironments(dir)
+      expect(names).toEqual(["dev"])
 
-    // 6. Delete original
-    await env.deleteEnvironment(dir, "dev")
-    names = await env.listEnvironments(dir)
-    expect(names).toEqual([])
-  })
+      // 6. Delete original
+      await env.deleteEnvironment(dir, "dev")
+      names = await env.listEnvironments(dir)
+      expect(names).toEqual([])
+    },
+  )
 
   it("preserves disabled vars on round-trip", async () => {
     await env.saveEnvironment(dir, {

--- a/tests/env-crud.test.ts
+++ b/tests/env-crud.test.ts
@@ -5,8 +5,6 @@ import { join } from "node:path"
 import { env } from "../src/env"
 
 let dir: string
-const itOnCI = process.env.CI ? it.skip : it
-
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "noodle-crud-"))
 })
@@ -16,53 +14,50 @@ afterEach(async () => {
 })
 
 describe("environment CRUD", () => {
-  itOnCI(
-    "full lifecycle: create → list → read → update → rename → delete",
-    async () => {
-      // 1. Create
-      await env.saveEnvironment(dir, {
-        name: "dev",
-        vars: { port: "3000", host: "localhost" },
-        color: "success",
-      })
-      let names = await env.listEnvironments(dir)
-      expect(names).toEqual(["dev"])
+  it("full lifecycle: create → list → read → update → rename → delete", async () => {
+    // 1. Create
+    await env.saveEnvironment(dir, {
+      name: "dev",
+      vars: { port: "3000", host: "localhost" },
+      color: "success",
+    })
+    let names = await env.listEnvironments(dir)
+    expect(names).toEqual(["dev"])
 
-      // 2. Read
-      let loaded = await env.loadEnvironment(dir, "dev")
-      expect(loaded.vars).toEqual({ port: "3000", host: "localhost" })
-      expect(loaded.color).toBe("success")
+    // 2. Read
+    let loaded = await env.loadEnvironment(dir, "dev")
+    expect(loaded.vars).toEqual({ port: "3000", host: "localhost" })
+    expect(loaded.color).toBe("success")
 
-      // 3. Clone (implied rename)
-      await env.cloneEnvironment(dir, "dev", "dev-staging")
-      names = await env.listEnvironments(dir)
-      expect(names).toEqual(["dev", "dev-staging"])
+    // 3. Clone (implied rename)
+    await env.cloneEnvironment(dir, "dev", "dev-staging")
+    names = await env.listEnvironments(dir)
+    expect(names).toEqual(["dev", "dev-staging"])
 
-      // 4. Update — add var, change color
-      await env.saveEnvironment(dir, {
-        name: "dev",
-        vars: { port: "3000", host: "localhost", debug: "true" },
-        color: "warning",
-      })
-      loaded = await env.loadEnvironment(dir, "dev")
-      expect(loaded.vars).toEqual({
-        port: "3000",
-        host: "localhost",
-        debug: "true",
-      })
-      expect(loaded.color).toBe("warning")
+    // 4. Update — add var, change color
+    await env.saveEnvironment(dir, {
+      name: "dev",
+      vars: { port: "3000", host: "localhost", debug: "true" },
+      color: "warning",
+    })
+    loaded = await env.loadEnvironment(dir, "dev")
+    expect(loaded.vars).toEqual({
+      port: "3000",
+      host: "localhost",
+      debug: "true",
+    })
+    expect(loaded.color).toBe("warning")
 
-      // 5. Delete cloned
-      await env.deleteEnvironment(dir, "dev-staging")
-      names = await env.listEnvironments(dir)
-      expect(names).toEqual(["dev"])
+    // 5. Delete cloned
+    await env.deleteEnvironment(dir, "dev-staging")
+    names = await env.listEnvironments(dir)
+    expect(names).toEqual(["dev"])
 
-      // 6. Delete original
-      await env.deleteEnvironment(dir, "dev")
-      names = await env.listEnvironments(dir)
-      expect(names).toEqual([])
-    },
-  )
+    // 6. Delete original
+    await env.deleteEnvironment(dir, "dev")
+    names = await env.listEnvironments(dir)
+    expect(names).toEqual([])
+  })
 
   it("preserves disabled vars on round-trip", async () => {
     await env.saveEnvironment(dir, {

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -608,3 +608,38 @@ describe("filestore — symlink handling", () => {
     expect(col.items.some((i) => i.type === "folder")).toBe(true)
   })
 })
+
+describe("loadCollectionBrowse", () => {
+  it("loads requests without migration writes", async () => {
+    await writeFile(
+      join(dir, "old-request.yml"),
+      yamlTmpl(makeReq({ id: "old-request", name: "Legacy" })),
+    )
+    const { loadCollectionBrowse } = await import("../src/filestore/load")
+    const col = await loadCollectionBrowse(dir)
+    expect(col.items).toHaveLength(1)
+    expect(col.items[0]!.type).toBe("request")
+    expect(col.items[0]!.data.name).toBe("Legacy")
+  })
+
+  it("tolerates invalid YAML files", async () => {
+    await writeFile(
+      join(dir, "bad.yml"),
+      "this is not valid yaml: : :\n\tbroken indentation",
+    )
+    await writeFile(
+      join(dir, "good.yml"),
+      yamlTmpl(makeReq({ id: "good", name: "Good" })),
+    )
+    const { loadCollectionBrowse } = await import("../src/filestore/load")
+    const col = await loadCollectionBrowse(dir)
+    expect(col.items).toHaveLength(1)
+    expect(col.items[0]!.data.name).toBe("Good")
+  })
+
+  it("returns empty items for non-existent directory", async () => {
+    const { loadCollectionBrowse } = await import("../src/filestore/load")
+    const col = await loadCollectionBrowse("/tmp/noodle-browse-nonexistent")
+    expect(col.items).toHaveLength(0)
+  })
+})

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -642,4 +642,11 @@ describe("loadCollectionBrowse", () => {
     const col = await loadCollectionBrowse("/tmp/noodle-browse-nonexistent")
     expect(col.items).toHaveLength(0)
   })
+
+  it("reports filesystem errors while browsing", async () => {
+    const { loadCollectionBrowse } = await import("../src/filestore/load")
+    const file = join(dir, "not-a-directory")
+    await writeFile(file, "content")
+    await expect(loadCollectionBrowse(file)).rejects.toThrow()
+  })
 })

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -11,6 +11,7 @@ import {
   shortMethod,
   formatRequestUrl,
   maskedAuthHeader,
+  buildDetailRequestHeaders,
 } from "../src/ui/timeline/formatTimeline"
 import type { TimelineEntry } from "../src/schema"
 
@@ -320,6 +321,110 @@ describe("maskedAuthHeader", () => {
         placement: "query",
       }),
     ).toBeNull()
+  })
+})
+
+describe("buildDetailRequestHeaders", () => {
+  it("includes masked auth header and filters matching raw header (bearer)", () => {
+    const headers = buildDetailRequestHeaders(
+      { type: "bearer", token: "secret12345" },
+      {
+        Authorization: { value: "Bearer secret12345", enabled: true },
+        "Content-Type": { value: "application/json", enabled: true },
+      },
+    )
+    expect(headers).toEqual([
+      { key: "Authorization", value: "Bearer ••••••••" },
+      { key: "Content-Type", value: "application/json" },
+    ])
+  })
+
+  it("includes masked auth header and filters matching raw header (basic)", () => {
+    const headers = buildDetailRequestHeaders(
+      { type: "basic", user: "alice", pass: "s3cret" },
+      {
+        Authorization: { value: "Basic YWxpY2U6czNjcmV0", enabled: true },
+        "Content-Type": { value: "application/json", enabled: true },
+      },
+    )
+    expect(headers).toEqual([
+      { key: "Authorization", value: "Basic ••••••••" },
+      { key: "Content-Type", value: "application/json" },
+    ])
+  })
+
+  it("includes masked api_key header and filters the matching raw key", () => {
+    const headers = buildDetailRequestHeaders(
+      {
+        type: "api_key",
+        key: "X-API-Key",
+        value: "my-secret",
+        placement: "header",
+      },
+      {
+        "X-API-Key": { value: "my-secret", enabled: true },
+        Accept: { value: "application/json", enabled: true },
+      },
+    )
+    expect(headers).toEqual([
+      { key: "Accept", value: "application/json" },
+      { key: "X-API-Key", value: "••••••••" },
+    ])
+  })
+
+  it("case-insensitive filter when raw header key differs in case", () => {
+    const headers = buildDetailRequestHeaders(
+      { type: "bearer", token: "tok" },
+      {
+        authorization: { value: "Bearer tok", enabled: true },
+        "Content-Type": { value: "text/plain", enabled: true },
+      },
+    )
+    expect(headers).toEqual([
+      { key: "Authorization", value: "Bearer ••••••••" },
+      { key: "Content-Type", value: "text/plain" },
+    ])
+  })
+
+  it("does not filter api_key when placement is query", () => {
+    const headers = buildDetailRequestHeaders(
+      { type: "api_key", key: "api_key", value: "secret", placement: "query" },
+      {
+        api_key: { value: "secret", enabled: true },
+      },
+    )
+    expect(headers).toEqual([{ key: "api_key", value: "secret" }])
+  })
+
+  it("returns empty array when no headers or auth", () => {
+    const headers = buildDetailRequestHeaders(undefined, {})
+    expect(headers).toEqual([])
+  })
+
+  it("returns only raw headers when auth is none", () => {
+    const headers = buildDetailRequestHeaders(
+      { type: "none" },
+      {
+        Authorization: { value: "Bearer explicit", enabled: true },
+      },
+    )
+    expect(headers).toEqual([
+      { key: "Authorization", value: "Bearer explicit" },
+    ])
+  })
+
+  it("skips disabled headers", () => {
+    const headers = buildDetailRequestHeaders(
+      { type: "bearer", token: "tok" },
+      {
+        Authorization: { value: "Bearer tok", enabled: false },
+        "Content-Type": { value: "application/json", enabled: true },
+      },
+    )
+    expect(headers).toEqual([
+      { key: "Authorization", value: "Bearer ••••••••" },
+      { key: "Content-Type", value: "application/json" },
+    ])
   })
 })
 

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -130,6 +130,78 @@ describe("TimelineDetailOverlay", () => {
     expect(captureCharFrame()).toContain("response")
     cleanup()
   })
+
+  it("masks bearer token when explicit Authorization header present", async () => {
+    const entry = makeEntry({
+      request: {
+        id: "req-auth",
+        name: "Auth test",
+        method: "GET",
+        url: "https://example.com",
+        headers: {
+          Authorization: {
+            value: "Bearer secret-leak-123",
+            enabled: true,
+          },
+          "Content-Type": {
+            value: "application/json",
+            enabled: true,
+          },
+        },
+        params: [],
+        auth: { type: "bearer", token: "secret-leak-123" },
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "{}",
+        timeMs: 5,
+        size: 2,
+      },
+    })
+    const { renderOnce, captureCharFrame, mockInput, cleanup } =
+      await renderOverlay(entry, () => {})
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_LEFT"))
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Bearer ")
+    expect(frame).not.toContain("secret-leak-123")
+    expect(frame).toContain("Content-Type")
+    expect(frame).toContain("application/json")
+    cleanup()
+  })
+
+  it("masks api_key header when raw key matches auth config", async () => {
+    const entry = makeEntry({
+      request: {
+        id: "req-apikey",
+        name: "API Key test",
+        method: "GET",
+        url: "https://example.com",
+        headers: {
+          "X-API-Key": { value: "secret-api-key", enabled: true },
+        },
+        params: [],
+        auth: {
+          type: "api_key",
+          key: "X-API-Key",
+          value: "secret-api-key",
+          placement: "header",
+        },
+      },
+    })
+    const { renderOnce, captureCharFrame, mockInput, cleanup } =
+      await renderOverlay(entry, () => {})
+    await renderOnce()
+    await act(async () => mockInput.pressKey("ARROW_LEFT"))
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("X-API-Key")
+    expect(frame).not.toContain("secret-api-key")
+    cleanup()
+  })
 })
 
 function TimelineDetailHarness({

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -30,6 +30,7 @@ function minimalContext(): CommandBuilderContext {
     folderDeletePathRef: { current: null } as never,
     getKeymapFocus: () => "sidebar",
     getView: () => "main",
+    getCollectionMode: () => "collection",
     setLayout: () => {},
     onLayoutChange: () => {},
     setHelpVisible: () => {},
@@ -255,5 +256,40 @@ describe("buildCommandPaletteCommands", () => {
     const result = cmd.run()
     expect(result).toBe(true)
     expect(reloaded).toBe(true)
+  })
+
+  it("excludes Environment section when collection mode is empty", () => {
+    const ctx = minimalContext()
+    ctx.getCollectionMode = () => "empty"
+    const commands = buildCommandPaletteCommands(ctx)
+    const sections = [...new Set(commands.map((c) => c.section))]
+    expect(sections).not.toContain("Environment")
+    expect(sections).toEqual(["Request", "Response", "Workspace", "System"])
+  })
+
+  it("excludes env.editor-open command when mode is empty", () => {
+    const ctx = minimalContext()
+    ctx.getCollectionMode = () => "empty"
+    const commands = buildCommandPaletteCommands(ctx)
+    const envCmds = commands.filter((c) => c.id.startsWith("env."))
+    expect(envCmds).toHaveLength(0)
+  })
+
+  it("env editor view shows env commands only in collection mode", () => {
+    const ctx = minimalContext()
+    ctx.getCollectionMode = () => "collection"
+    ctx.getView = () => "env-editor"
+    const commands = buildCommandPaletteCommands(ctx)
+    const sections = [...new Set(commands.map((c) => c.section))]
+    expect(sections).toContain("Environment")
+  })
+
+  it("env editor view excludes env commands when mode is empty", () => {
+    const ctx = minimalContext()
+    ctx.getCollectionMode = () => "empty"
+    ctx.getView = () => "env-editor"
+    const commands = buildCommandPaletteCommands(ctx)
+    const sections = [...new Set(commands.map((c) => c.section))]
+    expect(sections).not.toContain("Environment")
   })
 })

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -46,6 +46,7 @@ function minimalContext(): CommandBuilderContext {
     setView: () => {},
     setFocus: () => {},
     setUndoAllPending: () => {},
+    setInitPending: () => {},
     setExpanded: () => {},
     setPreviewIndexProp: () => {},
     setEnvDeletePending: () => {},
@@ -264,7 +265,7 @@ describe("buildCommandPaletteCommands", () => {
     const commands = buildCommandPaletteCommands(ctx)
     const sections = [...new Set(commands.map((c) => c.section))]
     expect(sections).not.toContain("Environment")
-    expect(sections).toEqual(["Request", "Response", "Workspace", "System"])
+    expect(sections).toEqual(["Response", "Collection", "Workspace", "System"])
   })
 
   it("excludes env.editor-open command when mode is empty", () => {


### PR DESCRIPTION
## Summary
- add collection mode detection and read-only browsing for uninitialized directories
- add `collection init` and workspace/collection audit commands with JSON output and fixes
- gate collection mutations in TUI and improve timeline/request handling
- add CLI, filestore, automation, timeline, and UI command coverage

## Verification
- `bun test`
- `bun run typecheck`
- `bun run lint`

All tests pass: 1508.