### PR TITLE
style(ui): use primary color for key columns and refine row striping

### DIFF
--- a/src/ui/FormEditor.tsx
+++ b/src/ui/FormEditor.tsx
@@ -74,14 +74,17 @@ export function FormEditor({
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
-            style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+            paddingX={1}
+            style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
           />
           <VarInput
             value=""
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
-            style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+            backgroundColor={stripeBg}
+            paddingX={1}
+            style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
           />
         </box>
       ) : (
@@ -98,11 +101,7 @@ export function FormEditor({
             const displayKey =
               entry.type === "file" ? `[F] ${entry.name}` : entry.name
 
-            const keyBaseColor = dimmed
-              ? theme.textMuted
-              : entry.type === "file"
-                ? theme.primary
-                : theme.text
+            const keyBaseColor = dimmed ? theme.textMuted : theme.primary
 
             const valueBaseColor = dimmed
               ? theme.textMuted
@@ -120,9 +119,7 @@ export function FormEditor({
                   backgroundColor:
                     cursorOnThisRow || isEditingThisRow
                       ? theme.backgroundElement
-                      : i % 2 !== 0
-                        ? stripeBg
-                        : undefined,
+                      : undefined,
                 }}
               >
                 <Checkbox checked={entry.enabled} theme={theme} />
@@ -137,7 +134,8 @@ export function FormEditor({
                     isEditingThisRow ? theme.backgroundElement : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
-                  style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+                  paddingX={1}
+                  style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
                 />
                 <VarInput
                   value={isEditingThisRow ? editValue : entry.value}
@@ -147,10 +145,15 @@ export function FormEditor({
                   isFocused={editState.cursor.subfield === "value"}
                   baseColor={valueBaseColor}
                   backgroundColor={
-                    isEditingThisRow ? theme.backgroundElement : undefined
+                    isEditingThisRow || cursorOnThisRow
+                      ? theme.backgroundElement
+                      : i % 2 !== 0
+                        ? stripeBg
+                        : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
-                  style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+                  paddingX={1}
+                  style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
                 />
               </box>
             )
@@ -175,12 +178,17 @@ export function FormEditor({
               isFocused={editState.cursor.subfield === "key"}
               baseColor={
                 editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.text
+                  ? theme.primary
                   : theme.textMuted
               }
-              backgroundColor={editingAdd ? theme.backgroundElement : undefined}
+              backgroundColor={
+                editingAdd || (cursorHere && editState.cursor.addingRow)
+                  ? theme.backgroundElement
+                  : undefined
+              }
               focusedBackgroundColor={theme.borderSubtle}
-              style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+              paddingX={1}
+              style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
             />
             <VarInput
               value={editingAdd ? editValue : ""}
@@ -193,9 +201,16 @@ export function FormEditor({
                   ? theme.text
                   : theme.textMuted
               }
-              backgroundColor={editingAdd ? theme.backgroundElement : undefined}
+              backgroundColor={
+                editingAdd || (cursorHere && editState.cursor.addingRow)
+                  ? theme.backgroundElement
+                  : rows.length % 2 !== 0
+                    ? stripeBg
+                    : undefined
+              }
               focusedBackgroundColor={theme.borderSubtle}
-              style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+              paddingX={1}
+              style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
             />
           </box>
         </>

--- a/src/ui/FormEditor.tsx
+++ b/src/ui/FormEditor.tsx
@@ -71,6 +71,7 @@ export function FormEditor({
           <Checkbox checked={false} theme={theme} />
           <VarInput
             value=""
+            placeholder="Key..."
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
@@ -79,10 +80,10 @@ export function FormEditor({
           />
           <VarInput
             value=""
+            placeholder="Value..."
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
-            backgroundColor={stripeBg}
             paddingX={1}
             style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
           />
@@ -108,6 +109,12 @@ export function FormEditor({
               : cursorOnThisRow
                 ? theme.text
                 : theme.textMuted
+            const rowBg =
+              cursorOnThisRow || isEditingThisRow
+                ? theme.backgroundElement
+                : i % 2 !== 0
+                  ? stripeBg
+                  : undefined
 
             return (
               <box
@@ -116,15 +123,13 @@ export function FormEditor({
                 style={{
                   flexDirection: "row",
                   gap: 0,
-                  backgroundColor:
-                    cursorOnThisRow || isEditingThisRow
-                      ? theme.backgroundElement
-                      : undefined,
+                  backgroundColor: rowBg,
                 }}
               >
                 <Checkbox checked={entry.enabled} theme={theme} />
                 <VarInput
                   value={isEditingThisRow ? editKey : displayKey}
+                  placeholder="Key..."
                   env={activeEnv ?? null}
                   isEditing={isEditingThisRow}
                   onChange={setEditKey}
@@ -139,17 +144,14 @@ export function FormEditor({
                 />
                 <VarInput
                   value={isEditingThisRow ? editValue : entry.value}
+                  placeholder="Value..."
                   env={activeEnv ?? null}
                   isEditing={isEditingThisRow}
                   onChange={setEditValue}
                   isFocused={editState.cursor.subfield === "value"}
                   baseColor={valueBaseColor}
                   backgroundColor={
-                    isEditingThisRow || cursorOnThisRow
-                      ? theme.backgroundElement
-                      : i % 2 !== 0
-                        ? stripeBg
-                        : undefined
+                    isEditingThisRow ? theme.backgroundElement : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
                   paddingX={1}
@@ -158,61 +160,69 @@ export function FormEditor({
               </box>
             )
           })}
-          <box
-            id="body-add"
-            style={{
-              flexDirection: "row",
-              gap: 0,
-              backgroundColor:
-                cursorHere && editState.cursor.addingRow
-                  ? theme.backgroundElement
-                  : undefined,
-            }}
-          >
-            <Checkbox checked={false} theme={theme} />
-            <VarInput
-              value={editingAdd ? editKey : ""}
-              env={activeEnv ?? null}
-              isEditing={editingAdd}
-              onChange={setEditKey}
-              isFocused={editState.cursor.subfield === "key"}
-              baseColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.primary
-                  : theme.textMuted
-              }
-              backgroundColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.backgroundElement
+          {(() => {
+            const addRowBg =
+              cursorHere && editState.cursor.addingRow
+                ? theme.backgroundElement
+                : rows.length % 2 !== 0
+                  ? stripeBg
                   : undefined
-              }
-              focusedBackgroundColor={theme.borderSubtle}
-              paddingX={1}
-              style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-            />
-            <VarInput
-              value={editingAdd ? editValue : ""}
-              env={activeEnv ?? null}
-              isEditing={editingAdd}
-              onChange={setEditValue}
-              isFocused={editState.cursor.subfield === "value"}
-              baseColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.text
-                  : theme.textMuted
-              }
-              backgroundColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.backgroundElement
-                  : rows.length % 2 !== 0
-                    ? stripeBg
-                    : undefined
-              }
-              focusedBackgroundColor={theme.borderSubtle}
-              paddingX={1}
-              style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-            />
-          </box>
+
+            return (
+              <box
+                id="body-add"
+                style={{
+                  flexDirection: "row",
+                  gap: 0,
+                  backgroundColor: addRowBg,
+                }}
+              >
+                <Checkbox checked={false} theme={theme} />
+                <VarInput
+                  value={editingAdd ? editKey : ""}
+                  placeholder="Key..."
+                  env={activeEnv ?? null}
+                  isEditing={editingAdd}
+                  onChange={setEditKey}
+                  isFocused={editState.cursor.subfield === "key"}
+                  baseColor={
+                    editingAdd || (cursorHere && editState.cursor.addingRow)
+                      ? theme.primary
+                      : theme.textMuted
+                  }
+                  backgroundColor={
+                    editingAdd || (cursorHere && editState.cursor.addingRow)
+                      ? theme.backgroundElement
+                      : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
+                />
+                <VarInput
+                  value={editingAdd ? editValue : ""}
+                  placeholder="Value..."
+                  env={activeEnv ?? null}
+                  isEditing={editingAdd}
+                  onChange={setEditValue}
+                  isFocused={editState.cursor.subfield === "value"}
+                  baseColor={
+                    editingAdd || (cursorHere && editState.cursor.addingRow)
+                      ? theme.text
+                      : theme.textMuted
+                  }
+                  backgroundColor={
+                    editingAdd || (cursorHere && editState.cursor.addingRow)
+                      ? theme.backgroundElement
+                      : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
+                />
+              </box>
+            )
+          })()}
         </>
       )}
     </box>

--- a/src/ui/HeaderTable.tsx
+++ b/src/ui/HeaderTable.tsx
@@ -45,23 +45,29 @@ export function HeaderTable({
             gap: 0,
             paddingLeft: 1,
             paddingRight: 1,
-            backgroundColor: i % 2 !== 0 ? stripeBg : undefined,
           }}
         >
           <text
-            fg={theme.text}
+            fg={theme.primary}
             wrapMode="none"
             style={{ minWidth: keyWidth, flexShrink: 0 }}
           >
             {entry.key.padEnd(keyWidth)}
           </text>
-          <text
-            fg={theme.textMuted}
-            wrapMode="none"
-            style={{ flexGrow: 1, flexShrink: 1, minWidth: 5 }}
+          <box
+            style={{
+              flexGrow: 1,
+              flexShrink: 1,
+              minWidth: 5,
+              backgroundColor: i % 2 !== 0 ? stripeBg : undefined,
+              paddingLeft: 1,
+              paddingRight: 1,
+            }}
           >
-            {entry.value}
-          </text>
+            <text fg={theme.textMuted} wrapMode="none">
+              {entry.value}
+            </text>
+          </box>
         </box>
       ))}
     </box>

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -61,6 +61,7 @@ export function KeyValueSection({
           <Checkbox checked={false} theme={theme} />
           <VarInput
             value=""
+            placeholder="Key..."
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
@@ -69,10 +70,10 @@ export function KeyValueSection({
           />
           <VarInput
             value=""
+            placeholder="Value..."
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
-            backgroundColor={stripeBg}
             paddingX={1}
             style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
           />
@@ -91,6 +92,12 @@ export function KeyValueSection({
 
             const keyBaseColor = dimmed ? theme.textMuted : theme.primary
             const valueBaseColor = dimmed ? theme.textMuted : theme.text
+            const rowBg =
+              cursorOnThisRow || isEditingThisRow
+                ? theme.backgroundElement
+                : i % 2 !== 0
+                  ? stripeBg
+                  : undefined
 
             return (
               <box
@@ -99,15 +106,13 @@ export function KeyValueSection({
                 style={{
                   flexDirection: "row",
                   gap: 0,
-                  backgroundColor:
-                    cursorOnThisRow || isEditingThisRow
-                      ? theme.backgroundElement
-                      : undefined,
+                  backgroundColor: rowBg,
                 }}
               >
                 <Checkbox checked={kv.enabled} theme={theme} />
                 <VarInput
                   value={isEditingThisRow ? editKey : entry.key}
+                  placeholder="Key..."
                   env={activeEnv ?? null}
                   isEditing={isEditingThisRow}
                   onChange={setEditKey}
@@ -122,17 +127,14 @@ export function KeyValueSection({
                 />
                 <VarInput
                   value={isEditingThisRow ? editValue : kv.value}
+                  placeholder="Value..."
                   env={activeEnv ?? null}
                   isEditing={isEditingThisRow}
                   onChange={setEditValue}
                   isFocused={editState.cursor.subfield === "value"}
                   baseColor={valueBaseColor}
                   backgroundColor={
-                    isEditingThisRow || cursorOnThisRow
-                      ? theme.backgroundElement
-                      : i % 2 !== 0
-                        ? stripeBg
-                        : undefined
+                    isEditingThisRow ? theme.backgroundElement : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
                   paddingX={1}
@@ -141,61 +143,65 @@ export function KeyValueSection({
               </box>
             )
           })}
-          <box
-            id={`${kind === "headers" ? "hdr" : "prm"}-add`}
-            style={{
-              flexDirection: "row",
-              gap: 0,
-              backgroundColor:
-                cursorHere && editState.cursor.addingRow
-                  ? theme.backgroundElement
-                  : undefined,
-            }}
-          >
-            <Checkbox checked={false} theme={theme} />
-            <VarInput
-              value={editingAdd ? editKey : ""}
-              env={activeEnv ?? null}
-              isEditing={editingAdd}
-              onChange={setEditKey}
-              isFocused={editState.cursor.subfield === "key"}
-              baseColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.primary
-                  : theme.textMuted
-              }
-              backgroundColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.backgroundElement
+          {(() => {
+            const addRowBg =
+              cursorHere && editState.cursor.addingRow
+                ? theme.backgroundElement
+                : rows.length % 2 !== 0
+                  ? stripeBg
                   : undefined
-              }
-              focusedBackgroundColor={theme.borderSubtle}
-              paddingX={1}
-              style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-            />
-            <VarInput
-              value={editingAdd ? editValue : ""}
-              env={activeEnv ?? null}
-              isEditing={editingAdd}
-              onChange={setEditValue}
-              isFocused={editState.cursor.subfield === "value"}
-              baseColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.text
-                  : theme.textMuted
-              }
-              backgroundColor={
-                editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.backgroundElement
-                  : rows.length % 2 !== 0
-                    ? stripeBg
-                    : undefined
-              }
-              focusedBackgroundColor={theme.borderSubtle}
-              paddingX={1}
-              style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-            />
-          </box>
+
+            return (
+              <box
+                id={`${kind === "headers" ? "hdr" : "prm"}-add`}
+                style={{
+                  flexDirection: "row",
+                  gap: 0,
+                  backgroundColor: addRowBg,
+                }}
+              >
+                <Checkbox checked={false} theme={theme} />
+                <VarInput
+                  value={editingAdd ? editKey : ""}
+                  placeholder="Key..."
+                  env={activeEnv ?? null}
+                  isEditing={editingAdd}
+                  onChange={setEditKey}
+                  isFocused={editState.cursor.subfield === "key"}
+                  baseColor={
+                    editingAdd || (cursorHere && editState.cursor.addingRow)
+                      ? theme.primary
+                      : theme.textMuted
+                  }
+                  backgroundColor={
+                    editingAdd ? theme.backgroundElement : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
+                />
+                <VarInput
+                  value={editingAdd ? editValue : ""}
+                  placeholder="Value..."
+                  env={activeEnv ?? null}
+                  isEditing={editingAdd}
+                  onChange={setEditValue}
+                  isFocused={editState.cursor.subfield === "value"}
+                  baseColor={
+                    editingAdd || (cursorHere && editState.cursor.addingRow)
+                      ? theme.text
+                      : theme.textMuted
+                  }
+                  backgroundColor={
+                    editingAdd ? theme.backgroundElement : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
+                />
+              </box>
+            )
+          })()}
         </>
       )}
     </box>

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -64,14 +64,17 @@ export function KeyValueSection({
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
-            style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+            paddingX={1}
+            style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
           />
           <VarInput
             value=""
             env={activeEnv ?? null}
             isEditing={false}
             baseColor={theme.textMuted}
-            style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+            backgroundColor={stripeBg}
+            paddingX={1}
+            style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
           />
         </box>
       ) : (
@@ -86,7 +89,7 @@ export function KeyValueSection({
               editState.cursor.row === i
             const dimmed = (inEdit && !isEditingThisRow) || !kv.enabled
 
-            const keyBaseColor = dimmed ? theme.textMuted : theme.text
+            const keyBaseColor = dimmed ? theme.textMuted : theme.primary
             const valueBaseColor = dimmed ? theme.textMuted : theme.text
 
             return (
@@ -99,9 +102,7 @@ export function KeyValueSection({
                   backgroundColor:
                     cursorOnThisRow || isEditingThisRow
                       ? theme.backgroundElement
-                      : i % 2 !== 0
-                        ? stripeBg
-                        : undefined,
+                      : undefined,
                 }}
               >
                 <Checkbox checked={kv.enabled} theme={theme} />
@@ -116,7 +117,8 @@ export function KeyValueSection({
                     isEditingThisRow ? theme.backgroundElement : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
-                  style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+                  paddingX={1}
+                  style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
                 />
                 <VarInput
                   value={isEditingThisRow ? editValue : kv.value}
@@ -126,10 +128,15 @@ export function KeyValueSection({
                   isFocused={editState.cursor.subfield === "value"}
                   baseColor={valueBaseColor}
                   backgroundColor={
-                    isEditingThisRow ? theme.backgroundElement : undefined
+                    isEditingThisRow || cursorOnThisRow
+                      ? theme.backgroundElement
+                      : i % 2 !== 0
+                        ? stripeBg
+                        : undefined
                   }
                   focusedBackgroundColor={theme.borderSubtle}
-                  style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+                  paddingX={1}
+                  style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
                 />
               </box>
             )
@@ -154,12 +161,17 @@ export function KeyValueSection({
               isFocused={editState.cursor.subfield === "key"}
               baseColor={
                 editingAdd || (cursorHere && editState.cursor.addingRow)
-                  ? theme.text
+                  ? theme.primary
                   : theme.textMuted
               }
-              backgroundColor={editingAdd ? theme.backgroundElement : undefined}
+              backgroundColor={
+                editingAdd || (cursorHere && editState.cursor.addingRow)
+                  ? theme.backgroundElement
+                  : undefined
+              }
               focusedBackgroundColor={theme.borderSubtle}
-              style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+              paddingX={1}
+              style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
             />
             <VarInput
               value={editingAdd ? editValue : ""}
@@ -172,9 +184,16 @@ export function KeyValueSection({
                   ? theme.text
                   : theme.textMuted
               }
-              backgroundColor={editingAdd ? theme.backgroundElement : undefined}
+              backgroundColor={
+                editingAdd || (cursorHere && editState.cursor.addingRow)
+                  ? theme.backgroundElement
+                  : rows.length % 2 !== 0
+                    ? stripeBg
+                    : undefined
+              }
               focusedBackgroundColor={theme.borderSubtle}
-              style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+              paddingX={1}
+              style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
             />
           </box>
         </>

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -268,6 +268,9 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       )
     }
 
+    const displayColor = value ? defaultColor : theme.textMuted
+    const displayText = value ? value : (placeholder ?? "")
+
     return (
       <box
         style={{
@@ -281,7 +284,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
           paddingRight: paddingX,
         }}
       >
-        <VarText text={value} env={env} baseColor={defaultColor} />
+        <VarText text={displayText} env={env} baseColor={displayColor} />
       </box>
     )
   },

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -143,6 +143,12 @@ export function EnvEditorPane({
 
           const keyBaseColor = dimmed ? theme.textMuted : theme.primary
           const valueBaseColor = dimmed ? theme.textMuted : theme.text
+          const rowBg =
+            cursorOnThisRow || isEditingThisRow
+              ? theme.backgroundElement
+              : i % 2 !== 0
+                ? stripeBg
+                : undefined
 
           return (
             <box
@@ -151,15 +157,13 @@ export function EnvEditorPane({
               style={{
                 flexDirection: "row",
                 gap: 0,
-                backgroundColor:
-                  cursorOnThisRow || isEditingThisRow
-                    ? theme.backgroundElement
-                    : undefined,
+                backgroundColor: rowBg,
               }}
             >
               <Checkbox checked={row.enabled} theme={theme} />
               <VarInput
                 value={isEditingThisRow ? editKey : row.key}
+                placeholder="Key..."
                 env={draftEnv}
                 isEditing={isEditingThisRow}
                 onChange={setEditKey}
@@ -175,17 +179,14 @@ export function EnvEditorPane({
               />
               <VarInput
                 value={isEditingThisRow ? editValue : row.value}
+                placeholder="Value..."
                 env={draftEnv}
                 isEditing={isEditingThisRow}
                 onChange={setEditValue}
                 isFocused={isEditingThisRow && editState.subfield === "value"}
                 baseColor={valueBaseColor}
                 backgroundColor={
-                  isEditingThisRow || cursorOnThisRow
-                    ? theme.backgroundElement
-                    : i % 2 !== 0
-                      ? stripeBg
-                      : undefined
+                  isEditingThisRow ? theme.backgroundElement : undefined
                 }
                 focusedBackgroundColor={theme.borderSubtle}
                 paddingX={1}
@@ -195,66 +196,68 @@ export function EnvEditorPane({
             </box>
           )
         })}
-        <box
-          key="add"
-          id="vrow-add"
-          style={{
-            flexDirection: "row",
-            gap: 0,
-            backgroundColor:
-              inBrowse && editState.addingRow
-                ? theme.backgroundElement
-                : editingAdd
-                  ? theme.backgroundElement
-                  : undefined,
-          }}
-        >
-          <Checkbox checked={false} theme={theme} />
-          <VarInput
-            value={editingAdd ? editKey : ""}
-            env={draftEnv}
-            isEditing={editingAdd}
-            onChange={setEditKey}
-            isFocused={editingAdd && editState.subfield === "key"}
-            baseColor={
-              editingAdd || (inBrowse && editState.addingRow)
-                ? theme.primary
-                : theme.textMuted
-            }
-            backgroundColor={
-              editingAdd || (inBrowse && editState.addingRow)
-                ? theme.backgroundElement
+        {(() => {
+          const addRowBg =
+            (inBrowse && editState.addingRow) || editingAdd
+              ? theme.backgroundElement
+              : rows.length % 2 !== 0
+                ? stripeBg
                 : undefined
-            }
-            focusedBackgroundColor={theme.borderSubtle}
-            paddingX={1}
-            style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-            variableNames={variableNames}
-          />
-          <VarInput
-            value={editingAdd ? editValue : ""}
-            env={draftEnv}
-            isEditing={editingAdd}
-            onChange={setEditValue}
-            isFocused={editingAdd && editState.subfield === "value"}
-            baseColor={
-              editingAdd || (inBrowse && editState.addingRow)
-                ? theme.text
-                : theme.textMuted
-            }
-            backgroundColor={
-              editingAdd || (inBrowse && editState.addingRow)
-                ? theme.backgroundElement
-                : rows.length % 2 !== 0
-                  ? stripeBg
-                  : undefined
-            }
-            focusedBackgroundColor={theme.borderSubtle}
-            paddingX={1}
-            style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-            variableNames={variableNames}
-          />
-        </box>
+
+          return (
+            <box
+              key="add"
+              id="vrow-add"
+              style={{
+                flexDirection: "row",
+                gap: 0,
+                backgroundColor: addRowBg,
+              }}
+            >
+              <Checkbox checked={false} theme={theme} />
+              <VarInput
+                value={editingAdd ? editKey : ""}
+                placeholder="Key..."
+                env={draftEnv}
+                isEditing={editingAdd}
+                onChange={setEditKey}
+                isFocused={editingAdd && editState.subfield === "key"}
+                baseColor={
+                  editingAdd || (inBrowse && editState.addingRow)
+                    ? theme.primary
+                    : theme.textMuted
+                }
+                backgroundColor={
+                  editingAdd ? theme.backgroundElement : undefined
+                }
+                focusedBackgroundColor={theme.borderSubtle}
+                paddingX={1}
+                style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
+                variableNames={variableNames}
+              />
+              <VarInput
+                value={editingAdd ? editValue : ""}
+                placeholder="Value..."
+                env={draftEnv}
+                isEditing={editingAdd}
+                onChange={setEditValue}
+                isFocused={editingAdd && editState.subfield === "value"}
+                baseColor={
+                  editingAdd || (inBrowse && editState.addingRow)
+                    ? theme.text
+                    : theme.textMuted
+                }
+                backgroundColor={
+                  editingAdd ? theme.backgroundElement : undefined
+                }
+                focusedBackgroundColor={theme.borderSubtle}
+                paddingX={1}
+                style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
+                variableNames={variableNames}
+              />
+            </box>
+          )
+        })()}
       </scrollbox>
       {error && <text fg={theme.error}>Error: {error}</text>}
       {saving && <text fg={theme.info}>Saving...</text>}

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -141,7 +141,7 @@ export function EnvEditorPane({
             inBrowse && !editState.addingRow && editState.row === i
           const dimmed = (inEdit && !isEditingThisRow) || !row.enabled
 
-          const keyBaseColor = dimmed ? theme.textMuted : theme.text
+          const keyBaseColor = dimmed ? theme.textMuted : theme.primary
           const valueBaseColor = dimmed ? theme.textMuted : theme.text
 
           return (
@@ -154,9 +154,7 @@ export function EnvEditorPane({
                 backgroundColor:
                   cursorOnThisRow || isEditingThisRow
                     ? theme.backgroundElement
-                    : i % 2 !== 0
-                      ? stripeBg
-                      : undefined,
+                    : undefined,
               }}
             >
               <Checkbox checked={row.enabled} theme={theme} />
@@ -171,7 +169,8 @@ export function EnvEditorPane({
                   isEditingThisRow ? theme.backgroundElement : undefined
                 }
                 focusedBackgroundColor={theme.borderSubtle}
-                style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+                paddingX={1}
+                style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
                 variableNames={variableNames}
               />
               <VarInput
@@ -182,10 +181,15 @@ export function EnvEditorPane({
                 isFocused={isEditingThisRow && editState.subfield === "value"}
                 baseColor={valueBaseColor}
                 backgroundColor={
-                  isEditingThisRow ? theme.backgroundElement : undefined
+                  isEditingThisRow || cursorOnThisRow
+                    ? theme.backgroundElement
+                    : i % 2 !== 0
+                      ? stripeBg
+                      : undefined
                 }
                 focusedBackgroundColor={theme.borderSubtle}
-                style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+                paddingX={1}
+                style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
                 variableNames={variableNames}
               />
             </box>
@@ -214,12 +218,17 @@ export function EnvEditorPane({
             isFocused={editingAdd && editState.subfield === "key"}
             baseColor={
               editingAdd || (inBrowse && editState.addingRow)
-                ? theme.text
+                ? theme.primary
                 : theme.textMuted
             }
-            backgroundColor={editingAdd ? theme.backgroundElement : undefined}
+            backgroundColor={
+              editingAdd || (inBrowse && editState.addingRow)
+                ? theme.backgroundElement
+                : undefined
+            }
             focusedBackgroundColor={theme.borderSubtle}
-            style={{ flexGrow: 3, flexShrink: 1, flexBasis: 0 }}
+            paddingX={1}
+            style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
             variableNames={variableNames}
           />
           <VarInput
@@ -233,9 +242,16 @@ export function EnvEditorPane({
                 ? theme.text
                 : theme.textMuted
             }
-            backgroundColor={editingAdd ? theme.backgroundElement : undefined}
+            backgroundColor={
+              editingAdd || (inBrowse && editState.addingRow)
+                ? theme.backgroundElement
+                : rows.length % 2 !== 0
+                  ? stripeBg
+                  : undefined
+            }
             focusedBackgroundColor={theme.borderSubtle}
-            style={{ flexGrow: 7, flexShrink: 1, flexBasis: 0 }}
+            paddingX={1}
+            style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
             variableNames={variableNames}
           />
         </box>


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Uses primary color for key column labels in KeyValueSection, HeaderTable, FormEditor, and EnvEditorPane. Refines alternating row striping for consistency across key-value editors.

### How did you verify your code works?

`bun test`, `bun run lint`, `bun run typecheck` all pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR
