### PR TITLE
feat(finder): extend request finder (Ctrl+F) to include folders

### DIFF
--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import type { CollectionItem, Request } from "../schema"
 import {
+  findFolderByPath,
   findRequestById,
   flattenRequests,
   visibleNodes,
@@ -18,6 +19,7 @@ export interface UseTreeNavigationResult {
   cursorIndex: number
   setSelectedId: (id: string) => void
   revealRequest: (id: string) => void
+  revealFolder: (path: string) => void
   toggleFolder: (path: string) => void
   expandFolder: (path: string) => void
   collapseFolder: (path: string) => void
@@ -83,6 +85,24 @@ export function useTreeNavigation(
 
     setExpanded(nextExpanded)
     setSelectedIdState(id)
+    if (nextCursor >= 0) setCursorIndex(nextCursor)
+  }, [])
+
+  const revealFolder = useCallback((path: string) => {
+    const folder = findFolderByPath(itemsRef.current, path)
+    if (!folder) return
+
+    const nextExpanded = new Set(expandedRef.current)
+    const parts = path.split("/")
+    for (let i = 1; i < parts.length; i++) {
+      nextExpanded.add(parts.slice(0, i).join("/"))
+    }
+    const nextVisible = visibleNodes(itemsRef.current, nextExpanded)
+    const nextCursor = nextVisible.findIndex(
+      (node) => node.type === "folder" && node.id === path,
+    )
+
+    setExpanded(nextExpanded)
     if (nextCursor >= 0) setCursorIndex(nextCursor)
   }, [])
 
@@ -280,6 +300,7 @@ export function useTreeNavigation(
     cursorIndex: clampedCursor,
     setSelectedId,
     revealRequest,
+    revealFolder,
     toggleFolder,
     expandFolder,
     collapseFolder,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -30,6 +30,7 @@ import { StatusBar } from "./StatusBar"
 import { showToast } from "./Toast"
 import { type EnvHeaderPaneHandle } from "./env-editor/EnvHeaderPane"
 
+import type { FinderItem } from "./requestFinder"
 import { type Keybinds, displayKey } from "./keybind"
 import { useSaveFile } from "./useSaveFile"
 import { useAppKeymap } from "./useAppKeymap"
@@ -222,6 +223,7 @@ export function AppInner({
     focusedFolderName,
     setSelectedId,
     revealRequest,
+    revealFolder,
     expandFolder,
   } = useTreeNavigation(
     items,
@@ -232,12 +234,16 @@ export function AppInner({
 
   const requests = useMemo(() => flattenRequests(items), [items])
   const findRequest = useCallback(
-    (requestId: string) => {
-      revealRequest(requestId)
+    (item: FinderItem) => {
+      if (item.type === "request") {
+        revealRequest(item.id)
+      } else {
+        revealFolder(item.id)
+      }
       setFocus("sidebar")
       setRequestFinderVisible(false)
     },
-    [revealRequest],
+    [revealRequest, revealFolder],
   )
 
   const focusedFolder = useMemo(

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -33,6 +33,7 @@ import type {
   TimelineEntry,
   TimelineBodyRef,
 } from "../schema"
+import type { FinderItem } from "./requestFinder"
 import { TimelineDetailOverlay } from "./overlays/TimelineDetailOverlay"
 import { CodeGeneratorOverlay } from "./overlays/CodeGeneratorOverlay"
 import type { Keybinds } from "./keybind"
@@ -74,7 +75,7 @@ interface AppOverlaysProps {
   collection: Collection | null
   requestFinderVisible: boolean
   requests: NoodleRequest[]
-  onFindRequest: (requestId: string) => void
+  onFindRequest: (item: FinderItem) => void
   setRequestFinderVisible: (visible: boolean) => void
   collectionSwitcherVisible: boolean
   collectionPaths: string[]
@@ -241,6 +242,7 @@ export function AppOverlays({
       {requestFinderVisible && (
         <RequestFinderOverlay
           visible
+          collectionItems={collection?.items}
           requests={requests}
           activeEnv={activeEnv}
           onSelect={onFindRequest}

--- a/src/ui/overlays/RequestFinderOverlay.tsx
+++ b/src/ui/overlays/RequestFinderOverlay.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { TextAttributes } from "@opentui/core"
-import type { Environment, Request } from "../../schema"
+import type { CollectionItem, Environment, Request } from "../../schema"
 import { methodColor } from "../formatRequest"
 import {
   requestFinderItems,
   searchRequests,
-  type RequestFinderItem,
+  type FinderItem,
 } from "../requestFinder"
 import { useTheme } from "../theme"
 import { PickerOverlay } from "./PickerOverlay"
@@ -16,75 +16,101 @@ function truncate(value: string, maxLength: number): string {
 
 export function RequestFinderOverlay({
   visible,
+  collectionItems,
   requests,
   activeEnv,
   onSelect,
   onClose,
 }: {
   visible: boolean
-  requests: Request[]
+  collectionItems?: CollectionItem[]
+  requests?: Request[]
   activeEnv: Environment | null
-  onSelect: (requestId: string) => void
+  onSelect: (item: FinderItem) => void
   onClose: () => void
 }) {
   const theme = useTheme()
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
   const items = useMemo(
-    () => requestFinderItems(requests, activeEnv),
-    [requests, activeEnv],
+    () => requestFinderItems(collectionItems ?? requests ?? [], activeEnv),
+    [collectionItems, requests, activeEnv],
   )
 
   useEffect(() => {
-    if (visible) setHighlightedId(items[0]?.request.id ?? null)
+    if (visible) {
+      const first = items[0]
+      setHighlightedId(first ? `${first.type}:${first.id}` : null)
+    }
   }, [visible, items])
 
   const keyExtractor = useCallback(
-    (item: RequestFinderItem) => item.request.id,
+    (item: FinderItem) => `${item.type}:${item.id}`,
     [],
   )
-  const filter = useCallback(
-    (_item: RequestFinderItem, _query: string) => true,
-    [],
-  )
+  const filter = useCallback((_item: FinderItem, _query: string) => true, [])
   const sortItems = useCallback(
-    (matches: RequestFinderItem[], query: string) =>
-      searchRequests(matches, query),
+    (matches: FinderItem[], query: string) => searchRequests(matches, query),
     [],
   )
   const highlightedItem = useMemo(
     () =>
-      items.find((item) => item.request.id === highlightedId) ??
+      items.find((item) => `${item.type}:${item.id}` === highlightedId) ??
       items[0] ??
       null,
     [items, highlightedId],
   )
   const handleHighlightChange = useCallback(
-    (item: RequestFinderItem | null) =>
-      setHighlightedId(item?.request.id ?? null),
+    (item: FinderItem | null) =>
+      setHighlightedId(item ? `${item.type}:${item.id}` : null),
     [],
   )
   const renderItem = useCallback(
     (
-      item: RequestFinderItem,
+      item: FinderItem,
       { highlighted }: { highlighted: boolean; active: boolean },
     ) => {
       const fg = highlighted ? "#1a1a1a" : theme.text
       const mutedFg = highlighted ? "#333333" : theme.textMuted
+
+      if (item.type === "request") {
+        return (
+          <box flexDirection="row" flexGrow={1}>
+            <text
+              fg={
+                highlighted
+                  ? "#333333"
+                  : methodColor(item.request.method, theme)
+              }
+            >
+              {item.request.method.padEnd(8)}
+            </text>
+            <text fg={fg} attributes={TextAttributes.BOLD} wrapMode="none">
+              {truncate(item.name, 28)}
+            </text>
+            <box flexGrow={1} />
+            <text fg={mutedFg} wrapMode="none">
+              {truncate(item.folderPath, 20)}
+            </text>
+          </box>
+        )
+      }
+
+      const countSuffix = `(${item.requestCount} req${item.requestCount === 1 ? "" : "s"})`
+      const displayPath =
+        item.folderPath === "(root)" ? "" : `${truncate(item.folderPath, 14)} `
+      const rightText = `${displayPath}${countSuffix}`
+
       return (
         <box flexDirection="row" flexGrow={1}>
-          <text
-            fg={
-              highlighted ? "#333333" : methodColor(item.request.method, theme)
-            }
-          >
-            {item.request.method.padEnd(8)}
+          <text fg={highlighted ? "#333333" : theme.info}>
+            {"FOLDER".padEnd(8)}
           </text>
           <text fg={fg} attributes={TextAttributes.BOLD} wrapMode="none">
-            {truncate(item.request.name, 30)}
+            {truncate(item.name, 28)}
           </text>
           <box flexGrow={1} />
           <text fg={mutedFg} wrapMode="none">
-            {item.folderPath}
+            {truncate(rightText, 22)}
           </text>
         </box>
       )
@@ -105,7 +131,7 @@ export function RequestFinderOverlay({
       renderItem={renderItem}
       highlightedItem={highlightedItem}
       onHighlightChange={handleHighlightChange}
-      onSelect={(item) => onSelect(item.request.id)}
+      onSelect={onSelect}
       onClose={onClose}
     />
   )

--- a/src/ui/requestFinder.ts
+++ b/src/ui/requestFinder.ts
@@ -1,12 +1,27 @@
-import type { Environment, Request } from "../schema"
+import type { CollectionItem, Environment, Folder, Request } from "../schema"
+import { flattenRequests } from "./tree"
 
 const VAR_RE = /\$(\w+)/g
 
-export interface RequestFinderItem {
-  request: Request
-  folderPath: string
-  resolvedUrl: string
-}
+export type FinderItem =
+  | {
+      type: "request"
+      id: string
+      name: string
+      folderPath: string
+      request: Request
+      resolvedUrl: string
+    }
+  | {
+      type: "folder"
+      id: string
+      name: string
+      folderPath: string
+      folder: Folder
+      requestCount: number
+    }
+
+export type RequestFinderItem = FinderItem
 
 export function resolveFinderUrl(
   url: string,
@@ -31,18 +46,24 @@ function fieldRank(value: string, token: string, weight: number): number {
   return weight + value.indexOf(token)
 }
 
-function scoreRequest(
-  item: RequestFinderItem,
-  tokens: string[],
-): number | null {
-  const { request } = item
-  const fields: { value: string; weight: number; fuzzy?: boolean }[] = [
-    { value: request.name.toLowerCase(), weight: 0, fuzzy: true },
-    { value: request.id.toLowerCase(), weight: 100, fuzzy: true },
-    { value: request.method.toLowerCase(), weight: 200 },
-    { value: request.url.toLowerCase(), weight: 300 },
-    { value: item.resolvedUrl.toLowerCase(), weight: 300 },
-  ]
+function scoreItem(item: FinderItem, tokens: string[]): number | null {
+  const fields: { value: string; weight: number; fuzzy?: boolean }[] =
+    item.type === "request"
+      ? [
+          { value: item.request.name.toLowerCase(), weight: 0, fuzzy: true },
+          { value: item.request.id.toLowerCase(), weight: 100, fuzzy: true },
+          { value: item.request.method.toLowerCase(), weight: 200 },
+          { value: item.request.url.toLowerCase(), weight: 300 },
+          { value: item.resolvedUrl.toLowerCase(), weight: 300 },
+        ]
+      : [
+          { value: item.folder.name.toLowerCase(), weight: 0, fuzzy: true },
+          { value: item.folder.path.toLowerCase(), weight: 100, fuzzy: true },
+          { value: "folder", weight: 200 },
+          { value: "dir", weight: 200 },
+          { value: item.folderPath.toLowerCase(), weight: 300 },
+        ]
+
   let score = 0
 
   for (const token of tokens) {
@@ -60,37 +81,89 @@ function scoreRequest(
   return score
 }
 
+function collectFolderFinderItems(
+  items: CollectionItem[],
+  out: FinderItem[] = [],
+): FinderItem[] {
+  for (const item of items) {
+    if (item.type === "folder") {
+      const f = item.data
+      const parentPath = f.path.includes("/")
+        ? f.path.slice(0, f.path.lastIndexOf("/"))
+        : "(root)"
+      const reqs = flattenRequests(f.children)
+      out.push({
+        type: "folder",
+        id: f.path,
+        name: f.name,
+        folderPath: parentPath,
+        folder: f,
+        requestCount: reqs.length,
+      })
+      collectFolderFinderItems(f.children, out)
+    }
+  }
+  return out
+}
+
 export function requestFinderItems(
-  requests: Request[],
+  input: CollectionItem[] | Request[],
   activeEnv: Environment | null = null,
-): RequestFinderItem[] {
-  return requests.map((request) => ({
-    request,
+): FinderItem[] {
+  if (input.length === 0) return []
+
+  const first = input[0]!
+  if (
+    "type" in first &&
+    (first.type === "request" || first.type === "folder")
+  ) {
+    const items = input as CollectionItem[]
+    const reqs = flattenRequests(items)
+    const reqItems: FinderItem[] = reqs.map((request) => ({
+      type: "request",
+      id: request.id,
+      name: request.name,
+      folderPath: request.id.includes("/")
+        ? request.id.slice(0, request.id.lastIndexOf("/"))
+        : "(root)",
+      request,
+      resolvedUrl: resolveFinderUrl(request.url, activeEnv),
+    }))
+    const folderItems = collectFolderFinderItems(items)
+    return [...reqItems, ...folderItems]
+  }
+
+  const reqs = input as Request[]
+  return reqs.map((request) => ({
+    type: "request",
+    id: request.id,
+    name: request.name,
     folderPath: request.id.includes("/")
       ? request.id.slice(0, request.id.lastIndexOf("/"))
       : "(root)",
+    request,
     resolvedUrl: resolveFinderUrl(request.url, activeEnv),
   }))
 }
 
 export function searchRequests(
-  items: RequestFinderItem[],
+  items: FinderItem[],
   query: string,
-): RequestFinderItem[] {
+): FinderItem[] {
   const tokens = query.toLowerCase().trim().split(/\s+/).filter(Boolean)
   if (tokens.length === 0) return items
 
   return items
-    .map((item) => ({ item, score: scoreRequest(item, tokens) }))
+    .map((item) => ({ item, score: scoreItem(item, tokens) }))
     .filter(
-      (result): result is { item: RequestFinderItem; score: number } =>
+      (result): result is { item: FinderItem; score: number } =>
         result.score !== null,
     )
     .sort(
       (a, b) =>
         a.score - b.score ||
-        a.item.request.name.localeCompare(b.item.request.name) ||
-        a.item.request.id.localeCompare(b.item.request.id),
+        a.item.name.localeCompare(b.item.name) ||
+        a.item.id.localeCompare(b.item.id),
     )
     .map((result) => result.item)
 }

--- a/tests/unit/RequestFinderOverlay.test.tsx
+++ b/tests/unit/RequestFinderOverlay.test.tsx
@@ -52,8 +52,8 @@ describe("RequestFinderOverlay", () => {
               name: "dev",
               vars: { API_HOST: "dev.api.example.com" },
             }}
-            onSelect={(id) => {
-              selected = id
+            onSelect={(item) => {
+              selected = typeof item === "string" ? item : item.id
             }}
             onClose={() => {}}
           />
@@ -71,6 +71,45 @@ describe("RequestFinderOverlay", () => {
     expect(frame).not.toContain("dev.api.example.com")
     host.press("return")
     expect(selected).toBe("users/get")
+    cleanup()
+  })
+
+  it("renders folder items with FOLDER badge and request count", async () => {
+    const { keymap, cleanup } = setup()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <RequestFinderOverlay
+            visible
+            collectionItems={[
+              {
+                type: "folder",
+                data: {
+                  id: "auth-id",
+                  name: "Auth API",
+                  path: "auth",
+                  children: [
+                    {
+                      type: "request",
+                      data: requests[0]!,
+                    },
+                  ],
+                },
+              },
+            ]}
+            activeEnv={null}
+            onSelect={() => {}}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 24 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("FOLDER")
+    expect(frame).toContain("Auth API")
+    expect(frame).toContain("(1 req)")
     cleanup()
   })
 
@@ -149,9 +188,38 @@ describe("RequestFinderOverlay", () => {
     )
     await renderOnce()
     const frame = captureCharFrame()
-    expect(frame).toContain("This is a request with a very…")
+    expect(frame).toContain("This is a request with a ve…")
     expect(frame).not.toContain("This is a request with a very very long name")
     expect(frame).toContain("users")
+    cleanup()
+  })
+
+  it("truncates a long folder path to prevent UI collision", async () => {
+    const { keymap, cleanup } = setup()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <RequestFinderOverlay
+            visible
+            requests={[
+              {
+                ...requests[0],
+                id: "versionaliasesforbundlecomponent/get",
+                name: "Get Alias",
+              },
+            ]}
+            activeEnv={null}
+            onSelect={() => {}}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("versionaliasesforbu…")
+    expect(frame).not.toContain("versionaliasesforbundlecomponent")
     cleanup()
   })
 })

--- a/tests/unit/requestFinder.test.ts
+++ b/tests/unit/requestFinder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import type { Environment, Request } from "../../src/schema"
+import type { CollectionItem, Environment, Request } from "../../src/schema"
 import {
   requestFinderItems,
   resolveFinderUrl,
@@ -56,21 +56,15 @@ describe("requestFinder", () => {
 
   it("matches name, path, method, and URL case-insensitively", () => {
     const items = requestFinderItems(requests)
-    expect(searchRequests(items, "get user")[0]?.request.id).toBe(
-      "users/get-user",
-    )
-    expect(searchRequests(items, "ADMIN")[0]?.request.id).toBe(
-      "admin/create-user",
-    )
-    expect(searchRequests(items, "post")[0]?.request.id).toBe(
-      "admin/create-user",
-    )
-    expect(searchRequests(items, "healthz")[0]?.request.id).toBe("health")
+    expect(searchRequests(items, "get user")[0]?.id).toBe("users/get-user")
+    expect(searchRequests(items, "ADMIN")[0]?.id).toBe("admin/create-user")
+    expect(searchRequests(items, "post")[0]?.id).toBe("admin/create-user")
+    expect(searchRequests(items, "healthz")[0]?.id).toBe("health")
   })
 
   it("requires every whitespace-separated token and supports fuzzy matching", () => {
     const items = requestFinderItems(requests)
-    expect(searchRequests(items, "g usr")[0]?.request.id).toBe("users/get-user")
+    expect(searchRequests(items, "g usr")[0]?.id).toBe("users/get-user")
     expect(searchRequests(items, "get missing")).toEqual([])
   })
 
@@ -83,7 +77,7 @@ describe("requestFinder", () => {
         url: "https://example.com/other",
       },
     ])
-    expect(searchRequests(items, "users")[0]?.request.name).toBe("Users status")
+    expect(searchRequests(items, "users")[0]?.name).toBe("Users status")
   })
 
   it("matches a URL resolved with the active environment", () => {
@@ -91,10 +85,10 @@ describe("requestFinder", () => {
       [{ ...requests[0]!, url: "https://$API_HOST/users/$USER_ID" }],
       devEnv,
     )
-    expect(items[0]?.resolvedUrl).toBe("https://dev.api.example.com/users/42")
-    expect(searchRequests(items, "dev.api")[0]?.request.id).toBe(
-      "users/get-user",
+    expect(items[0]?.type === "request" && items[0].resolvedUrl).toBe(
+      "https://dev.api.example.com/users/42",
     )
+    expect(searchRequests(items, "dev.api")[0]?.id).toBe("users/get-user")
   })
 
   it("keeps missing variables searchable and does not require an environment", () => {
@@ -105,9 +99,7 @@ describe("requestFinder", () => {
     expect(resolveFinderUrl(url, null)).toBe(url)
 
     const items = requestFinderItems([{ ...requests[0]!, url }], devEnv)
-    expect(searchRequests(items, "missing")[0]?.request.id).toBe(
-      "users/get-user",
-    )
+    expect(searchRequests(items, "missing")[0]?.id).toBe("users/get-user")
   })
 
   it("fuzzy-matches tokens spread across name", () => {
@@ -131,7 +123,7 @@ describe("requestFinder", () => {
         timeout: 0,
       },
     ])
-    expect(searchRequests(items, "crt")[0]?.request.id).toBe("a")
+    expect(searchRequests(items, "crt")[0]?.id).toBe("a")
   })
 
   it("fuzzy-matches tokens spread across id", () => {
@@ -155,7 +147,7 @@ describe("requestFinder", () => {
         timeout: 0,
       },
     ])
-    expect(searchRequests(items, "crt")[0]?.request.id).toBe("users/create")
+    expect(searchRequests(items, "crt")[0]?.id).toBe("users/create")
   })
 
   it("does NOT fuzzy-match on URL or resolvedUrl", () => {
@@ -173,7 +165,7 @@ describe("requestFinder", () => {
       ],
       jsonPlaceholderEnv,
     )
-    expect(searchRequests(items, "todo")[0]?.request.id).toBe("test")
+    expect(searchRequests(items, "todo")[0]?.id).toBe("test")
     expect(searchRequests(items, "photo")).toEqual([])
   })
 
@@ -192,6 +184,59 @@ describe("requestFinder", () => {
       ],
       jsonPlaceholderEnv,
     )
-    expect(searchRequests(items, "photo")[0]?.request.id).toBe("test")
+    expect(searchRequests(items, "photo")[0]?.id).toBe("test")
+  })
+
+  it("indexes and matches folder items alongside request items", () => {
+    const collectionItems: CollectionItem[] = [
+      {
+        type: "folder",
+        data: {
+          id: "auth-id",
+          name: "Auth",
+          path: "auth",
+          children: [
+            {
+              type: "folder",
+              data: {
+                id: "v1-id",
+                name: "v1 API",
+                path: "auth/v1",
+                children: [
+                  {
+                    type: "request",
+                    data: requests[0]!,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: "request",
+        data: requests[2]!,
+      },
+    ]
+
+    const items = requestFinderItems(collectionItems)
+    expect(items).toHaveLength(4) // 2 requests + 2 folders
+
+    const folderItem = items.find(
+      (i) => i.type === "folder" && i.id === "auth/v1",
+    )
+    expect(folderItem).toBeDefined()
+    if (folderItem && folderItem.type === "folder") {
+      expect(folderItem.name).toBe("v1 API")
+      expect(folderItem.folderPath).toBe("auth")
+      expect(folderItem.requestCount).toBe(1)
+    }
+
+    const matchedFolder = searchRequests(items, "v1 api")
+    expect(matchedFolder[0]?.id).toBe("auth/v1")
+
+    const folderTokenMatches = searchRequests(items, "folder")
+    expect(folderTokenMatches.every((i) => i.type === "folder")).toBe(true)
+    expect(folderTokenMatches).toHaveLength(2)
   })
 })

--- a/tests/unit/useTreeNavigation.test.tsx
+++ b/tests/unit/useTreeNavigation.test.tsx
@@ -40,6 +40,7 @@ interface Props {
     setItems: (items: CollectionItem[]) => void,
     expandFolder: (path: string) => void,
     revealRequest: (id: string) => void,
+    revealFolder: (path: string) => void,
   ) => void
 }
 
@@ -54,11 +55,18 @@ function Harness({
     setSelectedId,
     expandFolder,
     revealRequest,
+    revealFolder,
     cursorIndex,
   } = useTreeNavigation(items, () => true, initialSelectedId)
 
   useEffect(() => {
-    afterMount?.(setSelectedId, setItems, expandFolder, revealRequest)
+    afterMount?.(
+      setSelectedId,
+      setItems,
+      expandFolder,
+      revealRequest,
+      revealFolder,
+    )
   }, [])
 
   return <text>{`s:${selectedId ?? ""}|c:${cursorIndex}`}</text>
@@ -175,5 +183,34 @@ describe("useTreeNavigation", () => {
     // Finder selection must reveal both collapsed ancestors and move the
     // sidebar cursor to the selected request.
     expect(frame).toContain("c:3")
+  })
+
+  it("reveals a folder inside collapsed ancestor folders and positions cursor on folder node", async () => {
+    const items = [
+      req("root/list"),
+      fld("users", [fld("users/admin", [req("users/admin/list")])]),
+    ]
+    const { renderOnce, captureCharFrame } = await render(
+      <Harness
+        initialItems={items}
+        afterMount={(
+          _setSelectedId,
+          _setItems,
+          _expandFolder,
+          _revealRequest,
+          revealFolder,
+        ) => {
+          setTimeout(() => revealFolder("users/admin"), 5)
+        }}
+      />,
+    )
+
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await renderOnce()
+    const frame = captureCharFrame()
+
+    // Cursor position should land on users/admin folder (index 2: root/list=0, users=1, users/admin=2)
+    expect(frame).toContain("c:2")
   })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature

### What does this PR do?

Extends the Ctrl+F request finder to also search and highlight folders alongside requests. Folders display with a `FOLDER` badge and request count, are searchable by name/path/keyword, and selecting one reveals and focuses it in the sidebar.

### How did you verify your code works?

Added tests for folder rendering, folder indexing/matching via `searchRequests`, `revealFolder` cursor positioning, and truncation edge cases. `bun test`, `bun run lint`, `bun run typecheck` all pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR