### PR TITLE
fix(lang,ui,filestore): YAML serialization fixes, error display improvements, Home/End navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ CONTINUE.md
 .noodle/
 homebrew-noodle/
 lead-hub
+openapi.json
+import

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -166,8 +166,12 @@ async function walk(
       if (folderYmlContent) {
         try {
           folderMeta = lang.parseFolder(folderYmlContent)
-        } catch {
-          // ignore invalid folder.yml, use defaults
+        } catch (e) {
+          if (!opts.tolerant) {
+            const msg = e instanceof Error ? e.message : String(e)
+            const folderYmlRel = `${childRel}/folder.yml`
+            fileErrors.push(parseUserFriendlyFileError(folderYmlRel, msg))
+          }
         }
       }
 

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -10,6 +10,91 @@ import type {
   Request,
 } from "../schema"
 
+export interface CollectionFileError {
+  file: string
+  message: string
+  rawError: string
+  snippet?: string
+}
+
+export function parseUserFriendlyFileError(
+  file: string,
+  rawError: string,
+): CollectionFileError {
+  let msg = rawError
+    .replace(/^filestore\.loadCollection:\s*/, "")
+    .replace(/^failed to parse "[^"]+":\s*/, "")
+    .replace(/^lang\.parseRequest:\s*/, "")
+    .replace(/^lang\.parseFolder:\s*/, "")
+    .replace(/^YAML syntax:\s*/, "")
+    .trim()
+
+  let snippet: string | undefined
+  const snippetIdx = msg.search(/\n\s*\d+\s*\|/)
+  if (snippetIdx !== -1) {
+    snippet = msg.slice(snippetIdx).trim()
+    msg = msg.slice(0, snippetIdx).trim()
+  }
+
+  const posMatch = msg.match(/\((\d+):(\d+)\)$/)
+  let locationPrefix = ""
+  if (posMatch) {
+    const line = posMatch[1]
+    const col = posMatch[2]
+    locationPrefix = `Line ${line}, Col ${col}: `
+    msg = msg.replace(/\s*\(\d+:\d+\)$/, "").trim()
+  }
+
+  if (
+    msg.includes("can not read an implicit mapping pair; a colon is missed")
+  ) {
+    msg = "Missing colon after key name"
+  } else if (msg.includes("bad indentation of a mapping entry")) {
+    msg = "Bad indentation of YAML entry"
+  } else if (
+    msg.includes("end of the stream or a document separator is expected")
+  ) {
+    msg = "Unexpected YAML formatting or structure"
+  } else if (msg.includes("duplicated mapping key")) {
+    msg = "Duplicate key in YAML mapping"
+  } else if (msg.includes("incomplete explicit mapping pair")) {
+    msg = "Incomplete mapping pair"
+  }
+
+  return {
+    file,
+    message: locationPrefix ? `${locationPrefix}${msg}` : msg,
+    rawError,
+    snippet,
+  }
+}
+
+export function extractFileErrors(error: Error): CollectionFileError[] {
+  if (
+    Array.isArray(
+      (error as unknown as { fileErrors?: CollectionFileError[] }).fileErrors,
+    ) &&
+    (error as unknown as { fileErrors: CollectionFileError[] }).fileErrors
+      .length > 0
+  ) {
+    return (error as unknown as { fileErrors: CollectionFileError[] })
+      .fileErrors
+  }
+  const fileMatch = error.message.match(
+    /failed to parse "([^"]+)":\s*([\s\S]+)/,
+  )
+  if (fileMatch) {
+    return [parseUserFriendlyFileError(fileMatch[1], fileMatch[2])]
+  }
+  return [
+    {
+      file: "collection",
+      message: error.message.replace(/^filestore\.loadCollection:\s*/, ""),
+      rawError: error.message,
+    },
+  ]
+}
+
 const SKIP_DIRS = new Set([".noodle", ".timeline", ".git", "node_modules"])
 
 export interface LoadOptions {
@@ -23,6 +108,7 @@ async function walk(
   visited = new Set<string>(),
   root?: string,
   opts: LoadOptions = {},
+  fileErrors: CollectionFileError[] = [],
 ): Promise<CollectionItem[]> {
   let resolved: string
   try {
@@ -85,7 +171,14 @@ async function walk(
         }
       }
 
-      const children = await walk(childAbs, childRel, visited, root, opts)
+      const children = await walk(
+        childAbs,
+        childRel,
+        visited,
+        root,
+        opts,
+        fileErrors,
+      )
       const folder: Folder = {
         id: entry.name,
         name: folderMeta.meta?.name ?? entry.name,
@@ -112,25 +205,29 @@ async function walk(
       let req: Request
       try {
         req = lang.parseRequest(reqId, content)
+        requests.push({
+          item: { type: "request", data: req },
+          name: entry.name,
+        })
       } catch (e) {
         if (opts.tolerant) continue
         const msg = e instanceof Error ? e.message : String(e)
-        throw new Error(
-          `filestore.loadCollection: failed to parse "${entry.name}": ${msg}`,
-          { cause: e },
-        )
+        const relFileName = relPath ? `${relPath}/${entry.name}` : entry.name
+        fileErrors.push(parseUserFriendlyFileError(relFileName, msg))
       }
-      requests.push({ item: { type: "request", data: req }, name: entry.name })
 
-      if (!opts.readOnly && !/^timeout:\s/m.test(content)) {
-        try {
-          await writeFile(
-            join(absDir, entry.name),
-            lang.serializeRequest(req),
-            "utf8",
-          )
-        } catch {
-          /* migration non-critical */
+      if (requests.length > 0 && !opts.readOnly) {
+        const lastReq = requests[requests.length - 1].item.data as Request
+        if (lastReq.id === reqId && !/^timeout:\s/m.test(content)) {
+          try {
+            await writeFile(
+              join(absDir, entry.name),
+              lang.serializeRequest(lastReq),
+              "utf8",
+            )
+          } catch {
+            /* migration non-critical */
+          }
         }
       }
     }
@@ -169,7 +266,22 @@ export async function loadCollection(dir: string): Promise<Collection> {
 
   const id = basename(dir)
   const root = await realpath(dir)
-  const items = await walk(dir, "", new Set(), root)
+  const fileErrors: CollectionFileError[] = []
+  const items = await walk(dir, "", new Set(), root, {}, fileErrors)
+
+  if (fileErrors.length > 0) {
+    const first = fileErrors[0]
+    const errMsg =
+      fileErrors.length === 1
+        ? `filestore.loadCollection: failed to parse "${first.file}": ${first.rawError}`
+        : `filestore.loadCollection: ${fileErrors.length} files failed to parse in collection:\n` +
+          fileErrors.map((f) => `• ${f.file}: ${f.message}`).join("\n")
+    const err = new Error(errMsg)
+    ;(err as unknown as { fileErrors: CollectionFileError[] }).fileErrors =
+      fileErrors
+    throw err
+  }
+
   return { id, name: id, items }
 }
 

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -6,6 +6,8 @@ import {
   exitEditBrowse,
   moveFieldCursor,
   moveRowCursor,
+  moveRowFirst,
+  moveRowLast,
   beginEditing,
   commitEditing,
   cancelEditing,
@@ -176,6 +178,8 @@ export interface UseEditBrowseResult {
   exitBrowse: () => void
   browseUp: () => void
   browseDown: () => void
+  browseFirst: () => void
+  browseLast: () => void
   browseLeft: () => void
   browseRight: () => void
   enterAndEdit: () => void
@@ -335,6 +339,22 @@ export function useEditBrowse(
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       return moveRowCursor(prev, +1, c)
+    })
+  }, [])
+
+  const browseFirst = useCallback(() => {
+    const c = rowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      return moveRowFirst(prev, c)
+    })
+  }, [])
+
+  const browseLast = useCallback(() => {
+    const c = rowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      return moveRowLast(prev, c)
     })
   }, [])
 
