### PR TITLE
refactor(ResponsePane): display status in colored badge with truncation

### DIFF
--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -20,6 +20,7 @@ import {
 
 import { HeaderTable } from "./HeaderTable"
 import { TimelineTab } from "./timeline/TimelineTab"
+import { Badge } from "./Badge"
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 const AUTO_RENDER_LIMIT = 5 * 1024 * 1024
@@ -265,21 +266,30 @@ export function ResponsePane({
   }, [responseQueryRef, isDone, activeTab, queryVisible])
 
   const headerLeft = (
-    <box style={{ flexDirection: "row" }}>
-      <text fg={focused ? theme.primary : theme.borderSubtle}>Response</text>
-      {isDone ? (
-        <text fg={statusColor(state.response.status, theme)}>
-          {` ${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}`}
-        </text>
-      ) : null}
-    </box>
+    <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
   )
 
-  const headerRight = isDone ? (
-    <text fg={focused ? theme.primary : theme.textMuted}>
-      {`${formatSize(bodySize)} in ${Math.round(state.response.timeMs)}ms`}
-    </text>
-  ) : undefined
+  const headerRight = isDone
+    ? (() => {
+        const rawText = state.response.statusText ?? ""
+        const truncatedStatusText =
+          rawText.length > 5 ? `${rawText.slice(0, 5)}…` : rawText
+        const statusStr = `${state.response.status}${truncatedStatusText !== "" ? ` ${truncatedStatusText}` : ""}`
+        return (
+          <box style={{ flexDirection: "row" }}>
+            <text fg={focused ? theme.primary : theme.textMuted}>
+              {`${formatSize(bodySize)} in ${Math.round(state.response.timeMs)}ms `}
+            </text>
+            <Badge
+              bg={statusColor(state.response.status, theme)}
+              fg={theme.backgroundPanel}
+            >
+              {statusStr}
+            </Badge>
+          </box>
+        )
+      })()
+    : undefined
 
   const bottomTitle = focused
     ? `${expandHint}${queryHint ? ` - ${queryHint}` : ""}`
@@ -303,7 +313,6 @@ export function ResponsePane({
       titleLeft={headerLeft}
       titleRight={headerRight}
       bottomTitle={bottomTitle}
-      bottomTitleColor={focused ? theme.primary : theme.textMuted}
       bottomTitleAlignment="left"
     >
       {state.status === "idle" ? (

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -271,7 +271,7 @@ export function ResponsePane({
 
   const headerRight = isDone
     ? (() => {
-        const rawText = state.response.statusText ?? ""
+        const rawText = state.response.statusText
         const truncatedStatusText =
           rawText.length > 5 ? `${rawText.slice(0, 5)}…` : rawText
         const statusStr = `${state.response.status}${truncatedStatusText !== "" ? ` ${truncatedStatusText}` : ""}`
@@ -292,7 +292,7 @@ export function ResponsePane({
     : undefined
 
   const bottomTitle = focused
-    ? `${expandHint}${queryHint ? ` - ${queryHint}` : ""}`
+    ? `${expandHint}${queryHint ? ` · ${queryHint}` : ""}`
     : undefined
 
   return (

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -291,9 +291,8 @@ export function ResponsePane({
       })()
     : undefined
 
-  const bottomTitle = focused
-    ? `${expandHint}${queryHint ? ` · ${queryHint}` : ""}`
-    : undefined
+  const hints = [expandHint, queryHint].filter(Boolean).join(" · ")
+  const bottomTitle = focused && hints !== "" ? hints : undefined
 
   return (
     <Frame

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -265,27 +265,25 @@ export function ResponsePane({
   }, [responseQueryRef, isDone, activeTab, queryVisible])
 
   const headerLeft = (
-    <text fg={focused ? theme.primary : theme.textMuted}>Response</text>
+    <box style={{ flexDirection: "row" }}>
+      <text fg={focused ? theme.primary : theme.borderSubtle}>Response</text>
+      {isDone ? (
+        <text fg={statusColor(state.response.status, theme)}>
+          {` ${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}`}
+        </text>
+      ) : null}
+    </box>
   )
 
   const headerRight = isDone ? (
-    <text fg={statusColor(state.response.status, theme)}>
-      {`${state.response.status}${state.response.statusText !== "" ? ` ${state.response.statusText}` : ""}`}
-    </text>
-  ) : undefined
-
-  const footerLeft = focused ? (
-    <text fg={theme.primary}>
-      {expandHint}
-      {queryHint ? ` · ${queryHint}` : ""}
-    </text>
-  ) : undefined
-
-  const footerRight = isDone ? (
     <text fg={focused ? theme.primary : theme.textMuted}>
       {`${formatSize(bodySize)} in ${Math.round(state.response.timeMs)}ms`}
     </text>
   ) : undefined
+
+  const bottomTitle = focused
+    ? `${expandHint}${queryHint ? ` - ${queryHint}` : ""}`
+    : undefined
 
   return (
     <Frame
@@ -294,7 +292,7 @@ export function ResponsePane({
         flexDirection: "column",
         paddingLeft: 1,
         paddingRight: 1,
-        paddingBottom: 1,
+        paddingBottom: 0,
         flexBasis: 0,
         minHeight: 0,
         backgroundColor: theme.backgroundPanel,
@@ -304,8 +302,9 @@ export function ResponsePane({
       borderColor={borderColor}
       titleLeft={headerLeft}
       titleRight={headerRight}
-      bottomLeft={footerLeft}
-      bottomRight={footerRight}
+      bottomTitle={bottomTitle}
+      bottomTitleColor={focused ? theme.primary : theme.textMuted}
+      bottomTitleAlignment="left"
     >
       {state.status === "idle" ? (
         <Tips />

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -257,7 +257,7 @@ describe("ResponsePane scrollbox", () => {
       .split("\n")
       .find((line: string) => line.includes("120B") && line.includes("42ms"))
     expect(metadataLine).toBeDefined()
-    expect(metadataLine ?? "").toContain("└")
+    expect(metadataLine ?? "").toMatch(/[┌└]/)
   })
 
   it("renders with large response body without overflowing", async () => {

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -7,7 +7,7 @@ import { ThemeProvider } from "../../src/ui/theme"
 import type { SendState } from "../../src/ui/sendState"
 
 describe("ResponsePane status text truncation and layout tests", () => {
-  it("renders short status text unchanged and truncates status text > 5 chars with ellipsis", async () => {
+  const createTestProps = () => {
     const keymap = createTestKeymap()
     const draft = {
       draft: {
@@ -37,8 +37,11 @@ describe("ResponsePane status text truncation and layout tests", () => {
       setEditValue: () => {},
       activeTab: "body" as const,
     }
+    return { keymap, draft, eb }
+  }
 
-    // Test 1: Short statusText "OK" (<= 5 chars)
+  it("renders short status text (≤5 chars) unchanged", async () => {
+    const { keymap, draft, eb } = createTestProps()
     const responseOK: SendState = {
       status: "done",
       response: {
@@ -49,51 +52,50 @@ describe("ResponsePane status text truncation and layout tests", () => {
         timeMs: 123,
       },
     }
-    {
-      const { renderOnce, captureCharFrame } = await testRender(
-        <KeymapProvider
-          keymap={
-            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
-          }
-        >
-          <ThemeProvider activeIndex={0} previewIndex={null}>
-            <box style={{ width: 100, height: 20, flexDirection: "column" }}>
-              <RequestResponseView
-                draft={
-                  draft as unknown as Parameters<
-                    typeof RequestResponseView
-                  >[0]["draft"]
-                }
-                eb={
-                  eb as unknown as Parameters<
-                    typeof RequestResponseView
-                  >[0]["eb"]
-                }
-                error={null}
-                focus="response"
-                layout="stacked"
-                expanded={null}
-                activeEnv={null}
-                responseState={responseOK}
-                timelineEntries={[]}
-                onResponseTabChange={() => {}}
-                setSelectOpen={() => {}}
-                urlbarSubFocus="text"
-                urlbarInteractive={true}
-                expandHint="f2 expand"
-                queryHint="/ query"
-              />
-            </box>
-          </ThemeProvider>
-        </KeymapProvider>,
-        { width: 100, height: 20 },
-      )
-      await renderOnce()
-      const frame = captureCharFrame()
-      expect(frame).toContain("200 OK")
-    }
 
-    // Test 2: Long statusText "Internal Server Error" (> 5 chars) -> "Inter…"
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider
+        keymap={
+          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+        }
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ width: 100, height: 20, flexDirection: "column" }}>
+            <RequestResponseView
+              draft={
+                draft as unknown as Parameters<
+                  typeof RequestResponseView
+                >[0]["draft"]
+              }
+              eb={
+                eb as unknown as Parameters<typeof RequestResponseView>[0]["eb"]
+              }
+              error={null}
+              focus="response"
+              layout="stacked"
+              expanded={null}
+              activeEnv={null}
+              responseState={responseOK}
+              timelineEntries={[]}
+              onResponseTabChange={() => {}}
+              setSelectOpen={() => {}}
+              urlbarSubFocus="text"
+              urlbarInteractive={true}
+              expandHint="f2 expand"
+              queryHint="/ query"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("200 OK")
+  })
+
+  it("truncates status text > 5 chars with ellipsis", async () => {
+    const { keymap, draft, eb } = createTestProps()
     const responseErr: SendState = {
       status: "done",
       response: {
@@ -104,48 +106,45 @@ describe("ResponsePane status text truncation and layout tests", () => {
         timeMs: 456,
       },
     }
-    {
-      const { renderOnce, captureCharFrame } = await testRender(
-        <KeymapProvider
-          keymap={
-            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
-          }
-        >
-          <ThemeProvider activeIndex={0} previewIndex={null}>
-            <box style={{ width: 100, height: 20, flexDirection: "column" }}>
-              <RequestResponseView
-                draft={
-                  draft as unknown as Parameters<
-                    typeof RequestResponseView
-                  >[0]["draft"]
-                }
-                eb={
-                  eb as unknown as Parameters<
-                    typeof RequestResponseView
-                  >[0]["eb"]
-                }
-                error={null}
-                focus="response"
-                layout="stacked"
-                expanded={null}
-                activeEnv={null}
-                responseState={responseErr}
-                timelineEntries={[]}
-                onResponseTabChange={() => {}}
-                setSelectOpen={() => {}}
-                urlbarSubFocus="text"
-                urlbarInteractive={true}
-                expandHint="f2 expand"
-                queryHint="/ query"
-              />
-            </box>
-          </ThemeProvider>
-        </KeymapProvider>,
-        { width: 100, height: 20 },
-      )
-      await renderOnce()
-      const frame = captureCharFrame()
-      expect(frame).toContain("500 Inter…")
-    }
+
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider
+        keymap={
+          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+        }
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ width: 100, height: 20, flexDirection: "column" }}>
+            <RequestResponseView
+              draft={
+                draft as unknown as Parameters<
+                  typeof RequestResponseView
+                >[0]["draft"]
+              }
+              eb={
+                eb as unknown as Parameters<typeof RequestResponseView>[0]["eb"]
+              }
+              error={null}
+              focus="response"
+              layout="stacked"
+              expanded={null}
+              activeEnv={null}
+              responseState={responseErr}
+              timelineEntries={[]}
+              onResponseTabChange={() => {}}
+              setSelectOpen={() => {}}
+              urlbarSubFocus="text"
+              urlbarInteractive={true}
+              expandHint="f2 expand"
+              queryHint="/ query"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("500 Inter…")
   })
 })

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import { RequestResponseView } from "../../src/ui/RequestResponseView"
+import { ThemeProvider } from "../../src/ui/theme"
+import type { SendState } from "../../src/ui/sendState"
+
+describe("ResponsePane status text truncation and layout tests", () => {
+  it("renders short status text unchanged and truncates status text > 5 chars with ellipsis", async () => {
+    const keymap = createTestKeymap()
+    const draft = {
+      draft: {
+        method: "GET" as const,
+        url: "https://api.example.com",
+        headers: {},
+        params: [],
+        auth: { type: "none" as const },
+        bodyType: "json" as const,
+      },
+      setUrl: () => {},
+      setMethod: () => {},
+      syncUrlParams: () => {},
+      setAuthType: () => {},
+      setApiKeyPlacement: () => {},
+      setBodyType: () => {},
+      dirtyRequestIds: new Set<string>(),
+    }
+    const eb = {
+      editState: {
+        mode: "browsing" as const,
+        cursor: { field: "body" as const, index: 0 },
+      },
+      editKey: "",
+      editValue: "",
+      setEditKey: () => {},
+      setEditValue: () => {},
+      activeTab: "body" as const,
+    }
+
+    // Test 1: Short statusText "OK" (<= 5 chars)
+    const responseOK: SendState = {
+      status: "done",
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: '{"ok":true}',
+        timeMs: 123,
+      },
+    }
+    {
+      const { renderOnce, captureCharFrame } = await testRender(
+        <KeymapProvider
+          keymap={
+            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+          }
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box style={{ width: 100, height: 20, flexDirection: "column" }}>
+              <RequestResponseView
+                draft={
+                  draft as unknown as Parameters<
+                    typeof RequestResponseView
+                  >[0]["draft"]
+                }
+                eb={
+                  eb as unknown as Parameters<
+                    typeof RequestResponseView
+                  >[0]["eb"]
+                }
+                error={null}
+                focus="response"
+                layout="stacked"
+                expanded={null}
+                activeEnv={null}
+                responseState={responseOK}
+                timelineEntries={[]}
+                onResponseTabChange={() => {}}
+                setSelectOpen={() => {}}
+                urlbarSubFocus="text"
+                urlbarInteractive={true}
+                expandHint="f2 expand"
+                queryHint="/ query"
+              />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 20 },
+      )
+      await renderOnce()
+      const frame = captureCharFrame()
+      expect(frame).toContain("200 OK")
+    }
+
+    // Test 2: Long statusText "Internal Server Error" (> 5 chars) -> "Inter…"
+    const responseErr: SendState = {
+      status: "done",
+      response: {
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: {},
+        body: '{"error":true}',
+        timeMs: 456,
+      },
+    }
+    {
+      const { renderOnce, captureCharFrame } = await testRender(
+        <KeymapProvider
+          keymap={
+            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+          }
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box style={{ width: 100, height: 20, flexDirection: "column" }}>
+              <RequestResponseView
+                draft={
+                  draft as unknown as Parameters<
+                    typeof RequestResponseView
+                  >[0]["draft"]
+                }
+                eb={
+                  eb as unknown as Parameters<
+                    typeof RequestResponseView
+                  >[0]["eb"]
+                }
+                error={null}
+                focus="response"
+                layout="stacked"
+                expanded={null}
+                activeEnv={null}
+                responseState={responseErr}
+                timelineEntries={[]}
+                onResponseTabChange={() => {}}
+                setSelectOpen={() => {}}
+                urlbarSubFocus="text"
+                urlbarInteractive={true}
+                expandHint="f2 expand"
+                queryHint="/ query"
+              />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 20 },
+      )
+      await renderOnce()
+      const frame = captureCharFrame()
+      expect(frame).toContain("500 Inter…")
+    }
+  })
+})

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -147,4 +147,57 @@ describe("ResponsePane status text truncation and layout tests", () => {
     const frame = captureCharFrame()
     expect(frame).toContain("500 Inter…")
   })
+
+  it("does not render 'undefined' when expandHint or queryHint is omitted", async () => {
+    const { keymap, draft, eb } = createTestProps()
+    const responseOK: SendState = {
+      status: "done",
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: '{"ok":true}',
+        timeMs: 123,
+      },
+    }
+
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider
+        keymap={
+          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+        }
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ width: 100, height: 20, flexDirection: "column" }}>
+            <RequestResponseView
+              draft={
+                draft as unknown as Parameters<
+                  typeof RequestResponseView
+                >[0]["draft"]
+              }
+              eb={
+                eb as unknown as Parameters<typeof RequestResponseView>[0]["eb"]
+              }
+              error={null}
+              focus="response"
+              layout="stacked"
+              expanded={null}
+              activeEnv={null}
+              responseState={responseOK}
+              timelineEntries={[]}
+              onResponseTabChange={() => {}}
+              setSelectOpen={() => {}}
+              urlbarSubFocus="text"
+              urlbarInteractive={true}
+              expandHint="f2 expand"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).not.toContain("undefined")
+  })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves response status into a colored Badge component in the header, truncates long statusText (>5 chars) with ellipsis, merges footer into a single bottom title, and adds unit tests for status truncation.

### How did you verify your code works?

Added  with testRender cases for short status ("200 OK") and long status truncation ("500 Inter…"). Existing scrollbox test updated for new footer alignment.

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR