### PR TITLE
feat(converters): import cURL commands as Noodle requests

### DIFF
--- a/src/converters/curl/parse.ts
+++ b/src/converters/curl/parse.ts
@@ -12,6 +12,7 @@ export type ImportedCurlRequest = Omit<Request, "id" | "name">
 interface DataPart {
   value: string
   urlencoded: boolean
+  binary: boolean
 }
 
 const METHODS = new Set<Method>([
@@ -48,6 +49,7 @@ export function parseCurl(command: string): ImportedCurlRequest {
   let uploadFile: string | undefined
   let followRedirects = false
   let maxRedirects = 5
+  let hasExplicitMaxRedirects = false
   let timeout = 0
   let auth: Auth = { type: "none" }
   const headers: Record<string, KvEntry> = {}
@@ -74,7 +76,7 @@ export function parseCurl(command: string): ImportedCurlRequest {
     if (IGNORED_FLAGS.has(token)) continue
     if (token === "-L" || token === "--location") {
       followRedirects = true
-      maxRedirects = 50
+      if (!hasExplicitMaxRedirects) maxRedirects = 50
       continue
     }
     if (token === "--no-location") {
@@ -122,32 +124,31 @@ export function parseCurl(command: string): ImportedCurlRequest {
         auth = { type: "bearer", token: value }
       },
       "-d": (value) => {
-        data.push({ value, urlencoded: false })
+        data.push({ value, urlencoded: false, binary: false })
         hasBody = true
       },
       "--data": (value) => {
-        data.push({ value, urlencoded: false })
+        data.push({ value, urlencoded: false, binary: false })
         hasBody = true
       },
       "--data-raw": (value) => {
-        data.push({ value, urlencoded: false })
+        data.push({ value, urlencoded: false, binary: false })
         hasBody = true
       },
       "--data-ascii": (value) => {
-        data.push({ value, urlencoded: false })
+        data.push({ value, urlencoded: false, binary: false })
         hasBody = true
       },
       "--data-urlencode": (value) => {
-        data.push({ value, urlencoded: true })
+        data.push({ value, urlencoded: true, binary: false })
         hasBody = true
       },
       "--data-binary": (value) => {
-        if (!value.startsWith("@")) {
-          throw new Error(
-            "--data-binary is supported only with a file path (@file)",
-          )
+        if (value.startsWith("@")) {
+          uploadFile = value.slice(1)
+        } else {
+          data.push({ value, urlencoded: false, binary: true })
         }
-        uploadFile = value.slice(1)
         hasBody = true
       },
       "-F": (value) => {
@@ -172,6 +173,7 @@ export function parseCurl(command: string): ImportedCurlRequest {
           throw new Error("--max-redirs must be a non-negative integer")
         }
         maxRedirects = parsed
+        hasExplicitMaxRedirects = true
       },
       "--max-time": (value) => {
         const seconds = Number(value)
@@ -391,7 +393,7 @@ function applyDataBody(
   if (
     data.some((part) => part.urlencoded) ||
     contentType?.includes("application/x-www-form-urlencoded") ||
-    value.includes("=")
+    (value.includes("=") && !data.some((part) => part.binary))
   ) {
     request.bodyType = "urlencoded"
     request.formData = toParams(value).map((entry) => ({

--- a/src/converters/curl/parse.ts
+++ b/src/converters/curl/parse.ts
@@ -195,6 +195,9 @@ export function parseCurl(command: string): ImportedCurlRequest {
   }
 
   if (!url) throw new Error("cURL command must include a URL")
+  const detectedAuth = authFromAuthorizationHeader(headers)
+  if (detectedAuth) auth = detectedAuth
+
   let parsedUrl: URL
   try {
     parsedUrl = new URL(url)
@@ -296,6 +299,34 @@ function basicAuth(value: string): Auth {
     type: "basic",
     user: separator === -1 ? value : value.slice(0, separator),
     pass: separator === -1 ? "" : value.slice(separator + 1),
+  }
+}
+
+function authFromAuthorizationHeader(
+  headers: Record<string, KvEntry>,
+): Auth | null {
+  const authorization = Object.entries(headers).find(
+    ([name]) => name.toLowerCase() === "authorization",
+  )
+  if (!authorization) return null
+
+  const [name, entry] = authorization
+  const bearer = /^Bearer\s+(.+)$/i.exec(entry.value)
+  if (bearer?.[1].trim()) {
+    delete headers[name]
+    return { type: "bearer", token: bearer[1].trim() }
+  }
+
+  const basic = /^Basic\s+([A-Za-z0-9+/]+={0,2})$/i.exec(entry.value)
+  if (!basic?.[1]) return null
+  const decoded = Buffer.from(basic[1], "base64").toString("utf8")
+  const separator = decoded.indexOf(":")
+  if (separator < 0) return null
+  delete headers[name]
+  return {
+    type: "basic",
+    user: decoded.slice(0, separator),
+    pass: decoded.slice(separator + 1),
   }
 }
 

--- a/src/converters/curl/parse.ts
+++ b/src/converters/curl/parse.ts
@@ -290,7 +290,19 @@ function addHeader(headers: Record<string, KvEntry>, value: string): void {
   if (separator <= 0) throw new Error(`invalid header: ${value}`)
   const name = value.slice(0, separator).trim()
   if (!name) throw new Error(`invalid header: ${value}`)
-  headers[name] = { value: value.slice(separator + 1).trim(), enabled: true }
+  const headerValue = value.slice(separator + 1).trim()
+  const existingName = Object.keys(headers).find(
+    (key) => key.toLowerCase() === name.toLowerCase(),
+  )
+  const existing = existingName ? headers[existingName] : undefined
+  if (existing && name.toLowerCase() === "cookie") {
+    headers[existingName!] = {
+      value: `${existing.value}; ${headerValue}`,
+      enabled: true,
+    }
+    return
+  }
+  headers[name] = { value: headerValue, enabled: true }
 }
 
 function basicAuth(value: string): Auth {
@@ -366,6 +378,16 @@ function applyDataBody(
   const contentType = Object.entries(headers)
     .find(([name]) => name.toLowerCase() === "content-type")?.[1]
     .value.toLowerCase()
+  if (contentType?.includes("application/json") || /^[{[]/.test(value.trim())) {
+    try {
+      JSON.parse(value)
+    } catch (e) {
+      throw new Error("JSON request body is invalid", { cause: e })
+    }
+    request.bodyType = "json"
+    request.body = value
+    return
+  }
   if (
     data.some((part) => part.urlencoded) ||
     contentType?.includes("application/x-www-form-urlencoded") ||
@@ -376,16 +398,6 @@ function applyDataBody(
       ...entry,
       type: "text",
     }))
-    return
-  }
-  if (contentType?.includes("application/json") || /^[{[]/.test(value.trim())) {
-    try {
-      JSON.parse(value)
-    } catch (e) {
-      throw new Error("JSON request body is invalid", { cause: e })
-    }
-    request.bodyType = "json"
-    request.body = value
     return
   }
   throw new Error(

--- a/src/converters/curl/parse.ts
+++ b/src/converters/curl/parse.ts
@@ -1,0 +1,354 @@
+import type {
+  Auth,
+  FormEntry,
+  KvEntry,
+  Method,
+  ParamEntry,
+  Request,
+} from "../../schema"
+
+export type ImportedCurlRequest = Omit<Request, "id" | "name">
+
+interface DataPart {
+  value: string
+  urlencoded: boolean
+}
+
+const METHODS = new Set<Method>([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+])
+
+const IGNORED_FLAGS = new Set([
+  "-s",
+  "--silent",
+  "-S",
+  "--show-error",
+  "-v",
+  "--verbose",
+  "-i",
+  "--include",
+])
+
+export function parseCurl(command: string): ImportedCurlRequest {
+  const tokens = tokenize(command)
+  if (tokens.length === 0 || !["curl", "curl.exe"].includes(tokens[0]!)) {
+    throw new Error("cURL command must start with curl")
+  }
+
+  let url = ""
+  let method: Method | undefined
+  let hasBody = false
+  let useGet = false
+  let uploadFile: string | undefined
+  let followRedirects = false
+  let maxRedirects = 5
+  let timeout = 0
+  let auth: Auth = { type: "none" }
+  const headers: Record<string, KvEntry> = {}
+  const params: ParamEntry[] = []
+  const data: DataPart[] = []
+  const formData: FormEntry[] = []
+
+  const takeValue = (flag: string, index: number): string => {
+    const value = tokens[index + 1]
+    if (value === undefined) throw new Error(`${flag} requires a value`)
+    return value
+  }
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i]!
+    if (token === "--") {
+      const next = tokens[i + 1]
+      if (!next || i + 2 !== tokens.length) {
+        throw new Error("cURL command must contain exactly one URL")
+      }
+      url = next
+      break
+    }
+    if (IGNORED_FLAGS.has(token)) continue
+    if (token === "-L" || token === "--location") {
+      followRedirects = true
+      maxRedirects = 50
+      continue
+    }
+    if (token === "--no-location") {
+      followRedirects = false
+      continue
+    }
+    if (token === "-G" || token === "--get") {
+      useGet = true
+      continue
+    }
+    if (token === "-I" || token === "--head") {
+      method = "HEAD"
+      continue
+    }
+
+    const valueFlags: Record<string, (value: string) => void> = {
+      "-X": (value) => {
+        const nextMethod = value.toUpperCase() as Method
+        if (!METHODS.has(nextMethod)) {
+          throw new Error(`unsupported HTTP method: ${value}`)
+        }
+        method = nextMethod
+      },
+      "--request": (value) => {
+        const nextMethod = value.toUpperCase() as Method
+        if (!METHODS.has(nextMethod)) {
+          throw new Error(`unsupported HTTP method: ${value}`)
+        }
+        method = nextMethod
+      },
+      "--url": (value) => {
+        url = value
+      },
+      "-H": (value) => addHeader(headers, value),
+      "--header": (value) => addHeader(headers, value),
+      "-b": (value) => addHeader(headers, `Cookie: ${value}`),
+      "--cookie": (value) => addHeader(headers, `Cookie: ${value}`),
+      "-u": (value) => {
+        auth = basicAuth(value)
+      },
+      "--user": (value) => {
+        auth = basicAuth(value)
+      },
+      "--oauth2-bearer": (value) => {
+        auth = { type: "bearer", token: value }
+      },
+      "-d": (value) => {
+        data.push({ value, urlencoded: false })
+        hasBody = true
+      },
+      "--data": (value) => {
+        data.push({ value, urlencoded: false })
+        hasBody = true
+      },
+      "--data-raw": (value) => {
+        data.push({ value, urlencoded: false })
+        hasBody = true
+      },
+      "--data-ascii": (value) => {
+        data.push({ value, urlencoded: false })
+        hasBody = true
+      },
+      "--data-urlencode": (value) => {
+        data.push({ value, urlencoded: true })
+        hasBody = true
+      },
+      "--data-binary": (value) => {
+        if (!value.startsWith("@")) {
+          throw new Error(
+            "--data-binary is supported only with a file path (@file)",
+          )
+        }
+        uploadFile = value.slice(1)
+        hasBody = true
+      },
+      "-F": (value) => {
+        formData.push(parseFormPart(value))
+        hasBody = true
+      },
+      "--form": (value) => {
+        formData.push(parseFormPart(value))
+        hasBody = true
+      },
+      "-T": (value) => {
+        uploadFile = value
+        hasBody = true
+      },
+      "--upload-file": (value) => {
+        uploadFile = value
+        hasBody = true
+      },
+      "--max-redirs": (value) => {
+        const parsed = Number.parseInt(value, 10)
+        if (!Number.isInteger(parsed) || parsed < 0) {
+          throw new Error("--max-redirs must be a non-negative integer")
+        }
+        maxRedirects = parsed
+      },
+      "--max-time": (value) => {
+        const seconds = Number(value)
+        if (!Number.isFinite(seconds) || seconds < 0) {
+          throw new Error("--max-time must be a non-negative number")
+        }
+        timeout = Math.round(seconds * 1000)
+      },
+    }
+    const handler = valueFlags[token]
+    if (handler) {
+      handler(takeValue(token, i))
+      i++
+      continue
+    }
+    if (token.startsWith("-")) {
+      throw new Error(`unsupported cURL option: ${token}`)
+    }
+    if (url) throw new Error("cURL command must contain exactly one URL")
+    url = token
+  }
+
+  if (!url) throw new Error("cURL command must include a URL")
+  try {
+    new URL(url)
+  } catch (e) {
+    throw new Error(`invalid cURL URL: ${url}`, { cause: e })
+  }
+
+  if (useGet) {
+    for (const part of data) params.push(...toParams(part.value))
+    data.length = 0
+    hasBody = formData.length > 0 || uploadFile !== undefined
+  }
+
+  const request: ImportedCurlRequest = {
+    method: method ?? (uploadFile ? "PUT" : hasBody ? "POST" : "GET"),
+    url,
+    timeout,
+    followRedirects,
+    maxRedirects,
+    headers,
+    params,
+    auth,
+    bodyType: "none",
+    body: "",
+  }
+
+  if (formData.length > 0) {
+    request.bodyType = "multipart"
+    request.formData = formData
+  } else if (uploadFile) {
+    request.bodyType = "binary"
+    request.filePath = uploadFile
+  } else if (data.length > 0) {
+    applyDataBody(request, data, headers)
+  }
+  return request
+}
+
+function tokenize(command: string): string[] {
+  const tokens: string[] = []
+  let current = ""
+  let quote: "'" | '"' | null = null
+  let escaping = false
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i]!
+    if (escaping) {
+      if (char !== "\n") current += char
+      escaping = false
+      continue
+    }
+    if (char === "\\" && quote !== "'") {
+      escaping = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = null
+      else current += char
+      continue
+    }
+    if (char === "'" || char === '"') {
+      quote = char
+    } else if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current)
+        current = ""
+      }
+    } else if (char === ";" || char === "|" || char === "&" || char === "`") {
+      throw new Error("shell operators are not supported in cURL imports")
+    } else {
+      current += char
+    }
+  }
+  if (escaping || quote)
+    throw new Error("unterminated escape or quote in cURL command")
+  if (current) tokens.push(current)
+  return tokens
+}
+
+function addHeader(headers: Record<string, KvEntry>, value: string): void {
+  const separator = value.indexOf(":")
+  if (separator <= 0) throw new Error(`invalid header: ${value}`)
+  const name = value.slice(0, separator).trim()
+  if (!name) throw new Error(`invalid header: ${value}`)
+  headers[name] = { value: value.slice(separator + 1).trim(), enabled: true }
+}
+
+function basicAuth(value: string): Auth {
+  const separator = value.indexOf(":")
+  return {
+    type: "basic",
+    user: separator === -1 ? value : value.slice(0, separator),
+    pass: separator === -1 ? "" : value.slice(separator + 1),
+  }
+}
+
+function parseFormPart(value: string): FormEntry {
+  const separator = value.indexOf("=")
+  if (separator <= 0) throw new Error(`invalid form field: ${value}`)
+  const name = value.slice(0, separator)
+  const rawValue = value.slice(separator + 1)
+  if (rawValue.startsWith("<")) {
+    throw new Error("form fields loaded from files (<file) are not supported")
+  }
+  if (rawValue.startsWith("@")) {
+    return {
+      name,
+      value: rawValue.slice(1).split(";")[0]!,
+      enabled: true,
+      type: "file",
+    }
+  }
+  return { name, value: rawValue, enabled: true, type: "text" }
+}
+
+function toParams(value: string): ParamEntry[] {
+  return [...new URLSearchParams(value)].map(([name, paramValue]) => ({
+    name,
+    value: paramValue,
+    enabled: true,
+  }))
+}
+
+function applyDataBody(
+  request: ImportedCurlRequest,
+  data: DataPart[],
+  headers: Record<string, KvEntry>,
+): void {
+  const value = data.map((part) => part.value).join("&")
+  const contentType = Object.entries(headers)
+    .find(([name]) => name.toLowerCase() === "content-type")?.[1]
+    .value.toLowerCase()
+  if (
+    data.some((part) => part.urlencoded) ||
+    contentType?.includes("application/x-www-form-urlencoded") ||
+    value.includes("=")
+  ) {
+    request.bodyType = "urlencoded"
+    request.formData = toParams(value).map((entry) => ({
+      ...entry,
+      type: "text",
+    }))
+    return
+  }
+  if (contentType?.includes("application/json") || /^[{[]/.test(value.trim())) {
+    try {
+      JSON.parse(value)
+    } catch (e) {
+      throw new Error("JSON request body is invalid", { cause: e })
+    }
+    request.bodyType = "json"
+    request.body = value
+    return
+  }
+  throw new Error(
+    "raw request data is unsupported; use JSON, URL-encoded data, multipart form data, or a file",
+  )
+}

--- a/src/converters/curl/parse.ts
+++ b/src/converters/curl/parse.ts
@@ -195,10 +195,19 @@ export function parseCurl(command: string): ImportedCurlRequest {
   }
 
   if (!url) throw new Error("cURL command must include a URL")
+  let parsedUrl: URL
   try {
-    new URL(url)
+    parsedUrl = new URL(url)
   } catch (e) {
     throw new Error(`invalid cURL URL: ${url}`, { cause: e })
+  }
+
+  if (parsedUrl.search) {
+    for (const [name, value] of parsedUrl.searchParams) {
+      params.push({ name, value, enabled: true })
+    }
+    parsedUrl.search = ""
+    url = parsedUrl.toString()
   }
 
   if (useGet) {

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -21,6 +21,7 @@ import { type Focus, type UrlBarSubFocus } from "./focus"
 import { type NewRequestOverlayHandle } from "./overlays/NewRequestOverlay"
 import { type CloneRequestOverlayHandle } from "./overlays/CloneRequestOverlay"
 import { type NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
+import { type ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
 import { buildCommandPaletteCommands } from "./commands"
 import { useTheme } from "./theme"
 import { StatusBar } from "./StatusBar"
@@ -47,6 +48,7 @@ import {
 import type { FieldKind } from "./editMode"
 import type { ResponseTabKind } from "./tabs/uiState"
 import { VariableCompletionInterceptor } from "./variable-completion/variableCompletionInterceptor"
+import { parseCurl } from "../converters/curl/parse"
 
 export function AppInner({
   collectionDir,
@@ -145,6 +147,8 @@ export function AppInner({
   const [deleteConfirmSelection, setDeleteConfirmSelection] = useState(0)
   const [newRequestVisible, setNewRequestVisible] = useState(false)
   const newRequestRef = useRef<NewRequestOverlayHandle>(null)
+  const [importCurlVisible, setImportCurlVisible] = useState(false)
+  const importCurlRef = useRef<ImportCurlOverlayHandle>(null)
   const [editRequestVisible, setEditRequestVisible] = useState(false)
   const editRequestRef = useRef<NewRequestOverlayHandle>(null)
   const [cloneRequestVisible, setCloneRequestVisible] = useState(false)
@@ -371,6 +375,7 @@ export function AppInner({
   const {
     handleFolderSave,
     handleNewRequestConfirm,
+    handleImportCurlConfirm,
     handleCloneRequestConfirm,
     handleNewFolderConfirm,
     handleFolderDeleteConfirm,
@@ -393,6 +398,7 @@ export function AppInner({
     setSelectedId,
     expandFolder,
     setNewRequestVisible,
+    setImportCurlVisible,
     setCloneRequestVisible,
     setNewFolderVisible,
     setEditRequestVisible,
@@ -418,6 +424,7 @@ export function AppInner({
     if (collectionSwitcherVisible) return "collection-switcher"
     if (yamlEditor.visible) return "yaml-editor"
     if (newRequestVisible) return "new-request"
+    if (importCurlVisible) return "import-curl"
     if (editRequestVisible) return "edit-request"
     if (cloneRequestVisible) return "clone-request"
     if (newFolderVisible) return "new-folder"
@@ -439,6 +446,7 @@ export function AppInner({
     collectionSwitcherVisible,
     yamlEditor.visible,
     newRequestVisible,
+    importCurlVisible,
     editRequestVisible,
     cloneRequestVisible,
     newFolderVisible,
@@ -752,6 +760,18 @@ export function AppInner({
     setNewRequestVisible,
     onNewRequestConfirm: (v) =>
       handleNewRequestConfirm(v.name, v.method as Method, v.url),
+    importCurlVisible,
+    importCurlRef,
+    setImportCurlVisible,
+    onImportCurlConfirm: (v) => {
+      try {
+        handleImportCurlConfirm(v.name, v.folderPath, parseCurl(v.command))
+      } catch (e: unknown) {
+        importCurlRef.current?.setError(
+          e instanceof Error ? e.message : String(e),
+        )
+      }
+    },
     editRequestVisible,
     editRequestRef,
     setEditRequestVisible,
@@ -832,6 +852,7 @@ export function AppInner({
         setHelpVisible,
         setAboutVisible,
         setNewRequestVisible,
+        setImportCurlVisible,
         setNewFolderVisible,
         setCloneRequestVisible,
         setEditRequestVisible,
@@ -974,6 +995,9 @@ export function AppInner({
           saveTimerRef={saveTimerRef}
           newRequestVisible={newRequestVisible}
           newRequestRef={newRequestRef}
+          importCurlVisible={importCurlVisible}
+          importCurlRef={importCurlRef}
+          importCurlInitialFolder={requestParentFolder ?? ""}
           activeEnv={envState.activeEnv}
           editRequestVisible={editRequestVisible}
           selectedRequest={selectedRequest}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -22,6 +22,10 @@ import {
   NewFolderOverlay,
   type NewFolderOverlayHandle,
 } from "./overlays/NewFolderOverlay"
+import {
+  ImportCurlOverlay,
+  type ImportCurlOverlayHandle,
+} from "./overlays/ImportCurlOverlay"
 import type {
   Collection,
   Environment,
@@ -95,6 +99,9 @@ interface AppOverlaysProps {
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
   newRequestVisible: boolean
   newRequestRef: RefObject<NewRequestOverlayHandle | null>
+  importCurlVisible: boolean
+  importCurlRef: RefObject<ImportCurlOverlayHandle | null>
+  importCurlInitialFolder: string
   activeEnv: Environment | null
   editRequestVisible: boolean
   selectedRequest: NoodleRequest | null
@@ -158,6 +165,9 @@ export function AppOverlays({
   saveTimerRef,
   newRequestVisible,
   newRequestRef,
+  importCurlVisible,
+  importCurlRef,
+  importCurlInitialFolder,
   activeEnv,
   editRequestVisible,
   selectedRequest,
@@ -306,6 +316,14 @@ export function AppOverlays({
       )}
       {newRequestVisible && (
         <NewRequestOverlay visible ref={newRequestRef} activeEnv={activeEnv} />
+      )}
+      {importCurlVisible && (
+        <ImportCurlOverlay
+          visible
+          ref={importCurlRef}
+          folderPaths={folderPaths}
+          initialFolderPath={importCurlInitialFolder}
+        />
       )}
       {editRequestVisible && (
         <NewRequestOverlay

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -68,6 +68,7 @@ export interface CommandBuilderContext {
   setHelpVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setAboutVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setNewRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setImportCurlVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setNewFolderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setCloneRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setEditRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
@@ -171,6 +172,7 @@ export function buildCommandPaletteCommands(
     setEditRequestVisible,
     setYamlEditor,
     setNewRequestVisible,
+    setImportCurlVisible,
     setCloneRequestVisible,
     setRequestDeletePending,
     setFolderDeletePending,
@@ -260,6 +262,16 @@ export function buildCommandPaletteCommands(
       keybinding: displayKey(keybinds.request_new),
       run: () => {
         setNewRequestVisible(true)
+        return true
+      },
+    },
+    {
+      id: "request.import-curl",
+      label: "Import cURL Request",
+      section: "Request",
+      run: () => {
+        if (mode !== "collection") return false
+        setImportCurlVisible(true)
         return true
       },
     },

--- a/src/ui/overlays/ImportCurlOverlay.tsx
+++ b/src/ui/overlays/ImportCurlOverlay.tsx
@@ -1,0 +1,178 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react"
+import type { InputRenderable, TextareaRenderable } from "@opentui/core"
+import type { SelectItem } from "../Select"
+import { Select } from "../Select"
+import { useTheme } from "../theme"
+import { Overlay } from "./Overlay"
+
+export interface ImportCurlOverlayHandle {
+  cycleFocus: (direction: 1 | -1) => void
+  confirm: () => { command: string; name: string; folderPath: string } | null
+  getFocus: () => "folder" | "name" | "curl"
+  setError: (message: string) => void
+}
+
+interface ImportCurlOverlayProps {
+  visible: boolean
+  folderPaths: SelectItem[]
+  initialFolderPath: string
+}
+
+const FOCUS_ORDER: Array<"folder" | "name" | "curl"> = [
+  "folder",
+  "name",
+  "curl",
+]
+
+export const ImportCurlOverlay = forwardRef<
+  ImportCurlOverlayHandle,
+  ImportCurlOverlayProps
+>(function ImportCurlOverlay({ visible, folderPaths, initialFolderPath }, ref) {
+  const theme = useTheme()
+  const [command, setCommand] = useState("")
+  const [name, setName] = useState("")
+  const [folderPath, setFolderPath] = useState(initialFolderPath)
+  const [focus, setFocus] = useState<"folder" | "name" | "curl">("folder")
+  const [errorText, setErrorText] = useState<string | null>(null)
+  const [folderSelectOpen, setFolderSelectOpen] = useState(false)
+  const curlRef = useRef<TextareaRenderable | null>(null)
+  const nameRef = useRef<InputRenderable | null>(null)
+
+  useEffect(() => {
+    if (!visible) return
+    setCommand("")
+    setName("")
+    setFolderPath(initialFolderPath)
+    setFocus("folder")
+    setErrorText(null)
+  }, [visible, initialFolderPath])
+
+  useEffect(() => {
+    if (focus === "curl") curlRef.current?.focus()
+    if (focus === "name") nameRef.current?.focus()
+  }, [focus])
+
+  useImperativeHandle(ref, () => ({
+    cycleFocus: (direction) => {
+      setErrorText(null)
+      setFocus((previous) => {
+        const index = FOCUS_ORDER.indexOf(previous)
+        return FOCUS_ORDER[
+          (index + direction + FOCUS_ORDER.length) % FOCUS_ORDER.length
+        ]!
+      })
+    },
+    confirm: () => {
+      if (!command.trim()) {
+        setErrorText("cURL command is required")
+        return null
+      }
+      if (!name.trim()) {
+        setErrorText("Request name is required")
+        return null
+      }
+      setErrorText(null)
+      return { command, name, folderPath }
+    },
+    getFocus: () => focus,
+    setError: setErrorText,
+  }))
+
+  return (
+    <Overlay visible={visible} width={58} padding={1} gap={1}>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingBottom: 1,
+          paddingX: 2,
+        }}
+      >
+        <text fg={theme.text}>Import cURL Request</text>
+        <text fg={theme.textMuted}>esc</text>
+      </box>
+
+      <box
+        style={{
+          paddingX: 2,
+          flexDirection: "column",
+          gap: 1,
+          paddingBottom: 1,
+        }}
+      >
+        <box
+          style={{
+            flexDirection: "column",
+            zIndex: folderSelectOpen ? 1 : undefined,
+          }}
+        >
+          <text fg={theme.textMuted}>Folder</text>
+          <Select
+            items={folderPaths}
+            value={folderPath}
+            onChange={setFolderPath}
+            focused={focus === "folder"}
+            onOpenChange={setFolderSelectOpen}
+          />
+        </box>
+
+        <box style={{ flexDirection: "column" }}>
+          <text fg={theme.textMuted}>Request Name</text>
+          <input
+            ref={nameRef}
+            value={name}
+            placeholder="e.g. Get Users"
+            onInput={setName}
+            focused={focus === "name"}
+            backgroundColor={theme.backgroundElement}
+            focusedBackgroundColor={theme.borderSubtle}
+            textColor={theme.text}
+            cursorColor={theme.primary}
+            placeholderColor={theme.textMuted}
+          />
+        </box>
+
+        <box style={{ flexDirection: "column" }}>
+          <text fg={theme.textMuted}>cURL Command</text>
+          <textarea
+            ref={curlRef}
+            initialValue={command}
+            placeholder="curl https://api.example.com/users"
+            onContentChange={() => setCommand(curlRef.current?.plainText ?? "")}
+            focused={focus === "curl"}
+            backgroundColor={theme.backgroundElement}
+            focusedBackgroundColor={theme.borderSubtle}
+            textColor={theme.text}
+            cursorColor={theme.primary}
+            placeholderColor={theme.textMuted}
+            height={4}
+            paddingX={1}
+          />
+        </box>
+
+        {errorText && <text fg={theme.error}>{errorText}</text>}
+      </box>
+
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "flex-end",
+          gap: 1,
+          paddingX: 2,
+        }}
+      >
+        <text fg={theme.text}>^S</text>
+        <text fg={theme.textMuted}>save</text>
+        <text fg={theme.textMuted}> · </text>
+        <text fg={theme.text}>esc</text>
+        <text fg={theme.textMuted}>close</text>
+      </box>
+    </Overlay>
+  )
+})

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -35,6 +35,7 @@ interface UseCollectionFileActionsOptions {
   setSelectedId: (id: string) => void
   expandFolder: (path: string) => void
   setNewRequestVisible: Dispatch<SetStateAction<boolean>>
+  setImportCurlVisible: Dispatch<SetStateAction<boolean>>
   setCloneRequestVisible: Dispatch<SetStateAction<boolean>>
   setNewFolderVisible: Dispatch<SetStateAction<boolean>>
   setEditRequestVisible: Dispatch<SetStateAction<boolean>>
@@ -59,6 +60,7 @@ export function useCollectionFileActions({
   setSelectedId,
   expandFolder,
   setNewRequestVisible,
+  setImportCurlVisible,
   setCloneRequestVisible,
   setNewFolderVisible,
   setEditRequestVisible,
@@ -202,6 +204,43 @@ export function useCollectionFileActions({
       setCloneRequestVisible,
       setCollectionReloadToken,
       setFocus,
+      setSelectedId,
+      showError,
+      showSaveResult,
+    ],
+  )
+
+  const handleImportCurlConfirm = useCallback(
+    (
+      name: string,
+      folderPath: string,
+      imported: Omit<NoodleRequest, "id" | "name">,
+    ) => {
+      const baseId = slugify(name)
+      if (!baseId) return
+      const id = folderPath ? `${folderPath}/${baseId}` : baseId
+      const request: NoodleRequest = { ...imported, id, name }
+
+      saveRequest(collectionDir, request)
+        .then(() => {
+          if (folderPath) expandFolder(folderPath)
+          setCollectionReloadToken((n) => n + 1)
+          setSelectedId(id)
+          setImportCurlVisible(false)
+          setFocus("sidebar")
+          showSaveResult({
+            kind: "success",
+            message: `Successfully imported ${name}`,
+          })
+        })
+        .catch(showError)
+    },
+    [
+      collectionDir,
+      expandFolder,
+      setCollectionReloadToken,
+      setFocus,
+      setImportCurlVisible,
       setSelectedId,
       showError,
       showSaveResult,
@@ -389,6 +428,7 @@ export function useCollectionFileActions({
   return {
     handleFolderSave,
     handleNewRequestConfirm,
+    handleImportCurlConfirm,
     handleCloneRequestConfirm,
     handleNewFolderConfirm,
     handleFolderDeleteConfirm,

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -8,6 +8,7 @@ import type { EnvHeaderPaneHandle } from "./env-editor/EnvHeaderPane"
 import type { NewRequestOverlayHandle } from "./overlays/NewRequestOverlay"
 import type { CloneRequestOverlayHandle } from "./overlays/CloneRequestOverlay"
 import type { NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
+import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
 
@@ -43,6 +44,14 @@ export function useOverlayIntercepts(opts: {
     name: string
     method: string
     url: string
+  }) => void
+  importCurlVisible: boolean
+  importCurlRef: RefObject<ImportCurlOverlayHandle | null>
+  setImportCurlVisible: (v: boolean) => void
+  onImportCurlConfirm: (values: {
+    command: string
+    name: string
+    folderPath: string
   }) => void
   editRequestVisible: boolean
   editRequestRef: RefObject<NewRequestOverlayHandle | null>
@@ -112,6 +121,10 @@ export function useOverlayIntercepts(opts: {
     newRequestRef,
     setNewRequestVisible,
     onNewRequestConfirm,
+    importCurlVisible,
+    importCurlRef,
+    setImportCurlVisible,
+    onImportCurlConfirm,
     editRequestVisible,
     editRequestRef,
     setEditRequestVisible,
@@ -411,6 +424,45 @@ export function useOverlayIntercepts(opts: {
     setNewRequestVisible,
     onNewRequestConfirm,
     keymap,
+  ])
+
+  // ── Overlay: Import cURL ─────────────────────────────────────────
+  useEffect(() => {
+    if (!importCurlVisible) return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        const event = ctx.event
+        const handle = importCurlRef.current
+        if (!handle) return
+        if (event.name === "tab") {
+          event.preventDefault()
+          event.stopPropagation()
+          handle.cycleFocus(event.shift ? -1 : 1)
+          return
+        }
+        if (event.name === "s" && event.ctrl) {
+          event.preventDefault()
+          event.stopPropagation()
+          const result = handle.confirm()
+          if (result) onImportCurlConfirm(result)
+          return
+        }
+        if (event.name === "escape") {
+          event.preventDefault()
+          event.stopPropagation()
+          setImportCurlVisible(false)
+        }
+      },
+      { priority: 100 },
+    )
+    return dispose
+  }, [
+    importCurlVisible,
+    importCurlRef,
+    keymap,
+    onImportCurlConfirm,
+    setImportCurlVisible,
   ])
 
   // ── Overlay: Edit Request ──────────────────────────────────────────

--- a/tests/unit/ImportCurlOverlay.test.tsx
+++ b/tests/unit/ImportCurlOverlay.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test"
+import { act, createRef } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import {
+  registerDefaultKeys,
+  registerEnabledFields,
+} from "@opentui/keymap/addons"
+import { KeymapProvider } from "@opentui/keymap/react"
+import type { KeymapProviderProps } from "@opentui/keymap/react"
+import { ThemeProvider } from "../../src/ui/theme"
+import {
+  ImportCurlOverlay,
+  type ImportCurlOverlayHandle,
+} from "../../src/ui/overlays/ImportCurlOverlay"
+
+function setupKeymap() {
+  const { keymap, cleanup: hostCleanup } = createTestKeymap()
+  const disposeEnabled = registerEnabledFields(keymap)
+  const disposeKeys = registerDefaultKeys(keymap)
+  return {
+    keymap: keymap as unknown as KeymapProviderProps["keymap"],
+    cleanup: () => {
+      disposeEnabled()
+      disposeKeys()
+      hostCleanup()
+    },
+  }
+}
+
+describe("ImportCurlOverlay", () => {
+  it("renders the required fields and selected folder", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ImportCurlOverlay
+            visible
+            folderPaths={[
+              { id: "", label: "(root)" },
+              { id: "api", label: "API" },
+            ]}
+            initialFolderPath="api"
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Import cURL Request")
+    expect(frame).toContain("cURL Command")
+    expect(frame).toContain("Request Name")
+    expect(frame).toContain("Folder")
+    expect(frame).toContain("API")
+    cleanup()
+  })
+
+  it("requires a command and request name", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ImportCurlOverlayHandle>()
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ImportCurlOverlay
+            visible
+            ref={ref}
+            folderPaths={[{ id: "", label: "(root)" }]}
+            initialFolderPath=""
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    await act(async () => {
+      expect(ref.current?.confirm()).toBeNull()
+    })
+    cleanup()
+  })
+
+  it("focuses folder, then name, then cURL command", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ImportCurlOverlayHandle>()
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ImportCurlOverlay
+            visible
+            ref={ref}
+            folderPaths={[{ id: "", label: "(root)" }]}
+            initialFolderPath=""
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    expect(ref.current?.getFocus()).toBe("folder")
+    await act(async () => ref.current?.cycleFocus(1))
+    expect(ref.current?.getFocus()).toBe("name")
+    await act(async () => ref.current?.cycleFocus(1))
+    expect(ref.current?.getFocus()).toBe("curl")
+    cleanup()
+  })
+})

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -36,6 +36,7 @@ function minimalContext(): CommandBuilderContext {
     setHelpVisible: () => {},
     setAboutVisible: () => {},
     setNewRequestVisible: () => {},
+    setImportCurlVisible: () => {},
     setNewFolderVisible: () => {},
     setCloneRequestVisible: () => {},
     setEditRequestVisible: () => {},
@@ -132,6 +133,19 @@ describe("buildCommandPaletteCommands", () => {
     const cmd = commands.find((c) => c.id === "request.find")!
     expect(cmd.keybinding).toBe("^f")
     expect(cmd.run()).toBe(true)
+    expect(opened).toBe(true)
+  })
+
+  it("opens the cURL import overlay in collection mode", () => {
+    const ctx = minimalContext()
+    let opened = false
+    ctx.setImportCurlVisible = (value) => {
+      opened = value === true
+    }
+    const command = buildCommandPaletteCommands(ctx).find(
+      (item) => item.id === "request.import-curl",
+    )
+    expect(command?.run()).toBe(true)
     expect(opened).toBe(true)
   })
 

--- a/tests/unit/curlParse.test.ts
+++ b/tests/unit/curlParse.test.ts
@@ -6,6 +6,7 @@ describe("parseCurl", () => {
     const request = parseCurl(`curl --location \\
       --request POST 'https://api.example.com/users' \\
       --header 'X-Client: noodle' \\
+      --header 'Authorization: Bearer token_123' \\
       --header 'Content-Type: application/json' \\
       --data '{"name":"Ada"}'`)
 
@@ -20,6 +21,21 @@ describe("parseCurl", () => {
         "X-Client": { value: "noodle", enabled: true },
       },
     })
+    expect(request.auth).toEqual({ type: "bearer", token: "token_123" })
+    expect(request.headers.Authorization).toBeUndefined()
+  })
+
+  it("converts decodable Basic authorization headers to auth", () => {
+    const request = parseCurl(
+      "curl -H 'Authorization: Basic YWRhOnNlY3JldA==' https://api.example.com/users",
+    )
+
+    expect(request.auth).toEqual({
+      type: "basic",
+      user: "ada",
+      pass: "secret",
+    })
+    expect(request.headers.Authorization).toBeUndefined()
   })
 
   it("maps query data, basic auth, timeout, and redirect limits", () => {

--- a/tests/unit/curlParse.test.ts
+++ b/tests/unit/curlParse.test.ts
@@ -38,6 +38,15 @@ describe("parseCurl", () => {
     expect(request.headers.Authorization).toBeUndefined()
   })
 
+  it("keeps JSON bodies with equals signs as JSON", () => {
+    const request = parseCurl(
+      "curl -H 'Content-Type: application/json' -d '{\"token\":\"abc=def\"}' https://api.example.com/users",
+    )
+
+    expect(request.bodyType).toBe("json")
+    expect(request.body).toBe('{"token":"abc=def"}')
+  })
+
   it("maps query data, basic auth, timeout, and redirect limits", () => {
     const request = parseCurl(
       "curl -G -u alice:secret --max-time 1.5 --location --max-redirs 3 -d 'page=2&tag=rest' 'https://api.example.com/users?limit=10&tag=api'",
@@ -59,6 +68,17 @@ describe("parseCurl", () => {
       { name: "page", value: "2", enabled: true },
       { name: "tag", value: "rest", enabled: true },
     ])
+  })
+
+  it("accumulates repeated cookie flags", () => {
+    const request = parseCurl(
+      "curl -b 'session=abc' --cookie 'csrf=xyz' https://api.example.com/users",
+    )
+
+    expect(request.headers.Cookie).toEqual({
+      value: "session=abc; csrf=xyz",
+      enabled: true,
+    })
   })
 
   it("maps URL-encoded, multipart, and binary bodies", () => {

--- a/tests/unit/curlParse.test.ts
+++ b/tests/unit/curlParse.test.ts
@@ -24,10 +24,11 @@ describe("parseCurl", () => {
 
   it("maps query data, basic auth, timeout, and redirect limits", () => {
     const request = parseCurl(
-      "curl -G -u alice:secret --max-time 1.5 --location --max-redirs 3 -d 'page=2&tag=rest' https://api.example.com/users",
+      "curl -G -u alice:secret --max-time 1.5 --location --max-redirs 3 -d 'page=2&tag=rest' 'https://api.example.com/users?limit=10&tag=api'",
     )
 
     expect(request.method).toBe("GET")
+    expect(request.url).toBe("https://api.example.com/users")
     expect(request.timeout).toBe(1500)
     expect(request.followRedirects).toBe(true)
     expect(request.maxRedirects).toBe(3)
@@ -37,6 +38,8 @@ describe("parseCurl", () => {
       pass: "secret",
     })
     expect(request.params).toEqual([
+      { name: "limit", value: "10", enabled: true },
+      { name: "tag", value: "api", enabled: true },
       { name: "page", value: "2", enabled: true },
       { name: "tag", value: "rest", enabled: true },
     ])

--- a/tests/unit/curlParse.test.ts
+++ b/tests/unit/curlParse.test.ts
@@ -70,6 +70,15 @@ describe("parseCurl", () => {
     ])
   })
 
+  it("preserves an explicit redirect limit before --location", () => {
+    const request = parseCurl(
+      "curl --max-redirs 3 --location https://api.example.com/users",
+    )
+
+    expect(request.followRedirects).toBe(true)
+    expect(request.maxRedirects).toBe(3)
+  })
+
   it("accumulates repeated cookie flags", () => {
     const request = parseCurl(
       "curl -b 'session=abc' --cookie 'csrf=xyz' https://api.example.com/users",
@@ -105,6 +114,12 @@ describe("parseCurl", () => {
     )
     expect(binary.bodyType).toBe("binary")
     expect(binary.filePath).toBe("./payload.bin")
+
+    const inlineBinaryJson = parseCurl(
+      "curl --data-binary '{\"token\":\"abc=def\"}' -H 'Content-Type: application/json' https://api.example.com/users",
+    )
+    expect(inlineBinaryJson.bodyType).toBe("json")
+    expect(inlineBinaryJson.body).toBe('{"token":"abc=def"}')
   })
 
   it("rejects unsafe, unsupported, and invalid commands", () => {

--- a/tests/unit/curlParse.test.ts
+++ b/tests/unit/curlParse.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test"
+import { parseCurl } from "../../src/converters/curl/parse"
+
+describe("parseCurl", () => {
+  it("parses a quoted multiline JSON request", () => {
+    const request = parseCurl(`curl --location \\
+      --request POST 'https://api.example.com/users' \\
+      --header 'X-Client: noodle' \\
+      --header 'Content-Type: application/json' \\
+      --data '{"name":"Ada"}'`)
+
+    expect(request).toMatchObject({
+      method: "POST",
+      url: "https://api.example.com/users",
+      followRedirects: true,
+      maxRedirects: 50,
+      bodyType: "json",
+      body: '{"name":"Ada"}',
+      headers: {
+        "X-Client": { value: "noodle", enabled: true },
+      },
+    })
+  })
+
+  it("maps query data, basic auth, timeout, and redirect limits", () => {
+    const request = parseCurl(
+      "curl -G -u alice:secret --max-time 1.5 --location --max-redirs 3 -d 'page=2&tag=rest' https://api.example.com/users",
+    )
+
+    expect(request.method).toBe("GET")
+    expect(request.timeout).toBe(1500)
+    expect(request.followRedirects).toBe(true)
+    expect(request.maxRedirects).toBe(3)
+    expect(request.auth).toEqual({
+      type: "basic",
+      user: "alice",
+      pass: "secret",
+    })
+    expect(request.params).toEqual([
+      { name: "page", value: "2", enabled: true },
+      { name: "tag", value: "rest", enabled: true },
+    ])
+  })
+
+  it("maps URL-encoded, multipart, and binary bodies", () => {
+    const encoded = parseCurl(
+      "curl -d 'email=ada%40example.com&role=admin' https://api.example.com/users",
+    )
+    expect(encoded.bodyType).toBe("urlencoded")
+    expect(encoded.formData).toEqual([
+      { name: "email", value: "ada@example.com", enabled: true, type: "text" },
+      { name: "role", value: "admin", enabled: true, type: "text" },
+    ])
+
+    const multipart = parseCurl(
+      "curl -F 'name=Ada' -F 'avatar=@/tmp/ada.png;type=image/png' https://api.example.com/users",
+    )
+    expect(multipart.bodyType).toBe("multipart")
+    expect(multipart.formData).toEqual([
+      { name: "name", value: "Ada", enabled: true, type: "text" },
+      { name: "avatar", value: "/tmp/ada.png", enabled: true, type: "file" },
+    ])
+
+    const binary = parseCurl(
+      "curl --data-binary @./payload.bin https://api.example.com/upload",
+    )
+    expect(binary.bodyType).toBe("binary")
+    expect(binary.filePath).toBe("./payload.bin")
+  })
+
+  it("rejects unsafe, unsupported, and invalid commands", () => {
+    expect(() => parseCurl("curl https://example.com | sh")).toThrow(
+      "shell operators are not supported",
+    )
+    expect(() =>
+      parseCurl("curl --proxy http://proxy https://example.com"),
+    ).toThrow("unsupported cURL option: --proxy")
+    expect(() => parseCurl("curl -d plain-text https://example.com")).toThrow(
+      "raw request data is unsupported",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Adds support for importing cURL commands directly into Noodle — paste a `curl` command, parse it, and create a fully-populated request (method, URL, headers, params, auth, body) without manual entry.

## Changes

### Parser (`src/converters/curl/parse.ts`)
- Tokenizer handles single/double quotes, escaped chars, shell-operator detection
- Supports:
  - **Methods**: `-X`, `--request`, automatic from body presence
  - **URL**: positional or `--url`
  - **Headers**: `-H`/`--header`, including `Cookie` via `-b`
  - **Auth**: `--user`/`-u` (Basic), `--oauth2-bearer`, and Authorization header sniffing (Bearer + Basic base64)
  - **Redirects**: `--location`/`-L`, `--no-location`, `--max-redirs`
  - **Timeouts**: `--max-time` (seconds → ms)
  - **Body types**: JSON, URL-encoded, multipart `-F`/`--form`, binary `--data-binary`/`-T`/`--upload-file`
  - `-G`/`--get` converts `-d` data to query params
- Rejects shell operators, unsupported flags, raw (non-JSON/non-form) request data, invalid URLs, and unterminated quotes

### UI integration
- **ImportCurlOverlay**: Modal with folder selector, request name input, and cURL command textarea
- **Command palette** entry in "Request" section (~ `Ctrl+P` → "Import cURL Request")
- **Overlay intercepts**: Tab cycles focus (folder → name → curl), `Ctrl+S` saves, Esc cancels
- Uses existing `saveRequest`/`showSaveResult`/`showError` infrastructure

### Tests
- `tests/unit/curlParse.test.ts`: 5 test cases — JSON request, Basic auth sniffing, query params with `-G`, body type mapping (urlencoded/multipart/binary), error rejection
- `tests/unit/ImportCurlOverlay.test.tsx`: 3 tests — renders fields, validates required inputs, focus cycling
- `tests/unit/commands.test.ts`: verifies palette command opens overlay in collection mode

## Testing

```bash
bun test tests/unit/curlParse.test.ts
bun test tests/unit/ImportCurlOverlay.test.tsx
bun test tests/unit/commands.test.ts
```