### PR TITLE
Harden install and update flows

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ mkdir -p "$INSTALL_DIR"
 TMP_FILE=$(mktemp)
 CHECKSUM_FILE=$(mktemp)
 STAGED_FILE=""
-trap 'rm -f "$TMP_FILE" "$CHECKSUM_FILE" "$STAGED_FILE"' EXIT
+trap 'rm -f "$TMP_FILE" "$CHECKSUM_FILE"; if [ -n "$STAGED_FILE" ]; then rm -f "$STAGED_FILE"; fi' EXIT
 
 echo "Downloading $DOWNLOAD_URL..."
 if ! curl -LsSf "$DOWNLOAD_URL" -o "$TMP_FILE"; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@ detect_platform() {
     Darwin) os="macos" ;;
     Linux)  os="linux" ;;
     *)
-      echo -e "${RED}Error: Unsupported OS: $(uname -s)${NC}" >&2
+      printf '%b\n' "${RED}Error: Unsupported OS: $(uname -s)${NC}" >&2
       echo "noodle supports macOS and Linux only." >&2
       exit 1
       ;;
@@ -28,7 +28,7 @@ detect_platform() {
     x86_64|amd64)   arch="x86_64" ;;
     aarch64|arm64)  arch="arm64" ;;
     *)
-      echo -e "${RED}Error: Unsupported architecture: $(uname -m)${NC}" >&2
+      printf '%b\n' "${RED}Error: Unsupported architecture: $(uname -m)${NC}" >&2
       echo "noodle supports x86_64 and arm64 only." >&2
       exit 1
       ;;
@@ -45,7 +45,7 @@ else
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BIN_NAME}-${PLATFORM}"
 fi
 
-echo -e "${GREEN}Installing noodle ${VERSION} for ${PLATFORM}...${NC}"
+printf '%b\n' "${GREEN}Installing noodle ${VERSION} for ${PLATFORM}...${NC}"
 
 mkdir -p "$INSTALL_DIR"
 
@@ -55,7 +55,7 @@ trap 'rm -f "$TMP_FILE" "$CHECKSUM_FILE"' EXIT
 
 echo "Downloading $DOWNLOAD_URL..."
 if ! curl -LsSf "$DOWNLOAD_URL" -o "$TMP_FILE"; then
-  echo -e "${RED}Error: Failed to download from $DOWNLOAD_URL${NC}" >&2
+  printf '%b\n' "${RED}Error: Failed to download from $DOWNLOAD_URL${NC}" >&2
   echo "Check that the version exists and your platform is supported." >&2
   exit 1
 fi
@@ -67,13 +67,13 @@ else
   CHECKSUM_URL="https://github.com/${REPO}/releases/download/${VERSION}/SHA256SUMS"
 fi
 if ! curl -LsSf "$CHECKSUM_URL" -o "$CHECKSUM_FILE"; then
-  echo -e "${RED}Error: Failed to download SHA256SUMS${NC}" >&2
+  printf '%b\n' "${RED}Error: Failed to download SHA256SUMS${NC}" >&2
   exit 1
 fi
 
 EXPECTED_HASH=$(awk -v name="${BIN_NAME}-${PLATFORM}" '$2 == name { print $1; exit }' "$CHECKSUM_FILE")
 if ! printf '%s' "$EXPECTED_HASH" | grep -Eq '^[[:xdigit:]]{64}$'; then
-  echo -e "${RED}Error: No valid checksum found for ${BIN_NAME}-${PLATFORM}${NC}" >&2
+  printf '%b\n' "${RED}Error: No valid checksum found for ${BIN_NAME}-${PLATFORM}${NC}" >&2
   exit 1
 fi
 
@@ -82,21 +82,21 @@ if command -v shasum >/dev/null 2>&1; then
 elif command -v sha256sum >/dev/null 2>&1; then
   ACTUAL_HASH=$(sha256sum "$TMP_FILE" | awk '{print $1}')
 else
-  echo -e "${RED}Error: Neither shasum nor sha256sum is available${NC}" >&2
+  printf '%b\n' "${RED}Error: Neither shasum nor sha256sum is available${NC}" >&2
   exit 1
 fi
 if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
-  echo -e "${RED}Error: Download checksum mismatch${NC}" >&2
+  printf '%b\n' "${RED}Error: Download checksum mismatch${NC}" >&2
   exit 1
 fi
 
 chmod +x "$TMP_FILE"
 mv "$TMP_FILE" "$INSTALL_DIR/$BIN_NAME"
 
-echo -e "${GREEN}Installed to $INSTALL_DIR/$BIN_NAME${NC}"
+printf '%b\n' "${GREEN}Installed to $INSTALL_DIR/$BIN_NAME${NC}"
 
 if ! echo "$PATH" | tr ':' '\n' | grep -qxF "$INSTALL_DIR"; then
-  echo -e "${YELLOW}Warning: $INSTALL_DIR is not in your PATH.${NC}"
+  printf '%b\n' "${YELLOW}Warning: $INSTALL_DIR is not in your PATH.${NC}"
   echo "Add this to your shell config (~/.bashrc, ~/.zshrc, etc.):"
   echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,8 @@ mkdir -p "$INSTALL_DIR"
 
 TMP_FILE=$(mktemp)
 CHECKSUM_FILE=$(mktemp)
-trap 'rm -f "$TMP_FILE" "$CHECKSUM_FILE"' EXIT
+STAGED_FILE=""
+trap 'rm -f "$TMP_FILE" "$CHECKSUM_FILE" "$STAGED_FILE"' EXIT
 
 echo "Downloading $DOWNLOAD_URL..."
 if ! curl -LsSf "$DOWNLOAD_URL" -o "$TMP_FILE"; then
@@ -90,8 +91,14 @@ if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
   exit 1
 fi
 
-chmod +x "$TMP_FILE"
-mv "$TMP_FILE" "$INSTALL_DIR/$BIN_NAME"
+# Stage in the destination directory so the final rename replaces an existing
+# installation atomically. A system temporary directory can be on another
+# filesystem, where mv would otherwise fall back to a non-atomic copy.
+STAGED_FILE=$(mktemp "$INSTALL_DIR/.noodle-install.XXXXXX")
+cp "$TMP_FILE" "$STAGED_FILE"
+chmod 755 "$STAGED_FILE"
+mv "$STAGED_FILE" "$INSTALL_DIR/$BIN_NAME"
+STAGED_FILE=""
 
 printf '%b\n' "${GREEN}Installed to $INSTALL_DIR/$BIN_NAME${NC}"
 

--- a/src/app/commands/update.ts
+++ b/src/app/commands/update.ts
@@ -1,10 +1,15 @@
 import { defineCommand } from "citty"
+import { createHash } from "node:crypto"
+import { chmod, mkdtemp, rename, rm, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
 import pkg from "../../../package.json" with { type: "json" }
 import { emitCommand } from "../commandResult"
 
 export function getPlatformString(platform: string, arch: string): string {
-  const os = platform === "darwin" ? "macos" : "linux"
-  const cpu = arch === "arm64" ? "arm64" : "x86_64"
+  const os =
+    platform === "darwin" ? "macos" : platform === "linux" ? "linux" : null
+  const cpu = arch === "arm64" ? "arm64" : arch === "x64" ? "x86_64" : null
+  if (!os || !cpu) throw new Error(`Unsupported platform: ${platform}-${arch}`)
   return `${os}-${cpu}`
 }
 
@@ -12,16 +17,54 @@ export function getAssetName(platform: string, arch: string): string {
   return `noodle-${getPlatformString(platform, arch)}`
 }
 
+export function compareStableVersions(
+  current: string,
+  latest: string,
+): number | null {
+  const parse = (version: string): [number, number, number] | null => {
+    const match = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(version)
+    return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null
+  }
+  const currentParts = parse(current)
+  const latestParts = parse(latest)
+  if (!currentParts || !latestParts) return null
+  for (let index = 0; index < 3; index += 1) {
+    if (latestParts[index] !== currentParts[index])
+      return latestParts[index] > currentParts[index] ? 1 : -1
+  }
+  return 0
+}
+
 export function isNewerVersion(current: string, latest: string): boolean {
-  return current !== latest
+  return compareStableVersions(current, latest) === 1
 }
 
 export function isHomebrewInstall(execPath: string): boolean {
   return (
-    execPath.includes("/homebrew") ||
-    execPath.includes("/brew") ||
-    execPath.includes("/.linuxbrew")
+    execPath.includes("/homebrew/bin/") ||
+    execPath.includes("/linuxbrew/.linuxbrew/bin/") ||
+    execPath.includes("/brew/bin/")
   )
+}
+
+export function parseChecksumManifest(
+  manifest: string,
+  assetName: string,
+): string | null {
+  for (const line of manifest.split(/\r?\n/)) {
+    const fields = line.trim().split(/\s+/)
+    if (
+      fields.length >= 2 &&
+      fields[1] === assetName &&
+      /^[a-f\d]{64}$/i.test(fields[0])
+    )
+      return fields[0].toLowerCase()
+  }
+  return null
+}
+
+export function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex")
 }
 
 interface ReleaseAsset {
@@ -36,6 +79,10 @@ interface ReleaseData {
 
 function getReleaseApiUrl(): string {
   return "https://api.github.com/repos/wilfredinni/noodle/releases/latest"
+}
+
+function getReleaseDownloadUrl(tag: string, name: string): string {
+  return `https://github.com/wilfredinni/noodle/releases/download/${tag}/${name}`
 }
 
 export default defineCommand({
@@ -68,7 +115,13 @@ async function runUpdate(
     return { data: { status: "homebrew", command: "brew upgrade noodle" } }
   }
 
-  const platform = getPlatformString(process.platform, process.arch)
+  let platform: string
+  try {
+    platform = getPlatformString(process.platform, process.arch)
+  } catch {
+    output(`Unsupported platform: ${process.platform}-${process.arch}`)
+    return { data: { status: "unsupported_platform" }, failed: true }
+  }
   const currentVersion = `v${pkg.version}`
 
   output(`noodle ${currentVersion} (${platform})`)
@@ -87,7 +140,14 @@ async function runUpdate(
     if (
       !json ||
       typeof json.tag_name !== "string" ||
-      !Array.isArray(json.assets)
+      !Array.isArray(json.assets) ||
+      json.assets.some(
+        (asset: unknown) =>
+          !asset ||
+          typeof asset !== "object" ||
+          typeof (asset as ReleaseAsset).name !== "string" ||
+          typeof (asset as ReleaseAsset).browser_download_url !== "string",
+      )
     ) {
       throw new Error("Invalid release data")
     }
@@ -97,7 +157,15 @@ async function runUpdate(
     return { data: { status: "check_failed" }, failed: true }
   }
 
-  if (!isNewerVersion(currentVersion, releaseData.tag_name)) {
+  const versionComparison = compareStableVersions(
+    currentVersion,
+    releaseData.tag_name,
+  )
+  if (versionComparison === null) {
+    output(`Invalid release version: ${releaseData.tag_name}`)
+    return { data: { status: "invalid_release" }, failed: true }
+  }
+  if (versionComparison !== 1) {
     output("Already up to date.")
     return { data: { status: "up_to_date", version: currentVersion } }
   }
@@ -115,14 +183,38 @@ async function runUpdate(
 
   output(`Downloading ${releaseData.tag_name} for ${platform}...`)
 
-  const response = await fetch(asset.browser_download_url)
-  const buffer = await response.arrayBuffer()
+  let stagingDir: string | undefined
+  try {
+    const [binaryResponse, checksumResponse] = await Promise.all([
+      fetch(asset.browser_download_url),
+      fetch(getReleaseDownloadUrl(releaseData.tag_name, "SHA256SUMS")),
+    ])
+    if (!binaryResponse.ok || !checksumResponse.ok)
+      throw new Error(
+        `HTTP ${binaryResponse.ok ? checksumResponse.status : binaryResponse.status}`,
+      )
 
-  const tmpPath = process.execPath + ".new"
-  await Bun.write(tmpPath, new Uint8Array(buffer))
-  await Bun.spawn(["chmod", "+x", tmpPath]).exited
-  await Bun.spawn(["mv", tmpPath, process.execPath]).exited
+    const binary = new Uint8Array(await binaryResponse.arrayBuffer())
+    const expectedHash = parseChecksumManifest(
+      await checksumResponse.text(),
+      assetName,
+    )
+    if (!expectedHash || sha256(binary) !== expectedHash)
+      throw new Error("checksum mismatch")
 
-  output(`Updated to ${releaseData.tag_name}`)
-  return { data: { status: "updated", version: releaseData.tag_name } }
+    const executableDir = dirname(process.execPath)
+    stagingDir = await mkdtemp(join(executableDir, ".noodle-update-"))
+    const stagedPath = join(stagingDir, assetName)
+    await writeFile(stagedPath, binary, { mode: 0o755 })
+    await chmod(stagedPath, 0o755)
+    await rename(stagedPath, process.execPath)
+    output(`Updated to ${releaseData.tag_name}`)
+    return { data: { status: "updated", version: releaseData.tag_name } }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    output(`Failed to update: ${reason}`)
+    return { data: { status: "update_failed" }, failed: true }
+  } finally {
+    if (stagingDir) await rm(stagingDir, { recursive: true, force: true })
+  }
 }

--- a/src/app/commands/update.ts
+++ b/src/app/commands/update.ts
@@ -154,6 +154,7 @@ function getDefaultCachePath(): string {
 
 export interface UpdateDependencies {
   fetcher: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+  runProcess: (args: string[], captureOutput: boolean) => Promise<ProcessResult>
   execPath: string
   platform: string
   arch: string
@@ -162,11 +163,33 @@ export interface UpdateDependencies {
   now: () => number
 }
 
+export interface ProcessResult {
+  exitCode: number
+}
+
+async function runProcess(
+  args: string[],
+  captureOutput: boolean,
+): Promise<ProcessResult> {
+  const child = Bun.spawn(args, {
+    stdout: captureOutput ? "pipe" : "inherit",
+    stderr: captureOutput ? "pipe" : "inherit",
+  })
+  if (!captureOutput) return { exitCode: await child.exited }
+  await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { exitCode: child.exitCode ?? 1 }
+}
+
 function getUpdateDeps(
   overrides: Partial<UpdateDependencies>,
 ): UpdateDependencies {
   return {
     fetcher: globalThis.fetch,
+    runProcess,
     execPath: process.execPath,
     platform: process.platform,
     arch: process.arch,
@@ -180,6 +203,40 @@ function getUpdateDeps(
 class RateLimitError extends Error {
   constructor(readonly retryAt?: string) {
     super("GitHub API rate limit reached")
+  }
+}
+
+async function runHomebrewUpdate(
+  silent: boolean,
+  deps: UpdateDependencies,
+): Promise<{ data: Record<string, string>; failed?: boolean }> {
+  const output = (message: string) => {
+    if (!silent) console.log(message)
+  }
+  output("Updating noodle via Homebrew...")
+  try {
+    const result = await deps.runProcess(["brew", "upgrade", "noodle"], silent)
+    if (result.exitCode !== 0) {
+      output(`Homebrew upgrade failed (exit code ${result.exitCode}).`)
+      return {
+        data: {
+          status: "homebrew_failed",
+          command: "brew upgrade noodle",
+          exit_code: String(result.exitCode),
+        },
+        failed: true,
+      }
+    }
+    output("Homebrew upgrade completed.")
+    return {
+      data: { status: "homebrew_updated", command: "brew upgrade noodle" },
+    }
+  } catch {
+    output("Unable to run Homebrew. Is `brew` installed and available on PATH?")
+    return {
+      data: { status: "homebrew_failed", command: "brew upgrade noodle" },
+      failed: true,
+    }
   }
 }
 
@@ -232,9 +289,7 @@ export async function runUpdate(
     if (!silent) console.log(message)
   }
   if (isHomebrewInstall(deps.execPath)) {
-    output("noodle was installed via Homebrew.")
-    output("Run: brew upgrade noodle")
-    return { data: { status: "homebrew", command: "brew upgrade noodle" } }
+    return runHomebrewUpdate(silent, deps)
   }
 
   let platform: string

--- a/src/app/commands/update.ts
+++ b/src/app/commands/update.ts
@@ -51,7 +51,7 @@ export function isNewerVersion(current: string, latest: string): boolean {
 export function isHomebrewInstall(execPath: string): boolean {
   return (
     execPath.includes("/homebrew/bin/") ||
-    execPath.includes("/linuxbrew/.linuxbrew/bin/") ||
+    execPath.includes("/.linuxbrew/bin/") ||
     execPath.includes("/brew/bin/")
   )
 }

--- a/src/app/commands/update.ts
+++ b/src/app/commands/update.ts
@@ -311,7 +311,7 @@ export async function runUpdate(
         currentVersion,
         cache.latestTag,
       )
-      if (cachedComparison === 0) {
+      if (cachedComparison === 0 || cachedComparison === -1) {
         output("Already up to date.")
         return {
           data: {
@@ -320,6 +320,18 @@ export async function runUpdate(
             cached: "true",
           },
         }
+      }
+      if (cachedComparison === 1) {
+        output(`Using cached release ${cache.latestTag}.`)
+        return downloadAndInstall(
+          cache.latestTag,
+          getReleaseDownloadUrl(
+            cache.latestTag,
+            getAssetName(deps.platform, deps.arch),
+          ),
+          deps,
+          output,
+        )
       }
     }
   }
@@ -403,13 +415,28 @@ export async function runUpdate(
     return { data: { status: "asset_missing", platform }, failed: true }
   }
 
-  output(`Downloading ${releaseData.tag_name} for ${platform}...`)
+  return downloadAndInstall(
+    releaseData.tag_name,
+    asset.browser_download_url,
+    deps,
+    output,
+  )
+}
 
+async function downloadAndInstall(
+  tag: string,
+  binaryUrl: string,
+  deps: UpdateDependencies,
+  output: (message: string) => void,
+): Promise<{ data: Record<string, string>; failed?: boolean }> {
+  const assetName = getAssetName(deps.platform, deps.arch)
+  const platform = getPlatformString(deps.platform, deps.arch)
+  output(`Downloading ${tag} for ${platform}...`)
   let stagingDir: string | undefined
   try {
     const [binaryResponse, checksumResponse] = await Promise.all([
-      deps.fetcher(asset.browser_download_url),
-      deps.fetcher(getReleaseDownloadUrl(releaseData.tag_name, "SHA256SUMS")),
+      deps.fetcher(binaryUrl),
+      deps.fetcher(getReleaseDownloadUrl(tag, "SHA256SUMS")),
     ])
     if (!binaryResponse.ok || !checksumResponse.ok)
       throw new Error(
@@ -430,8 +457,8 @@ export async function runUpdate(
     await writeFile(stagedPath, binary, { mode: 0o755 })
     await chmod(stagedPath, 0o755)
     await rename(stagedPath, deps.execPath)
-    output(`Updated to ${releaseData.tag_name}`)
-    return { data: { status: "updated", version: releaseData.tag_name } }
+    output(`Updated to ${tag}`)
+    return { data: { status: "updated", version: tag } }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     output(`Failed to update: ${reason}`)

--- a/src/app/commands/update.ts
+++ b/src/app/commands/update.ts
@@ -1,7 +1,16 @@
 import { defineCommand } from "citty"
 import { createHash } from "node:crypto"
-import { chmod, mkdtemp, rename, rm, writeFile } from "node:fs/promises"
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises"
 import { dirname, join } from "node:path"
+import { homedir } from "node:os"
 import pkg from "../../../package.json" with { type: "json" }
 import { emitCommand } from "../commandResult"
 
@@ -67,6 +76,60 @@ export function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex")
 }
 
+export const UPDATE_CACHE_TTL_MS = 60 * 60 * 1000
+
+export interface UpdateCache {
+  latestTag: string
+  checkedAt: number
+}
+
+export function parseUpdateCache(value: unknown): UpdateCache | null {
+  if (!value || typeof value !== "object") return null
+  const cache = value as Record<string, unknown>
+  if (
+    typeof cache.latestTag !== "string" ||
+    compareStableVersions(cache.latestTag, cache.latestTag) !== 0 ||
+    typeof cache.checkedAt !== "number" ||
+    !Number.isFinite(cache.checkedAt) ||
+    cache.checkedAt < 0
+  )
+    return null
+  return { latestTag: cache.latestTag, checkedAt: cache.checkedAt }
+}
+
+export function isFreshUpdateCache(cache: UpdateCache, now: number): boolean {
+  return now >= cache.checkedAt && now - cache.checkedAt <= UPDATE_CACHE_TTL_MS
+}
+
+export async function loadUpdateCache(
+  cachePath: string,
+): Promise<UpdateCache | null> {
+  try {
+    return parseUpdateCache(JSON.parse(await readFile(cachePath, "utf8")))
+  } catch {
+    return null
+  }
+}
+
+export async function saveUpdateCache(
+  cachePath: string,
+  cache: UpdateCache,
+): Promise<void> {
+  const cacheDir = dirname(cachePath)
+  await mkdir(cacheDir, { recursive: true })
+  const tempDir = await mkdtemp(join(cacheDir, ".update-cache-"))
+  const tempPath = join(tempDir, "update-cache.json")
+  try {
+    await writeFile(tempPath, `${JSON.stringify(cache)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    })
+    await rename(tempPath, cachePath)
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
 interface ReleaseAsset {
   name: string
   browser_download_url: string
@@ -85,6 +148,56 @@ function getReleaseDownloadUrl(tag: string, name: string): string {
   return `https://github.com/wilfredinni/noodle/releases/download/${tag}/${name}`
 }
 
+function getDefaultCachePath(): string {
+  return join(homedir(), ".config", "noodle", "update-cache.json")
+}
+
+export interface UpdateDependencies {
+  fetcher: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+  execPath: string
+  platform: string
+  arch: string
+  env: Record<string, string | undefined>
+  cachePath: string
+  now: () => number
+}
+
+function getUpdateDeps(
+  overrides: Partial<UpdateDependencies>,
+): UpdateDependencies {
+  return {
+    fetcher: globalThis.fetch,
+    execPath: process.execPath,
+    platform: process.platform,
+    arch: process.arch,
+    env: process.env,
+    cachePath: getDefaultCachePath(),
+    now: Date.now,
+    ...overrides,
+  }
+}
+
+class RateLimitError extends Error {
+  constructor(readonly retryAt?: string) {
+    super("GitHub API rate limit reached")
+  }
+}
+
+function getRateLimitError(response: Response): RateLimitError | null {
+  const remaining = response.headers.get("x-ratelimit-remaining")
+  if (
+    response.status !== 429 &&
+    !(response.status === 403 && remaining === "0")
+  )
+    return null
+  const reset = Number(response.headers.get("x-ratelimit-reset"))
+  return new RateLimitError(
+    Number.isFinite(reset) && reset > 0
+      ? new Date(reset * 1000).toISOString()
+      : undefined,
+  )
+}
+
 export default defineCommand({
   meta: {
     name: "update",
@@ -96,20 +209,29 @@ export default defineCommand({
       default: false,
       description: "Write one JSON result envelope to stdout",
     },
+    force: {
+      type: "boolean",
+      default: false,
+      description: "Ignore the one-hour update check cache",
+    },
   },
   async run({ args }) {
-    if (args.json) return emitCommand(true, () => runUpdate(true))
-    await runUpdate(false)
+    const force = args.force === true
+    if (args.json) return emitCommand(true, () => runUpdate(true, force))
+    await runUpdate(false, force)
   },
 })
 
-async function runUpdate(
+export async function runUpdate(
   silent: boolean,
+  force = false,
+  dependencyOverrides: Partial<UpdateDependencies> = {},
 ): Promise<{ data: Record<string, string>; failed?: boolean }> {
+  const deps = getUpdateDeps(dependencyOverrides)
   const output = (message: string) => {
     if (!silent) console.log(message)
   }
-  if (isHomebrewInstall(process.execPath)) {
+  if (isHomebrewInstall(deps.execPath)) {
     output("noodle was installed via Homebrew.")
     output("Run: brew upgrade noodle")
     return { data: { status: "homebrew", command: "brew upgrade noodle" } }
@@ -117,9 +239,9 @@ async function runUpdate(
 
   let platform: string
   try {
-    platform = getPlatformString(process.platform, process.arch)
+    platform = getPlatformString(deps.platform, deps.arch)
   } catch {
-    output(`Unsupported platform: ${process.platform}-${process.arch}`)
+    output(`Unsupported platform: ${deps.platform}-${deps.arch}`)
     return { data: { status: "unsupported_platform" }, failed: true }
   }
   const currentVersion = `v${pkg.version}`
@@ -127,13 +249,40 @@ async function runUpdate(
   output(`noodle ${currentVersion} (${platform})`)
   output("Checking for updates...")
 
+  if (!force) {
+    const cache = await loadUpdateCache(deps.cachePath)
+    if (cache && isFreshUpdateCache(cache, deps.now())) {
+      const cachedComparison = compareStableVersions(
+        currentVersion,
+        cache.latestTag,
+      )
+      if (cachedComparison === 0) {
+        output("Already up to date.")
+        return {
+          data: {
+            status: "up_to_date",
+            version: currentVersion,
+            cached: "true",
+          },
+        }
+      }
+    }
+  }
+
   let releaseData: ReleaseData
 
   try {
-    const response = await fetch(getReleaseApiUrl(), {
-      headers: { Accept: "application/vnd.github+json" },
+    const token = deps.env.GH_TOKEN || deps.env.GITHUB_TOKEN
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+    }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const response = await deps.fetcher(getReleaseApiUrl(), {
+      headers,
     })
     if (!response.ok) {
+      const rateLimitError = getRateLimitError(response)
+      if (rateLimitError) throw rateLimitError
       throw new Error(`HTTP ${response.status}`)
     }
     const json = await response.json()
@@ -152,7 +301,25 @@ async function runUpdate(
       throw new Error("Invalid release data")
     }
     releaseData = json as ReleaseData
-  } catch {
+    const cache: UpdateCache = {
+      latestTag: releaseData.tag_name,
+      checkedAt: deps.now(),
+    }
+    if (parseUpdateCache(cache)) {
+      try {
+        await saveUpdateCache(deps.cachePath, cache)
+      } catch {
+        // A cache write must never prevent a valid update check.
+      }
+    }
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      output("GitHub API rate limit reached.")
+      if (error.retryAt) output(`Retry after ${error.retryAt}.`)
+      const data: Record<string, string> = { status: "rate_limited" }
+      if (error.retryAt) data.retry_at = error.retryAt
+      return { data, failed: true }
+    }
     output("Failed to check for updates.")
     return { data: { status: "check_failed" }, failed: true }
   }
@@ -170,7 +337,7 @@ async function runUpdate(
     return { data: { status: "up_to_date", version: currentVersion } }
   }
 
-  const assetName = getAssetName(process.platform, process.arch)
+  const assetName = getAssetName(deps.platform, deps.arch)
   const asset = releaseData.assets.find((a) => a.name === assetName)
 
   if (!asset) {
@@ -186,8 +353,8 @@ async function runUpdate(
   let stagingDir: string | undefined
   try {
     const [binaryResponse, checksumResponse] = await Promise.all([
-      fetch(asset.browser_download_url),
-      fetch(getReleaseDownloadUrl(releaseData.tag_name, "SHA256SUMS")),
+      deps.fetcher(asset.browser_download_url),
+      deps.fetcher(getReleaseDownloadUrl(releaseData.tag_name, "SHA256SUMS")),
     ])
     if (!binaryResponse.ok || !checksumResponse.ok)
       throw new Error(
@@ -202,12 +369,12 @@ async function runUpdate(
     if (!expectedHash || sha256(binary) !== expectedHash)
       throw new Error("checksum mismatch")
 
-    const executableDir = dirname(process.execPath)
+    const executableDir = dirname(deps.execPath)
     stagingDir = await mkdtemp(join(executableDir, ".noodle-update-"))
     const stagedPath = join(stagingDir, assetName)
     await writeFile(stagedPath, binary, { mode: 0o755 })
     await chmod(stagedPath, 0o755)
-    await rename(stagedPath, process.execPath)
+    await rename(stagedPath, deps.execPath)
     output(`Updated to ${releaseData.tag_name}`)
     return { data: { status: "updated", version: releaseData.tag_name } }
   } catch (error) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -60,6 +60,12 @@ describe("update command", () => {
     expect(json?.required).not.toBe(true)
   })
 
+  it("has an optional force flag", () => {
+    const args = updateCommand.args as ArgsDef | undefined
+    const force = args?.force as StringArgDef | undefined
+    expect(force?.required).not.toBe(true)
+  })
+
   it("has run handler", () => {
     expect(typeof updateCommand.run).toBe("function")
   })

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test"
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const INSTALL_SCRIPT = join(import.meta.dir, "../scripts/install.sh")
+const BINARY = "noodle release binary\n"
+const BINARY_SHA256 =
+  "e81696c732412c4e61ee52e9c13b40412292cf43965a8c566fd8e8699991a5b8"
+const ASSET_NAME = `noodle-${process.platform === "darwin" ? "macos" : "linux"}-${process.arch === "arm64" ? "arm64" : "x86_64"}`
+
+async function writeFakeCurl(
+  directory: string,
+  checksum: string,
+): Promise<void> {
+  const path = join(directory, "curl")
+  await writeFile(
+    path,
+    `#!/usr/bin/env bash
+set -eu
+output=""
+url="$*"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+case "$url" in
+  *SHA256SUMS*) printf '%s  ${ASSET_NAME}\\n' '${checksum}' > "$output" ;;
+  *) printf '%s' '${BINARY}' > "$output" ;;
+esac
+`,
+  )
+  await chmod(path, 0o755)
+}
+
+async function runInstaller(
+  installDir: string,
+  binDir: string,
+): Promise<ReturnType<typeof Bun.spawnSync>> {
+  return Bun.spawnSync(["/bin/bash", INSTALL_SCRIPT], {
+    env: {
+      ...process.env,
+      NOODLE_INSTALL_DIR: installDir,
+      NOODLE_VERSION: "v0.4.7",
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+  })
+}
+
+describe("install script", () => {
+  it("installs a binary only after its release checksum verifies", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "noodle-install-"))
+    const binDir = join(directory, "bin")
+    const installDir = join(directory, "install")
+    try {
+      await mkdir(binDir, { recursive: true })
+      await writeFakeCurl(binDir, BINARY_SHA256)
+
+      const result = await runInstaller(installDir, binDir)
+
+      expect(result.exitCode).toBe(0)
+      expect(await readFile(join(installDir, "noodle"), "utf8")).toBe(BINARY)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("preserves an existing installation when checksum verification fails", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "noodle-install-"))
+    const binDir = join(directory, "bin")
+    const installDir = join(directory, "install")
+    try {
+      await Promise.all([
+        mkdir(binDir, { recursive: true }),
+        mkdir(installDir, { recursive: true }),
+      ])
+      await writeFile(join(installDir, "noodle"), "old binary")
+      await writeFakeCurl(binDir, "0".repeat(64))
+
+      const result = await runInstaller(installDir, binDir)
+
+      expect(result.exitCode).not.toBe(0)
+      expect(await readFile(join(installDir, "noodle"), "utf8")).toBe(
+        "old binary",
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -44,6 +44,35 @@ esac
   await chmod(path, 0o755)
 }
 
+async function writeFailingCurl(directory: string): Promise<void> {
+  const path = join(directory, "curl")
+  await writeFile(
+    path,
+    `#!/usr/bin/env bash
+echo "simulated download failure" >&2
+exit 1
+`,
+  )
+  await chmod(path, 0o755)
+}
+
+async function writeStrictRm(directory: string): Promise<void> {
+  const path = join(directory, "rm")
+  await writeFile(
+    path,
+    `#!/usr/bin/env bash
+for path in "$@"; do
+  if [ -z "$path" ]; then
+    echo "rm: empty path" >&2
+    exit 1
+  fi
+done
+exec /bin/rm "$@"
+`,
+  )
+  await chmod(path, 0o755)
+}
+
 async function runInstaller(
   installDir: string,
   binDir: string,
@@ -93,6 +122,25 @@ describe("install script", () => {
       expect(result.exitCode).not.toBe(0)
       expect(await readFile(join(installDir, "noodle"), "utf8")).toBe(
         "old binary",
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("does not pass an empty staged path to cleanup after download failure", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "noodle-install-"))
+    const binDir = join(directory, "bin")
+    const installDir = join(directory, "install")
+    try {
+      await mkdir(binDir, { recursive: true })
+      await Promise.all([writeFailingCurl(binDir), writeStrictRm(binDir)])
+
+      const result = await runInstaller(installDir, binDir)
+
+      expect(result.exitCode).not.toBe(0)
+      expect(new TextDecoder().decode(result.stderr)).not.toContain(
+        "rm: empty path",
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { extend } from "@opentui/react"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -12,6 +12,9 @@ import { ThemeProvider } from "../../src/ui/theme"
 import { YamlEditorOverlay } from "../../src/ui/editor/YamlEditorOverlay"
 import { ConfirmOverlay } from "../../src/ui/overlays/ConfirmOverlay"
 import { CodeEditorRenderable } from "../../src/ui/editor/CodeEditor"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 extend({ "code-editor": CodeEditorRenderable })
 
@@ -34,16 +37,18 @@ function setupKeymap() {
 }
 
 const MOCK_YAML = "name: test\nmethod: GET\nurl: https://example.com\n"
-let mockedContent = MOCK_YAML
-let writeCallCount = 0
+let testDir: string
+let filePath: string
 
-mock.module("node:fs/promises", () => ({
-  readFile: () => Promise.resolve(mockedContent),
-  writeFile: () => {
-    writeCallCount++
-    return Promise.resolve()
-  },
-}))
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "noodle-yaml-editor-"))
+  filePath = join(testDir, "test.yml")
+  await writeFile(filePath, MOCK_YAML)
+})
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true })
+})
 
 describe("YamlEditorOverlay", () => {
   it("renders title with request name", async () => {
@@ -53,7 +58,7 @@ describe("YamlEditorOverlay", () => {
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <YamlEditorOverlay
             visible
-            filePath="/tmp/test.yml"
+            filePath={filePath}
             requestName="get-users"
             onSaved={() => {}}
             onClose={() => {}}
@@ -78,7 +83,7 @@ describe("YamlEditorOverlay", () => {
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <YamlEditorOverlay
             visible
-            filePath="/tmp/test.yml"
+            filePath={filePath}
             requestName="get-users"
             onSaved={() => {}}
             onClose={() => {}}
@@ -106,7 +111,7 @@ describe("YamlEditorOverlay", () => {
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <YamlEditorOverlay
             visible={false}
-            filePath="/tmp/test.yml"
+            filePath={filePath}
             requestName="get-users"
             onSaved={() => {}}
             onClose={() => {}}
@@ -128,7 +133,7 @@ describe("YamlEditorOverlay", () => {
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <YamlEditorOverlay
             visible={false}
-            filePath="/tmp/test.yml"
+            filePath={filePath}
             requestName="get-users"
             onSaved={() => {}}
             onClose={() => {}}
@@ -150,7 +155,7 @@ describe("YamlEditorOverlay", () => {
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <YamlEditorOverlay
             visible
-            filePath="/tmp/test.yml"
+            filePath={filePath}
             requestName="get-users"
             onSaved={() => {}}
             onClose={() => {}}
@@ -168,15 +173,15 @@ describe("YamlEditorOverlay", () => {
   })
 
   it("rejects invalid YAML on save", async () => {
-    mockedContent = "name: test\nmethod: GET\nurl: [broken\n"
-    writeCallCount = 0
+    const invalidYaml = "name: test\nmethod: GET\nurl: [broken\n"
+    await writeFile(filePath, invalidYaml)
     const { keymap, host, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <YamlEditorOverlay
             visible
-            filePath="/tmp/test.yml"
+            filePath={filePath}
             requestName="get-users"
             onSaved={() => {}}
             onClose={() => {}}
@@ -195,9 +200,8 @@ describe("YamlEditorOverlay", () => {
 
     const frame = captureCharFrame()
     expect(frame).toContain("Save error:")
-    expect(writeCallCount).toBe(0)
+    expect(await readFile(filePath, "utf8")).toBe(invalidYaml)
     cleanup()
-    mockedContent = MOCK_YAML
   })
 })
 

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -182,6 +182,43 @@ describe("update cache", () => {
       await rm(dir, { recursive: true, force: true })
     }
   })
+
+  it("uses a fresh newer cached release without checking GitHub again", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-cache-"))
+    const path = join(dir, "update-cache.json")
+    const executable = join(dir, "noodle")
+    const binary = new TextEncoder().encode("new")
+    let githubCalls = 0
+    try {
+      await writeFile(
+        path,
+        JSON.stringify({ latestTag: "v0.4.7", checkedAt: 1000 }),
+      )
+      await writeFile(executable, "old")
+      const result = await runUpdate(true, false, {
+        cachePath: path,
+        now: () => 1000,
+        execPath: executable,
+        platform: "darwin",
+        arch: "arm64",
+        env: {},
+        fetcher: async (input) => {
+          const url = String(input)
+          if (url.includes("api.github.com")) {
+            githubCalls += 1
+            return new Response(null, { status: 500 })
+          }
+          if (url.endsWith("noodle-macos-arm64")) return new Response(binary)
+          return new Response(`${sha256(binary)}  noodle-macos-arm64\n`)
+        },
+      })
+      expect(result.data).toEqual({ status: "updated", version: "v0.4.7" })
+      expect(githubCalls).toBe(0)
+      expect(await readFile(executable, "utf8")).toBe("new")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe("update release discovery", () => {

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -371,6 +371,81 @@ describe("update release discovery", () => {
   })
 })
 
+describe("Homebrew updates", () => {
+  const brewDeps = (
+    runProcess: (
+      args: string[],
+      captureOutput: boolean,
+    ) => Promise<{ exitCode: number }>,
+  ) => ({
+    cachePath: "/tmp/noodle-homebrew-cache.json",
+    now: () => 1000,
+    execPath: "/opt/homebrew/bin/noodle",
+    platform: "darwin",
+    arch: "arm64",
+    env: {},
+    runProcess,
+  })
+
+  it("runs brew upgrade noodle and captures output in JSON mode", async () => {
+    let receivedArgs: string[] | undefined
+    let captured: boolean | undefined
+    let fetchCalled = false
+    const result = await runUpdate(true, false, {
+      ...brewDeps(async (args, captureOutput) => {
+        receivedArgs = args
+        captured = captureOutput
+        return { exitCode: 0 }
+      }),
+      fetcher: async () => {
+        fetchCalled = true
+        return new Response()
+      },
+    })
+    expect(result).toEqual({
+      data: { status: "homebrew_updated", command: "brew upgrade noodle" },
+    })
+    expect(receivedArgs).toEqual(["brew", "upgrade", "noodle"])
+    expect(captured).toBe(true)
+    expect(fetchCalled).toBe(false)
+  })
+
+  it("lets human mode stream Brew output", async () => {
+    let captured: boolean | undefined
+    const result = await runUpdate(false, false, {
+      ...brewDeps(async (_args, captureOutput) => {
+        captured = captureOutput
+        return { exitCode: 0 }
+      }),
+    })
+    expect(result.data.status).toBe("homebrew_updated")
+    expect(captured).toBe(false)
+  })
+
+  it("reports Brew failures and unavailable Brew", async () => {
+    const failed = await runUpdate(true, false, {
+      ...brewDeps(async () => ({ exitCode: 1 })),
+    })
+    const unavailable = await runUpdate(true, false, {
+      ...brewDeps(async () => {
+        throw new Error("spawn failed")
+      }),
+    })
+    expect(failed).toEqual({
+      data: {
+        status: "homebrew_failed",
+        command: "brew upgrade noodle",
+        exit_code: "1",
+      },
+      failed: true,
+    })
+    expect(unavailable).toEqual({
+      data: { status: "homebrew_failed", command: "brew upgrade noodle" },
+      failed: true,
+    })
+  })
+})
+
 describe("isHomebrewInstall", () => {
   it("detects homebrew prefix", () => {
     expect(isHomebrewInstall("/opt/homebrew/bin/noodle")).toBe(true)

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "bun:test"
 import {
   getPlatformString,
+  compareStableVersions,
   getAssetName,
   isNewerVersion,
   isHomebrewInstall,
+  parseChecksumManifest,
+  sha256,
 } from "../../src/app/commands/update"
 
 describe("getPlatformString", () => {
@@ -19,16 +22,26 @@ describe("getPlatformString", () => {
     expect(getPlatformString("linux", "x64")).toBe("linux-x86_64")
   })
 
-  it("returns linux-x86_64 for linux + ia32", () => {
-    expect(getPlatformString("linux", "ia32")).toBe("linux-x86_64")
+  it("rejects unsupported 32-bit architectures", () => {
+    expect(() => getPlatformString("linux", "ia32")).toThrow(
+      "Unsupported platform",
+    )
   })
 
   it("returns linux-arm64 for linux + arm64", () => {
     expect(getPlatformString("linux", "arm64")).toBe("linux-arm64")
   })
 
-  it("maps unknown architectures to x86_64", () => {
-    expect(getPlatformString("linux", "mips")).toBe("linux-x86_64")
+  it("rejects unsupported architectures", () => {
+    expect(() => getPlatformString("linux", "mips")).toThrow(
+      "Unsupported platform",
+    )
+  })
+
+  it("rejects unsupported operating systems", () => {
+    expect(() => getPlatformString("freebsd", "x64")).toThrow(
+      "Unsupported platform",
+    )
   })
 })
 
@@ -44,10 +57,57 @@ describe("isNewerVersion", () => {
     expect(isNewerVersion("v0.1.0", "v0.1.0")).toBe(false)
   })
 
-  it("returns true when latest is different", () => {
+  it("returns true only when latest is newer", () => {
     expect(isNewerVersion("v0.1.0", "v0.2.0")).toBe(true)
     expect(isNewerVersion("v0.1.0", "v1.0.0")).toBe(true)
-    expect(isNewerVersion("v0.1.0", "v0.0.9")).toBe(true)
+    expect(isNewerVersion("v0.1.0", "v0.0.9")).toBe(false)
+    expect(isNewerVersion("v0.1.0", "v0.1.0-beta.1")).toBe(false)
+    expect(isNewerVersion("v0.1.0", "release")).toBe(false)
+  })
+})
+
+describe("compareStableVersions", () => {
+  it("returns ordering for v-prefixed stable versions", () => {
+    expect(compareStableVersions("v0.4.6", "v0.4.7")).toBe(1)
+    expect(compareStableVersions("v0.4.7", "v0.4.6")).toBe(-1)
+    expect(compareStableVersions("v0.4.6", "v0.4.6")).toBe(0)
+  })
+
+  it("returns null for malformed or prerelease tags", () => {
+    expect(compareStableVersions("v0.4.6", "0.4.7")).toBeNull()
+    expect(compareStableVersions("v0.4.6", "v0.4.7-beta.1")).toBeNull()
+  })
+})
+
+describe("checksum helpers", () => {
+  it("finds the exact asset checksum", () => {
+    expect(
+      parseChecksumManifest(
+        "a".repeat(64) +
+          "  noodle-linux-arm64\n" +
+          "b".repeat(64) +
+          "  noodle-linux-x86_64\n",
+        "noodle-linux-x86_64",
+      ),
+    ).toBe("b".repeat(64))
+  })
+
+  it("rejects missing and malformed checksums", () => {
+    expect(
+      parseChecksumManifest(
+        "not-a-checksum  noodle-linux-arm64",
+        "noodle-linux-arm64",
+      ),
+    ).toBeNull()
+    expect(
+      parseChecksumManifest("a".repeat(64) + "  other", "noodle-linux-arm64"),
+    ).toBeNull()
+  })
+
+  it("calculates SHA-256", () => {
+    expect(sha256(new TextEncoder().encode("noodle"))).toBe(
+      "49742b4b8dd3a7ff2a2a32410e34f55a57d09a2327edb26d726a30e400960966",
+    )
   })
 })
 

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   getPlatformString,
   compareStableVersions,
@@ -6,7 +9,13 @@ import {
   isNewerVersion,
   isHomebrewInstall,
   parseChecksumManifest,
+  isFreshUpdateCache,
+  loadUpdateCache,
+  parseUpdateCache,
+  runUpdate,
+  saveUpdateCache,
   sha256,
+  UPDATE_CACHE_TTL_MS,
 } from "../../src/app/commands/update"
 
 describe("getPlatformString", () => {
@@ -108,6 +117,257 @@ describe("checksum helpers", () => {
     expect(sha256(new TextEncoder().encode("noodle"))).toBe(
       "49742b4b8dd3a7ff2a2a32410e34f55a57d09a2327edb26d726a30e400960966",
     )
+  })
+})
+
+describe("update cache", () => {
+  it("validates and expires cache entries", () => {
+    const cache = parseUpdateCache({ latestTag: "v0.4.6", checkedAt: 1000 })
+    expect(cache).toEqual({ latestTag: "v0.4.6", checkedAt: 1000 })
+    expect(UPDATE_CACHE_TTL_MS).toBe(60 * 60 * 1000)
+    expect(isFreshUpdateCache(cache!, 1000 + UPDATE_CACHE_TTL_MS)).toBe(true)
+    expect(isFreshUpdateCache(cache!, 1001 + UPDATE_CACHE_TTL_MS)).toBe(false)
+    expect(
+      parseUpdateCache({ latestTag: "v0.4.6-beta.1", checkedAt: 1000 }),
+    ).toBeNull()
+    expect(parseUpdateCache({ latestTag: "v0.4.6", checkedAt: -1 })).toBeNull()
+  })
+
+  it("saves and loads cache atomically", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-cache-"))
+    const path = join(dir, "nested", "update-cache.json")
+    try {
+      await saveUpdateCache(path, { latestTag: "v0.4.6", checkedAt: 42 })
+      expect(await loadUpdateCache(path)).toEqual({
+        latestTag: "v0.4.6",
+        checkedAt: 42,
+      })
+      expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+        latestTag: "v0.4.6",
+        checkedAt: 42,
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("uses a fresh matching cache without calling GitHub", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-cache-"))
+    const path = join(dir, "update-cache.json")
+    let calls = 0
+    try {
+      await writeFile(
+        path,
+        JSON.stringify({ latestTag: "v0.4.6", checkedAt: 1000 }),
+      )
+      const result = await runUpdate(true, false, {
+        cachePath: path,
+        now: () => 1000,
+        execPath: "/tmp/noodle",
+        platform: "darwin",
+        arch: "arm64",
+        env: {},
+        fetcher: async () => {
+          calls += 1
+          return new Response()
+        },
+      })
+      expect(result.data).toEqual({
+        status: "up_to_date",
+        version: "v0.4.6",
+        cached: "true",
+      })
+      expect(calls).toBe(0)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("update release discovery", () => {
+  const baseDeps = (cachePath: string) => ({
+    cachePath,
+    now: () => 1000,
+    execPath: "/tmp/noodle",
+    platform: "darwin",
+    arch: "arm64",
+  })
+
+  it("bypasses cache with --force and sends GH_TOKEN first", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-force-"))
+    const path = join(dir, "update-cache.json")
+    let request: RequestInit | undefined
+    try {
+      const result = await runUpdate(true, true, {
+        ...baseDeps(path),
+        env: { GH_TOKEN: "gh-token", GITHUB_TOKEN: "github-token" },
+        fetcher: async (_url, init) => {
+          request = init
+          return Response.json({ tag_name: "v0.4.6", assets: [] })
+        },
+      })
+      expect(result.data.status).toBe("up_to_date")
+      expect((request?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer gh-token",
+      )
+      expect(await loadUpdateCache(path)).toEqual({
+        latestTag: "v0.4.6",
+        checkedAt: 1000,
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("uses GITHUB_TOKEN when GH_TOKEN is absent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-auth-"))
+    let request: RequestInit | undefined
+    try {
+      await runUpdate(true, true, {
+        ...baseDeps(join(dir, "cache.json")),
+        env: { GITHUB_TOKEN: "github-token" },
+        fetcher: async (_url, init) => {
+          request = init
+          return Response.json({ tag_name: "v0.4.6", assets: [] })
+        },
+      })
+      expect((request?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer github-token",
+      )
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("reports rate limits and reset time", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-rate-"))
+    try {
+      const result = await runUpdate(true, true, {
+        ...baseDeps(join(dir, "cache.json")),
+        env: {},
+        fetcher: async () =>
+          new Response(null, {
+            status: 403,
+            headers: {
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": "2000",
+            },
+          }),
+      })
+      expect(result).toEqual({
+        data: {
+          status: "rate_limited",
+          retry_at: "1970-01-01T00:33:20.000Z",
+        },
+        failed: true,
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("treats 429 as rate limited and ordinary 403 as a check failure", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-rate-"))
+    try {
+      const deps = baseDeps(join(dir, "cache.json"))
+      const rateLimited = await runUpdate(true, true, {
+        ...deps,
+        env: {},
+        fetcher: async () => new Response(null, { status: 429 }),
+      })
+      const forbidden = await runUpdate(true, true, {
+        ...deps,
+        env: {},
+        fetcher: async () =>
+          new Response(null, {
+            status: 403,
+            headers: { "x-ratelimit-remaining": "10" },
+          }),
+      })
+      expect(rateLimited.data.status).toBe("rate_limited")
+      expect(forbidden.data.status).toBe("check_failed")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not send an authorization header without a token", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-auth-"))
+    let request: RequestInit | undefined
+    try {
+      await runUpdate(true, true, {
+        ...baseDeps(join(dir, "cache.json")),
+        env: {},
+        fetcher: async (_url, init) => {
+          request = init
+          return Response.json({ tag_name: "v0.4.6", assets: [] })
+        },
+      })
+      expect(request?.headers).toEqual({
+        Accept: "application/vnd.github+json",
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("replaces the binary after a verified download", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-success-"))
+    const executable = join(dir, "noodle")
+    const binary = new TextEncoder().encode("new")
+    try {
+      await writeFile(executable, "old")
+      const result = await runUpdate(true, true, {
+        ...baseDeps(join(dir, "cache.json")),
+        execPath: executable,
+        env: {},
+        fetcher: async (input) => {
+          const url = String(input)
+          if (url.includes("api.github.com"))
+            return Response.json({
+              tag_name: "v0.4.7",
+              assets: [
+                { name: "noodle-macos-arm64", browser_download_url: "binary" },
+              ],
+            })
+          if (url === "binary") return new Response(binary)
+          return new Response(`${sha256(binary)}  noodle-macos-arm64\n`)
+        },
+      })
+      expect(result.data).toEqual({ status: "updated", version: "v0.4.7" })
+      expect(await readFile(executable, "utf8")).toBe("new")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not replace the binary when checksum verification fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-update-checksum-"))
+    const executable = join(dir, "noodle")
+    try {
+      await writeFile(executable, "old")
+      const result = await runUpdate(true, true, {
+        ...baseDeps(join(dir, "cache.json")),
+        execPath: executable,
+        env: {},
+        fetcher: async (input) => {
+          const url = String(input)
+          if (url.includes("api.github.com"))
+            return Response.json({
+              tag_name: "v0.4.7",
+              assets: [
+                { name: "noodle-macos-arm64", browser_download_url: "binary" },
+              ],
+            })
+          if (url === "binary") return new Response("new")
+          return new Response("0".repeat(64) + "  noodle-macos-arm64\n")
+        },
+      })
+      expect(result.data.status).toBe("update_failed")
+      expect(await readFile(executable, "utf8")).toBe("old")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -494,6 +494,10 @@ describe("isHomebrewInstall", () => {
     )
   })
 
+  it("detects user-local linuxbrew prefix", () => {
+    expect(isHomebrewInstall("/home/user/.linuxbrew/bin/noodle")).toBe(true)
+  })
+
   it("detects brew in path", () => {
     expect(isHomebrewInstall("/usr/local/brew/bin/noodle")).toBe(true)
   })


### PR DESCRIPTION
## What changed

- Verify installer downloads against the release SHA256 manifest before replacement.
- Stage installer replacements inside the destination directory for atomic replacement.
- Harden self-update version comparison, checksum verification, release validation, GitHub token support, rate-limit reporting, and Homebrew routing.
- Add one-hour update caching, including verified updates from a fresh cached release without another API check.
- Add end-to-end installer coverage and expanded update/CLI tests.

## Why

Installation and self-update failures could leave users with a partially replaced binary or repeatedly hit GitHub’s API. These changes make replacement safer, reject invalid or tampered downloads, and make update behavior more predictable.

## Validation

- 1,533 tests passing
- Typecheck passing
- Lint passing
- Real disposable-folder install smoke test against GitHub v0.4.6
- Invalid-version install smoke test confirmed no binary is created
- Real isolated updater smoke test confirmed current-version and cached responses
- Homebrew status checked separately: installed 0.4.6 and not outdated