### PR TITLE
fix(draft): enable two-way binding for URL query parameters

### DIFF
--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -324,9 +324,12 @@ export function applyDraft(
     case "setMethod":
       draft.method = op.method
       break
-    case "setUrl":
-      draft.url = op.url
+    case "setUrl": {
+      const parsed = parseUrlAndParams(op.url)
+      draft.url = parsed.baseUrl
+      draft.params = parsed.params
       break
+    }
     case "syncUrlParams": {
       const parsed = parseUrlAndParams(op.rawUrl)
       draft.url = parsed.baseUrl

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -9,7 +9,7 @@ import type {
   ParamEntry,
 } from "../schema"
 import type { FieldKind } from "../ui/editMode"
-import { parseUrlAndParams } from "../ui/urlParams"
+import { syncParamsWithUrl } from "../ui/urlParams"
 
 export type DraftOp =
   | { kind: "setMethod"; method: Method }
@@ -325,15 +325,15 @@ export function applyDraft(
       draft.method = op.method
       break
     case "setUrl": {
-      const parsed = parseUrlAndParams(op.url)
-      draft.url = parsed.baseUrl
-      draft.params = parsed.params
+      const synced = syncParamsWithUrl(current.params, op.url)
+      draft.url = synced.baseUrl
+      draft.params = synced.params
       break
     }
     case "syncUrlParams": {
-      const parsed = parseUrlAndParams(op.rawUrl)
-      draft.url = parsed.baseUrl
-      draft.params = parsed.params
+      const synced = syncParamsWithUrl(current.params, op.rawUrl)
+      draft.url = synced.baseUrl
+      draft.params = synced.params
       break
     }
     case "setBody":

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -48,20 +48,17 @@ export function UrlBar({
       initDisplayRef.current = displayUrl
     }
     if (!focused && prevFocused.current) {
-      const displayUrl = buildDisplayUrl(url, params)
-      if (inputValueRef.current !== displayUrl) {
-        onDefocus(inputValueRef.current)
-      }
+      onDefocus(inputValueRef.current)
     }
     prevFocused.current = focused
   }, [focused, onDefocus, params, url])
 
   useEffect(() => {
+    const displayUrl = buildDisplayUrl(url, params)
     if (!focused) {
-      setInputValue(url)
-      inputValueRef.current = url
+      setInputValue(displayUrl)
+      inputValueRef.current = displayUrl
     } else if (inputValueRef.current === initDisplayRef.current) {
-      const displayUrl = buildDisplayUrl(url, params)
       setInputValue(displayUrl)
       inputValueRef.current = displayUrl
       initDisplayRef.current = displayUrl

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -48,7 +48,9 @@ export function UrlBar({
       initDisplayRef.current = displayUrl
     }
     if (!focused && prevFocused.current) {
-      onDefocus(inputValueRef.current)
+      if (inputValueRef.current !== initDisplayRef.current) {
+        onDefocus(inputValueRef.current)
+      }
     }
     prevFocused.current = focused
   }, [focused, onDefocus, params, url])

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -101,11 +101,34 @@ export function syncParamsWithUrl(
 } {
   const parsed = parseUrlAndParams(rawUrl)
   const newParams: ParamEntry[] = [...parsed.params]
-  const parsedKeys = new Set(newParams.map((p) => p.name))
+
+  const enabledCounts = new Map<string, number>()
+  for (const p of currentParams) {
+    if (p.enabled) {
+      enabledCounts.set(p.name, (enabledCounts.get(p.name) ?? 0) + 1)
+    }
+  }
+
+  const parsedCounts = new Map<string, number>()
+  for (const p of parsed.params) {
+    parsedCounts.set(p.name, (parsedCounts.get(p.name) ?? 0) + 1)
+  }
+
+  const disabledConsumed = new Map<string, number>()
 
   for (const entry of currentParams) {
-    if (!entry.enabled && !parsedKeys.has(entry.name)) {
-      newParams.push({ ...entry })
+    if (!entry.enabled) {
+      const name = entry.name
+      const parsedCount = parsedCounts.get(name) ?? 0
+      const enabledCount = enabledCounts.get(name) ?? 0
+      const extraParsed = Math.max(0, parsedCount - enabledCount)
+      const consumed = disabledConsumed.get(name) ?? 0
+
+      if (consumed < extraParsed) {
+        disabledConsumed.set(name, consumed + 1)
+      } else {
+        newParams.push({ ...entry })
+      }
     }
   }
 

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -92,6 +92,26 @@ export function parseUrlAndParams(raw: string): {
   }
 }
 
+export function syncParamsWithUrl(
+  currentParams: ParamEntry[],
+  rawUrl: string,
+): {
+  baseUrl: string
+  params: ParamEntry[]
+} {
+  const parsed = parseUrlAndParams(rawUrl)
+  const newParams: ParamEntry[] = [...parsed.params]
+  const parsedKeys = new Set(newParams.map((p) => p.name))
+
+  for (const entry of currentParams) {
+    if (!entry.enabled && !parsedKeys.has(entry.name)) {
+      newParams.push({ ...entry })
+    }
+  }
+
+  return { baseUrl: parsed.baseUrl, params: newParams }
+}
+
 function normBaseUrl(origin: string, pathname: string): string {
   if (pathname === "/") return origin
   return origin + pathname

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -12,11 +12,13 @@ function UrlBarHarness({
   focused = true,
   initialMethod = "GET",
   onMethodChange,
+  onDefocus,
 }: {
   subFocus?: "select" | "text"
   focused?: boolean
   initialMethod?: Method
   onMethodChange?: (method: string) => void
+  onDefocus?: (rawUrl: string) => void
 }) {
   const [url, setUrl] = useState("https://example.com")
   const [method, setMethod] = useState<Method>(initialMethod)
@@ -30,7 +32,7 @@ function UrlBarHarness({
         setMethod(next)
         onMethodChange?.(next)
       }}
-      onDefocus={() => {}}
+      onDefocus={onDefocus ?? (() => {})}
       focused={focused}
       subFocus={subFocus}
       activeEnv={{
@@ -186,6 +188,43 @@ describe("UrlBar", () => {
     await renderOnce()
 
     expect(selectedMethod).toBe("")
+    cleanup()
+  })
+
+  it("triggers onDefocus callback when focus leaves UrlBar", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let defocusedUrl = ""
+    let toggleFocus: () => void = () => {}
+
+    function TestContainer() {
+      const [focused, setFocused] = useState(true)
+      toggleFocus = () => setFocused(false)
+      return (
+        <UrlBarHarness
+          focused={focused}
+          onDefocus={(rawUrl) => {
+            defocusedUrl = rawUrl
+          }}
+        />
+      )
+    }
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <TestContainer />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+
+    await renderOnce()
+    act(() => {
+      toggleFocus()
+    })
+    await renderOnce()
+
+    expect(defocusedUrl).toBe("https://example.com")
     cleanup()
   })
 })

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "bun:test"
-import { buildDisplayUrl, parseUrlAndParams } from "../../src/ui/urlParams"
+import {
+  buildDisplayUrl,
+  parseUrlAndParams,
+  syncParamsWithUrl,
+} from "../../src/ui/urlParams"
 import type { ParamEntry } from "../../src/schema"
 
 describe("buildDisplayUrl", () => {
@@ -202,5 +206,35 @@ describe("parseUrlAndParams", () => {
     expect(params).toEqual([
       { name: "token", value: "$API_KEY", enabled: true },
     ])
+  })
+})
+
+describe("syncParamsWithUrl", () => {
+  it("preserves disabled parameters when URL is synced", () => {
+    const current: ParamEntry[] = [
+      { name: "active", value: "1", enabled: true },
+      { name: "debug", value: "off", enabled: false },
+    ]
+    const { baseUrl, params } = syncParamsWithUrl(
+      current,
+      "https://example.com?active=1",
+    )
+    expect(baseUrl).toBe("https://example.com")
+    expect(params).toEqual([
+      { name: "active", value: "1", enabled: true },
+      { name: "debug", value: "off", enabled: false },
+    ])
+  })
+
+  it("overrides disabled parameter if explicitly enabled in URL", () => {
+    const current: ParamEntry[] = [
+      { name: "debug", value: "off", enabled: false },
+    ]
+    const { baseUrl, params } = syncParamsWithUrl(
+      current,
+      "https://example.com?debug=on",
+    )
+    expect(baseUrl).toBe("https://example.com")
+    expect(params).toEqual([{ name: "debug", value: "on", enabled: true }])
   })
 })

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -237,4 +237,20 @@ describe("syncParamsWithUrl", () => {
     expect(baseUrl).toBe("https://example.com")
     expect(params).toEqual([{ name: "debug", value: "on", enabled: true }])
   })
+
+  it("preserves disabled parameter when an enabled parameter with the same name exists", () => {
+    const current: ParamEntry[] = [
+      { name: "filter", value: "active", enabled: true },
+      { name: "filter", value: "pending", enabled: false },
+    ]
+    const { baseUrl, params } = syncParamsWithUrl(
+      current,
+      "https://example.com?filter=active",
+    )
+    expect(baseUrl).toBe("https://example.com")
+    expect(params).toEqual([
+      { name: "filter", value: "active", enabled: true },
+      { name: "filter", value: "pending", enabled: false },
+    ])
+  })
 })

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -189,6 +189,21 @@ describe("applyDraft", () => {
     expect(draft.method).toBe(original.method)
     expect(draft.headers).toEqual(original.headers)
   })
+
+  it("setUrl parses query parameters into draft.params (two-way binding)", () => {
+    const original = makeReq({ url: "https://a.com", params: [] })
+    const map = new Map<string, Request>()
+    const next = applyDraft(map, "r1", original, {
+      kind: "setUrl",
+      url: "https://a.com/search?q=noodle&page=1",
+    })
+    const draft = next.get("r1")!
+    expect(draft.url).toBe("https://a.com/search")
+    expect(draft.params).toEqual([
+      { name: "q", value: "noodle", enabled: true },
+      { name: "page", value: "1", enabled: true },
+    ])
+  })
   it("setBody updates body", () => {
     const original = makeReq({ body: "x" })
     const map = new Map<string, Request>()


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Typing query parameters into the URL bar now parses them into the params table (`setUrl` split into base URL + params). On defocus, the full display URL (base + enabled params) is shown instead of the raw base URL.

### How did you verify your code works?

Added tests for `setUrl` parsing query params into `draft.params` and a new UrlBar test for `onDefocus` callback. Existing tests pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR