### PR TITLE
refactor(ui): extract AppInner state/hooks into dedicated modules

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -45,28 +45,25 @@ import { useCollectionFileActions } from "./useCollectionFileActions"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
-import { exportTimelineEntry, loadTimelineBody } from "../filestore"
-import { copyToClipboard } from "./clipboard"
-import type { TimelineBodyRef } from "../schema"
 import type { SubstitutedRequest } from "../requests/substitute"
 import { flattenRequests, getRequestIds, findFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
-import {
-  saveLastRequest,
-  loadExpandedFolders,
-  saveExpandedFolders,
-} from "./tabs/uiState"
 import type { FieldKind } from "./editMode"
 import type { ResponseTabKind } from "./tabs/uiState"
 import { VariableCompletionInterceptor } from "./variable-completion/variableCompletionInterceptor"
 import { parseCurl } from "../converters/curl/parse"
 import type { ResponseQueryController } from "./responseQuery"
 import {
-  checkForUpdates as checkForUpdatesFn,
-  installBinaryUpdate,
-  installBrewUpdate,
-  type UpdateAvailableInfo,
-} from "../app/commands/update"
+  type AppView,
+  initialYamlEditorState,
+  type YamlEditorState,
+} from "./appState"
+import {
+  useCollectionUiPersistence,
+  useInitialExpandedFolders,
+} from "./useCollectionUiPersistence"
+import { useUpdateFlow } from "./useUpdateFlow"
+import { useTimelineActions } from "./useTimelineActions"
 
 export function AppInner({
   collectionDir,
@@ -125,7 +122,7 @@ export function AppInner({
   urlbarSubFocusRef.current = urlbarSubFocus
   const focusRef = useRef(focus)
   focusRef.current = focus
-  const [view, setView] = useState<"main" | "env-editor">("main")
+  const [view, setView] = useState<AppView>("main")
   const viewRef = useRef(view)
   viewRef.current = view
   const [helpVisible, setHelpVisible] = useState(false)
@@ -146,23 +143,9 @@ export function AppInner({
   const [filterOpenRequestId, setFilterOpenRequestId] = useState<string | null>(
     null,
   )
-  const [yamlEditor, setYamlEditor] = useState<{
-    visible: boolean
-    filePath: string
-    requestName: string
-    requestId: string
-    kind: "request" | "folder"
-    returnFocus: Focus
-    folderPath: string
-  }>({
-    visible: false,
-    filePath: "",
-    requestName: "",
-    requestId: "",
-    kind: "request",
-    returnFocus: "sidebar",
-    folderPath: "",
-  })
+  const [yamlEditor, setYamlEditor] = useState<YamlEditorState>(
+    initialYamlEditorState,
+  )
 
   const [envDeletePending, setEnvDeletePending] = useState<string | null>(null)
   const envDeletePendingRef = useRef(envDeletePending)
@@ -200,24 +183,6 @@ export function AppInner({
   const [collectionSwitchPending, setCollectionSwitchPending] = useState<
     string | null
   >(null)
-  const [updateCheckToken, setUpdateCheckToken] = useState(0)
-  const triggerUpdateCheck = useCallback(
-    () => setUpdateCheckToken((t) => t + 1),
-    [],
-  )
-  type UpdateFlowState =
-    | { phase: "idle" }
-    | ({ phase: "confirm" } & UpdateAvailableInfo)
-    | ({ phase: "installing" } & UpdateAvailableInfo)
-    | { phase: "done"; version: string }
-    | { phase: "failed"; message: string }
-  const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>({
-    phase: "idle",
-  })
-  const [restartVersion, setRestartVersion] = useState<string | null>(null)
-  const [updateAvailable, setUpdateAvailable] = useState<string | null>(null)
-  const [initialExpandedFolders, setInitialExpandedFolders] =
-    useState<Set<string> | null>(null)
   const headerFieldRef = useRef<"name" | "color">("name")
 
   // ── Collection ──────────────────────────────────────────────────────
@@ -236,10 +201,10 @@ export function AppInner({
   const requestIds = useMemo(() => getRequestIds(items), [items])
   const { getTab, setTab } = useUIState(collectionDir, requestIds, isReadOnly)
 
-  useEffect(() => {
-    if (!isCollection) return
-    loadExpandedFolders(collectionDir).then(setInitialExpandedFolders)
-  }, [collectionDir, isCollection])
+  const initialExpandedFolders = useInitialExpandedFolders(
+    collectionDir,
+    isCollection,
+  )
 
   // ── Sidebar selection + request draft + edit-browse ─────────────────
   const {
@@ -320,51 +285,14 @@ export function AppInner({
     setExpanded(null)
   }, [selectedRequest?.id])
 
-  const saveLastReqRef = useRef(false)
-  const saveLastDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    if (!isCollection) return
-    if (!saveLastReqRef.current) {
-      saveLastReqRef.current = true
-      return
-    }
-    const lastId = focusedFolderPath ? `${focusedFolderPath}/` : selectedId
-    if (!lastId) return
-    if (saveLastDebounceRef.current) clearTimeout(saveLastDebounceRef.current)
-    saveLastDebounceRef.current = setTimeout(() => {
-      saveLastRequest(collectionDir, lastId, new Set(requestIds)).catch(
-        (e: unknown) => {
-          console.error("Failed to save last request:", e)
-        },
-      )
-    }, 200)
-    return () => {
-      if (saveLastDebounceRef.current) clearTimeout(saveLastDebounceRef.current)
-    }
-  }, [selectedId, focusedFolderPath, isCollection])
-
-  const expandedSaveRef = useRef(false)
-  const expandedDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    if (!isCollection) return
-    if (!expandedSaveRef.current) {
-      expandedSaveRef.current = true
-      return
-    }
-    if (expandedDebounceRef.current) clearTimeout(expandedDebounceRef.current)
-    expandedDebounceRef.current = setTimeout(() => {
-      saveExpandedFolders(collectionDir, expandedFolders).catch(
-        (e: unknown) => {
-          console.error("Failed to save expanded folders:", e)
-        },
-      )
-    }, 300)
-    return () => {
-      if (expandedDebounceRef.current) clearTimeout(expandedDebounceRef.current)
-    }
-  }, [expandedFolders, collectionDir, isCollection])
+  useCollectionUiPersistence({
+    collectionDir,
+    isCollection,
+    selectedId,
+    focusedFolderPath,
+    requestIds,
+    expandedFolders,
+  })
 
   const draft = useRequestDraft(selectedRequest)
 
@@ -485,6 +413,15 @@ export function AppInner({
   folderSaveRef.current = handleFolderSave
 
   // ── keymap.setData effects ─────────────────────────────────────────
+  const overlayActiveRef = useRef(false)
+  const {
+    updateFlow,
+    restartVersion,
+    updateAvailable,
+    triggerUpdateCheck,
+    confirmInstall: onConfirmInstall,
+    cancelUpdate: onCancelUpdate,
+  } = useUpdateFlow(overlayActiveRef)
   const activeOverlay = useMemo(() => {
     if (commandPaletteVisible) return "command-palette"
     if (codeGeneratorVisible) return "code-generator"
@@ -545,6 +482,12 @@ export function AppInner({
     keymap.setData("app.overlay", activeOverlay)
   }, [activeOverlay, keymap])
 
+  const overlayActive = activeOverlay !== "none"
+
+  useEffect(() => {
+    overlayActiveRef.current = overlayActive
+  }, [overlayActive])
+
   useEffect(() => {
     keymap.setData("app.jump", jumpMode ? "active" : "none")
   }, [jumpMode, keymap])
@@ -558,110 +501,6 @@ export function AppInner({
   useEffect(() => {
     keymap.setData("app.view", view)
   }, [view, keymap])
-
-  // ── Update check flow ────────────────────────────────────────────
-  const updateFlowRef = useRef(updateFlow)
-  updateFlowRef.current = updateFlow
-
-  const overlayActiveRef = useRef(false)
-  const installTokenRef = useRef(0)
-
-  useEffect(() => {
-    if (updateCheckToken === 0) return
-    if (updateFlowRef.current.phase === "installing") return
-    let cancelled = false
-    checkForUpdatesFn(true).then((status) => {
-      if (cancelled) return
-      if (overlayActiveRef.current) return
-      if (status.kind === "up_to_date") {
-        setUpdateAvailable(null)
-        showToast("Noodle is up to date", "success")
-      } else if (status.kind === "error") {
-        showToast(status.message, "error")
-      } else if (status.kind === "update_available") {
-        setUpdateFlow({
-          phase: "confirm",
-          version: status.latestVersion || "latest",
-          installType: status.installType,
-          assetUrl:
-            status.installType === "binary" ? status.assetUrl : undefined,
-          expectedSha256:
-            status.installType === "binary" ? status.expectedSha256 : undefined,
-        })
-      }
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [updateCheckToken])
-
-  useEffect(() => {
-    if (updateFlow.phase !== "installing") return
-    const update = updateFlow
-    const token = ++installTokenRef.current
-    if (update.installType === "brew") {
-      installBrewUpdate().then((result) => {
-        if (token !== installTokenRef.current) return
-        if (result.data.status === "homebrew_updated") {
-          showToast("Updated via Homebrew", "success")
-          setUpdateFlow({ phase: "done", version: update.version || "latest" })
-          setRestartVersion(update.version || "latest")
-          setUpdateAvailable(null)
-        } else {
-          const msg = result.data.exit_code
-            ? `Homebrew upgrade failed (exit ${result.data.exit_code})`
-            : "Homebrew upgrade failed"
-          showToast(msg, "error")
-          setUpdateFlow({
-            phase: "failed",
-            message: msg,
-          })
-        }
-      })
-      return
-    }
-    if (
-      update.installType === "binary" &&
-      update.assetUrl &&
-      update.expectedSha256
-    ) {
-      installBinaryUpdate(
-        update.version,
-        update.assetUrl,
-        update.expectedSha256,
-      ).then((result) => {
-        if (token !== installTokenRef.current) return
-        if (result.data.status === "updated") {
-          const v = result.data.version ?? update.version
-          showToast(`Updated to ${v}`, "success")
-          setUpdateFlow({ phase: "done", version: v })
-          setRestartVersion(v)
-          setUpdateAvailable(null)
-        } else {
-          const msg =
-            (result.data as Record<string, string>).reason ?? "Update failed"
-          showToast(msg, "error")
-          setUpdateFlow({ phase: "failed", message: msg })
-        }
-      })
-      return
-    }
-    setUpdateFlow({ phase: "idle" })
-  }, [updateFlow.phase, updateFlow])
-
-  // ── Banner update check ──────────────────────────────────────────
-  useEffect(() => {
-    let cancelled = false
-    checkForUpdatesFn().then((status) => {
-      if (cancelled) return
-      if (status.kind === "update_available") {
-        setUpdateAvailable(status.latestVersion)
-      }
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   // ── Environments + response ────────────────────────────────────────
   const envState = useEnvironments(
@@ -762,12 +601,6 @@ export function AppInner({
     folderEb.editState.mode,
     eb.editState.mode,
   ])
-
-  const overlayActive = activeOverlay !== "none"
-
-  useEffect(() => {
-    overlayActiveRef.current = overlayActive
-  }, [overlayActive])
 
   const displayTab = useMemo((): string | undefined => {
     if (focus === "request") return eb.activeTab
@@ -945,20 +778,6 @@ export function AppInner({
   })
 
   // ── Overlay intercepts ────────────────────────────────────────────
-  const onConfirmInstall = useCallback(() => {
-    if (updateFlowRef.current.phase !== "confirm") return
-    setUpdateFlow({
-      phase: "installing",
-      version: updateFlowRef.current.version,
-      installType: updateFlowRef.current.installType,
-      assetUrl: updateFlowRef.current.assetUrl,
-      expectedSha256: updateFlowRef.current.expectedSha256,
-    })
-  }, [])
-  const onCancelUpdate = useCallback(() => {
-    setUpdateFlow({ phase: "idle" })
-  }, [])
-
   useOverlayIntercepts({
     activeOverlay,
     cancelSendRef,
@@ -1041,39 +860,12 @@ export function AppInner({
   }, [envEditor.draft])
 
   const renderer = useRenderer()
-
-  const onLoadTimelineBody = useCallback(
-    (entry: TimelineEntry, ref: TimelineBodyRef) =>
-      loadTimelineBody(collectionDir, entry.request.id, ref),
-    [collectionDir],
-  )
-  const onCopyTimelineHeaders = useCallback(
-    (headersText: string) => {
-      if (copyToClipboard(headersText, renderer))
-        showToast("Timeline headers copied", "success")
-      else showToast("Failed to copy timeline headers", "error")
-    },
-    [renderer],
-  )
-  const onCopyTimelineBody = useCallback(
-    (body: string) => {
-      if (copyToClipboard(body, renderer))
-        showToast("Timeline body copied", "success")
-      else showToast("Failed to copy timeline body", "error")
-    },
-    [renderer],
-  )
-  const onExportTimelineBody = useCallback(
-    async (
-      entry: TimelineEntry,
-      kind: "request" | "response",
-      body?: string,
-    ) => {
-      const path = await exportTimelineEntry(collectionDir, entry, kind, body)
-      showToast(`Timeline entry exported to ${path}`, "success")
-    },
-    [collectionDir],
-  )
+  const {
+    onLoadTimelineBody,
+    onCopyTimelineHeaders,
+    onCopyTimelineBody,
+    onExportTimelineBody,
+  } = useTimelineActions(collectionDir, renderer)
 
   const commandPaletteCommands = useMemo(
     () =>

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -39,20 +39,11 @@ import { CodeGeneratorOverlay } from "./overlays/CodeGeneratorOverlay"
 import type { Keybinds } from "./keybind"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
+import { initialYamlEditorState, type YamlEditorState } from "./appState"
 
 interface FolderPathOption {
   id: string
   label: string
-}
-
-interface YamlEditorState {
-  visible: boolean
-  filePath: string
-  requestName: string
-  requestId: string
-  kind: "request" | "folder"
-  returnFocus: Focus
-  folderPath: string
 }
 
 interface AppOverlaysProps {
@@ -288,15 +279,7 @@ export function AppOverlays({
               resetRequestDraft(yamlEditor.requestId)
             }
             setCollectionReloadToken((n) => n + 1)
-            setYamlEditor({
-              visible: false,
-              filePath: "",
-              requestName: "",
-              requestId: "",
-              kind: "request",
-              returnFocus: "sidebar",
-              folderPath: "",
-            })
+            setYamlEditor(initialYamlEditorState)
             setFocus(yamlEditor.returnFocus)
             setSaveState({
               kind: "success",
@@ -308,15 +291,7 @@ export function AppOverlays({
             }, 2000)
           }}
           onClose={() => {
-            setYamlEditor({
-              visible: false,
-              filePath: "",
-              requestName: "",
-              requestId: "",
-              kind: "request",
-              returnFocus: "sidebar",
-              folderPath: "",
-            })
+            setYamlEditor(initialYamlEditorState)
             setFocus(yamlEditor.returnFocus)
           }}
         />

--- a/src/ui/appState.ts
+++ b/src/ui/appState.ts
@@ -1,0 +1,31 @@
+import type { Focus } from "./focus"
+import type { UpdateAvailableInfo } from "../app/commands/update"
+
+export type AppView = "main" | "env-editor"
+
+export interface YamlEditorState {
+  visible: boolean
+  filePath: string
+  requestName: string
+  requestId: string
+  kind: "request" | "folder"
+  returnFocus: Focus
+  folderPath: string
+}
+
+export const initialYamlEditorState: YamlEditorState = {
+  visible: false,
+  filePath: "",
+  requestName: "",
+  requestId: "",
+  kind: "request",
+  returnFocus: "sidebar",
+  folderPath: "",
+}
+
+export type UpdateFlowState =
+  | { phase: "idle" }
+  | ({ phase: "confirm" } & UpdateAvailableInfo)
+  | ({ phase: "installing" } & UpdateAvailableInfo)
+  | { phase: "done"; version: string }
+  | { phase: "failed"; message: string }

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -4,6 +4,7 @@ import type { CommandItem } from "./overlays/CommandPaletteOverlay"
 import type { Keybinds } from "./keybind"
 import { displayKey } from "./keybind"
 import type { Focus } from "./focus"
+import type { AppView, YamlEditorState } from "./appState"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
 import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
@@ -88,40 +89,9 @@ export interface CommandBuilderContext {
   setRequestFinderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setCodeGeneratorVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setYamlEditor: (
-    v:
-      | {
-          visible: boolean
-          filePath: string
-          requestName: string
-          requestId: string
-          kind: "request" | "folder"
-          returnFocus: Focus
-          folderPath: string
-        }
-      | ((prev: {
-          visible: boolean
-          filePath: string
-          requestName: string
-          requestId: string
-          kind: "request" | "folder"
-          returnFocus: Focus
-          folderPath: string
-        }) => {
-          visible: boolean
-          filePath: string
-          requestName: string
-          requestId: string
-          kind: "request" | "folder"
-          returnFocus: Focus
-          folderPath: string
-        }),
+    v: YamlEditorState | ((prev: YamlEditorState) => YamlEditorState),
   ) => void
-  setView: (
-    v:
-      | "main"
-      | "env-editor"
-      | ((prev: "main" | "env-editor") => "main" | "env-editor"),
-  ) => void
+  setView: (v: AppView | ((prev: AppView) => AppView)) => void
   setFocus: (focus: Focus | ((prev: Focus) => Focus)) => void
   setUndoAllPending: (v: boolean | ((prev: boolean) => boolean)) => void
   setInitPending: (v: boolean | ((prev: boolean) => boolean)) => void

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -1,6 +1,7 @@
 import { useBindings, useKeymap } from "@opentui/keymap/react"
 import type { RefObject } from "react"
 import { cycleFocus, type Focus, type UrlBarSubFocus } from "./focus"
+import type { AppView, YamlEditorState } from "./appState"
 import type { Keybinds } from "./keybind"
 import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
@@ -37,7 +38,7 @@ export interface UseAppKeymapRefs {
   doSaveRef: RefObject<() => void>
   focusRef: RefObject<Focus>
   urlbarSubFocusRef: RefObject<UrlBarSubFocus>
-  viewRef: RefObject<"main" | "env-editor">
+  viewRef: RefObject<AppView>
   activeIndexRef: RefObject<number>
   savingRef: RefObject<boolean>
   expandedRef: RefObject<"request" | "response" | null>
@@ -71,40 +72,9 @@ export interface UseAppKeymapSetters {
           prev: "request" | "response" | null,
         ) => "request" | "response" | null),
   ) => void
-  setView: (
-    v:
-      | "main"
-      | "env-editor"
-      | ((prev: "main" | "env-editor") => "main" | "env-editor"),
-  ) => void
+  setView: (v: AppView | ((prev: AppView) => AppView)) => void
   setYamlEditor: (
-    v:
-      | {
-          visible: boolean
-          filePath: string
-          requestName: string
-          requestId: string
-          kind: "request" | "folder"
-          returnFocus: Focus
-          folderPath: string
-        }
-      | ((prev: {
-          visible: boolean
-          filePath: string
-          requestName: string
-          requestId: string
-          kind: "request" | "folder"
-          returnFocus: Focus
-          folderPath: string
-        }) => {
-          visible: boolean
-          filePath: string
-          requestName: string
-          requestId: string
-          kind: "request" | "folder"
-          returnFocus: Focus
-          folderPath: string
-        }),
+    v: YamlEditorState | ((prev: YamlEditorState) => YamlEditorState),
   ) => void
   setCollectionReloadToken: (n: number | ((prev: number) => number)) => void
   setPreviewIndex: (

--- a/src/ui/useCollectionUiPersistence.ts
+++ b/src/ui/useCollectionUiPersistence.ts
@@ -14,7 +14,13 @@ export function useInitialExpandedFolders(
 
   useEffect(() => {
     if (!isCollection) return
-    loadExpandedFolders(collectionDir).then(setInitialExpandedFolders)
+    let active = true
+    loadExpandedFolders(collectionDir).then((folders) => {
+      if (active) setInitialExpandedFolders(folders)
+    })
+    return () => {
+      active = false
+    }
   }, [collectionDir, isCollection])
 
   return initialExpandedFolders

--- a/src/ui/useCollectionUiPersistence.ts
+++ b/src/ui/useCollectionUiPersistence.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react"
+import {
+  loadExpandedFolders,
+  saveExpandedFolders,
+  saveLastRequest,
+} from "./tabs/uiState"
+
+export function useInitialExpandedFolders(
+  collectionDir: string,
+  isCollection: boolean,
+): Set<string> | null {
+  const [initialExpandedFolders, setInitialExpandedFolders] =
+    useState<Set<string> | null>(null)
+
+  useEffect(() => {
+    if (!isCollection) return
+    loadExpandedFolders(collectionDir).then(setInitialExpandedFolders)
+  }, [collectionDir, isCollection])
+
+  return initialExpandedFolders
+}
+
+export function useCollectionUiPersistence({
+  collectionDir,
+  isCollection,
+  selectedId,
+  focusedFolderPath,
+  requestIds,
+  expandedFolders,
+}: {
+  collectionDir: string
+  isCollection: boolean
+  selectedId: string | null
+  focusedFolderPath: string | null
+  requestIds: string[]
+  expandedFolders: Set<string>
+}): void {
+  const saveLastRequestStarted = useRef(false)
+  const saveLastRequestTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+  const saveExpandedFoldersStarted = useRef(false)
+  const saveExpandedFoldersTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+
+  useEffect(() => {
+    if (!isCollection) return
+    if (!saveLastRequestStarted.current) {
+      saveLastRequestStarted.current = true
+      return
+    }
+    const lastId = focusedFolderPath ? `${focusedFolderPath}/` : selectedId
+    if (!lastId) return
+    if (saveLastRequestTimer.current) clearTimeout(saveLastRequestTimer.current)
+    saveLastRequestTimer.current = setTimeout(() => {
+      saveLastRequest(collectionDir, lastId, new Set(requestIds)).catch(
+        (e: unknown) => {
+          console.error("Failed to save last request:", e)
+        },
+      )
+    }, 200)
+    return () => {
+      if (saveLastRequestTimer.current)
+        clearTimeout(saveLastRequestTimer.current)
+    }
+  }, [collectionDir, focusedFolderPath, isCollection, requestIds, selectedId])
+
+  useEffect(() => {
+    if (!isCollection) return
+    if (!saveExpandedFoldersStarted.current) {
+      saveExpandedFoldersStarted.current = true
+      return
+    }
+    if (saveExpandedFoldersTimer.current)
+      clearTimeout(saveExpandedFoldersTimer.current)
+    saveExpandedFoldersTimer.current = setTimeout(() => {
+      saveExpandedFolders(collectionDir, expandedFolders).catch(
+        (e: unknown) => {
+          console.error("Failed to save expanded folders:", e)
+        },
+      )
+    }, 300)
+    return () => {
+      if (saveExpandedFoldersTimer.current)
+        clearTimeout(saveExpandedFoldersTimer.current)
+    }
+  }, [collectionDir, expandedFolders, isCollection])
+}

--- a/src/ui/useTimelineActions.ts
+++ b/src/ui/useTimelineActions.ts
@@ -1,0 +1,51 @@
+import { useCallback } from "react"
+import type { CliRenderer } from "@opentui/core"
+import type { TimelineBodyRef, TimelineEntry } from "../schema"
+import { exportTimelineEntry, loadTimelineBody } from "../filestore"
+import { copyToClipboard } from "./clipboard"
+import { showToast } from "./Toast"
+
+export function useTimelineActions(
+  collectionDir: string,
+  renderer: CliRenderer,
+) {
+  const onLoadTimelineBody = useCallback(
+    (entry: TimelineEntry, ref: TimelineBodyRef) =>
+      loadTimelineBody(collectionDir, entry.request.id, ref),
+    [collectionDir],
+  )
+  const onCopyTimelineHeaders = useCallback(
+    (headersText: string) => {
+      if (copyToClipboard(headersText, renderer))
+        showToast("Timeline headers copied", "success")
+      else showToast("Failed to copy timeline headers", "error")
+    },
+    [renderer],
+  )
+  const onCopyTimelineBody = useCallback(
+    (body: string) => {
+      if (copyToClipboard(body, renderer))
+        showToast("Timeline body copied", "success")
+      else showToast("Failed to copy timeline body", "error")
+    },
+    [renderer],
+  )
+  const onExportTimelineBody = useCallback(
+    async (
+      entry: TimelineEntry,
+      kind: "request" | "response",
+      body?: string,
+    ) => {
+      const path = await exportTimelineEntry(collectionDir, entry, kind, body)
+      showToast(`Timeline entry exported to ${path}`, "success")
+    },
+    [collectionDir],
+  )
+
+  return {
+    onLoadTimelineBody,
+    onCopyTimelineHeaders,
+    onCopyTimelineBody,
+    onExportTimelineBody,
+  }
+}

--- a/src/ui/useUpdateFlow.ts
+++ b/src/ui/useUpdateFlow.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { RefObject } from "react"
+import {
+  checkForUpdates,
+  installBinaryUpdate,
+  installBrewUpdate,
+} from "../app/commands/update"
+import { showToast } from "./Toast"
+import type { UpdateFlowState } from "./appState"
+
+export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
+  const [checkToken, setCheckToken] = useState(0)
+  const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>({
+    phase: "idle",
+  })
+  const [restartVersion, setRestartVersion] = useState<string | null>(null)
+  const [updateAvailable, setUpdateAvailable] = useState<string | null>(null)
+  const updateFlowRef = useRef(updateFlow)
+  updateFlowRef.current = updateFlow
+  const installTokenRef = useRef(0)
+
+  const triggerUpdateCheck = useCallback(
+    () => setCheckToken((token) => token + 1),
+    [],
+  )
+
+  useEffect(() => {
+    if (checkToken === 0 || updateFlowRef.current.phase === "installing") return
+    let cancelled = false
+    checkForUpdates(true).then((status) => {
+      if (cancelled || overlayActiveRef.current) return
+      if (status.kind === "up_to_date") {
+        setUpdateAvailable(null)
+        showToast("Noodle is up to date", "success")
+      } else if (status.kind === "error") {
+        showToast(status.message, "error")
+      } else if (status.kind === "update_available") {
+        setUpdateFlow({
+          phase: "confirm",
+          version: status.latestVersion || "latest",
+          installType: status.installType,
+          assetUrl:
+            status.installType === "binary" ? status.assetUrl : undefined,
+          expectedSha256:
+            status.installType === "binary" ? status.expectedSha256 : undefined,
+        })
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [checkToken])
+
+  useEffect(() => {
+    if (updateFlow.phase !== "installing") return
+    const update = updateFlow
+    const token = ++installTokenRef.current
+    if (update.installType === "brew") {
+      installBrewUpdate().then((result) => {
+        if (token !== installTokenRef.current) return
+        if (result.data.status === "homebrew_updated") {
+          showToast("Updated via Homebrew", "success")
+          setUpdateFlow({ phase: "done", version: update.version || "latest" })
+          setRestartVersion(update.version || "latest")
+          setUpdateAvailable(null)
+        } else {
+          const message = result.data.exit_code
+            ? `Homebrew upgrade failed (exit ${result.data.exit_code})`
+            : "Homebrew upgrade failed"
+          showToast(message, "error")
+          setUpdateFlow({ phase: "failed", message })
+        }
+      })
+      return
+    }
+    if (
+      update.installType === "binary" &&
+      update.assetUrl &&
+      update.expectedSha256
+    ) {
+      installBinaryUpdate(
+        update.version,
+        update.assetUrl,
+        update.expectedSha256,
+      ).then((result) => {
+        if (token !== installTokenRef.current) return
+        if (result.data.status === "updated") {
+          const version = result.data.version ?? update.version
+          showToast(`Updated to ${version}`, "success")
+          setUpdateFlow({ phase: "done", version })
+          setRestartVersion(version)
+          setUpdateAvailable(null)
+        } else {
+          const message =
+            (result.data as Record<string, string>).reason ?? "Update failed"
+          showToast(message, "error")
+          setUpdateFlow({ phase: "failed", message })
+        }
+      })
+      return
+    }
+    setUpdateFlow({ phase: "idle" })
+  }, [updateFlow])
+
+  useEffect(() => {
+    let cancelled = false
+    checkForUpdates().then((status) => {
+      if (!cancelled && status.kind === "update_available") {
+        setUpdateAvailable(status.latestVersion)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const confirmInstall = useCallback(() => {
+    const update = updateFlowRef.current
+    if (update.phase !== "confirm") return
+    setUpdateFlow({
+      phase: "installing",
+      version: update.version,
+      installType: update.installType,
+      assetUrl: update.assetUrl,
+      expectedSha256: update.expectedSha256,
+    })
+  }, [])
+  const cancelUpdate = useCallback(() => setUpdateFlow({ phase: "idle" }), [])
+
+  return {
+    updateFlow,
+    restartVersion,
+    updateAvailable,
+    triggerUpdateCheck,
+    confirmInstall,
+    cancelUpdate,
+  }
+}

--- a/src/ui/useUpdateFlow.ts
+++ b/src/ui/useUpdateFlow.ts
@@ -8,6 +8,10 @@ import {
 import { showToast } from "./Toast"
 import type { UpdateFlowState } from "./appState"
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
   const [checkToken, setCheckToken] = useState(0)
   const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>({
@@ -27,25 +31,31 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
   useEffect(() => {
     if (checkToken === 0 || updateFlowRef.current.phase === "installing") return
     let cancelled = false
-    checkForUpdates(true).then((status) => {
-      if (cancelled || overlayActiveRef.current) return
-      if (status.kind === "up_to_date") {
-        setUpdateAvailable(null)
-        showToast("Noodle is up to date", "success")
-      } else if (status.kind === "error") {
-        showToast(status.message, "error")
-      } else if (status.kind === "update_available") {
-        setUpdateFlow({
-          phase: "confirm",
-          version: status.latestVersion || "latest",
-          installType: status.installType,
-          assetUrl:
-            status.installType === "binary" ? status.assetUrl : undefined,
-          expectedSha256:
-            status.installType === "binary" ? status.expectedSha256 : undefined,
-        })
-      }
-    })
+    checkForUpdates(true)
+      .then((status) => {
+        if (cancelled || overlayActiveRef.current) return
+        if (status.kind === "up_to_date") {
+          setUpdateAvailable(null)
+          showToast("Noodle is up to date", "success")
+        } else if (status.kind === "error") {
+          showToast(status.message, "error")
+        } else if (status.kind === "update_available") {
+          setUpdateFlow({
+            phase: "confirm",
+            version: status.latestVersion || "latest",
+            installType: status.installType,
+            assetUrl:
+              status.installType === "binary" ? status.assetUrl : undefined,
+            expectedSha256:
+              status.installType === "binary"
+                ? status.expectedSha256
+                : undefined,
+          })
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) showToast(getErrorMessage(error), "error")
+      })
     return () => {
       cancelled = true
     }
@@ -56,21 +66,31 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
     const update = updateFlow
     const token = ++installTokenRef.current
     if (update.installType === "brew") {
-      installBrewUpdate().then((result) => {
-        if (token !== installTokenRef.current) return
-        if (result.data.status === "homebrew_updated") {
-          showToast("Updated via Homebrew", "success")
-          setUpdateFlow({ phase: "done", version: update.version || "latest" })
-          setRestartVersion(update.version || "latest")
-          setUpdateAvailable(null)
-        } else {
-          const message = result.data.exit_code
-            ? `Homebrew upgrade failed (exit ${result.data.exit_code})`
-            : "Homebrew upgrade failed"
+      installBrewUpdate()
+        .then((result) => {
+          if (token !== installTokenRef.current) return
+          if (result.data.status === "homebrew_updated") {
+            showToast("Updated via Homebrew", "success")
+            setUpdateFlow({
+              phase: "done",
+              version: update.version || "latest",
+            })
+            setRestartVersion(update.version || "latest")
+            setUpdateAvailable(null)
+          } else {
+            const message = result.data.exit_code
+              ? `Homebrew upgrade failed (exit ${result.data.exit_code})`
+              : "Homebrew upgrade failed"
+            showToast(message, "error")
+            setUpdateFlow({ phase: "failed", message })
+          }
+        })
+        .catch((error: unknown) => {
+          if (token !== installTokenRef.current) return
+          const message = getErrorMessage(error)
           showToast(message, "error")
           setUpdateFlow({ phase: "failed", message })
-        }
-      })
+        })
       return
     }
     if (
@@ -82,21 +102,28 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
         update.version,
         update.assetUrl,
         update.expectedSha256,
-      ).then((result) => {
-        if (token !== installTokenRef.current) return
-        if (result.data.status === "updated") {
-          const version = result.data.version ?? update.version
-          showToast(`Updated to ${version}`, "success")
-          setUpdateFlow({ phase: "done", version })
-          setRestartVersion(version)
-          setUpdateAvailable(null)
-        } else {
-          const message =
-            (result.data as Record<string, string>).reason ?? "Update failed"
+      )
+        .then((result) => {
+          if (token !== installTokenRef.current) return
+          if (result.data.status === "updated") {
+            const version = result.data.version ?? update.version
+            showToast(`Updated to ${version}`, "success")
+            setUpdateFlow({ phase: "done", version })
+            setRestartVersion(version)
+            setUpdateAvailable(null)
+          } else {
+            const message =
+              (result.data as Record<string, string>).reason ?? "Update failed"
+            showToast(message, "error")
+            setUpdateFlow({ phase: "failed", message })
+          }
+        })
+        .catch((error: unknown) => {
+          if (token !== installTokenRef.current) return
+          const message = getErrorMessage(error)
           showToast(message, "error")
           setUpdateFlow({ phase: "failed", message })
-        }
-      })
+        })
       return
     }
     setUpdateFlow({ phase: "idle" })
@@ -104,11 +131,15 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
 
   useEffect(() => {
     let cancelled = false
-    checkForUpdates().then((status) => {
-      if (!cancelled && status.kind === "update_available") {
-        setUpdateAvailable(status.latestVersion)
-      }
-    })
+    checkForUpdates()
+      .then((status) => {
+        if (!cancelled && status.kind === "update_available") {
+          setUpdateAvailable(status.latestVersion)
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) showToast(getErrorMessage(error), "error")
+      })
     return () => {
       cancelled = true
     }


### PR DESCRIPTION
### Type of change

- [X] Refactor / code improvement

### What does this PR do?

Extracts four concerns from AppInner into dedicated modules to reduce its size and improve separation of concerns:

- **`appState.ts`** — shared types (`AppView`, `YamlEditorState`, `UpdateFlowState`) and the `initialYamlEditorState` constant, removing inline type duplication across `AppInner`, `AppOverlays`, `commands.ts`, and `useAppKeymap.ts`.
- **`useCollectionUiPersistence.ts`** — debounced persistence of the last-selected request and expanded-folder state to disk.
- **`useTimelineActions.ts`** — wraps timeline body load/copy/export callbacks that were previously defined inline.
- **`useUpdateFlow.ts`** — encapsulates the update-check/install state machine (trigger, confirm, installing, done, failed) with overlay-aware cancellation.

### How did you verify your code works?

- `bun test` — 1829 pass, 0 fail
- `bun run lint` — clean
- `bun run typecheck` — clean
- The extracted hooks preserve the same `useCallback` dependency arrays and effect semantics, confirmed by unchanged test output.

### Checklist

- [X] I have tested my changes locally
- [X] `bun test` passes
- [X] `bun run lint` passes
- [X] `bun run typecheck` passes
- [X] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured update flow with confirmation, installation progress, restart prompts, and clear success/error handling.
  * Added timeline actions for loading, copying (headers/body), and exporting timeline entries.
  * Improved persistence of expanded folders and “last request” selection for collections.
  * Refreshed YAML editor behavior so it resets consistently when closed.

* **Refactor**
  * Consolidated persistence, update management, and timeline action logic into dedicated hooks.
  * Centralized shared app/view and editor state types for consistent usage across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->