### PR TITLE
fix(overlays): fix layout overflow and spacing with large content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Noodle are documented in this file.
 - Include inline URL query parameters and correctly represent form-data bodies in generated code.
 - Keep response metadata visible at the bottom of the response pane and position selection menus correctly in overlays.
 - Prevent keyboard events from modal overlays leaking into underlying panes, including Generate Code and Timeline Detail, while preserving editable fields and Select menus.
+- Keep large generated-code and YAML editor content scrollable inside fixed overlays while preserving consistent top and bottom spacing.
 - Keep the URL bar method selector wide enough to show complete method names and its dropdown indicator after opening.
 
 ### 🔧 Refactors

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -294,6 +294,7 @@ export function YamlEditorOverlay({
       )}
       {saveError && <text fg={theme.error}>Save error: {saveError}</text>}
       <box
+        paddingBottom={1}
         style={{
           flexDirection: "row",
           flexShrink: 0,

--- a/src/ui/overlays/CodeGeneratorOverlay.tsx
+++ b/src/ui/overlays/CodeGeneratorOverlay.tsx
@@ -151,7 +151,7 @@ export function CodeGeneratorOverlay({
       height="80%"
       gap={1}
       padding={1}
-      overflow="visible"
+      overflow="hidden"
     >
       <box
         paddingLeft={4}
@@ -207,7 +207,13 @@ export function CodeGeneratorOverlay({
           scrollY
           paddingLeft={4}
           paddingRight={4}
-          style={{ flexGrow: 1, minHeight: 0 }}
+          style={{
+            flexGrow: 1,
+            flexShrink: 1,
+            flexBasis: 0,
+            height: 0,
+            minHeight: 0,
+          }}
           scrollbarOptions={{ visible: false }}
         >
           <box style={{ flexDirection: "column" }}>
@@ -231,6 +237,7 @@ export function CodeGeneratorOverlay({
         </scrollbox>
       )}
       <box
+        paddingBottom={1}
         style={{
           flexDirection: "row",
           flexShrink: 0,

--- a/src/ui/overlays/Overlay.tsx
+++ b/src/ui/overlays/Overlay.tsx
@@ -42,6 +42,7 @@ export function Overlay({
       <box
         style={{
           width,
+          flexShrink: 0,
           ...(height !== undefined && { height }),
           backgroundColor: theme.backgroundPanel,
           flexDirection: "column",

--- a/tests/unit/CodeGeneratorOverlay.test.tsx
+++ b/tests/unit/CodeGeneratorOverlay.test.tsx
@@ -20,6 +20,40 @@ const baseRequest = {
 }
 
 describe("CodeGeneratorOverlay", () => {
+  it("keeps the modal vertical spacing stable for large previews", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <RendererProvider renderer={{} as unknown as CliRenderer}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <CodeGeneratorOverlay
+              visible
+              request={{
+                ...baseRequest,
+                body: JSON.stringify({ value: "x".repeat(4000) }),
+                bodyType: "json",
+              }}
+              onClose={() => {}}
+            />
+          </ThemeProvider>
+        </RendererProvider>
+      </KeymapProvider>,
+      { width: 100, height: 32 },
+    )
+
+    await render.renderOnce()
+    const rows = render
+      .captureCharFrame()
+      .split("\n")
+      .map((row) => row.replace(/\s+$/, ""))
+    expect(rows.findIndex((row) => row.includes("Generate code"))).toBe(4)
+    expect(rows.findIndex((row) => row.includes("close"))).toBe(26)
+    await act(async () => host.press("down"))
+    await render.renderOnce()
+    expect(render.captureCharFrame()).not.toContain("1  curl --request GET")
+    cleanup()
+  })
+
   it("renders a cURL preview by default", async () => {
     const { keymap, cleanup } = setupKeymap()
     const render = await testRender(


### PR DESCRIPTION
## Changes

Fix overlay layout overflow and spacing issues when rendering large content.

### CodeGeneratorOverlay
- `overflow: "visible"` → `overflow: "hidden"` to prevent content breaking out of the overlay bounds
- Added `flexShrink: 1`, `flexBasis: 0`, `height: 0` to the scrollable code box so it shrinks properly within the flex container
- Added `paddingBottom: 1` to the action button row for consistent bottom spacing

### YamlEditorOverlay
- Added `paddingBottom: 1` to the action button row for consistent bottom spacing with other overlays

### Overlay base component
- Added `flexShrink: 0` to the overlay container so it doesn't collapse when the child overflows

## Testing
- Added unit tests for CodeGeneratorOverlay layout behavior