### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/.agents/skills/noodle-dev/architecture.md
+++ b/.agents/skills/noodle-dev/architecture.md
@@ -180,7 +180,8 @@ Cursor-aware `$variable` completion system across all text inputs:
 - All command logic centralized in exported functions:
   `sendRequest`, `saveRequest`, `editRequestOverlay`, `editRequestYaml`,
   `newRequest`, `cloneRequest`, `deleteRequest`, `deleteFolder`,
-  `copyResponseBody`, `cycleEnvironment`, `openEnvironmentEditor`,
+  `copyResponseBody`, `openResponseQuery`, `canGenerateClientCode`,
+  `cycleEnvironment`, `openEnvironmentEditor`,
   `saveEnvironment`, `newEnvironment`, `cloneEnvironment`, `deleteEnvironment`,
   `newFolder`, `toggleLayout`, `togglePaneExpand`, `undoAll`,
   `toggleHelp`, `openThemePicker`, `openCollectionSwitcher`
@@ -300,10 +301,11 @@ App (src/ui/App.tsx)
       │   ├── EnvHeaderPane
       │   └── EnvEditorPane
       ├── [overlays] (rendered in AppOverlays.tsx)
-      │   ├── PickerOverlay (generic base) → used by CommandPalette, CollectionSwitcher, ThemePicker
+      │   ├── PickerOverlay (generic base) → used by CommandPalette, CollectionSwitcher, ThemePicker, RequestFinder
       │   ├── HelpOverlay, YamlEditorOverlay (CodeEditor for YAML)
       │   ├── NewRequestOverlay, CloneRequestOverlay, NewFolderOverlay
-      │   ├── CommandPaletteOverlay, CollectionSwitcherOverlay
+      │   ├── CommandPaletteOverlay, CollectionSwitcherOverlay, RequestFinderOverlay
+      │   ├── ImportCurlOverlay, CodeGeneratorOverlay
       │   ├── ConfirmOverlay (save, delete, undo-all, collection-switch)
       │   └── ValidationNotice
       └── StatusBar
@@ -423,6 +425,10 @@ State data syncs via `keymap.setData("app.focus", ...)`, `keymap.setData("app.mo
 | Code editor | `src/ui/editor/CodeEditor.ts`, `src/ui/editor/CodeEditorCompletion.tsx`, `src/ui/editor/codeEditorParsers.ts`, `src/ui/editor/YamlEditorOverlay.tsx`, `src/ui/editor/ValidationNotice.tsx` |
 | Variable completion | `src/ui/variable-completion/variableCompletion.ts`, `src/ui/variable-completion/useVariableCompletion.ts`, `src/ui/variable-completion/variableCompletionInterceptor.tsx`, `src/ui/variable-completion/variableHighlight.ts`, `src/ui/variable-completion/highlightOffsets.ts`, `src/ui/variable-completion/envHighlight.ts` |
 | Command palette | `src/ui/commands.ts`, `src/ui/commandActions.ts`, `src/ui/CommandPaletteOverlay.tsx` |
+| Request finder | `src/ui/requestFinder.ts`, `src/ui/overlays/RequestFinderOverlay.tsx` |
+| cURL import (TUI) | `src/converters/curl/parse.ts`, `src/ui/overlays/ImportCurlOverlay.tsx`, `src/ui/useOverlayIntercepts.ts` |
+| Code generation | `src/codegen/buildHar.ts`, `src/codegen/targets.ts`, `src/codegen/variableHash.ts`, `src/ui/overlays/CodeGeneratorOverlay.tsx` |
+| JSONPath response filtering | `src/ui/responseQuery.ts`, `src/ui/ResponsePane.tsx` |
 | Themes | `src/ui/theme.tsx`, `src/ui/theme-data.ts` |
 | Clipboard | `src/ui/clipboard.ts` |
 | CLI | `src/app/cli.ts` (entry), `src/app/main.tsx` (bootstrap), `src/app/commands/default.ts` (TUI cmd), `src/app/commands/import.ts` (import cmd), `src/app/commands/update.ts` (update cmd), `src/app/import.ts` (importer logic) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ command_palette: ctrl+p
 | `Ctrl+W` | Delete request |
 | `Ctrl+U` | Cycle environment |
 | `Ctrl+P` | Open command palette |
+| `Ctrl+F` | Find request |
 | `Ctrl+L` | Toggle layout (stacked / side-by-side) |
 | `F2` | Expand/collapse focused pane |
 | `F1` | Toggle help overlay |
@@ -220,6 +221,8 @@ command_palette: ctrl+p
 | `Ctrl+C` | Quit (copies selection first if text is selected) |
 
 In browse or empty mode, collection-only actions above are unavailable. Command palette still exposes inspection, reload, layout, theme, help, and collection initialization actions.
+
+The command palette also provides **Import cURL Request** and **Generate Code** for the selected request. Code generation supports choosing a language and library, and can optionally interpolate the active environment.
 
 ### Browse mode (request pane focused, not editing)
 | Key | Action |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Noodle are documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-18
+
+### Features
+
+- Find requests from anywhere in the TUI with a fuzzy search that also matches resolved environment-variable URLs.
+- Import a cURL command into a new request from the command palette, including headers, authentication, query parameters, bodies, forms, uploads, redirects, and timeouts supported by the importer.
+- Generate client code for the selected request from the command palette, choosing a language and supported library, with optional environment-variable interpolation.
+- Filter JSON response bodies with JSONPath from the response pane or command palette.
+
+### Fixes
+
+- Preserve explicit redirect limits and correctly import inline binary data, query parameters, Authorization headers, JSON bodies containing equals signs, and repeated Cookie headers from cURL commands.
+- Display a clear error when a response body is not valid JSON and prevent opening JSONPath filtering when it cannot run.
+- Include inline URL query parameters and correctly represent form-data bodies in generated code.
+- Keep response metadata visible at the bottom of the response pane and position selection menus correctly in overlays.
+
+### Refactors
+
+- Generate snippets through HAR with `httpsnippet`, replacing the previous code-generation converter.
+- Separate JSON response parsing from JSONPath evaluation.
+
+### Documentation
+
+- Add contributor guidelines, security reporting guidance, and GitHub issue, discussion, and pull-request templates.
+
 ## [0.4.8] - 2026-07-17
 
 ### Features
@@ -42,6 +67,7 @@ All notable changes to Noodle are documented in this file.
 - Add pre-commit and pre-push quality checks.
 - Expand installation and update coverage, including filesystem isolation for editor tests.
 
-[Unreleased]: https://github.com/wilfredinni/noodle/compare/v0.4.8...HEAD
+[Unreleased]: https://github.com/wilfredinni/noodle/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/wilfredinni/noodle/compare/v0.4.8...v0.5.0
 [0.4.8]: https://github.com/wilfredinni/noodle/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/wilfredinni/noodle/compare/v0.4.6...v0.4.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "type": "module",
   "license": "Apache-2.0",
   "private": true,

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -158,7 +158,7 @@ describe("update cache", () => {
     try {
       await writeFile(
         path,
-        JSON.stringify({ latestTag: "v0.4.8", checkedAt: 1000 }),
+        JSON.stringify({ latestTag: "v0.5.0", checkedAt: 1000 }),
       )
       const result = await runUpdate(true, false, {
         cachePath: path,
@@ -174,7 +174,7 @@ describe("update cache", () => {
       })
       expect(result.data).toEqual({
         status: "up_to_date",
-        version: "v0.4.8",
+        version: "v0.5.0",
         cached: "true",
       })
       expect(calls).toBe(0)
@@ -192,7 +192,7 @@ describe("update cache", () => {
     try {
       await writeFile(
         path,
-        JSON.stringify({ latestTag: "v0.4.9", checkedAt: 1000 }),
+        JSON.stringify({ latestTag: "v0.5.1", checkedAt: 1000 }),
       )
       await writeFile(executable, "old")
       const result = await runUpdate(true, false, {
@@ -212,7 +212,7 @@ describe("update cache", () => {
           return new Response(`${sha256(binary)}  noodle-macos-arm64\n`)
         },
       })
-      expect(result.data).toEqual({ status: "updated", version: "v0.4.9" })
+      expect(result.data).toEqual({ status: "updated", version: "v0.5.1" })
       expect(githubCalls).toBe(0)
       expect(await readFile(executable, "utf8")).toBe("new")
     } finally {
@@ -362,7 +362,7 @@ describe("update release discovery", () => {
           const url = String(input)
           if (url.includes("api.github.com"))
             return Response.json({
-              tag_name: "v0.4.9",
+              tag_name: "v0.5.1",
               assets: [
                 { name: "noodle-macos-arm64", browser_download_url: "binary" },
               ],
@@ -371,7 +371,7 @@ describe("update release discovery", () => {
           return new Response(`${sha256(binary)}  noodle-macos-arm64\n`)
         },
       })
-      expect(result.data).toEqual({ status: "updated", version: "v0.4.9" })
+      expect(result.data).toEqual({ status: "updated", version: "v0.5.1" })
       expect(await readFile(executable, "utf8")).toBe("new")
     } finally {
       await rm(dir, { recursive: true, force: true })
@@ -391,7 +391,7 @@ describe("update release discovery", () => {
           const url = String(input)
           if (url.includes("api.github.com"))
             return Response.json({
-              tag_name: "v0.4.9",
+              tag_name: "v0.5.1",
               assets: [
                 { name: "noodle-macos-arm64", browser_download_url: "binary" },
               ],


### PR DESCRIPTION
Release v0.5.0

- Update package version to 0.5.0
- Update CHANGELOG with v0.5.0 entries
- Update AGENTS.md with new skill documentation
- Update dev skill architecture docs
- Update tests for release compatibility