@@ -592,6 +612,8 @@ export function useEditBrowse(
       exitBrowse,
       browseUp,
       browseDown,
+      browseFirst,
+      browseLast,
       browseLeft,
       browseRight,
       enterAndEdit,
@@ -614,6 +636,8 @@ export function useEditBrowse(
       exitBrowse,
       browseUp,
       browseDown,
+      browseFirst,
+      browseLast,
       browseLeft,
       browseRight,
       enterAndEdit,

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -67,6 +67,8 @@ export interface UseEnvironmentEditorResult {
   exitBrowse: () => void
   browseUp: () => void
   browseDown: () => void
+  browseFirst: () => void
+  browseLast: () => void
   enterEdit: () => void
   commitEdit: () => void
   cancelEdit: () => void
@@ -328,6 +330,24 @@ export function useEnvironmentEditor({
         return { ...prev, row: -1, addingRow: true }
       }
       return { ...prev, row: prev.row + 1 }
+    })
+  }, [])
+
+  const browseFirst = useCallback(() => {
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      const rows = draftRef.current?.varRows.length ?? 0
+      if (rows === 0) {
+        return { ...prev, row: -1, addingRow: true }
+      }
+      return { ...prev, row: 0, addingRow: false }
+    })
+  }, [])
+
+  const browseLast = useCallback(() => {
+    setEditState((prev) => {
+      if (prev.mode !== "browsing") return prev
+      return { ...prev, row: -1, addingRow: true }
     })
   }, [])
 
@@ -611,6 +631,8 @@ export function useEnvironmentEditor({
     exitBrowse,
     browseUp,
     browseDown,
+    browseFirst,
+    browseLast,
     enterEdit,
     commitEdit,
     cancelEdit,

--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -223,6 +223,19 @@ export function useTreeNavigation(
       if (target && target.type === "request") {
         setSelectedIdState(target.id)
       }
+    } else if (key.name === "home") {
+      setCursorIndex(0)
+      const target = v[0]
+      if (target && target.type === "request") {
+        setSelectedIdState(target.id)
+      }
+    } else if (key.name === "end") {
+      const lastIdx = v.length - 1
+      setCursorIndex(lastIdx)
+      const target = v[lastIdx]
+      if (target && target.type === "request") {
+        setSelectedIdState(target.id)
+      }
     } else if (key.name === "right") {
       if (
         node &&

--- a/src/lang/folder.ts
+++ b/src/lang/folder.ts
@@ -119,8 +119,14 @@ function parseFolderAuth(value: unknown): Auth {
   throw new Error(`lang.parseFolder: invalid auth.type "${String(a.type)}"`)
 }
 
-function yamlVal(val: string): string {
-  return yaml.dump(val, { lineWidth: 0 }).trim()
+function yamlVal(val: string, indent = 0): string {
+  const dumped = yaml.dump(val, { lineWidth: -1 }).trim()
+  if (indent === 0 || !dumped.includes("\n")) {
+    return dumped
+  }
+  const lines = dumped.split("\n")
+  const pad = " ".repeat(indent)
+  return [lines[0], ...lines.slice(1).map((l) => pad + l)].join("\n")
 }
 
 export function serializeFolder(folder: Folder): string {
@@ -129,7 +135,7 @@ export function serializeFolder(folder: Folder): string {
   if (folder.seq !== undefined || folder.name !== folder.id) {
     out += "meta:\n"
     if (folder.name !== folder.id) {
-      out += `  name: ${yamlVal(folder.name)}\n`
+      out += `  name: ${yamlVal(folder.name, 2)}\n`
     }
     if (folder.seq !== undefined) {
       out += `  seq: ${String(folder.seq)}\n`
@@ -141,8 +147,8 @@ export function serializeFolder(folder: Folder): string {
     if (o.headers && Object.keys(o.headers).length > 0) {
       out += "headers:\n"
       for (const [k, v] of Object.entries(o.headers)) {
-        const key = yamlVal(k)
-        const val = yamlVal(v.value)
+        const key = yamlVal(k, 2)
+        const val = yamlVal(v.value, 2)
         if (v.enabled) {
           out += `  ${key}: ${val}\n`
         } else {
@@ -156,15 +162,15 @@ export function serializeFolder(folder: Folder): string {
         out += "  type: none\n"
       } else if (o.auth.type === "bearer") {
         out += "  type: bearer\n"
-        out += `  token: ${yamlVal(o.auth.token)}\n`
+        out += `  token: ${yamlVal(o.auth.token, 2)}\n`
       } else if (o.auth.type === "basic") {
         out += "  type: basic\n"
-        out += `  user: ${yamlVal(o.auth.user)}\n`
-        out += `  pass: ${yamlVal(o.auth.pass)}\n`
+        out += `  user: ${yamlVal(o.auth.user, 2)}\n`
+        out += `  pass: ${yamlVal(o.auth.pass, 2)}\n`
       } else if (o.auth.type === "api_key") {
         out += "  type: api_key\n"
-        out += `  key: ${yamlVal(o.auth.key)}\n`
-        out += `  value: ${yamlVal(o.auth.value)}\n`
+        out += `  key: ${yamlVal(o.auth.key, 2)}\n`
+        out += `  value: ${yamlVal(o.auth.value, 2)}\n`
         out += `  placement: ${o.auth.placement}\n`
       }
     }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -1,8 +1,14 @@
 import yaml from "js-yaml"
 import type { Auth, Request } from "../schema"
 
-function yamlVal(val: string): string {
-  return yaml.dump(val, { lineWidth: 0 }).trim()
+function yamlVal(val: string, indent = 0): string {
+  const dumped = yaml.dump(val, { lineWidth: -1 }).trim()
+  if (indent === 0 || !dumped.includes("\n")) {
+    return dumped
+  }
+  const lines = dumped.split("\n")
+  const pad = " ".repeat(indent)
+  return [lines[0], ...lines.slice(1).map((l) => pad + l)].join("\n")
 }
 
 export function serializeRequest(req: Request): string {
@@ -18,7 +24,7 @@ export function serializeRequest(req: Request): string {
   if (Object.keys(req.headers).length > 0) {
     out += "headers:\n"
     for (const [k, v] of Object.entries(req.headers)) {
-      const val = yamlVal(v.value)
+      const val = yamlVal(v.value, 2)
       if (v.enabled) {
         out += `  ${k}: ${val}\n`
       } else {
@@ -30,8 +36,8 @@ export function serializeRequest(req: Request): string {
   if (req.params.length > 0) {
     out += "params:\n"
     for (const entry of req.params) {
-      const nameVal = yamlVal(entry.name)
-      const valVal = yamlVal(entry.value)
+      const nameVal = yamlVal(entry.name, 4)
+      const valVal = yamlVal(entry.value, 4)
       if (entry.enabled) {
         out += `  - name: ${nameVal}\n    value: ${valVal}\n`
       } else {
@@ -51,8 +57,8 @@ export function serializeRequest(req: Request): string {
   if (req.formData !== undefined && req.formData.length > 0) {
     out += "form_data:\n"
     for (const entry of req.formData) {
-      const nameVal = yamlVal(entry.name)
-      const valVal = yamlVal(entry.value)
+      const nameVal = yamlVal(entry.name, 4)
+      const valVal = yamlVal(entry.value, 4)
       if (entry.enabled && entry.type === "text") {
         out += `  - name: ${nameVal}\n    value: ${valVal}\n`
       } else {
@@ -69,7 +75,14 @@ export function serializeRequest(req: Request): string {
     const authObj = authToObj(req.auth)
     out += "auth:\n"
     for (const [k, v] of Object.entries(authObj)) {
-      out += `  ${k}: ${yaml.dump(v, { lineWidth: 0 }).trim()}\n`
+      const dumped = yaml.dump(v, { lineWidth: -1 }).trim()
+      const valFormatted = dumped.includes("\n")
+        ? dumped
+            .split("\n")
+            .map((line, idx) => (idx === 0 ? line : `  ${line}`))
+            .join("\n")
+        : dumped
+      out += `  ${k}: ${valFormatted}\n`
     }
   }
 

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -80,7 +80,6 @@ export function RequestPane({
   expandHint,
 }: Props) {
   const theme = useTheme()
-  const title = "Request"
   const inEdit = editState.mode === "editing"
   const browseActive = editState.mode === "browsing"
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -107,7 +106,7 @@ export function RequestPane({
   })
 
   useEffect(() => {
-    if (editState.mode !== "browsing") return
+    if (editState.mode === "inactive") return
     const { field, row, addingRow } = editState.cursor
     if (field === "headers" || field === "params") {
       const prefix = field === "headers" ? "hdr" : "prm"
@@ -119,7 +118,7 @@ export function RequestPane({
     } else {
       scrollRef.current?.scrollChildIntoView(`${field}-field`)
     }
-  }, [editState.cursor])
+  }, [editState.cursor, editState.mode])
 
   const handleSelectOpenChange = useCallback(
     (open: boolean) => {
@@ -168,15 +167,13 @@ export function RequestPane({
     })
   }, [request])
 
+  const title = request ? request.name : "Request"
+
   return (
     <box
       style={{
-        flexGrow: 1,
         flexDirection: "column",
-        paddingTop: 0,
-        paddingBottom: 0,
-        paddingLeft: 1,
-        paddingRight: 1,
+        flexGrow: 1,
         gap: 1,
         flexBasis: 0,
         minHeight: 0,
@@ -217,7 +214,7 @@ export function RequestPane({
                 scrollY
                 style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
               >
-                {activeTab === "body" ? (
+                {activeTab === "body" && (
                   <BodySection
                     request={request}
                     editState={editState}
@@ -230,72 +227,65 @@ export function RequestPane({
                     theme={theme}
                     activeEnv={activeEnv}
                   />
-                ) : (
-                  <scrollbox
-                    ref={scrollRef}
-                    scrollY
-                    style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
-                  >
-                    {activeTab === "headers" && (
-                      <KeyValueSection
-                        kind="headers"
-                        entries={Object.entries(request?.headers ?? {}).map(
-                          ([key, value]) => ({ key, value }),
-                        )}
-                        editState={editState}
-                        editKey={editKey}
-                        editValue={editValue}
-                        setEditKey={setEditKey}
-                        setEditValue={setEditValue}
-                        theme={theme}
-                        activeEnv={activeEnv}
-                      />
+                )}
+                {activeTab === "headers" && (
+                  <KeyValueSection
+                    kind="headers"
+                    entries={Object.entries(request?.headers ?? {}).map(
+                      ([key, value]) => ({ key, value }),
                     )}
-                    {activeTab === "params" && (
-                      <KeyValueSection
-                        kind="params"
-                        entries={(request?.params ?? []).map((p) => ({
-                          key: p.name,
-                          value: { value: p.value, enabled: p.enabled },
-                        }))}
-                        editState={editState}
-                        editKey={editKey}
-                        editValue={editValue}
-                        setEditKey={setEditKey}
-                        setEditValue={setEditValue}
-                        theme={theme}
-                        activeEnv={activeEnv}
-                      />
-                    )}
-                    {activeTab === "auth" && (
-                      <AuthEditor
-                        auth={request?.auth ?? { type: "none" }}
-                        editState={editState}
-                        inEdit={inEdit}
-                        browseActive={browseActive}
-                        setEditValue={setEditValue}
-                        theme={theme}
-                        activeEnv={activeEnv}
-                        onAuthTypeChange={onAuthTypeChange ?? (() => {})}
-                        onApiKeyPlacementChange={
-                          onApiKeyPlacementChange ?? (() => {})
-                        }
-                        onSelectOpenChange={handleSelectOpenChange}
-                        showInherit={true}
-                      />
-                    )}
-                    {activeTab === "settings" && (
-                      <SettingsSection
-                        request={request}
-                        editState={editState}
-                        setEditValue={setEditValue}
-                        inEdit={inEdit}
-                        browseActive={browseActive}
-                        theme={theme}
-                        activeEnv={activeEnv}
-                      />
-                    )}
-                  </scrollbox>
+                    editState={editState}
+                    editKey={editKey}
+                    editValue={editValue}
+                    setEditKey={setEditKey}
+                    setEditValue={setEditValue}
+                    theme={theme}
+                    activeEnv={activeEnv}
+                  />
+                )}
+                {activeTab === "params" && (
+                  <KeyValueSection
+                    kind="params"
+                    entries={(request?.params ?? []).map((p) => ({
+                      key: p.name,
+                      value: { value: p.value, enabled: p.enabled },
+                    }))}
+                    editState={editState}
+                    editKey={editKey}
+                    editValue={editValue}
+                    setEditKey={setEditKey}
+                    setEditValue={setEditValue}
+                    theme={theme}
+                    activeEnv={activeEnv}
+                  />
+                )}
+                {activeTab === "auth" && (
+                  <AuthEditor
+                    auth={request?.auth ?? { type: "none" }}
+                    editState={editState}
+                    inEdit={inEdit}
+                    browseActive={browseActive}
+                    setEditValue={setEditValue}
+                    theme={theme}
+                    activeEnv={activeEnv}
+                    onAuthTypeChange={onAuthTypeChange ?? (() => {})}
+                    onApiKeyPlacementChange={
+                      onApiKeyPlacementChange ?? (() => {})
+                    }
+                    onSelectOpenChange={handleSelectOpenChange}
+                    showInherit={true}
+                  />
+                )}
+                {activeTab === "settings" && (
+                  <SettingsSection
+                    request={request}
+                    editState={editState}
+                    setEditValue={setEditValue}
+                    inEdit={inEdit}
+                    browseActive={browseActive}
+                    theme={theme}
+                    activeEnv={activeEnv}
+                  />
                 )}
               </scrollbox>
             </box>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -80,6 +80,7 @@ export function RequestPane({
   expandHint,
 }: Props) {
   const theme = useTheme()
+  const title = "Request"
   const inEdit = editState.mode === "editing"
   const browseActive = editState.mode === "browsing"
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -94,15 +95,6 @@ export function RequestPane({
     if (editState.mode !== "browsing") return
     if (key.name === "pagedown") scrollRef.current?.scrollBy(1, "viewport")
     else if (key.name === "pageup") scrollRef.current?.scrollBy(-1, "viewport")
-    else if (key.name === "home") {
-      key.preventDefault()
-      scrollRef.current?.scrollTo(0)
-    } else if (key.name === "end") {
-      key.preventDefault()
-      scrollRef.current?.scrollTo(
-        Math.max(0, scrollRef.current.scrollHeight - scrollRef.current.height),
-      )
-    }
   })
 
   useEffect(() => {
@@ -167,13 +159,15 @@ export function RequestPane({
     })
   }, [request])
 
-  const title = request ? request.name : "Request"
-
   return (
     <box
       style={{
         flexDirection: "column",
         flexGrow: 1,
+        paddingTop: 0,
+        paddingBottom: 0,
+        paddingLeft: 1,
+        paddingRight: 1,
         gap: 1,
         flexBasis: 0,
         minHeight: 0,

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -218,10 +218,11 @@ export function Select({
         flexDirection: "column",
         position: "relative",
         zIndex: open ? 100 : 0,
+        flexShrink: 0,
         ...(width !== undefined ? { width } : {}),
       }}
     >
-      <box style={{ position: "relative" }}>
+      <box style={{ position: "relative", flexShrink: 0 }}>
         <box
           ref={triggerRef}
           height={1}
@@ -232,9 +233,10 @@ export function Select({
             paddingLeft: 1,
             paddingRight: 1,
             backgroundColor: selectBg,
+            flexShrink: 0,
           }}
         >
-          <box style={{ flexDirection: "row", flexGrow: 1 }}>
+          <box style={{ flexDirection: "row", flexGrow: 1, flexShrink: 0 }}>
             {selectedItem ? (
               renderLabel(
                 badge && selectedBadgeBg

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -212,6 +212,16 @@ export function Select({
     [maxDropdownHeight, items],
   )
 
+  const selectedText = selectedItem
+    ? badge && selectedBadgeBg
+      ? extractText(selectedItem.label)
+      : typeof selectedItem.label === "string"
+        ? selectedItem.label
+        : extractText(selectedItem.label)
+    : placeholder
+
+  const triggerWidth = width !== undefined ? width : selectedText.length + 4
+
   return (
     <box
       style={{
@@ -219,7 +229,7 @@ export function Select({
         position: "relative",
         zIndex: open ? 100 : 0,
         flexShrink: 0,
-        ...(width !== undefined ? { width } : {}),
+        width: width !== undefined ? width : triggerWidth,
       }}
     >
       <box style={{ position: "relative", flexShrink: 0 }}>
@@ -234,6 +244,7 @@ export function Select({
             paddingRight: 1,
             backgroundColor: selectBg,
             flexShrink: 0,
+            width: width !== undefined ? width : triggerWidth,
           }}
         >
           <box style={{ flexDirection: "row", flexGrow: 1, flexShrink: 0 }}>
@@ -246,10 +257,15 @@ export function Select({
                 focused && selectedBadgeBg ? TextAttributes.BOLD : undefined,
               )
             ) : (
-              <text fg={theme.textMuted}>{placeholder}</text>
+              <text fg={theme.textMuted} style={{ flexShrink: 0 }}>
+                {placeholder}
+              </text>
             )}
           </box>
-          <text fg={indicatorColor}> ▼</text>
+          <text fg={indicatorColor} style={{ flexShrink: 0 }}>
+            {" "}
+            ▼
+          </text>
         </box>
 
         {open &&
@@ -363,7 +379,7 @@ function renderLabel(
 ): ReactNode {
   if (typeof label === "string") {
     return (
-      <text fg={fg} attributes={attributes}>
+      <text fg={fg} attributes={attributes} style={{ flexShrink: 0 }}>
         {label}
       </text>
     )

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -7,6 +7,8 @@ import { FullBorder, LeftBar } from "./borders"
 import type { Keybinds } from "./keybind"
 import type { VisibleNode } from "./tree"
 
+import { extractFileErrors } from "../filestore/load"
+
 function shortMethod(m: string): string {
   return m === "DELETE" ? "DEL" : m
 }
@@ -50,6 +52,8 @@ export function Sidebar({
     }
   }, [cursorIndex, visibleItems])
 
+  const fileErrors = error ? extractFileErrors(error) : []
+
   return (
     <box
       style={{
@@ -80,7 +84,57 @@ export function Sidebar({
         >
           <text fg={theme.textMuted}>Loading...</text>
         </box>
-      ) : error || visibleItems.length === 0 ? (
+      ) : error ? (
+        <box
+          style={{
+            flexGrow: 1,
+            flexDirection: "column",
+            paddingTop: 1,
+            paddingLeft: 1,
+            paddingRight: 1,
+            gap: 1,
+          }}
+        >
+          <text fg={theme.error}>
+            Collection {fileErrors.length > 1 ? "Errors" : "Error"} (
+            {fileErrors.length})
+          </text>
+          <scrollbox
+            scrollY
+            style={{ flexGrow: 1 }}
+            verticalScrollbarOptions={{
+              trackOptions: {
+                backgroundColor: theme.background,
+                foregroundColor: theme.borderActive,
+              },
+            }}
+          >
+            {fileErrors.map((err, idx) => (
+              <box
+                key={idx}
+                style={{
+                  flexDirection: "column",
+                  marginBottom: 1,
+                }}
+              >
+                <text fg={theme.primary} wrapMode="none">
+                  {err.file}
+                </text>
+                <text fg={theme.warning}>{err.message}</text>
+                {err.snippet && (
+                  <box style={{ flexDirection: "column", marginTop: 1 }}>
+                    {err.snippet.split("\n").map((line, lIdx) => (
+                      <text key={lIdx} fg={theme.textMuted} wrapMode="none">
+                        {line}
+                      </text>
+                    ))}
+                  </box>
+                )}
+              </box>
+            ))}
+          </scrollbox>
+        </box>
+      ) : visibleItems.length === 0 ? (
         <box
           style={{
             flexGrow: 1,

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -115,7 +115,7 @@ export function UrlBar({
             onOpenChange={setMethodSelectOpen}
           />
           {focused && subFocus === "text" && interactive ? (
-            <box style={{ flexGrow: 1 }}>
+            <box style={{ flexGrow: 1, flexShrink: 1 }}>
               <VarInput
                 value={inputValue}
                 env={activeEnv ?? null}
@@ -125,7 +125,7 @@ export function UrlBar({
                 backgroundColor={theme.backgroundElement}
                 focusedBackgroundColor={theme.borderSubtle}
                 paddingX={1}
-                style={{ flexGrow: 1 }}
+                style={{ flexGrow: 1, flexShrink: 1 }}
               />
             </box>
           ) : (

--- a/src/ui/VarText.tsx
+++ b/src/ui/VarText.tsx
@@ -37,6 +37,7 @@ export function VarText({
               : defaultColor
           }
           wrapMode="none"
+          style={{ flexShrink: 0 }}
         >
           {seg.text}
         </text>

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -281,6 +281,65 @@ export function moveRowCursor(
   return { ...prev, cursor: { field, row: next, addingRow: false } }
 }
 
+export function moveRowFirst(
+  prev: EditState,
+  counts: SectionRowCount,
+): EditState {
+  if (prev.mode !== "browsing") return prev
+  const { field } = prev.cursor
+  if (
+    field !== "headers" &&
+    field !== "params" &&
+    field !== "settings" &&
+    field !== "auth" &&
+    field !== "body"
+  )
+    return prev
+  let count = 0
+  if (field === "headers") count = counts.headers
+  else if (field === "params") count = counts.params
+  else if (field === "settings") count = counts.settings
+  else if (field === "auth") count = counts.auth
+  else if (field === "body") count = counts.body
+
+  if (count === 0) {
+    if (field === "headers" || field === "params") {
+      return { ...prev, cursor: { field, row: -1, addingRow: true } }
+    }
+    return prev
+  }
+
+  return { ...prev, cursor: { field, row: 0, addingRow: false } }
+}
+
+export function moveRowLast(
+  prev: EditState,
+  counts: SectionRowCount,
+): EditState {
+  if (prev.mode !== "browsing") return prev
+  const { field } = prev.cursor
+  if (
+    field !== "headers" &&
+    field !== "params" &&
+    field !== "settings" &&
+    field !== "auth" &&
+    field !== "body"
+  )
+    return prev
+  let count = 0
+  if (field === "headers") count = counts.headers
+  else if (field === "params") count = counts.params
+  else if (field === "settings") count = counts.settings
+  else if (field === "auth") count = counts.auth
+  else if (field === "body") count = counts.body
+
+  if (field === "headers" || field === "params") {
+    return { ...prev, cursor: { field, row: -1, addingRow: true } }
+  }
+  if (count === 0) return prev
+  return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
+}
+
 export function moveFolderRowCursor(
   prev: EditState,
   delta: 1 | -1,

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -4,6 +4,8 @@ import { useTheme } from "../theme"
 import { FullBorder } from "../borders"
 import { Checkbox } from "../Checkbox"
 import { VarInput } from "../VarInput"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useEffect, useRef } from "react"
 
 export function EnvEditorPane({
   draft,
@@ -27,6 +29,28 @@ export function EnvEditorPane({
   focused: boolean
 }) {
   const theme = useTheme()
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+
+  const inEdit = editState?.mode === "editing"
+  const inBrowse = editState?.mode === "browsing"
+  const editingRow = inEdit && !editState.addingRow ? editState.editingRow : -1
+  const editingAdd = inEdit && editState.addingRow
+
+  const targetRowId = editState
+    ? editState.addingRow
+      ? "vrow-add"
+      : editingRow >= 0
+        ? `vrow-${editingRow}`
+        : inBrowse && editState.row >= 0
+          ? `vrow-${editState.row}`
+          : null
+    : null
+
+  useEffect(() => {
+    if (targetRowId) {
+      scrollRef.current?.scrollChildIntoView(targetRowId)
+    }
+  }, [targetRowId])
 
   if (!draft) {
     return (
@@ -34,6 +58,7 @@ export function EnvEditorPane({
         style={{
           flexDirection: "column",
           flexGrow: 1,
+          minHeight: 0,
           padding: 1,
           backgroundColor: theme.backgroundPanel,
         }}
@@ -72,16 +97,13 @@ export function EnvEditorPane({
         .map((row) => [row.key, row.value]),
     ),
   }
-  const inEdit = editState.mode === "editing"
-  const inBrowse = editState.mode === "browsing"
-  const editingRow = inEdit && !editState.addingRow ? editState.editingRow : -1
-  const editingAdd = inEdit && editState.addingRow
 
   return (
     <box
       style={{
         flexDirection: "column",
         flexGrow: 1,
+        minHeight: 0,
         padding: 1,
         gap: 1,
         backgroundColor: theme.backgroundPanel,
@@ -94,6 +116,7 @@ export function EnvEditorPane({
       titleAlignment="left"
     >
       <scrollbox
+        ref={scrollRef}
         scrollY
         style={{ flexGrow: 1, minHeight: 0 }}
         verticalScrollbarOptions={{
@@ -161,6 +184,7 @@ export function EnvEditorPane({
         })}
         <box
           key="add"
+          id="vrow-add"
           style={{
             flexDirection: "row",
             gap: 0,

--- a/src/ui/env-editor/EnvHeaderPane.tsx
+++ b/src/ui/env-editor/EnvHeaderPane.tsx
@@ -81,6 +81,7 @@ export const EnvHeaderPane = forwardRef<
         paddingRight: 1,
         backgroundColor: theme.backgroundPanel,
         zIndex: selectOpen ? 1 : undefined,
+        flexShrink: 0,
       }}
       border={[...FullBorder.border]}
       customBorderChars={FullBorder.customBorderChars}

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -224,7 +224,7 @@ export const NewRequestOverlay = forwardRef<
               backgroundColor={theme.backgroundElement}
               focusedBackgroundColor={theme.borderSubtle}
               paddingX={1}
-              style={{ flexGrow: 1 }}
+              style={{ flexGrow: 1, flexShrink: 1 }}
             />
           </box>
         </box>

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -908,6 +908,14 @@ export function useAppKeymap(
         run: () => refs.envEditorRef.current.browseDown(),
       },
       {
+        name: "env-browse.first",
+        run: () => refs.envEditorRef.current.browseFirst(),
+      },
+      {
+        name: "env-browse.last",
+        run: () => refs.envEditorRef.current.browseLast(),
+      },
+      {
         name: "env-browse.enter",
         run: () => refs.envEditorRef.current.enterEdit(),
       },
@@ -941,6 +949,8 @@ export function useAppKeymap(
     bindings: [
       { key: "up", cmd: "env-browse.up" },
       { key: "down", cmd: "env-browse.down" },
+      { key: "home", cmd: "env-browse.first" },
+      { key: "end", cmd: "env-browse.last" },
       { key: "return", cmd: "env-browse.enter" },
       { key: "escape", cmd: "env-browse.escape" },
       { key: "space", cmd: "env-browse.toggle" },

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -590,6 +590,8 @@ export function useAppKeymap(
     commands: [
       { name: "browse.up", run: () => refs.ebRef.current.browseUp() },
       { name: "browse.down", run: () => refs.ebRef.current.browseDown() },
+      { name: "browse.first", run: () => refs.ebRef.current.browseFirst() },
+      { name: "browse.last", run: () => refs.ebRef.current.browseLast() },
       { name: "browse.left", run: () => refs.ebRef.current.browseLeft() },
       { name: "browse.right", run: () => refs.ebRef.current.browseRight() },
       {
@@ -629,6 +631,8 @@ export function useAppKeymap(
     bindings: [
       { key: "up", cmd: "browse.up" },
       { key: "down", cmd: "browse.down" },
+      { key: "home", cmd: "browse.first" },
+      { key: "end", cmd: "browse.last" },
       { key: "left", cmd: "browse.left" },
       { key: "right", cmd: "browse.right" },
       { key: "return", cmd: "browse.enter" },

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -785,6 +785,21 @@ export function useOverlayIntercepts(opts: {
             if (names[next]) ee.selectEnv(names[next]!)
             return
           }
+          if (e.name === "home" && ee.draft !== null) {
+            e.preventDefault()
+            e.stopPropagation()
+            const names = ee.envNames
+            if (names[0]) ee.selectEnv(names[0])
+            return
+          }
+          if (e.name === "end" && ee.draft !== null) {
+            e.preventDefault()
+            e.stopPropagation()
+            const names = ee.envNames
+            const last = names[names.length - 1]
+            if (last) ee.selectEnv(last)
+            return
+          }
         }
 
         if (f === "env-header") {

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -5,6 +5,8 @@ import {
   exitEditBrowse,
   moveFieldCursor,
   moveRowCursor,
+  moveRowFirst,
+  moveRowLast,
   beginEditing,
   commitEditing,
   cancelEditing,
@@ -190,6 +192,115 @@ describe("moveRowCursor", () => {
     s = moveFieldCursor(s, +1, c(2, 0))
     const editing = beginEditing(s)
     expect(moveRowCursor(editing, +1, c(2, 0))).toBe(editing)
+  })
+})
+
+describe("moveRowFirst", () => {
+  it("jumps to row 0 in headers section", () => {
+    let s = enterEditBrowse(inactive, c(3, 0))
+    s = moveRowCursor(s, +1, c(3, 0))
+    s = moveRowCursor(s, +1, c(3, 0))
+    expect(s.cursor.row).toBe(2)
+    const first = moveRowFirst(s, c(3, 0))
+    expect(first.cursor.row).toBe(0)
+    expect(first.cursor.addingRow).toBe(false)
+  })
+
+  it("empty headers/params section jumps to addingRow", () => {
+    const s = enterEditBrowse(inactive, c(0, 0))
+    const first = moveRowFirst(s, c(0, 0))
+    expect(first.cursor.addingRow).toBe(true)
+    expect(first.cursor.row).toBe(-1)
+  })
+
+  it("empty settings/auth/body section is no-op", () => {
+    let s = enterEditBrowse(inactive, c(2, 0))
+    // move to settings
+    s = moveFieldCursor(s, -1, {
+      headers: 2,
+      params: 0,
+      body: 0,
+      auth: 0,
+      settings: 0,
+    })
+    expect(s.cursor.field).toBe("settings")
+    const first = moveRowFirst(s, {
+      headers: 2,
+      params: 0,
+      body: 0,
+      auth: 0,
+      settings: 0,
+    })
+    // settings with 0 rows is no-op
+    expect(first).toBe(s)
+  })
+
+  it("no-op when not browsing", () => {
+    const first = moveRowFirst(inactive, c(2, 0))
+    expect(first).toBe(inactive)
+  })
+})
+
+describe("moveRowLast", () => {
+  it("jumps to last row in headers section", () => {
+    const s = enterEditBrowse(inactive, c(3, 0))
+    const last = moveRowLast(s, c(3, 0))
+    expect(last.cursor.addingRow).toBe(true)
+    expect(last.cursor.row).toBe(-1)
+  })
+
+  it("for params, last goes to addingRow", () => {
+    let s = enterEditBrowse(inactive, c(0, 2))
+    s = moveFieldCursor(s, +1, c(0, 2))
+    expect(s.cursor.field).toBe("params")
+    const last = moveRowLast(s, c(0, 2))
+    expect(last.cursor.addingRow).toBe(true)
+    expect(last.cursor.row).toBe(-1)
+  })
+
+  it("for settings, last goes to row N-1", () => {
+    let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, -1, c(0, 0))
+    expect(s.cursor.field).toBe("settings")
+    const last = moveRowLast(s, c(0, 0))
+    expect(last.cursor.row).toBe(2) // settings default count is 3, so row 2
+    expect(last.cursor.addingRow).toBe(false)
+  })
+
+  it("for auth, last goes to row N-1", () => {
+    const counts = { headers: 0, params: 0, body: 0, auth: 4, settings: 3 }
+    let s = enterEditBrowse(inactive, counts)
+    s = moveFieldCursor(s, -1, counts)
+    s = moveFieldCursor(s, -1, counts)
+    expect(s.cursor.field).toBe("auth")
+    const last = moveRowLast(s, counts)
+    expect(last.cursor.row).toBe(3)
+    expect(last.cursor.addingRow).toBe(false)
+  })
+
+  it("empty settings/auth/body section is no-op", () => {
+    let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, -1, {
+      headers: 2,
+      params: 0,
+      body: 0,
+      auth: 0,
+      settings: 0,
+    })
+    expect(s.cursor.field).toBe("settings")
+    const last = moveRowLast(s, {
+      headers: 2,
+      params: 0,
+      body: 0,
+      auth: 0,
+      settings: 0,
+    })
+    expect(last).toBe(s)
+  })
+
+  it("no-op when not browsing", () => {
+    const last = moveRowLast(inactive, c(2, 0))
+    expect(last).toBe(inactive)
   })
 })
 

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -175,6 +175,24 @@ describe("filestore.loadCollection — file selection and order", () => {
     }
   })
 
+  it("accumulates folder.yml parse errors alongside request parse errors", async () => {
+    const { extractFileErrors } = await import("../src/filestore/load")
+    await mkdir(join(dir, "sub"))
+    await writeFile(join(dir, "sub", "folder.yml"), "meta:\n  : : :\n")
+    await writeFile(join(dir, "sub", "bad.yml"), "name: Bar\n  : : :\n")
+
+    try {
+      await filestore.loadCollection(dir)
+      expect(true).toBe(false)
+    } catch (e) {
+      const err = e as Error
+      const fileErrors = extractFileErrors(err)
+      expect(fileErrors).toHaveLength(2)
+      expect(fileErrors.map((f) => f.file)).toContain("sub/folder.yml")
+      expect(fileErrors.map((f) => f.file)).toContain("sub/bad.yml")
+    }
+  })
+
   it("collapses trailing slash in dir basename", async () => {
     await writeFile(join(dir, "x.yml"), yamlTmpl(makeReq()))
     const col = await filestore.loadCollection(dir + "/")

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -146,6 +146,35 @@ describe("filestore.loadCollection — file selection and order", () => {
     )
   })
 
+  it("accumulates multiple file parse errors with user-friendly formatting", async () => {
+    const { parseUserFriendlyFileError, extractFileErrors } =
+      await import("../src/filestore/load")
+    await writeFile(
+      join(dir, "bad1.yml"),
+      "name: Foo\nparams:\n  - name: x\n    value: '1'\n    dsfsdf (10:11)",
+    )
+    await writeFile(join(dir, "bad2.yml"), "name: Bar\n  : : :\n")
+
+    try {
+      await filestore.loadCollection(dir)
+      expect(true).toBe(false)
+    } catch (e) {
+      const err = e as Error
+      const fileErrors = extractFileErrors(err)
+      expect(fileErrors).toHaveLength(2)
+      expect(fileErrors.map((f) => f.file)).toContain("bad1.yml")
+      expect(fileErrors.map((f) => f.file)).toContain("bad2.yml")
+
+      const parsedErr = parseUserFriendlyFileError(
+        "delete-v1-alb-clusters-id.yml",
+        "can not read an implicit mapping pair; a colon is missed (10:11)",
+      )
+      expect(parsedErr.message).toBe(
+        "Line 10, Col 11: Missing colon after key name",
+      )
+    }
+  })
+
   it("collapses trailing slash in dir basename", async () => {
     await writeFile(join(dir, "x.yml"), yamlTmpl(makeReq()))
     const col = await filestore.loadCollection(dir + "/")

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import type { Request } from "../src/schema"
+import type { Folder, Request } from "../src/schema"
 import { lang } from "../src/lang"
 
 describe("lang.parseRequest — required fields", () => {
@@ -825,24 +825,122 @@ describe("lang.serializeRequest — body_type, form_data, file_path", () => {
     expect(reparsed.params[0].value).toBe(longValue)
   })
 
-  it("serializes multiline parameter values with proper indentation and round-trips correctly", () => {
-    const multilineValue = "line 1\nline 2\nline 3"
+  it("serializes multiline auth values with proper indentation and round-trips correctly", () => {
     const original: Request = {
-      id: "multiline-param-req",
-      name: "Multiline param req",
+      id: "multiline-auth-req",
+      name: "Multiline auth req",
       method: "GET",
       url: "https://example.com/api",
       headers: {},
-      params: [{ name: "description", value: multilineValue, enabled: true }],
+      params: [],
       timeout: 0,
       followRedirects: true,
       maxRedirects: 5,
-      auth: { type: "none" },
+      auth: {
+        type: "bearer",
+        token:
+          "eyJhbGciOiJSUzI1NiJ9.\neyJzdWIiOiJ1c2VyMTIzIn0.\nSflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+      },
     }
 
     const yamlStr = lang.serializeRequest(original)
     expect(() => lang.parseRequest(original.id, yamlStr)).not.toThrow()
     const reparsed = lang.parseRequest(original.id, yamlStr)
-    expect(reparsed.params[0].value).toBe(multilineValue)
+    expect(reparsed.auth).toEqual(original.auth)
+  })
+
+  it("serializes multiline basic auth credentials with proper indentation and round-trips correctly", () => {
+    const original: Request = {
+      id: "multiline-basic-auth-req",
+      name: "Multiline basic auth req",
+      method: "GET",
+      url: "https://example.com/api",
+      headers: {},
+      params: [],
+      timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
+      auth: {
+        type: "basic",
+        user: "multi\nline\nuser",
+        pass: "multi\nline\npass",
+      },
+    }
+
+    const yamlStr = lang.serializeRequest(original)
+    expect(() => lang.parseRequest(original.id, yamlStr)).not.toThrow()
+    const reparsed = lang.parseRequest(original.id, yamlStr)
+    expect(reparsed.auth).toEqual(original.auth)
+  })
+
+  it("serializes multiline api_key auth with proper indentation and round-trips correctly", () => {
+    const original: Request = {
+      id: "multiline-apikey-auth-req",
+      name: "Multiline apikey auth req",
+      method: "GET",
+      url: "https://example.com/api",
+      headers: {},
+      params: [],
+      timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
+      auth: {
+        type: "api_key",
+        key: "X-API-Key",
+        value: "multi\nline\nsecret",
+        placement: "header",
+      },
+    }
+
+    const yamlStr = lang.serializeRequest(original)
+    expect(() => lang.parseRequest(original.id, yamlStr)).not.toThrow()
+    const reparsed = lang.parseRequest(original.id, yamlStr)
+    expect(reparsed.auth).toEqual(original.auth)
+  })
+})
+
+describe("lang.serializeFolder — multiline values", () => {
+  it("serializes multiline folder header values with proper indentation and round-trips correctly", () => {
+    const folder: Folder = {
+      id: "test-folder",
+      name: "Test Folder",
+      path: "/test-folder",
+      children: [],
+      overrides: {
+        headers: {
+          "X-Custom": { value: "line1\nline2\nline3", enabled: true },
+        },
+      },
+    }
+
+    const yamlStr = lang.serializeFolder(folder)
+    expect(() => lang.parseFolder(yamlStr)).not.toThrow()
+    const parsed = lang.parseFolder(yamlStr)
+    expect(parsed.overrides?.headers?.["X-Custom"]?.value).toBe(
+      "line1\nline2\nline3",
+    )
+  })
+
+  it("serializes multiline folder auth bearer token with proper indentation and round-trips correctly", () => {
+    const folder: Folder = {
+      id: "test-folder",
+      name: "Test Folder",
+      path: "/test-folder",
+      children: [],
+      overrides: {
+        auth: {
+          type: "bearer",
+          token: "line1\nline2\nline3",
+        },
+      },
+    }
+
+    const yamlStr = lang.serializeFolder(folder)
+    expect(() => lang.parseFolder(yamlStr)).not.toThrow()
+    const parsed = lang.parseFolder(yamlStr)
+    expect(parsed.overrides?.auth).toEqual({
+      type: "bearer",
+      token: "line1\nline2\nline3",
+    })
   })
 })

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -802,4 +802,47 @@ describe("lang.serializeRequest — body_type, form_data, file_path", () => {
     const reparsed = lang.parseRequest(original.id, yaml)
     expect(reparsed).toEqual(original)
   })
+
+  it("serializes long parameter values without invalid YAML indentation and round-trips correctly", () => {
+    const longValue =
+      "e.g. VCENTER, NSX_T_MANAGER, SDDC_MANAGER, VRSLCM, VROPS, VCF_OPS_CLOUD_PROXY, VRA"
+    const original: Request = {
+      id: "long-param-req",
+      name: "Long param req",
+      method: "GET",
+      url: "https://example.com/api",
+      headers: {},
+      params: [{ name: "productType", value: longValue, enabled: true }],
+      timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
+      auth: { type: "none" },
+    }
+
+    const yamlStr = lang.serializeRequest(original)
+    expect(() => lang.parseRequest(original.id, yamlStr)).not.toThrow()
+    const reparsed = lang.parseRequest(original.id, yamlStr)
+    expect(reparsed.params[0].value).toBe(longValue)
+  })
+
+  it("serializes multiline parameter values with proper indentation and round-trips correctly", () => {
+    const multilineValue = "line 1\nline 2\nline 3"
+    const original: Request = {
+      id: "multiline-param-req",
+      name: "Multiline param req",
+      method: "GET",
+      url: "https://example.com/api",
+      headers: {},
+      params: [{ name: "description", value: multilineValue, enabled: true }],
+      timeout: 0,
+      followRedirects: true,
+      maxRedirects: 5,
+      auth: { type: "none" },
+    }
+
+    const yamlStr = lang.serializeRequest(original)
+    expect(() => lang.parseRequest(original.id, yamlStr)).not.toThrow()
+    const reparsed = lang.parseRequest(original.id, yamlStr)
+    expect(reparsed.params[0].value).toBe(multilineValue)
+  })
 })

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -357,4 +357,26 @@ describe("Select", () => {
     expect(frame).toContain("PUT")
     cleanup()
   })
+
+  it("does not shrink when placed next to a long input in a row container", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ flexDirection: "row", width: 30 }}>
+            <Select items={testItems} value="get" badge />
+            <text style={{ flexGrow: 1 }}>
+              https://very-long-domain-name.com/api/v1/resource/endpoint
+            </text>
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 30, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("GET")
+    expect(frame).toContain("▼")
+    cleanup()
+  })
 })

--- a/tests/unit/VarText.test.tsx
+++ b/tests/unit/VarText.test.tsx
@@ -184,6 +184,26 @@ describe("VarText", () => {
     expect(varSpan).toBeDefined()
     expect(varSpan!.fg.equals(primaryRgba)).toBe(true)
   })
+
+  it("does not shrink individual segments in long text within narrow containers", async () => {
+    const longUrl =
+      "$base_url/v1/releases/dom$domain/custom-patches?vcfRelease=4.0.1.0&productType=e.g. VCENTER"
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarText
+          text={longUrl}
+          env={env({ base_url: "http://example.com", domain: "test" })}
+        />
+      </ThemeProvider>,
+      { width: 40, height: 5 },
+    )
+    await renderOnce()
+    const frame = captureSpans()
+    const spans = frame.lines.flatMap((l) => l.spans)
+    const baseUrlSpan = spans.find((s) => s.text.includes("$base_url"))
+    expect(baseUrlSpan).toBeDefined()
+    expect(baseUrlSpan!.text).toBe("$base_url")
+  })
 })
 
 function hexToRgba(hex: string): RGBA {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -256,4 +256,38 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     expect(spy).toHaveBeenCalled()
     expect(editor.envNames).toContain("new-env")
   })
+
+  it("navigates to first and last row using browseFirst and browseLast", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await new Promise((r) => setTimeout(r, 50))
+    await renderOnce()
+
+    ref.current!.enterBrowse()
+    await new Promise((r) => setTimeout(r, 10))
+    await renderOnce()
+
+    expect(ref.current!.editState.mode).toBe("browsing")
+
+    // Go to last item (add row)
+    ref.current!.browseLast()
+    await new Promise((r) => setTimeout(r, 10))
+    await renderOnce()
+    expect(ref.current!.editState.addingRow).toBe(true)
+
+    // Go to first item (row 0)
+    ref.current!.browseFirst()
+    await new Promise((r) => setTimeout(r, 10))
+    await renderOnce()
+    expect(ref.current!.editState.row).toBe(0)
+    expect(ref.current!.editState.addingRow).toBe(false)
+  })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Four groups of fixes:

1. **YAML serialization** — fixes `yamlVal` to use `lineWidth: -1` and propely indent multiline values for params, headers, auth (bearer/basic/api_key), and folder overrides. Prevents invalid YAML being written when values are long or multiline.

2. **File error display** — `loadCollection` now collects all parse errors instead of failing on the first one. Exposes `extractFileErrors`/`parseUserFriendlyFileError` with user-friendly messages, line/col hints, and YAML snippets. Sidebar shows a scrollable error list when a collection fails to load.

3. **Home/End navigation** — adds `browseFirst`/`browseLast` to request pane browsing, env editor browsing, sidebar tree, and env list navigation. Bindings wired through `useAppKeymap` and `useOverlayIntercepts`.

4. **UI layout fixes** — fixes `Select` badge shrinkage, `VarText` segment shrinkage, URL bar input flex, env editor header/scroll behavior, and `RequestPane` tab rendering to be mutually exclusive (body always renders in a dedicated scrollbox; all tabs are siblings).

### How did you verify your code works?

- New tests for `moveRowFirst`/`moveRowLast` in `editMode.test.ts`
- New test for multi-file parse errors in `filestore.test.ts`
- New round-trip tests for long/multiline param and auth serialization in `lang.test.ts`
- New component tests for Select and VarText shrinkage
- New env editor browse navigation test
- `bun test` passes
- `bun run lint` passes
- `bun run typecheck` passes

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR