### PR TITLE
fix(ui): gate variable completion popup on input focus

### DIFF
--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -85,11 +85,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       return Object.keys(env?.vars ?? {})
     }, [variableNames, env?.vars])
 
+    const inputFocused = isFocused ?? true
+
     const { completion, makeHandleKey } = useVariableCompletion({
       getEditor: getEditable,
       variableNames: suggestionNames,
       value,
-      isEditing,
+      isEditing: isEditing && inputFocused,
     })
 
     const applyHighlights = useCallback(() => {
@@ -159,6 +161,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       const editable = getEditable()
       if (
         !isEditing ||
+        !inputFocused ||
         !editable?.focused ||
         completionDismissed ||
         !token ||
@@ -172,6 +175,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       completionDismissed,
       getEditable,
       handleCompletionKey,
+      inputFocused,
       isComplete,
       isEditing,
       suggestions.length,
@@ -188,6 +192,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
     const showCompletion =
       isEditing &&
+      inputFocused &&
       !completionDismissed &&
       token &&
       suggestions.length > 0 &&
@@ -213,13 +218,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
               textColor={defaultColor}
               cursorColor={theme.primary}
               paddingX={paddingX}
-              focused
+              focused={inputFocused}
             />
             {showCompletion && (
               <CompletionPopup
                 suggestions={suggestions}
                 completionIndex={completionIndex}
-                isEditing={isEditing}
+                isEditing={isEditing && inputFocused}
                 getEditable={getEditable}
                 value={value}
               />
@@ -241,7 +246,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             value={value}
             placeholder={placeholder}
             onInput={handleInput}
-            focused={isFocused ?? false}
+            focused={inputFocused}
             backgroundColor={backgroundColor}
             focusedBackgroundColor={
               focusedBackgroundColor ?? theme.borderSubtle
@@ -254,7 +259,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             <CompletionPopup
               suggestions={suggestions}
               completionIndex={completionIndex}
-              isEditing={isEditing}
+              isEditing={isEditing && inputFocused}
               getEditable={getEditable}
               value={value}
             />

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -422,6 +422,24 @@ describe("VarInput — edit mode (isEditing=true)", () => {
     expect(frame).not.toContain("┌")
   })
 
+  it("does not show completion menu when isFocused is false", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$host"
+          env={env({ host: "localhost", host_alt: "127.0.0.1" })}
+          isEditing
+          isFocused={false}
+          onChange={() => {}}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).not.toContain("┌")
+  })
+
   it("does not crash with many suggestions navigating within visible range", async () => {
     const manyVars: Record<string, string> = {}
     for (let i = 0; i < 12; i++) manyVars[`a${i}`] = String(i)


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix

### What does this PR do?

Gates the variable completion popup on the  prop so it doesn't appear when  is used in non-focused contexts like KeyValueSection toggle fields.

### How did you verify your code works?

Added a test asserting no completion popup when `isFocused={false}`. `bun test`, `bun run lint`, `bun run typecheck` all pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR