### PR TITLE
fix(cli): open current directory when no collection is registered

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ noodle request <create|run> ... [--json]
 noodle environment set <key> <value> --env <name> [--collection <dir>] [--json]
 ```
 
-- **Default command** (TUI mode): optional positional `<path>` (use `.` for current directory), `--collection/-c`, and `--env/-e`. Positional path overrides `--collection`; supplying both is invalid. Without either, the first existing registered collection in `~/.config/noodle/config.yml` is used, then `./collections`.
+- **Default command** (TUI mode): optional positional `<path>` (use `.` for current directory), `--collection/-c`, and `--env/-e`. Positional path overrides `--collection`; supplying both is invalid. Without either, the first existing registered collection in `~/.config/noodle/config.yml` is used, then the current directory.
 - **Import subcommand**: `source` (positional, required), `--format/-i` (openapi/postman, auto-detected if omitted), `--output/-o` (default: ./collections)
 - **Update subcommand**: Self-update. Checks GitHub for latest release and replaces binary. Detects Homebrew installs and redirects to `brew upgrade`.
 - **Automation commands**: `workspace list`, `workspace audit [--fix]`; `collection create`, `init`, `list`, `inspect`, `audit [--fix]`, `run [--env]`; `request create --url --method --collection`, `run [--env]`; and `environment set`. They are non-interactive and support `--json`, which writes one `{ status, data, errors }` envelope and uses a nonzero exit status for invalid input or failed runs. `collection init` bootstraps missing collection markers in an existing directory and registers it. `workspace audit --fix` removes invalid registered paths.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ noodle .
 noodle --collection ./collections --env development
 ```
 
-Without either option, noodle uses the first existing collection registered in `~/.config/noodle/config.yml`, then falls back to `./collections`. A directory with request YAML but no collection markers opens in read-only browse mode; an empty directory opens in read-only empty mode. Initialize either mode from the command palette before editing or sending requests.
+Without either option, noodle uses the first existing collection registered in `~/.config/noodle/config.yml`, then falls back to the current directory. A directory with request YAML but no collection markers opens in read-only browse mode; an empty directory opens in read-only empty mode. Initialize either mode from the command palette before editing or sending requests.
 
 | Command | Purpose |
 | --- | --- |

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -52,6 +52,8 @@ export function formatWorkspaceList(data: { collections: string[] }): string {
 }
 
 export function formatWorkspaceAudit(data: WorkspaceAuditResult): string {
+  if (data.collections.length === 0 && data.issues.length === 0)
+    return "No registered collections."
   if (data.issues.length === 0)
     return `${color("✓", "green")} All registered collections are valid`
   const fixed = data.issues.filter((issue) => issue.fixed).length

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -98,27 +98,26 @@ export function classifyPath(dir: string): CollectionMode {
   return "empty"
 }
 
-export async function bootstrap(options: BootstrapOptions): Promise<void> {
-  let collectionDir: string
+export function resolveStartupCollectionDir(
+  options: BootstrapOptions,
+  collectionPaths: string[],
+  cwd = process.cwd(),
+): string {
+  if (options.targetPath) return resolve(options.targetPath)
+  if (options.collectionDir) return resolve(options.collectionDir)
 
-  if (options.targetPath) {
-    collectionDir = options.targetPath
-  } else if (options.collectionDir) {
-    collectionDir = options.collectionDir
-  } else {
-    let fromConfig: string | undefined
-    try {
-      const cfg = loadConfig(CONFIG_DIR)
-      fromConfig = cfg.collections.find(isDirectoryPath)
-    } catch {
-      // config unavailable
-    }
-    if (fromConfig) {
-      collectionDir = resolve(fromConfig)
-    } else {
-      collectionDir = resolve("./collections")
-    }
+  const fromConfig = collectionPaths.find(isDirectoryPath)
+  return fromConfig ? resolve(fromConfig) : resolve(cwd)
+}
+
+export async function bootstrap(options: BootstrapOptions): Promise<void> {
+  let collectionPaths: string[] = []
+  try {
+    collectionPaths = loadConfig(CONFIG_DIR).collections
+  } catch {
+    // config unavailable
   }
+  const collectionDir = resolveStartupCollectionDir(options, collectionPaths)
 
   const mode: CollectionMode = classifyPath(collectionDir)
   if (mode === "invalid") {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -6,7 +6,7 @@ import type { CommandMeta, ArgsDef, StringArgDef } from "citty"
 import defaultCommand from "../src/app/commands/default"
 import importCommand from "../src/app/commands/import"
 import updateCommand from "../src/app/commands/update"
-import { classifyPath } from "../src/app/main"
+import { classifyPath, resolveStartupCollectionDir } from "../src/app/main"
 import { getUserArgsStart } from "../src/app/argv"
 
 const CLI = join(import.meta.dir, "../src/app/cli.ts")
@@ -380,5 +380,42 @@ describe("classifyPath", () => {
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
+  })
+})
+
+describe("resolveStartupCollectionDir", () => {
+  it("uses the current directory when no registered collection exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-startup-"))
+    try {
+      expect(resolveStartupCollectionDir({}, [], dir)).toBe(dir)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("uses the first existing registered collection before the current directory", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-startup-"))
+    const collection = join(dir, "collection")
+    await mkdir(collection)
+    try {
+      expect(
+        resolveStartupCollectionDir(
+          {},
+          [join(dir, "missing"), collection],
+          dir,
+        ),
+      ).toBe(collection)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps an explicit collection path even when it does not exist", () => {
+    expect(
+      resolveStartupCollectionDir(
+        { collectionDir: "/tmp/noodle-explicit-missing" },
+        [],
+      ),
+    ).toBe("/tmp/noodle-explicit-missing")
   })
 })

--- a/tests/humanOutput.test.ts
+++ b/tests/humanOutput.test.ts
@@ -6,6 +6,7 @@ import {
   formatCollectionList,
   formatImport,
   formatRequestRun,
+  formatWorkspaceAudit,
   formatWorkspaceList,
 } from "../src/app/humanOutput"
 
@@ -21,6 +22,16 @@ describe("human CLI output", () => {
     expect(formatWorkspaceList({ collections: [] })).toBe(
       "No registered collections.",
     )
+  })
+
+  it("explains when an audit has no registered collections", () => {
+    expect(
+      formatWorkspaceAudit({
+        valid: true,
+        collections: [],
+        issues: [],
+      }),
+    ).toBe("No registered collections.")
   })
 
   it("renders collection trees for list and inspect", () => {


### PR DESCRIPTION
## What changed

- Keep the first existing registered collection as the startup target.
- Fall back to the current directory when no registered collection exists.
- Preserve read-only browse/empty modes for uninitialized directories.
- Report `No registered collections.` when workspace audit has no entries.

## Why

When `noodle` was launched without arguments and no registered collection was available, it fell back to `./collections`. If that directory did not exist, startup exited before the TUI could use its existing read-only empty/browse modes.

## Validation

- `bun test tests/cli.test.ts tests/humanOutput.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx prettier --check ./src ./tests`
- Full suite: 1539 pass, 0 fail
