### PR TITLE
fix(ui): remove confirm selection state, fix scroll, and polish UI

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -123,7 +123,6 @@ export function AppInner({
   const [expanded, setExpanded] = useState<"request" | "response" | null>(null)
   const expandedRef = useRef(expanded)
   expandedRef.current = expanded
-  const [confirmSelection, setConfirmSelection] = useState(0)
   const [collectionReloadToken, setCollectionReloadToken] = useState(0)
   const [, setSelectOpen] = useState(false)
   const [yamlEditor, setYamlEditor] = useState<{
@@ -149,7 +148,6 @@ export function AppInner({
   useEffect(() => {
     envDeletePendingRef.current = envDeletePending
   }, [envDeletePending])
-  const [deleteConfirmSelection, setDeleteConfirmSelection] = useState(0)
   const [newRequestVisible, setNewRequestVisible] = useState(false)
   const newRequestRef = useRef<NewRequestOverlayHandle>(null)
   const [importCurlVisible, setImportCurlVisible] = useState(false)
@@ -169,7 +167,6 @@ export function AppInner({
   const folderDeletePathRef = useRef<string | null>(null)
   const [undoAllPending, setUndoAllPending] = useState(false)
   const [initPending, setInitPending] = useState(false)
-  const [initConfirmSelection, setInitConfirmSelection] = useState(0)
   const [commandPaletteVisible, setCommandPaletteVisible] = useState(false)
   const [codeGeneratorVisible, setCodeGeneratorVisible] = useState(false)
   const [requestFinderVisible, setRequestFinderVisible] = useState(false)
@@ -180,7 +177,6 @@ export function AppInner({
   const [collectionSwitchPending, setCollectionSwitchPending] = useState<
     string | null
   >(null)
-  const [collectionSwitchSelection, setCollectionSwitchSelection] = useState(0)
   const [initialExpandedFolders, setInitialExpandedFolders] =
     useState<Set<string> | null>(null)
   const headerFieldRef = useRef<"name" | "color">("name")
@@ -659,16 +655,13 @@ export function AppInner({
       setCollectionSwitcherVisible(false)
       if (normalized === collectionDirRef.current) {
         setCollectionSwitchPending(null)
-        setCollectionSwitchSelection(0)
         return
       }
       if (draft.isDirty || folderDraft.isDirty || envEditor.dirty) {
         setCollectionSwitchPending(normalized)
-        setCollectionSwitchSelection(0)
         return
       }
       setCollectionSwitchPending(null)
-      setCollectionSwitchSelection(0)
       onCollectionChange(normalized)
     },
     [draft.isDirty, folderDraft.isDirty, envEditor.dirty, onCollectionChange],
@@ -677,7 +670,6 @@ export function AppInner({
   const confirmCollectionSwitch = useCallback(
     (nextDir: string) => {
       setCollectionSwitchPending(null)
-      setCollectionSwitchSelection(0)
       setCollectionSwitcherVisible(false)
       onCollectionChange(nextDir)
     },
@@ -724,7 +716,6 @@ export function AppInner({
       setCollectionReloadToken,
       setPreviewIndex: setPreviewIndexProp,
       setEnvDeletePending,
-      setDeleteConfirmSelection,
       setNewRequestVisible,
       setEditRequestVisible,
       setCloneRequestVisible,
@@ -747,15 +738,11 @@ export function AppInner({
     activeOverlay,
     cancelSendRef,
     saveState,
-    confirmSelection,
-    setConfirmSelection,
     setSaveState,
     doSave,
     envDeletePending,
     envDeletePendingRef,
     setEnvDeletePending,
-    deleteConfirmSelection,
-    setDeleteConfirmSelection,
     envEditorRef,
     clearSaveTimer,
     saveTimerRef,
@@ -806,15 +793,11 @@ export function AppInner({
     setFolderDeletePending,
     onFolderDeleteConfirm: handleFolderDeleteConfirm,
     collectionSwitchPending,
-    collectionSwitchSelection,
-    setCollectionSwitchSelection,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm: confirmCollectionSwitch,
     undoAllPending,
     setUndoAllPending,
     initPending,
-    initConfirmSelection,
-    setInitConfirmSelection,
     setInitPending,
     onInitConfirm: () => executeInitPending(),
     draftRef,
@@ -915,7 +898,6 @@ export function AppInner({
         setExpanded,
         setPreviewIndexProp,
         setEnvDeletePending,
-        setDeleteConfirmSelection,
         onReloadCollection,
       }),
     [
@@ -995,7 +977,6 @@ export function AppInner({
             envHeaderRef={envHeaderRef}
             setFocus={setFocus}
             setEnvDeletePending={setEnvDeletePending}
-            setDeleteConfirmSelection={setDeleteConfirmSelection}
           />
         ) : null}
         <AppOverlays
@@ -1003,14 +984,10 @@ export function AppInner({
           helpVisible={helpVisible}
           aboutVisible={aboutVisible}
           saveState={saveState}
-          confirmSelection={confirmSelection}
           envDeletePending={envDeletePending}
-          deleteConfirmSelection={deleteConfirmSelection}
           undoAllPending={undoAllPending}
           initPending={initPending}
-          initConfirmSelection={initConfirmSelection}
           collectionSwitchPending={collectionSwitchPending}
-          collectionSwitchSelection={collectionSwitchSelection}
           commandPaletteVisible={commandPaletteVisible}
           commandPaletteCommands={commandPaletteCommands}
           setCommandPaletteVisible={setCommandPaletteVisible}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -59,14 +59,10 @@ interface AppOverlaysProps {
   helpVisible: boolean
   aboutVisible: boolean
   saveState: SaveState
-  confirmSelection: number
   envDeletePending: string | null
-  deleteConfirmSelection: number
   undoAllPending: boolean
   initPending: boolean
-  initConfirmSelection: number
   collectionSwitchPending: string | null
-  collectionSwitchSelection: number
   commandPaletteVisible: boolean
   commandPaletteCommands: CommandItem[]
   setCommandPaletteVisible: (visible: boolean) => void
@@ -135,14 +131,10 @@ export function AppOverlays({
   helpVisible,
   aboutVisible,
   saveState,
-  confirmSelection,
   envDeletePending,
-  deleteConfirmSelection,
   undoAllPending,
   initPending,
-  initConfirmSelection,
   collectionSwitchPending,
-  collectionSwitchSelection,
   commandPaletteVisible,
   commandPaletteCommands,
   setCommandPaletteVisible,
@@ -206,35 +198,27 @@ export function AppOverlays({
         <ConfirmOverlay
           visible
           message={`Save changes to ${saveState.requestId}?`}
-          selectedIndex={confirmSelection}
         />
       )}
       {envDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete environment "${envDeletePending}"?`}
-          selectedIndex={deleteConfirmSelection}
         />
       )}
       {undoAllPending && (
-        <ConfirmOverlay
-          visible
-          message="Discard all unsaved changes? (y/n)"
-          selectedIndex={confirmSelection}
-        />
+        <ConfirmOverlay visible message="Discard all unsaved changes? (y/n)" />
       )}
       {initPending && (
         <ConfirmOverlay
           visible
           message={`Initialize collection in ${collectionDir}? (y/n)`}
-          selectedIndex={initConfirmSelection}
         />
       )}
       {collectionSwitchPending !== null && (
         <ConfirmOverlay
           visible
           message={`Switch to "${collectionSwitchPending}" and discard unsaved changes?`}
-          selectedIndex={collectionSwitchSelection}
         />
       )}
       {commandPaletteVisible && (
@@ -364,15 +348,10 @@ export function AppOverlays({
         <ConfirmOverlay
           visible
           message={`Delete folder "${folderDeletePending}" and all requests inside?`}
-          selectedIndex={deleteConfirmSelection}
         />
       )}
       {requestDeletePending !== null && (
-        <ConfirmOverlay
-          visible
-          message={`Delete "${requestDeletePending}"?`}
-          selectedIndex={deleteConfirmSelection}
-        />
+        <ConfirmOverlay visible message={`Delete "${requestDeletePending}"?`} />
       )}
       {timelineDetailEntry !== null && (
         <TimelineDetailOverlay

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -151,9 +151,6 @@ export function AuthEditor({
         id={`${idPrefix}-field`}
         style={{
           zIndex: typeSelectOpen ? 1 : undefined,
-          backgroundColor: isTypeSelectorActive
-            ? theme.backgroundElement
-            : undefined,
         }}
       >
         <Select

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -198,7 +198,6 @@ export function RequestPane({
                   request={request}
                   editState={editState}
                   browseActive={browseActive}
-                  theme={theme}
                   onBodyTypeChange={onBodyTypeChange ?? (() => {})}
                   onSelectOpenChange={onSelectOpenChange}
                 />
@@ -326,14 +325,12 @@ function BodyTypeSelector({
   request,
   editState,
   browseActive,
-  theme,
   onBodyTypeChange,
   onSelectOpenChange,
 }: {
   request: Request
   editState: EditState
   browseActive: boolean
-  theme: Theme
   onBodyTypeChange: (t: BodyType) => void
   onSelectOpenChange?: (open: boolean) => void
 }) {
@@ -362,12 +359,6 @@ function BodyTypeSelector({
       id="body-type"
       style={{
         zIndex: typeSelectOpen ? 1 : undefined,
-        backgroundColor:
-          browseActive &&
-          editState.cursor.field === "body" &&
-          editState.cursor.row === 0
-            ? theme.backgroundElement
-            : undefined,
       }}
     >
       <Select

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -200,7 +200,9 @@ export function Select({
       if (item.description)
         maxLabel = Math.max(maxLabel, item.description.length)
     }
-    return width !== undefined ? Math.max(width, maxLabel + 6) : maxLabel + 6
+    return typeof width === "number"
+      ? Math.max(width, maxLabel + 6)
+      : maxLabel + 6
   }, [items, width])
 
   const dropdownMaxHeight = useMemo(
@@ -220,7 +222,8 @@ export function Select({
         : extractText(selectedItem.label)
     : placeholder
 
-  const triggerWidth = width !== undefined ? width : selectedText.length + 4
+  const triggerWidth =
+    width !== undefined ? width : badge ? selectedText.length + 4 : "100%"
 
   return (
     <box

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -200,9 +200,7 @@ export function Select({
       if (item.description)
         maxLabel = Math.max(maxLabel, item.description.length)
     }
-    return typeof width === "number"
-      ? Math.max(width, maxLabel + 6)
-      : maxLabel + 6
+    return width !== undefined ? Math.max(width, maxLabel + 6) : maxLabel + 6
   }, [items, width])
 
   const dropdownMaxHeight = useMemo(

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -140,7 +140,6 @@ export interface CommandBuilderContext {
   setEnvDeletePending: (
     s: string | null | ((prev: string | null) => string | null),
   ) => void
-  setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
   onReloadCollection: () => void
 }
 
@@ -199,7 +198,6 @@ export function buildCommandPaletteCommands(
     setRequestFinderVisible,
     setCodeGeneratorVisible,
     setEnvDeletePending,
-    setDeleteConfirmSelection,
     getCollectionMode,
   } = ctx
 
@@ -390,7 +388,6 @@ export function buildCommandPaletteCommands(
         const result = deleteEnvironment(c)
         if (!result) return false
         setEnvDeletePending(result.envName)
-        setDeleteConfirmSelection(0)
         return true
       },
     },

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -14,7 +14,6 @@ interface EnvironmentEditorViewProps {
   envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
   setFocus: (focus: Focus) => void
   setEnvDeletePending: (name: string | null) => void
-  setDeleteConfirmSelection: (selection: number) => void
 }
 
 export function EnvironmentEditorView({
@@ -25,7 +24,6 @@ export function EnvironmentEditorView({
   envHeaderRef,
   setFocus,
   setEnvDeletePending,
-  setDeleteConfirmSelection,
 }: EnvironmentEditorViewProps) {
   return (
     <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
@@ -49,7 +47,6 @@ export function EnvironmentEditorView({
         onDelete={() => {
           if (envEditor.selectedEnvName) {
             setEnvDeletePending(envEditor.selectedEnvName)
-            setDeleteConfirmSelection(0)
           }
         }}
         focused={focus === "env-sidebar"}

--- a/src/ui/overlays/ConfirmOverlay.tsx
+++ b/src/ui/overlays/ConfirmOverlay.tsx
@@ -10,7 +10,7 @@ export interface ConfirmOverlayProps {
 export function ConfirmOverlay({
   visible,
   message,
-  selectedIndex,
+  selectedIndex: _selectedIndex,
 }: ConfirmOverlayProps) {
   const theme = useTheme()
 
@@ -38,10 +38,10 @@ export function ConfirmOverlay({
           paddingX: 2,
         }}
       >
-        <text fg={selectedIndex === 0 ? theme.primary : theme.text}>y</text>
+        <text fg={theme.text}>y</text>
         <text fg={theme.textMuted}>confirm</text>
         <text fg={theme.textMuted}> · </text>
-        <text fg={selectedIndex === 1 ? theme.primary : theme.text}>n</text>
+        <text fg={theme.text}>n</text>
         <text fg={theme.textMuted}>cancel</text>
       </box>
     </Overlay>

--- a/src/ui/overlays/ConfirmOverlay.tsx
+++ b/src/ui/overlays/ConfirmOverlay.tsx
@@ -4,14 +4,9 @@ import { Overlay } from "./Overlay"
 export interface ConfirmOverlayProps {
   visible: boolean
   message: string
-  selectedIndex: number
 }
 
-export function ConfirmOverlay({
-  visible,
-  message,
-  selectedIndex: _selectedIndex,
-}: ConfirmOverlayProps) {
+export function ConfirmOverlay({ visible, message }: ConfirmOverlayProps) {
   const theme = useTheme()
 
   return (

--- a/src/ui/overlays/HelpOverlay.tsx
+++ b/src/ui/overlays/HelpOverlay.tsx
@@ -30,19 +30,19 @@ export function HelpOverlay({
         if (key.name === "up" || (key.name === "k" && !key.ctrl)) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          scrollRef.current?.scrollBy(-1)
+          scrollRef.current?.scrollBy(-1 / 5, "viewport")
         } else if (key.name === "down" || (key.name === "j" && !key.ctrl)) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          scrollRef.current?.scrollBy(1)
+          scrollRef.current?.scrollBy(1 / 5, "viewport")
         } else if (key.name === "pageup") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          scrollRef.current?.scrollBy(-1, "viewport")
+          scrollRef.current?.scrollBy(-1 / 2, "viewport")
         } else if (key.name === "pagedown") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          scrollRef.current?.scrollBy(1, "viewport")
+          scrollRef.current?.scrollBy(1 / 2, "viewport")
         } else if (key.name === "home") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()

--- a/src/ui/overlays/HelpOverlay.tsx
+++ b/src/ui/overlays/HelpOverlay.tsx
@@ -4,7 +4,8 @@ import { Overlay } from "./Overlay"
 import type { Keybinds } from "../keybind"
 import { TextAttributes } from "@opentui/core"
 import type { ScrollBoxRenderable } from "@opentui/core"
-import { useRef } from "react"
+import { useEffect, useRef } from "react"
+import { useKeymap } from "@opentui/keymap/react"
 
 const keyColumnWidth = 16
 
@@ -16,8 +17,51 @@ export function HelpOverlay({
   keybinds: Keybinds
 }) {
   const theme = useTheme()
+  const keymap = useKeymap()
   const sections = getHelpSections(keybinds)
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+
+  useEffect(() => {
+    if (!visible) return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        const key = ctx.event
+        if (key.name === "up" || (key.name === "k" && !key.ctrl)) {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          scrollRef.current?.scrollBy(-1)
+        } else if (key.name === "down" || (key.name === "j" && !key.ctrl)) {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          scrollRef.current?.scrollBy(1)
+        } else if (key.name === "pageup") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          scrollRef.current?.scrollBy(-1, "viewport")
+        } else if (key.name === "pagedown") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          scrollRef.current?.scrollBy(1, "viewport")
+        } else if (key.name === "home") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          scrollRef.current?.scrollTo(0)
+        } else if (key.name === "end") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          const maxScroll = Math.max(
+            0,
+            (scrollRef.current?.scrollHeight ?? 0) -
+              (scrollRef.current?.height ?? 0),
+          )
+          scrollRef.current?.scrollTo(maxScroll)
+        }
+      },
+      { priority: 100 },
+    )
+    return dispose
+  }, [visible, keymap])
 
   return (
     <Overlay visible={visible} width={60} gap={1} padding={1}>

--- a/src/ui/overlays/NewFolderOverlay.tsx
+++ b/src/ui/overlays/NewFolderOverlay.tsx
@@ -89,10 +89,10 @@ export const NewFolderOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.primary}>^S</text>
+        <text fg={theme.text}>^S</text>
         <text fg={theme.textMuted}>save</text>
         <text fg={theme.textMuted}> · </text>
-        <text fg={theme.primary}>esc</text>
+        <text fg={theme.text}>esc</text>
         <text fg={theme.textMuted}>close</text>
       </box>
     </Overlay>

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -15,6 +15,7 @@ import {
   entryMethod,
   entryStatus,
   entryTiming,
+  formatRequestDisplayName,
   formatRequestUrl,
   buildDetailRequestHeaders,
   shortMethod,
@@ -261,16 +262,16 @@ export function TimelineDetailOverlay({
             }}
           >
             {activeTab === "request" ? (
-              <box style={{ flexDirection: "column", marginBottom: 2 }}>
+              <box style={{ flexDirection: "column", marginBottom: 1 }}>
                 <box style={{ flexDirection: "row", flexShrink: 0 }}>
                   <text
-                    wrapMode="none"
+                    wrapMode="word"
                     content={t`${fg(methodColor(method, theme))(shortMethod(method) + " ")}${fg(theme.primary)(formatRequestUrl(entry))}`}
                   />
                 </box>
                 <box style={{ flexDirection: "row", flexShrink: 0 }}>
                   <text fg={theme.textMuted} wrapMode="none">
-                    {truncateUrl(entry.request.id, 60)}
+                    {truncateUrl(formatRequestDisplayName(entry), 60)}
                   </text>
                 </box>
               </box>

--- a/src/ui/theme-data.ts
+++ b/src/ui/theme-data.ts
@@ -355,7 +355,7 @@ export const synthwave84Theme: Theme = {
   backgroundElement: "#2a2139",
   border: "#495495",
   borderActive: "#36f9f6",
-  borderSubtle: "#241b2f",
+  borderSubtle: "#495495",
 }
 
 export const catppuccinFrappeTheme: Theme = {

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -100,6 +100,16 @@ export function shortMethod(m: string): string {
   return m === "DELETE" ? "DEL" : m
 }
 
+export function formatRequestDisplayName(entry: TimelineEntry): string {
+  const { id, name } = entry.request
+  const slashIdx = id.lastIndexOf("/")
+  if (slashIdx !== -1) {
+    const folder = id.slice(0, slashIdx)
+    return `${folder}/${name || id.slice(slashIdx + 1)}`
+  }
+  return name || id
+}
+
 export function formatRequestUrl(entry: TimelineEntry): string {
   const u = entry.request.url
   const params = entry.request.params

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -113,7 +113,6 @@ export interface UseAppKeymapSetters {
   setEnvDeletePending: (
     s: string | null | ((prev: string | null) => string | null),
   ) => void
-  setDeleteConfirmSelection: (n: number | ((prev: number) => number)) => void
   setNewRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setEditRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setCloneRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
@@ -884,7 +883,6 @@ export function useAppKeymap(
           const result = deleteEnvironment(actionsConfig)
           if (!result) return
           setters.setEnvDeletePending(result.envName)
-          setters.setDeleteConfirmSelection(0)
         },
       },
     ],

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -27,15 +27,11 @@ export function useOverlayIntercepts(opts: {
   activeOverlay: string
   cancelSendRef: RefObject<() => void>
   saveState: SaveState
-  confirmSelection: number
-  setConfirmSelection: (n: number) => void
   setSaveState: (s: SaveState) => void
   doSave: () => void
   envDeletePending: string | null
   envDeletePendingRef: RefObject<string | null>
   setEnvDeletePending: (s: string | null) => void
-  deleteConfirmSelection: number
-  setDeleteConfirmSelection: (n: number) => void
   envEditorRef: RefObject<UseEnvironmentEditorResult>
   clearSaveTimer: () => void
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
@@ -89,15 +85,11 @@ export function useOverlayIntercepts(opts: {
   setFolderDeletePending: (s: string | null) => void
   onFolderDeleteConfirm: () => void
   collectionSwitchPending: string | null
-  collectionSwitchSelection: number
-  setCollectionSwitchSelection: (n: number) => void
   setCollectionSwitchPending: (s: string | null) => void
   onCollectionSwitchConfirm: (collectionDir: string) => void
   undoAllPending: boolean
   setUndoAllPending: (v: boolean) => void
   initPending: boolean
-  initConfirmSelection: number
-  setInitConfirmSelection: (n: number) => void
   setInitPending: (v: boolean) => void
   onInitConfirm: () => void
   draftRef: RefObject<UseRequestDraftResult>
@@ -108,15 +100,11 @@ export function useOverlayIntercepts(opts: {
     activeOverlay,
     cancelSendRef,
     saveState,
-    confirmSelection,
-    setConfirmSelection,
     setSaveState,
     doSave,
     envDeletePending,
     envDeletePendingRef,
     setEnvDeletePending,
-    deleteConfirmSelection,
-    setDeleteConfirmSelection,
     envEditorRef,
     clearSaveTimer,
     saveTimerRef,
@@ -157,15 +145,11 @@ export function useOverlayIntercepts(opts: {
     setFolderDeletePending,
     onFolderDeleteConfirm,
     collectionSwitchPending,
-    collectionSwitchSelection,
-    setCollectionSwitchSelection,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm,
     undoAllPending,
     setUndoAllPending,
     initPending,
-    initConfirmSelection,
-    setInitConfirmSelection,
     setInitPending,
     onInitConfirm,
     draftRef,
@@ -193,39 +177,20 @@ export function useOverlayIntercepts(opts: {
       "key",
       (ctx) => {
         const name = ctx.event.name
-        if (name === "y" || (name === "return" && confirmSelection === 0)) {
+        if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           doSave()
-        } else if (
-          name === "n" ||
-          name === "escape" ||
-          (name === "return" && confirmSelection === 1)
-        ) {
+        } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           setSaveState({ kind: "idle" })
-        } else if (name === "left" || name === "up") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setConfirmSelection(0)
-        } else if (name === "right" || name === "down") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setConfirmSelection(1)
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    saveState.kind,
-    confirmSelection,
-    doSave,
-    keymap,
-    setConfirmSelection,
-    setSaveState,
-  ])
+  }, [saveState.kind, doSave, keymap, setSaveState])
 
   // ── Overlay: Delete env confirmation ──────────────────────────────
   useEffect(() => {
@@ -235,10 +200,7 @@ export function useOverlayIntercepts(opts: {
       "key",
       (ctx) => {
         const name = ctx.event.name
-        if (
-          name === "y" ||
-          (name === "return" && deleteConfirmSelection === 0)
-        ) {
+        if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           const envName = envDeletePending
@@ -262,22 +224,10 @@ export function useOverlayIntercepts(opts: {
                 2000,
               )
             })
-        } else if (
-          name === "n" ||
-          name === "escape" ||
-          (name === "return" && deleteConfirmSelection === 1)
-        ) {
+        } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           setEnvDeletePending(null)
-        } else if (name === "left" || name === "up") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setDeleteConfirmSelection(0)
-        } else if (name === "right" || name === "down") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setDeleteConfirmSelection(1)
         }
       },
       { priority: 100 },
@@ -285,10 +235,8 @@ export function useOverlayIntercepts(opts: {
     return dispose
   }, [
     envDeletePending,
-    deleteConfirmSelection,
     keymap,
     setEnvDeletePending,
-    setDeleteConfirmSelection,
     setSaveState,
     clearSaveTimer,
     saveTimerRef,
@@ -302,33 +250,16 @@ export function useOverlayIntercepts(opts: {
       "key",
       (ctx) => {
         const name = ctx.event.name
-        if (
-          name === "y" ||
-          (name === "return" && collectionSwitchSelection === 0)
-        ) {
+        if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           const nextDir = collectionSwitchPending
           setCollectionSwitchPending(null)
-          setCollectionSwitchSelection(0)
           onCollectionSwitchConfirm(nextDir)
-        } else if (
-          name === "n" ||
-          name === "escape" ||
-          (name === "return" && collectionSwitchSelection === 1)
-        ) {
+        } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           setCollectionSwitchPending(null)
-          setCollectionSwitchSelection(0)
-        } else if (name === "left" || name === "up") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setCollectionSwitchSelection(0)
-        } else if (name === "right" || name === "down") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setCollectionSwitchSelection(1)
         }
       },
       { priority: 100 },
@@ -336,11 +267,9 @@ export function useOverlayIntercepts(opts: {
     return dispose
   }, [
     collectionSwitchPending,
-    collectionSwitchSelection,
     keymap,
     onCollectionSwitchConfirm,
     setCollectionSwitchPending,
-    setCollectionSwitchSelection,
   ])
 
   // ── Overlay: Help ──────────────────────────────────────────────────
@@ -677,42 +606,21 @@ export function useOverlayIntercepts(opts: {
       "key",
       (ctx) => {
         const name = ctx.event.name
-        if (name === "y" || (name === "return" && initConfirmSelection === 0)) {
+        if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setInitConfirmSelection(0)
           onInitConfirm()
           setInitPending(false)
-        } else if (
-          name === "n" ||
-          name === "escape" ||
-          (name === "return" && initConfirmSelection === 1)
-        ) {
+        } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setInitConfirmSelection(0)
           setInitPending(false)
-        } else if (name === "left" || name === "up") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setInitConfirmSelection(0)
-        } else if (name === "right" || name === "down") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          setInitConfirmSelection(1)
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    initPending,
-    initConfirmSelection,
-    keymap,
-    onInitConfirm,
-    setInitConfirmSelection,
-    setInitPending,
-  ])
+  }, [initPending, keymap, onInitConfirm, setInitPending])
 
   // ── Overlay: New Folder ───────────────────────────────────────────
   useEffect(() => {

--- a/tests/JsonBodyViewer.test.tsx
+++ b/tests/JsonBodyViewer.test.tsx
@@ -191,9 +191,13 @@ describe("JsonBodyViewer", () => {
     await act(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ;(globalThis as any).__flip()
-      await new Promise((resolve) => setTimeout(resolve, 50))
       await renderOnce()
     })
+
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await renderOnce()
+    }
 
     const tailNumbers = captureSpans()
       .lines.flatMap((line) => line.spans)

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -10,6 +10,7 @@ import {
   buildTimelineEntry,
   shortMethod,
   formatRequestUrl,
+  formatRequestDisplayName,
   maskedAuthHeader,
   buildDetailRequestHeaders,
 } from "../src/ui/timeline/formatTimeline"
@@ -287,6 +288,76 @@ describe("formatRequestUrl", () => {
         },
       }),
     ).toBe("https://example.com?existing=1&next=2")
+  })
+})
+
+describe("formatRequestDisplayName", () => {
+  it("combines folder path from id with request name when present", () => {
+    expect(
+      formatRequestDisplayName(
+        makeEntry({
+          request: {
+            id: "leads/get-leads",
+            name: "Get Leads",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+          },
+        }),
+      ),
+    ).toBe("leads/Get Leads")
+  })
+
+  it("handles multi-level folder path", () => {
+    expect(
+      formatRequestDisplayName(
+        makeEntry({
+          request: {
+            id: "api/v1/leads/get-leads",
+            name: "Get Leads",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+          },
+        }),
+      ),
+    ).toBe("api/v1/leads/Get Leads")
+  })
+
+  it("returns request name alone when no folder in id", () => {
+    expect(
+      formatRequestDisplayName(
+        makeEntry({
+          request: {
+            id: "get-leads",
+            name: "Get Leads",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+          },
+        }),
+      ),
+    ).toBe("Get Leads")
+  })
+
+  it("falls back to file slug if request name is empty", () => {
+    expect(
+      formatRequestDisplayName(
+        makeEntry({
+          request: {
+            id: "leads/get-leads",
+            name: "",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+          },
+        }),
+      ),
+    ).toBe("leads/get-leads")
   })
 })
 

--- a/tests/unit/DeleteConfirmation.test.tsx
+++ b/tests/unit/DeleteConfirmation.test.tsx
@@ -33,11 +33,7 @@ describe("Delete confirmation", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay
-            visible
-            message='Delete environment "staging"?'
-            selectedIndex={0}
-          />
+          <ConfirmOverlay visible message='Delete environment "staging"?' />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 10 },
@@ -60,7 +56,6 @@ describe("Delete confirmation", () => {
           <ConfirmOverlay
             visible={false}
             message='Delete environment "staging"?'
-            selectedIndex={0}
           />
         </ThemeProvider>
       </KeymapProvider>,
@@ -77,7 +72,7 @@ describe("Delete confirmation", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay visible message="Delete?" selectedIndex={0} />
+          <ConfirmOverlay visible message="Delete?" />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 10 },
@@ -94,7 +89,7 @@ describe("Delete confirmation", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay visible message="Delete?" selectedIndex={0} />
+          <ConfirmOverlay visible message="Delete?" />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 10 },

--- a/tests/unit/HelpOverlay.test.tsx
+++ b/tests/unit/HelpOverlay.test.tsx
@@ -26,7 +26,7 @@ describe("HelpOverlay", () => {
     cleanup()
   })
 
-  it("handles arrow key scrolling without errors", async () => {
+  it("scrolls to bottom with end and back to top with home", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
@@ -38,27 +38,43 @@ describe("HelpOverlay", () => {
     )
 
     await renderOnce()
-    expect(captureCharFrame()).toContain("Request Editing")
+    let frame = captureCharFrame()
+    expect(frame).toContain("Request Editing")
+
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        host.press("down")
+      })
+      await renderOnce()
+    }
+    frame = captureCharFrame()
+    expect(frame).toContain("Code Editor")
 
     act(() => {
-      host.press("down")
+      host.press("end")
     })
     await renderOnce()
+    frame = captureCharFrame()
+    expect(frame).toContain("Env Editor")
 
     act(() => {
-      host.press("up")
+      host.press("home")
     })
     await renderOnce()
+    frame = captureCharFrame()
+    expect(frame).toContain("Request Editing")
 
     act(() => {
-      host.press("j")
+      host.press("pagedown")
     })
     await renderOnce()
-
+    frame = captureCharFrame()
+    const pagedownFrame = frame
     act(() => {
-      host.press("k")
+      host.press("pageup")
     })
     await renderOnce()
+    expect(captureCharFrame()).not.toBe(pagedownFrame)
 
     cleanup()
   })

--- a/tests/unit/HelpOverlay.test.tsx
+++ b/tests/unit/HelpOverlay.test.tsx
@@ -1,15 +1,21 @@
 import { describe, it, expect } from "bun:test"
+import { act } from "react"
 import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { HelpOverlay } from "../../src/ui/overlays/HelpOverlay"
 import { bindingDefaults } from "../../src/ui/keybind"
+import { setupKeymap } from "./_helpers"
 
 describe("HelpOverlay", () => {
   it("keeps spacing between long key hints and descriptions", async () => {
+    const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(
-      <ThemeProvider activeIndex={0} previewIndex={null}>
-        <HelpOverlay visible keybinds={bindingDefaults()} />
-      </ThemeProvider>,
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <HelpOverlay visible keybinds={bindingDefaults()} />
+        </ThemeProvider>
+      </KeymapProvider>,
       { width: 80, height: 30 },
     )
 
@@ -17,5 +23,43 @@ describe("HelpOverlay", () => {
     const frame = captureCharFrame()
 
     expect(frame).toContain("^alt+e          Edit YAML")
+    cleanup()
+  })
+
+  it("handles arrow key scrolling without errors", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <HelpOverlay visible keybinds={bindingDefaults()} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 15 },
+    )
+
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Request Editing")
+
+    act(() => {
+      host.press("down")
+    })
+    await renderOnce()
+
+    act(() => {
+      host.press("up")
+    })
+    await renderOnce()
+
+    act(() => {
+      host.press("j")
+    })
+    await renderOnce()
+
+    act(() => {
+      host.press("k")
+    })
+    await renderOnce()
+
+    cleanup()
   })
 })

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -210,14 +210,46 @@ describe("TimelineDetailOverlay", () => {
       (line) => line.includes("GET") && line.includes("https://example.com"),
     )
     const requestNameLine = lines.findIndex((line) =>
-      line.includes("request-1"),
+      line.includes("Test request"),
     )
     const headersTitleLine = lines.findIndex(
       (line) => line.trim() === "Headers",
     )
     expect(methodUrlLine).toBeGreaterThanOrEqual(0)
     expect(requestNameLine).toBe(methodUrlLine + 1)
-    expect(headersTitleLine - requestNameLine).toBeGreaterThanOrEqual(2)
+    expect(headersTitleLine - requestNameLine).toBe(2)
+    cleanup()
+  })
+
+  it("wraps long request URL onto lines below method", async () => {
+    const longUrl =
+      "https://gci-leadhub.planok.dev/api/v1/leads/?status=incomplete&page=1&limit=50"
+    const { renderOnce, captureCharFrame, host, cleanup } = await renderOverlay(
+      makeEntry({
+        request: {
+          id: "leads/get-leads",
+          name: "Get Leads",
+          method: "GET",
+          url: longUrl,
+          headers: {},
+          params: [],
+        },
+      }),
+      () => {},
+    )
+    await renderOnce()
+    await act(async () => host.press("left"))
+    await renderOnce()
+    const frame = captureCharFrame()
+    const lines = frame.split("\n")
+    const methodLineIndex = lines.findIndex((l) =>
+      l.includes("GET https://gci-leadhub.planok.dev"),
+    )
+    const headersLineIndex = lines.findIndex((l) => l.trim() === "Headers")
+    expect(methodLineIndex).toBeGreaterThanOrEqual(0)
+    expect(lines[methodLineIndex + 1]).toContain("status=incomplete")
+    expect(lines[methodLineIndex + 2]).toContain("leads/Get Leads")
+    expect(headersLineIndex - (methodLineIndex + 2)).toBe(2)
     cleanup()
   })
 
@@ -306,7 +338,7 @@ describe("TimelineDetailOverlay", () => {
     await renderOnce()
     await act(async () => host.press("left"))
     await renderOnce()
-    expect(captureCharFrame()).toContain("request-1")
+    expect(captureCharFrame()).toContain("Test request")
 
     await act(async () => setVisible?.(false))
     await renderOnce()

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -211,11 +211,7 @@ describe("ConfirmOverlay", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay
-            visible
-            message="Save changes to test?"
-            selectedIndex={0}
-          />
+          <ConfirmOverlay visible message="Save changes to test?" />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 20 },
@@ -238,11 +234,7 @@ describe("ConfirmOverlay", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ConfirmOverlay
-            visible
-            message="Save changes to test?"
-            selectedIndex={0}
-          />
+          <ConfirmOverlay visible message="Save changes to test?" />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 20 },

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -55,7 +55,6 @@ function minimalContext(): CommandBuilderContext {
     setExpanded: () => {},
     setPreviewIndexProp: () => {},
     setEnvDeletePending: () => {},
-    setDeleteConfirmSelection: () => {},
     onReloadCollection: () => {},
   }
 }


### PR DESCRIPTION
Closes # (none)

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Remove dead selection state from confirm overlays:** The four confirm dialogs (save, delete env, collection switch, init) tracked `confirmSelection` state for invisible arrow-key navigation and Return-conditional logic. The ConfirmOverlay component also stopped rendering the selection highlight (both y/n in `theme.text`). This removes all selection state, setters, and arrow-key intercepts. `Return` now always confirms, `y`/`n`/`escape` unchanged.

**Fix HelpOverlay scroll:** Arrow keys used `scrollBy(-1)` (1 pixel, imperceptible). Switched to `scrollBy(±1/5, "viewport")` matching native ScrollBox behavior. `pageup`/`pagedown` use `±1/2` viewport.

**Robust scroll tests:** Replaced "no errors" test with assertions validating end/home/page jjumpand frame changes.

**Style consistency:** Unified `typeof width === "number"` to `width !== undefined` in Select component.

### How did you verify your code works?

- `bun test` — 1677 pass, 0 fail
- `bun run lint` — clean
- `bun run typecheck` — clean

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR