### PR TITLE
refactor(editor): extract code editor into focused modules

### DIFF
--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -393,6 +393,7 @@ function BodySection({
   const [editorInstance, setEditorInstance] =
     useState<CodeEditorRenderable | null>(null)
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
 
   const extraHighlights = useCallback(
     (content: string): Highlight[] => {
@@ -430,15 +431,18 @@ function BodySection({
 
   const editingBody = inEdit && editState.cursor.field === "body"
 
+  useEffect(() => {
+    if (!editingBody) setValidationError(null)
+  }, [editingBody])
+
   const validationNotice = useMemo(() => {
     if (!editingBody || isFormMode || isBinaryMode) return null
-    const error = validateJsonContent(editValue, activeEnv ?? null)
-    if (!error) return null
+    if (!validationError) return null
     return {
       title: "Invalid JSON",
-      detail: error.replace(/^Invalid JSON:\s*/, ""),
+      detail: validationError.replace(/^Invalid JSON:\s*/, ""),
     }
-  }, [activeEnv, editingBody, editValue, isBinaryMode, isFormMode])
+  }, [editingBody, isBinaryMode, isFormMode, validationError])
 
   useEffect(() => {
     if (editingBody && editorRef.current) {
@@ -504,6 +508,7 @@ function BodySection({
                 initialValue={formatBody(editValue)}
                 extraHighlights={activeEnv ? extraHighlights : undefined}
                 validateContent={validateContent}
+                onValidationChange={setValidationError}
                 onContentChange={handleContentChange}
                 onFoldsChange={handleFoldsChange}
                 backgroundColor={theme.backgroundPanel}

--- a/src/ui/editor/CodeEditor.ts
+++ b/src/ui/editor/CodeEditor.ts
@@ -8,21 +8,32 @@ import type { RenderContext, Highlight } from "@opentui/core"
 import type { SimpleHighlight } from "@opentui/core"
 import type { TreeSitterClient } from "@opentui/core"
 import type { Theme } from "../theme-data"
-import { highlightJsonTokens } from "./syntax"
-import { tokenizeYamlLine } from "./yamlSyntax"
 import {
-  buildCharToDisplayOffsets,
-  charOffsetToDisplayOffset,
-} from "../variable-completion/highlightOffsets"
+  buildFoldDisplay,
+  buildSourceDisplayMaps,
+  computeFoldRanges as deriveFoldRanges,
+  hasFoldedRanges,
+  isSourceLineHiddenByFold,
+  type FoldInfo,
+  type SourceCursor,
+} from "./codeEditorFolds"
+import { getEnvStyleIds, createCodeEditorSyntaxStyle } from "./codeEditorStyles"
+import {
+  getAutoCloseCharacter,
+  getEditorCommand,
+  isPotentialEditKey,
+  normalizeEditorKey,
+  shouldAutoSkipClosingCharacter,
+} from "./codeEditorKeys"
+import {
+  buildExtraHighlightRanges,
+  buildJsonHighlightRanges,
+  buildTreeSitterHighlightRanges,
+  buildYamlHighlightRanges,
+  type EditorHighlightRange,
+} from "./codeEditorHighlighting"
 
-export interface FoldInfo {
-  startLine: number
-  endLine: number
-  startOffset: number
-  endOffset: number
-  summary: string
-  folded: boolean
-}
+export type { FoldInfo } from "./codeEditorFolds"
 
 export interface CodeEditorOptions {
   filetype: string
@@ -40,67 +51,6 @@ export interface CodeEditorOptions {
   focusedBackgroundColor?: string
   focusedTextColor?: string
   cursorColor?: string
-}
-
-interface SourceCursor {
-  line: number
-  col: number
-}
-
-function createTsSyntaxStyle(theme: Theme): SyntaxStyle {
-  return SyntaxStyle.fromStyles({
-    "json.key": { fg: theme.secondary },
-    "json.string": { fg: theme.success },
-    "json.number": { fg: theme.warning },
-    "json.boolean": { fg: theme.info },
-    "json.null": { fg: theme.info },
-    "json.bracket": { fg: theme.textMuted },
-    "json.text": { fg: theme.text },
-    "yaml.key": { fg: theme.secondary },
-    "yaml.string": { fg: theme.success },
-    "yaml.number": { fg: theme.warning },
-    "yaml.boolean": { fg: theme.info },
-    "yaml.null": { fg: theme.info },
-    "yaml.punctuation": { fg: theme.textMuted },
-    "yaml.comment": { fg: theme.textMuted },
-    "yaml.text": { fg: theme.text },
-    string: { fg: theme.success },
-    number: { fg: theme.warning },
-    boolean: { fg: theme.info },
-    constant: { fg: theme.info },
-    "constant.builtin": { fg: theme.info },
-    property: { fg: theme.secondary },
-    comment: { fg: theme.textMuted },
-    punctuation: { fg: theme.textMuted },
-    "punctuation.delimiter": { fg: theme.textMuted },
-    "punctuation.bracket": { fg: theme.textMuted },
-    "punctuation.special": { fg: theme.textMuted },
-    keyword: { fg: theme.info },
-    "keyword.directive": { fg: theme.info },
-    label: { fg: theme.info },
-    type: { fg: theme.info },
-    "string.escape": { fg: theme.success },
-    "env.resolved": { fg: theme.primary },
-    "env.missing": { fg: theme.error },
-  })
-}
-
-const OPEN_TO_CLOSE: Record<string, string> = {
-  '"': '"',
-  "'": "'",
-  "(": ")",
-  "{": "}",
-  "[": "]",
-  "<": ">",
-}
-
-const CLOSE_TO_OPEN: Record<string, string> = {
-  '"': '"',
-  "'": "'",
-  ")": "(",
-  "}": "{",
-  "]": "[",
-  ">": "<",
 }
 
 export class CodeEditorRenderable extends TextareaRenderable {
@@ -149,9 +99,8 @@ export class CodeEditorRenderable extends TextareaRenderable {
     this._onContentChange = options.onContentChange
     this._onFoldsChange = options.onFoldsChange
     this._tsClient = getTreeSitterClient()
-    this._tsStyle = createTsSyntaxStyle(this._theme)
-    this._envResolvedStyleId = this._tsStyle.getStyleId("env.resolved") ?? 0
-    this._envMissingStyleId = this._tsStyle.getStyleId("env.missing") ?? 0
+    this._tsStyle = createCodeEditorSyntaxStyle(this._theme)
+    this.updateEnvStyleIds()
     this._sourceText = super.plainText
     this.rebuildSourceDisplayMaps(this._sourceText)
     this.refreshValidation(this._sourceText)
@@ -192,9 +141,8 @@ export class CodeEditorRenderable extends TextareaRenderable {
     if (this._filetype !== value) {
       this._filetype = value
       this.clearAllHighlights()
-      this._tsStyle = createTsSyntaxStyle(this._theme)
-      this._envResolvedStyleId = this._tsStyle.getStyleId("env.resolved") ?? 0
-      this._envMissingStyleId = this._tsStyle.getStyleId("env.missing") ?? 0
+      this._tsStyle = createCodeEditorSyntaxStyle(this._theme)
+      this.updateEnvStyleIds()
       this.refreshValidation(this._sourceText)
       this.scheduleHighlight()
       this.computeFoldRanges()
@@ -212,6 +160,16 @@ export class CodeEditorRenderable extends TextareaRenderable {
 
   get validationError(): string | null {
     return this._validationError
+  }
+
+  get onValidationChange(): ((error: string | null) => void) | undefined {
+    return this._onValidationChange
+  }
+
+  set onValidationChange(value: ((error: string | null) => void) | undefined) {
+    if (value === this._onValidationChange) return
+    this._onValidationChange = value
+    value?.(this._validationError)
   }
 
   get extraHighlights(): ((content: string) => Highlight[]) | undefined {
@@ -245,7 +203,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
   getFoldSigns(): Map<number, { before: string; beforeColor: string }> {
     const signs = new Map<number, { before: string; beforeColor: string }>()
     for (const [line, fold] of this._folds) {
-      if (this.isSourceLineHiddenByFold(line)) continue
+      if (isSourceLineHiddenByFold(line, this._folds)) continue
       const displayLine =
         this._displayMode === "folded"
           ? this._sourceLineToDisplayLine.get(line)
@@ -274,9 +232,8 @@ export class CodeEditorRenderable extends TextareaRenderable {
 
   set theme(value: Theme) {
     this._theme = value
-    this._tsStyle = createTsSyntaxStyle(this._theme)
-    this._envResolvedStyleId = this._tsStyle.getStyleId("env.resolved") ?? 0
-    this._envMissingStyleId = this._tsStyle.getStyleId("env.missing") ?? 0
+    this._tsStyle = createCodeEditorSyntaxStyle(this._theme)
+    this.updateEnvStyleIds()
     if (this.isFoldedDisplay()) {
       this.applyFoldedDisplayHighlights(super.plainText)
     } else {
@@ -310,6 +267,12 @@ export class CodeEditorRenderable extends TextareaRenderable {
       this._renderSuppressed = wasSuppressed
       if (!wasSuppressed) super.requestRender()
     }
+  }
+
+  private updateEnvStyleIds(): void {
+    const { resolved, missing } = getEnvStyleIds(this._tsStyle)
+    this._envResolvedStyleId = resolved
+    this._envMissingStyleId = missing
   }
 
   toggleFold(line: number): void {
@@ -381,79 +344,50 @@ export class CodeEditorRenderable extends TextareaRenderable {
   }
 
   override handleKeyPress(key: KeyEvent): boolean {
-    const normalizedKey: KeyEvent =
-      key.name === "return" && key.shift
-        ? ({ ...key, shift: false } as KeyEvent)
-        : key
-
-    if (key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
-      if (key.name === "g" && !key.shift) {
-        this.toggleFold(this.logicalCursor.row)
-        return true
-      }
+    const command = getEditorCommand(key)
+    if (command === "toggle-fold") {
+      this.toggleFold(this.logicalCursor.row)
+      return true
+    }
+    if (command === "fold-all") {
+      this.foldAll()
+      return true
+    }
+    if (command === "unfold-all") {
+      this.unfoldAll()
+      return true
     }
 
-    if (!key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
-      if (key.name === "f5") {
-        this.foldAll()
-        return true
-      }
-      if (key.name === "f6") {
-        this.unfoldAll()
-        return true
-      }
+    if (this.shouldAutoSkip(key)) {
+      this.editBuffer.moveCursorRight()
+      return true
     }
 
-    if (
-      key.ctrl &&
-      key.shift &&
-      !key.meta &&
-      !key.option &&
-      !key.super &&
-      !key.hyper
-    ) {
-      if (key.name === "[") {
-        this.foldAll()
-        return true
-      }
-      if (key.name === "]") {
-        this.unfoldAll()
-        return true
-      }
-    }
-
-    if (!key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
-      if (this.shouldAutoSkip(key)) {
-        this.editBuffer.moveCursorRight()
-        return true
-      }
-
-      const closeChar = OPEN_TO_CLOSE[key.sequence]
-      if (closeChar !== undefined) {
-        if (this.hasFoldedRanges() && this.isPotentialEditKey(key)) {
-          if (this.isFoldedDisplay()) {
-            const sourceCursor = this.getSourceCursorFromDisplay()
-            if (!this.isFoldedSummaryLine(sourceCursor.line)) {
-              this.restoreSourceDisplay(undefined, sourceCursor)
-              this.insertAutoClosePair(key.sequence, closeChar)
-              this.syncFoldDisplayAfterEdit()
-              return true
-            }
+    const closeChar = getAutoCloseCharacter(key)
+    if (closeChar !== undefined) {
+      if (this.hasFoldedRanges() && isPotentialEditKey(key)) {
+        if (this.isFoldedDisplay()) {
+          const sourceCursor = this.getSourceCursorFromDisplay()
+          if (!this.isFoldedSummaryLine(sourceCursor.line)) {
+            this.restoreSourceDisplay(undefined, sourceCursor)
+            this.insertAutoClosePair(key.sequence, closeChar)
+            this.syncFoldDisplayAfterEdit()
+            return true
           }
-          this.unfoldAll()
         }
-        this.insertAutoClosePair(key.sequence, closeChar)
-        this.scheduleHighlight()
-        return true
+        this.unfoldAll()
       }
+      this.insertAutoClosePair(key.sequence, closeChar)
+      this.scheduleHighlight()
+      return true
     }
 
-    if (this.hasFoldedRanges() && this.isPotentialEditKey(key)) {
+    if (this.hasFoldedRanges() && isPotentialEditKey(key)) {
       if (this.isFoldedDisplay()) {
         const sourceCursor = this.getSourceCursorFromDisplay()
         if (!this.isFoldedSummaryLine(sourceCursor.line)) {
           this.restoreSourceDisplay(undefined, sourceCursor)
-          const handled = super.handleKeyPress(normalizedKey)
+          const handled = super.handleKeyPress(normalizeEditorKey(key))
           if (handled) {
             this.syncFoldDisplayAfterEdit()
           }
@@ -463,7 +397,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
       this.unfoldAll()
     }
 
-    const handled = super.handleKeyPress(normalizedKey)
+    const handled = super.handleKeyPress(normalizeEditorKey(key))
     if (handled) {
       this.scheduleHighlight()
     }
@@ -472,17 +406,13 @@ export class CodeEditorRenderable extends TextareaRenderable {
 
   private shouldAutoSkip(key: KeyEvent): boolean {
     if (this.isFoldedDisplay()) return false
-    if (key.ctrl || key.meta || key.option || key.super || key.hyper)
-      return false
-    const seq = key.sequence
-    if (!seq || seq.length !== 1) return false
-    if (!CLOSE_TO_OPEN[seq]) return false
-
     const cursor = this.logicalCursor
     const offset = this.editBuffer.positionToOffset(cursor.row, cursor.col)
-    const text = this.editBuffer.getText()
-    if (offset >= text.length) return false
-    return text[offset] === seq
+    return shouldAutoSkipClosingCharacter(
+      key,
+      this.editBuffer.getText(),
+      offset,
+    )
   }
 
   private insertAutoClosePair(openChar: string, closeChar: string): void {
@@ -500,19 +430,8 @@ export class CodeEditorRenderable extends TextareaRenderable {
     this.editBuffer.moveCursorLeft()
   }
 
-  private isSourceLineHiddenByFold(line: number): boolean {
-    for (const fold of this._folds.values()) {
-      if (!fold.folded) continue
-      if (line > fold.startLine && line <= fold.endLine) return true
-    }
-    return false
-  }
-
   private hasFoldedRanges(): boolean {
-    for (const fold of this._folds.values()) {
-      if (fold.folded) return true
-    }
-    return false
+    return hasFoldedRanges(this._folds)
   }
 
   private isFoldedDisplay(): boolean {
@@ -537,35 +456,13 @@ export class CodeEditorRenderable extends TextareaRenderable {
       return
     }
 
-    const lines = this._sourceText.split("\n")
-    const displayLines: string[] = []
-    const sourceToDisplay = new Map<number, number>()
-    const displayToSource = new Map<number, number>()
-
-    for (let sourceLine = 0; sourceLine < lines.length;) {
-      const displayLine = displayLines.length
-      const fold = this._folds.get(sourceLine)
-
-      if (fold?.folded) {
-        sourceToDisplay.set(sourceLine, displayLine)
-        displayToSource.set(displayLine, sourceLine)
-        displayLines.push(`${getLineIndent(lines[sourceLine])}${fold.summary}`)
-        sourceLine = fold.endLine + 1
-        continue
-      }
-
-      sourceToDisplay.set(sourceLine, displayLine)
-      displayToSource.set(displayLine, sourceLine)
-      displayLines.push(lines[sourceLine])
-      sourceLine++
-    }
+    const display = buildFoldDisplay(this._sourceText, this._folds)
 
     this._displayMode = "folded"
-    this._sourceLineToDisplayLine = sourceToDisplay
-    this._displayLineToSourceLine = displayToSource
-    const foldedDisplayText = displayLines.join("\n")
-    this.setDisplayedText(foldedDisplayText)
-    this.applyFoldedDisplayHighlights(foldedDisplayText)
+    this._sourceLineToDisplayLine = display.sourceLineToDisplayLine
+    this._displayLineToSourceLine = display.displayLineToSourceLine
+    this.setDisplayedText(display.text)
+    this.applyFoldedDisplayHighlights(display.text)
     if (typeof preferredSourceLine === "object") {
       this.moveCursorToSourceCursor(preferredSourceLine)
     } else {
@@ -655,13 +552,9 @@ export class CodeEditorRenderable extends TextareaRenderable {
   }
 
   private rebuildSourceDisplayMaps(content: string): void {
-    const lines = content.split("\n")
-    this._sourceLineToDisplayLine = new Map()
-    this._displayLineToSourceLine = new Map()
-    for (let line = 0; line < lines.length; line++) {
-      this._sourceLineToDisplayLine.set(line, line)
-      this._displayLineToSourceLine.set(line, line)
-    }
+    const maps = buildSourceDisplayMaps(content)
+    this._sourceLineToDisplayLine = maps.sourceLineToDisplayLine
+    this._displayLineToSourceLine = maps.displayLineToSourceLine
   }
 
   private displayLineToSourceLine(displayLine: number): number {
@@ -721,20 +614,6 @@ export class CodeEditorRenderable extends TextareaRenderable {
       displayLine,
       Math.min(sourceCursor.col, sourceLineText.length),
     )
-  }
-
-  private isPotentialEditKey(key: KeyEvent): boolean {
-    if (key.name === "backspace" || key.name === "delete") return true
-    if (key.name === "return" || key.name === "linefeed") return true
-
-    if (key.ctrl) {
-      return ["d", "k", "u", "w", "z", ".", "-"].includes(key.name)
-    }
-
-    if (key.meta || key.option || key.super || key.hyper) return false
-    if (!key.sequence) return false
-
-    return key.sequence.length > 0 && key.sequence.charCodeAt(0) >= 32
   }
 
   override destroy(): void {
@@ -829,93 +708,43 @@ export class CodeEditorRenderable extends TextareaRenderable {
     content: string,
   ): void {
     this.clearAllHighlights()
-
-    const style = this._tsStyle
-    this.syntaxStyle = style
-    const displayOffsets = buildByteToDisplayOffsets(content)
-
-    for (const [start, end, group] of highlights) {
-      if (start >= end) continue
-      const styleId = style.getStyleId(group)
-      if (styleId === null) continue
-
-      this.addHighlightByCharRange({
-        start: byteOffsetToDisplayOffset(displayOffsets, start),
-        end: byteOffsetToDisplayOffset(displayOffsets, end),
-        styleId,
-        priority: 1,
-      })
-    }
+    this.syntaxStyle = this._tsStyle
+    this.applyHighlightRanges(
+      buildTreeSitterHighlightRanges(highlights, content, this._tsStyle),
+    )
   }
 
   private applyJsonHighlights(content: string): void {
     this.clearAllHighlights()
-
-    const tokens = highlightJsonTokens(content, this._theme)
-    const style = this._tsStyle
-    this.syntaxStyle = style
-
-    for (const token of tokens) {
-      const styleId = styleIdForJsonToken(
-        token.kind,
-        token.fg,
-        this._theme,
-        style,
-      )
-      this.addHighlightByCharRange({
-        start: token.offset,
-        end: token.offset + token.text.length,
-        styleId,
-        priority: 1,
-      })
-    }
+    this.syntaxStyle = this._tsStyle
+    this.applyHighlightRanges(
+      buildJsonHighlightRanges(content, this._theme, this._tsStyle),
+    )
   }
 
   private applyYamlHighlights(content: string): void {
     this.clearAllHighlights()
-
-    const style = this._tsStyle
-
-    this.syntaxStyle = style
-
-    let offset = 0
-    const lines = content.split("\n")
-
-    for (const line of lines) {
-      const cleanLine = line.endsWith("\r") ? line.slice(0, -1) : line
-      const spans = tokenizeYamlLine(cleanLine, this._theme)
-      for (const span of spans) {
-        if (span.text.length > 0) {
-          let tsName = "string"
-          if (span.fg === this._theme.secondary) tsName = "property"
-          else if (span.fg === this._theme.success) tsName = "string"
-          else if (span.fg === this._theme.warning) tsName = "number"
-          else if (span.fg === this._theme.info) tsName = "boolean"
-          else if (span.fg === this._theme.textMuted) tsName = "comment"
-          const styleId = style.getStyleId(tsName) ?? 0
-          this.addHighlightByCharRange({
-            start: offset,
-            end: offset + span.text.length,
-            styleId,
-            priority: 1,
-          })
-          offset += span.text.length
-        }
-      }
-    }
+    this.syntaxStyle = this._tsStyle
+    this.applyHighlightRanges(
+      buildYamlHighlightRanges(content, this._theme, this._tsStyle),
+    )
   }
 
   private applyExtraHighlights(content: string): void {
     if (!this._extraHighlights) return
 
-    const extras = this._extraHighlights(content)
-    const displayOffsets = buildCharToDisplayOffsets(content)
-    for (const hl of extras) {
+    this.applyHighlightRanges(
+      buildExtraHighlightRanges(content, this._extraHighlights(content)),
+    )
+  }
+
+  private applyHighlightRanges(ranges: EditorHighlightRange[]): void {
+    for (const range of ranges) {
       this.addHighlightByCharRange({
-        start: charOffsetToDisplayOffset(displayOffsets, hl.start),
-        end: charOffsetToDisplayOffset(displayOffsets, hl.end),
-        styleId: hl.styleId,
-        priority: hl.priority ?? 2,
+        start: range.start,
+        end: range.end,
+        styleId: range.styleId,
+        priority: range.priority,
       })
     }
   }
@@ -923,226 +752,11 @@ export class CodeEditorRenderable extends TextareaRenderable {
   private computeFoldRanges(): void {
     if (!this._foldable) return
 
-    const content = this.plainText
-    const prevFolds = this._folds
-    const newFolds = new Map<number, FoldInfo>()
-
-    if (this._filetype === "json") {
-      this.computeJsonFoldRanges(content, newFolds)
-    } else if (this._filetype === "yaml") {
-      this.computeYamlFoldRanges(content, newFolds)
-    }
-
-    this._folds = newFolds
-
-    for (const [line, fold] of newFolds) {
-      const previous = prevFolds.get(line)
-      fold.folded = previous?.folded ?? fold.folded
-    }
+    this._folds = deriveFoldRanges(this.plainText, this._filetype, this._folds)
 
     const hasFoldedRanges = this.hasFoldedRanges()
     if (hasFoldedRanges) this.applyFoldDisplay()
     this._onFoldsChange?.()
     if (!hasFoldedRanges) this.requestRender()
   }
-
-  private computeJsonFoldRanges(
-    content: string,
-    folds: Map<number, FoldInfo>,
-  ): void {
-    const lines = content.split("\n")
-    const stack: {
-      char: string
-      line: number
-      offset: number
-    }[] = []
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i]
-      for (let j = 0; j < line.length; j++) {
-        const ch = line[j]
-        if (ch === '"') {
-          j++
-          while (j < line.length) {
-            if (line[j] === "\\") {
-              j++
-            } else if (line[j] === '"') break
-            j++
-          }
-          continue
-        }
-        if (ch === "{" || ch === "[") {
-          stack.push({
-            char: ch,
-            line: i,
-            offset: this.lineAndColToOffset(i, j, lines),
-          })
-        } else if (ch === "}" || ch === "]") {
-          const expected = ch === "}" ? "{" : "["
-          for (let k = stack.length - 1; k >= 0; k--) {
-            if (stack[k].char === expected) {
-              const startLine = stack[k].line
-              if (startLine < i) {
-                const summary = this.getJsonFoldSummary(
-                  lines,
-                  startLine,
-                  i,
-                  stack[k].char,
-                )
-                folds.set(startLine, {
-                  startLine,
-                  endLine: i,
-                  startOffset: stack[k].offset,
-                  endOffset: this.lineAndColToOffset(i, j, lines),
-                  summary,
-                  folded: this._folds.get(startLine)?.folded ?? false,
-                })
-              }
-              stack.length = k
-              break
-            }
-          }
-        }
-      }
-    }
-  }
-
-  private computeYamlFoldRanges(
-    content: string,
-    folds: Map<number, FoldInfo>,
-  ): void {
-    const lines = content.split("\n")
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i]
-      if (line.trim() === "" || line.trim().startsWith("#")) continue
-
-      const indent = line.length - line.trimStart().length
-      let endLine = i
-
-      for (let j = i + 1; j < lines.length; j++) {
-        const nextLine = lines[j]
-        if (nextLine.trim() === "") {
-          endLine = j
-          continue
-        }
-        const nextIndent = nextLine.length - nextLine.trimStart().length
-        if (nextIndent > indent) {
-          endLine = j
-        } else {
-          break
-        }
-      }
-
-      if (endLine > i) {
-        const summary = lines[i].trim().slice(0, 40)
-        const startOffset = this.lineAndColToOffset(i, 0, lines)
-        const endOffset = this.lineAndColToOffset(
-          endLine,
-          (lines[endLine] || "").length,
-          lines,
-        )
-        folds.set(i, {
-          startLine: i,
-          endLine,
-          startOffset,
-          endOffset,
-          summary,
-          folded: this._folds.get(i)?.folded ?? false,
-        })
-        i = endLine
-      }
-    }
-  }
-
-  private getJsonFoldSummary(
-    lines: string[],
-    startLine: number,
-    endLine: number,
-    openingChar: string,
-  ): string {
-    const firstLine = lines[startLine].trim()
-    const bracket = openingChar === "{" ? "}" : "]"
-    const lineCount = endLine - startLine
-    return `${firstLine.slice(0, 30)}... ${bracket} (${lineCount} lines)`
-  }
-
-  private lineAndColToOffset(
-    line: number,
-    col: number,
-    lines: string[],
-  ): number {
-    let offset = 0
-    for (let i = 0; i < line; i++) {
-      offset += lines[i].length + 1
-    }
-    return offset + col
-  }
-}
-
-function buildByteToDisplayOffsets(content: string): number[] {
-  const offsets: number[] = []
-  offsets[0] = 0
-  let displayOffset = 0
-  let byteOffset = 0
-
-  for (const char of content) {
-    const codePoint = char.codePointAt(0)
-    if (codePoint === undefined) continue
-
-    byteOffset += utf8ByteLength(codePoint)
-    if (char !== "\n") {
-      displayOffset++
-    }
-
-    offsets[byteOffset] = displayOffset
-  }
-  return offsets
-}
-
-function styleIdForJsonToken(
-  kind: string | undefined,
-  fg: string,
-  theme: Theme,
-  style: SyntaxStyle,
-): number {
-  if (kind === "key") return style.getStyleId("json.key") ?? 0
-  if (kind === "string") return style.getStyleId("json.string") ?? 0
-  if (kind === "number") return style.getStyleId("json.number") ?? 0
-  if (kind === "boolean") return style.getStyleId("json.boolean") ?? 0
-  if (kind === "null") return style.getStyleId("json.null") ?? 0
-  if (kind === "bracket") return style.getStyleId("json.bracket") ?? 0
-  if (kind === "punctuation") return style.getStyleId("json.bracket") ?? 0
-  if (kind === "text") return style.getStyleId("json.text") ?? 0
-
-  if (fg === theme.secondary) return style.getStyleId("json.key") ?? 0
-  if (fg === theme.success) return style.getStyleId("json.string") ?? 0
-  if (fg === theme.warning) return style.getStyleId("json.number") ?? 0
-  if (fg === theme.info) return style.getStyleId("json.boolean") ?? 0
-  if (fg === theme.textMuted) return style.getStyleId("json.bracket") ?? 0
-  return style.getStyleId("json.text") ?? 0
-}
-
-function byteOffsetToDisplayOffset(
-  offsets: number[],
-  byteOffset: number,
-): number {
-  if (byteOffset <= 0) return 0
-  for (let i = byteOffset; i >= 0; i--) {
-    const value = offsets[i]
-    if (value !== undefined) return value
-  }
-  return 0
-}
-
-function getLineIndent(line: string): string {
-  const match = /^\s*/.exec(line)
-  return match?.[0] ?? ""
-}
-
-function utf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) return 1
-  if (codePoint <= 0x7ff) return 2
-  if (codePoint <= 0xffff) return 3
-  return 4
 }

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -41,6 +41,7 @@ export function YamlEditorOverlay({
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
   const [content, setContent] = useState<string | null>(null)
   const [draftContent, setDraftContent] = useState<string | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
   const [readError, setReadError] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const mountedRef = useRef(true)
@@ -55,6 +56,7 @@ export function YamlEditorOverlay({
     if (!visible) {
       setContent(null)
       setDraftContent(null)
+      setValidationError(null)
       return
     }
     setReadError(null)
@@ -146,19 +148,17 @@ export function YamlEditorOverlay({
   )
 
   const validationNotice = useMemo(() => {
-    if (draftContent === null) return null
-    const error = validateContent(draftContent)
-    if (!error) return null
+    if (!validationError) return null
     const prefix =
       kind === "folder" ? "Invalid folder YAML" : "Invalid request YAML"
     return {
       title: prefix,
-      detail: error.replace(
+      detail: validationError.replace(
         new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}: `),
         "",
       ),
     }
-  }, [draftContent, validateContent, kind])
+  }, [validationError, kind])
 
   const handleClose = useCallback(() => {
     onClose()
@@ -258,6 +258,7 @@ export function YamlEditorOverlay({
               initialValue={content}
               extraHighlights={activeEnv ? extraHighlights : undefined}
               validateContent={validateContent}
+              onValidationChange={setValidationError}
               onContentChange={handleContentChange}
               onFoldsChange={handleFoldsChange}
               backgroundColor={theme.backgroundPanel}

--- a/src/ui/editor/codeEditorFolds.ts
+++ b/src/ui/editor/codeEditorFolds.ts
@@ -1,0 +1,216 @@
+export interface FoldInfo {
+  startLine: number
+  endLine: number
+  startOffset: number
+  endOffset: number
+  summary: string
+  folded: boolean
+}
+
+export interface SourceCursor {
+  line: number
+  col: number
+}
+
+export interface FoldDisplay {
+  text: string
+  sourceLineToDisplayLine: Map<number, number>
+  displayLineToSourceLine: Map<number, number>
+}
+
+export function computeFoldRanges(
+  content: string,
+  filetype: string,
+  previousFolds: ReadonlyMap<number, FoldInfo>,
+): Map<number, FoldInfo> {
+  const folds = new Map<number, FoldInfo>()
+
+  if (filetype === "json") {
+    computeJsonFoldRanges(content, folds, previousFolds)
+  } else if (filetype === "yaml") {
+    computeYamlFoldRanges(content, folds, previousFolds)
+  }
+
+  return folds
+}
+
+export function buildFoldDisplay(
+  sourceText: string,
+  folds: ReadonlyMap<number, FoldInfo>,
+): FoldDisplay {
+  const lines = sourceText.split("\n")
+  const displayLines: string[] = []
+  const sourceLineToDisplayLine = new Map<number, number>()
+  const displayLineToSourceLine = new Map<number, number>()
+
+  for (let sourceLine = 0; sourceLine < lines.length;) {
+    const displayLine = displayLines.length
+    const fold = folds.get(sourceLine)
+
+    if (fold?.folded) {
+      sourceLineToDisplayLine.set(sourceLine, displayLine)
+      displayLineToSourceLine.set(displayLine, sourceLine)
+      displayLines.push(`${getLineIndent(lines[sourceLine])}${fold.summary}`)
+      sourceLine = fold.endLine + 1
+      continue
+    }
+
+    sourceLineToDisplayLine.set(sourceLine, displayLine)
+    displayLineToSourceLine.set(displayLine, sourceLine)
+    displayLines.push(lines[sourceLine])
+    sourceLine++
+  }
+
+  return {
+    text: displayLines.join("\n"),
+    sourceLineToDisplayLine,
+    displayLineToSourceLine,
+  }
+}
+
+export function buildSourceDisplayMaps(content: string): {
+  sourceLineToDisplayLine: Map<number, number>
+  displayLineToSourceLine: Map<number, number>
+} {
+  const sourceLineToDisplayLine = new Map<number, number>()
+  const displayLineToSourceLine = new Map<number, number>()
+
+  for (let line = 0; line < content.split("\n").length; line++) {
+    sourceLineToDisplayLine.set(line, line)
+    displayLineToSourceLine.set(line, line)
+  }
+
+  return { sourceLineToDisplayLine, displayLineToSourceLine }
+}
+
+export function hasFoldedRanges(folds: ReadonlyMap<number, FoldInfo>): boolean {
+  return Array.from(folds.values()).some((fold) => fold.folded)
+}
+
+export function isSourceLineHiddenByFold(
+  line: number,
+  folds: ReadonlyMap<number, FoldInfo>,
+): boolean {
+  return Array.from(folds.values()).some(
+    (fold) => fold.folded && line > fold.startLine && line <= fold.endLine,
+  )
+}
+
+function computeJsonFoldRanges(
+  content: string,
+  folds: Map<number, FoldInfo>,
+  previousFolds: ReadonlyMap<number, FoldInfo>,
+): void {
+  const lines = content.split("\n")
+  const stack: { char: string; line: number; offset: number }[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    for (let j = 0; j < line.length; j++) {
+      const char = line[j]
+      if (char === '"') {
+        j++
+        while (j < line.length) {
+          if (line[j] === "\\") j++
+          else if (line[j] === '"') break
+          j++
+        }
+        continue
+      }
+
+      if (char === "{" || char === "[") {
+        stack.push({
+          char,
+          line: i,
+          offset: lineAndColToOffset(i, j, lines),
+        })
+        continue
+      }
+
+      if (char !== "}" && char !== "]") continue
+      const expected = char === "}" ? "{" : "["
+      for (let k = stack.length - 1; k >= 0; k--) {
+        if (stack[k].char !== expected) continue
+        const start = stack[k]
+        if (start.line < i) {
+          folds.set(start.line, {
+            startLine: start.line,
+            endLine: i,
+            startOffset: start.offset,
+            endOffset: lineAndColToOffset(i, j, lines),
+            summary: getJsonFoldSummary(lines, start.line, i, start.char),
+            folded: previousFolds.get(start.line)?.folded ?? false,
+          })
+        }
+        stack.length = k
+        break
+      }
+    }
+  }
+}
+
+function computeYamlFoldRanges(
+  content: string,
+  folds: Map<number, FoldInfo>,
+  previousFolds: ReadonlyMap<number, FoldInfo>,
+): void {
+  const lines = content.split("\n")
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.trim() === "" || line.trim().startsWith("#")) continue
+
+    const indent = line.length - line.trimStart().length
+    let endLine = i
+
+    for (let j = i + 1; j < lines.length; j++) {
+      const nextLine = lines[j]
+      if (nextLine.trim() === "") {
+        endLine = j
+        continue
+      }
+      const nextIndent = nextLine.length - nextLine.trimStart().length
+      if (nextIndent > indent) endLine = j
+      else break
+    }
+
+    if (endLine <= i) continue
+    folds.set(i, {
+      startLine: i,
+      endLine,
+      startOffset: lineAndColToOffset(i, 0, lines),
+      endOffset: lineAndColToOffset(
+        endLine,
+        lines[endLine]?.length ?? 0,
+        lines,
+      ),
+      summary: lines[i].trim().slice(0, 40),
+      folded: previousFolds.get(i)?.folded ?? false,
+    })
+    i = endLine
+  }
+}
+
+function getJsonFoldSummary(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  openingChar: string,
+): string {
+  const bracket = openingChar === "{" ? "}" : "]"
+  return `${lines[startLine].trim().slice(0, 30)}... ${bracket} (${endLine - startLine} lines)`
+}
+
+function lineAndColToOffset(
+  line: number,
+  col: number,
+  lines: string[],
+): number {
+  let offset = 0
+  for (let i = 0; i < line; i++) offset += lines[i].length + 1
+  return offset + col
+}
+
+function getLineIndent(line: string): string {
+  return /^\s*/.exec(line)?.[0] ?? ""
+}

--- a/src/ui/editor/codeEditorHighlighting.ts
+++ b/src/ui/editor/codeEditorHighlighting.ts
@@ -1,0 +1,95 @@
+import type { Highlight, SimpleHighlight, SyntaxStyle } from "@opentui/core"
+import type { Theme } from "../theme-data"
+import {
+  buildCharToDisplayOffsets,
+  charOffsetToDisplayOffset,
+} from "../variable-completion/highlightOffsets"
+import { highlightJsonTokens } from "./syntax"
+import { tokenizeYamlLine } from "./yamlSyntax"
+import {
+  buildByteToDisplayOffsets,
+  byteOffsetToDisplayOffset,
+} from "./codeEditorOffsets"
+import {
+  styleIdForJsonToken,
+  styleIdForYamlForeground,
+} from "./codeEditorStyles"
+
+export interface EditorHighlightRange {
+  start: number
+  end: number
+  styleId: number
+  priority: number
+}
+
+export function buildTreeSitterHighlightRanges(
+  highlights: SimpleHighlight[],
+  content: string,
+  style: SyntaxStyle,
+): EditorHighlightRange[] {
+  const displayOffsets = buildByteToDisplayOffsets(content)
+  return highlights.flatMap(([start, end, group]) => {
+    if (start >= end) return []
+    const styleId = style.getStyleId(group)
+    if (styleId === null) return []
+    return [
+      {
+        start: byteOffsetToDisplayOffset(displayOffsets, start),
+        end: byteOffsetToDisplayOffset(displayOffsets, end),
+        styleId,
+        priority: 1,
+      },
+    ]
+  })
+}
+
+export function buildJsonHighlightRanges(
+  content: string,
+  theme: Theme,
+  style: SyntaxStyle,
+): EditorHighlightRange[] {
+  return highlightJsonTokens(content, theme).map((token) => ({
+    start: token.offset,
+    end: token.offset + token.text.length,
+    styleId: styleIdForJsonToken(token.kind, token.fg, theme, style),
+    priority: 1,
+  }))
+}
+
+export function buildYamlHighlightRanges(
+  content: string,
+  theme: Theme,
+  style: SyntaxStyle,
+): EditorHighlightRange[] {
+  const ranges: EditorHighlightRange[] = []
+  let offset = 0
+
+  for (const line of content.split("\n")) {
+    const cleanLine = line.endsWith("\r") ? line.slice(0, -1) : line
+    for (const span of tokenizeYamlLine(cleanLine, theme)) {
+      if (span.text.length === 0) continue
+      ranges.push({
+        start: offset,
+        end: offset + span.text.length,
+        styleId: styleIdForYamlForeground(span.fg, theme, style),
+        priority: 1,
+      })
+      offset += span.text.length
+    }
+  }
+
+  return ranges
+}
+
+export function buildExtraHighlightRanges(
+  content: string,
+  highlights: Highlight[],
+): EditorHighlightRange[] {
+  const displayOffsets = buildCharToDisplayOffsets(content)
+  return highlights.map((highlight) => ({
+    start: charOffsetToDisplayOffset(displayOffsets, highlight.start),
+    end: charOffsetToDisplayOffset(displayOffsets, highlight.end),
+    styleId: highlight.styleId,
+    priority: highlight.priority ?? 2,
+  }))
+}

--- a/src/ui/editor/codeEditorKeys.ts
+++ b/src/ui/editor/codeEditorKeys.ts
@@ -1,0 +1,80 @@
+import type { KeyEvent } from "@opentui/core"
+
+const OPEN_TO_CLOSE: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  "(": ")",
+  "{": "}",
+  "[": "]",
+  "<": ">",
+}
+
+const CLOSE_TO_OPEN: Record<string, string> = {
+  '"': '"',
+  "'": "'",
+  ")": "(",
+  "}": "{",
+  "]": "[",
+  ">": "<",
+}
+
+export type EditorCommand = "toggle-fold" | "fold-all" | "unfold-all"
+
+export function normalizeEditorKey(key: KeyEvent): KeyEvent {
+  if (key.name !== "return" || !key.shift) return key
+  return { ...key, shift: false } as KeyEvent
+}
+
+export function getEditorCommand(key: KeyEvent): EditorCommand | null {
+  if (key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
+    if (key.name === "g" && !key.shift) return "toggle-fold"
+  }
+
+  if (!key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
+    if (key.name === "f5") return "fold-all"
+    if (key.name === "f6") return "unfold-all"
+  }
+
+  if (
+    key.ctrl &&
+    key.shift &&
+    !key.meta &&
+    !key.option &&
+    !key.super &&
+    !key.hyper
+  ) {
+    if (key.name === "[") return "fold-all"
+    if (key.name === "]") return "unfold-all"
+  }
+
+  return null
+}
+
+export function getAutoCloseCharacter(key: KeyEvent): string | undefined {
+  if (hasModifier(key)) return undefined
+  return OPEN_TO_CLOSE[key.sequence]
+}
+
+export function shouldAutoSkipClosingCharacter(
+  key: KeyEvent,
+  text: string,
+  offset: number,
+): boolean {
+  if (hasModifier(key)) return false
+  const sequence = key.sequence
+  if (!sequence || sequence.length !== 1 || !CLOSE_TO_OPEN[sequence])
+    return false
+  return offset < text.length && text[offset] === sequence
+}
+
+export function isPotentialEditKey(key: KeyEvent): boolean {
+  if (key.name === "backspace" || key.name === "delete") return true
+  if (key.name === "return" || key.name === "linefeed") return true
+  if (key.ctrl) return ["d", "k", "u", "w", "z", ".", "-"].includes(key.name)
+  if (key.meta || key.option || key.super || key.hyper) return false
+  return Boolean(key.sequence && key.sequence.charCodeAt(0) >= 32)
+}
+
+function hasModifier(key: KeyEvent): boolean {
+  return Boolean(key.ctrl || key.meta || key.option || key.super || key.hyper)
+}

--- a/src/ui/editor/codeEditorOffsets.ts
+++ b/src/ui/editor/codeEditorOffsets.ts
@@ -1,0 +1,35 @@
+export function buildByteToDisplayOffsets(content: string): number[] {
+  const offsets: number[] = []
+  offsets[0] = 0
+  let displayOffset = 0
+  let byteOffset = 0
+
+  for (const char of content) {
+    const codePoint = char.codePointAt(0)
+    if (codePoint === undefined) continue
+    byteOffset += utf8ByteLength(codePoint)
+    if (char !== "\n") displayOffset++
+    offsets[byteOffset] = displayOffset
+  }
+
+  return offsets
+}
+
+export function byteOffsetToDisplayOffset(
+  offsets: number[],
+  byteOffset: number,
+): number {
+  if (byteOffset <= 0) return 0
+  for (let i = byteOffset; i >= 0; i--) {
+    const value = offsets[i]
+    if (value !== undefined) return value
+  }
+  return 0
+}
+
+function utf8ByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1
+  if (codePoint <= 0x7ff) return 2
+  if (codePoint <= 0xffff) return 3
+  return 4
+}

--- a/src/ui/editor/codeEditorStyles.ts
+++ b/src/ui/editor/codeEditorStyles.ts
@@ -1,0 +1,88 @@
+import { SyntaxStyle } from "@opentui/core"
+import type { Theme } from "../theme-data"
+
+export function createCodeEditorSyntaxStyle(theme: Theme): SyntaxStyle {
+  return SyntaxStyle.fromStyles({
+    "json.key": { fg: theme.secondary },
+    "json.string": { fg: theme.success },
+    "json.number": { fg: theme.warning },
+    "json.boolean": { fg: theme.info },
+    "json.null": { fg: theme.info },
+    "json.bracket": { fg: theme.textMuted },
+    "json.text": { fg: theme.text },
+    "yaml.key": { fg: theme.secondary },
+    "yaml.string": { fg: theme.success },
+    "yaml.number": { fg: theme.warning },
+    "yaml.boolean": { fg: theme.info },
+    "yaml.null": { fg: theme.info },
+    "yaml.punctuation": { fg: theme.textMuted },
+    "yaml.comment": { fg: theme.textMuted },
+    "yaml.text": { fg: theme.text },
+    string: { fg: theme.success },
+    number: { fg: theme.warning },
+    boolean: { fg: theme.info },
+    constant: { fg: theme.info },
+    "constant.builtin": { fg: theme.info },
+    property: { fg: theme.secondary },
+    comment: { fg: theme.textMuted },
+    punctuation: { fg: theme.textMuted },
+    "punctuation.delimiter": { fg: theme.textMuted },
+    "punctuation.bracket": { fg: theme.textMuted },
+    "punctuation.special": { fg: theme.textMuted },
+    keyword: { fg: theme.info },
+    "keyword.directive": { fg: theme.info },
+    label: { fg: theme.info },
+    type: { fg: theme.info },
+    "string.escape": { fg: theme.success },
+    "env.resolved": { fg: theme.primary },
+    "env.missing": { fg: theme.error },
+  })
+}
+
+export function getEnvStyleIds(style: SyntaxStyle): {
+  resolved: number
+  missing: number
+} {
+  return {
+    resolved: style.getStyleId("env.resolved") ?? 0,
+    missing: style.getStyleId("env.missing") ?? 0,
+  }
+}
+
+export function styleIdForJsonToken(
+  kind: string | undefined,
+  fg: string,
+  theme: Theme,
+  style: SyntaxStyle,
+): number {
+  const names: Record<string, string> = {
+    key: "json.key",
+    string: "json.string",
+    number: "json.number",
+    boolean: "json.boolean",
+    null: "json.null",
+    bracket: "json.bracket",
+    punctuation: "json.bracket",
+    text: "json.text",
+  }
+  if (kind) return style.getStyleId(names[kind] ?? "json.text") ?? 0
+  if (fg === theme.secondary) return style.getStyleId("json.key") ?? 0
+  if (fg === theme.success) return style.getStyleId("json.string") ?? 0
+  if (fg === theme.warning) return style.getStyleId("json.number") ?? 0
+  if (fg === theme.info) return style.getStyleId("json.boolean") ?? 0
+  if (fg === theme.textMuted) return style.getStyleId("json.bracket") ?? 0
+  return style.getStyleId("json.text") ?? 0
+}
+
+export function styleIdForYamlForeground(
+  fg: string,
+  theme: Theme,
+  style: SyntaxStyle,
+): number {
+  if (fg === theme.secondary) return style.getStyleId("property") ?? 0
+  if (fg === theme.success) return style.getStyleId("string") ?? 0
+  if (fg === theme.warning) return style.getStyleId("number") ?? 0
+  if (fg === theme.info) return style.getStyleId("boolean") ?? 0
+  if (fg === theme.textMuted) return style.getStyleId("comment") ?? 0
+  return style.getStyleId("string") ?? 0
+}

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -555,6 +555,41 @@ body:
     expect(getHighlightCount(editor!)).toBeGreaterThan(0)
   })
 
+  it("publishes current validation when validation callback changes", async () => {
+    let editor: CodeEditorRenderable | null = null
+    const initialErrors: (string | null)[] = []
+
+    const { renderOnce } = await testRender(
+      <box width={40} height={8}>
+        <code-editor
+          ref={(r) => {
+            editor = r
+          }}
+          filetype="json"
+          theme={opencodeTheme}
+          initialValue="invalid"
+          validateContent={() => "Invalid JSON: test"}
+          onValidationChange={(error) => initialErrors.push(error)}
+          backgroundColor={opencodeTheme.backgroundPanel}
+          focusedBackgroundColor={opencodeTheme.backgroundPanel}
+          textColor={opencodeTheme.text}
+          cursorColor={opencodeTheme.primary}
+        />
+      </box>,
+      { width: 40, height: 8 },
+    )
+
+    await renderOnce()
+    expect(initialErrors).toEqual(["Invalid JSON: test"])
+
+    const replacementErrors: (string | null)[] = []
+    editor!.onValidationChange = (error) => replacementErrors.push(error)
+    editor!.validateContent = () => null
+
+    expect(replacementErrors).toEqual(["Invalid JSON: test", null])
+    expect(editor!.validationError).toBeNull()
+  })
+
   describe("auto-close pairs", () => {
     async function setupEditor(
       content = "",

--- a/tests/unit/codeEditorFolds.test.ts
+++ b/tests/unit/codeEditorFolds.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test"
+import {
+  buildFoldDisplay,
+  buildSourceDisplayMaps,
+  computeFoldRanges,
+  hasFoldedRanges,
+  isSourceLineHiddenByFold,
+} from "../../src/ui/editor/codeEditorFolds"
+
+describe("codeEditorFolds", () => {
+  it("keeps nested JSON folds ordered by closing bracket", () => {
+    const content = `{
+  "outer": {
+    "inner": true
+  },
+  "after": false
+}`
+
+    const folds = computeFoldRanges(content, "json", new Map())
+
+    expect(Array.from(folds.keys())).toEqual([1, 0])
+    expect(folds.get(1)).toMatchObject({ endLine: 3, folded: false })
+    expect(folds.get(0)).toMatchObject({ endLine: 5, folded: false })
+  })
+
+  it("projects folded source into summary rows with reversible line maps", () => {
+    const content = `name: demo
+headers:
+  accept: application/json
+  enabled: true
+body_type: json`
+    const folds = computeFoldRanges(content, "yaml", new Map())
+    const headers = folds.get(1)
+    if (!headers) throw new Error("Expected headers fold")
+    headers.folded = true
+
+    const display = buildFoldDisplay(content, folds)
+
+    expect(hasFoldedRanges(folds)).toBe(true)
+    expect(display.text).toBe("name: demo\nheaders:\nbody_type: json")
+    expect(display.sourceLineToDisplayLine.get(1)).toBe(1)
+    expect(display.displayLineToSourceLine.get(2)).toBe(4)
+    expect(isSourceLineHiddenByFold(2, folds)).toBe(true)
+    expect(isSourceLineHiddenByFold(1, folds)).toBe(false)
+  })
+
+  it("builds identity maps for source display", () => {
+    const maps = buildSourceDisplayMaps("one\ntwo\nthree")
+
+    expect(Array.from(maps.sourceLineToDisplayLine.entries())).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+    ])
+    expect(Array.from(maps.displayLineToSourceLine.entries())).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+    ])
+  })
+})

--- a/tests/unit/codeEditorKeys.test.ts
+++ b/tests/unit/codeEditorKeys.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test"
+import type { KeyEvent } from "@opentui/core"
+import {
+  getAutoCloseCharacter,
+  getEditorCommand,
+  isPotentialEditKey,
+  normalizeEditorKey,
+  shouldAutoSkipClosingCharacter,
+} from "../../src/ui/editor/codeEditorKeys"
+
+function key(name: string, modifiers: Partial<KeyEvent> = {}): KeyEvent {
+  return {
+    name,
+    sequence: name,
+    raw: name,
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    super: false,
+    hyper: false,
+    ...modifiers,
+  } as KeyEvent
+}
+
+describe("codeEditorKeys", () => {
+  it("classifies fold shortcuts without matching modified function keys", () => {
+    expect(getEditorCommand(key("g", { ctrl: true }))).toBe("toggle-fold")
+    expect(getEditorCommand(key("f5"))).toBe("fold-all")
+    expect(getEditorCommand(key("]", { ctrl: true, shift: true }))).toBe(
+      "unfold-all",
+    )
+    expect(getEditorCommand(key("f5", { ctrl: true }))).toBeNull()
+  })
+
+  it("normalizes shift-return and preserves auto-pair policy", () => {
+    expect(normalizeEditorKey(key("return", { shift: true })).shift).toBe(false)
+    expect(getAutoCloseCharacter(key("{"))).toBe("}")
+    expect(getAutoCloseCharacter(key("{", { ctrl: true }))).toBeUndefined()
+    expect(shouldAutoSkipClosingCharacter(key("}"), "{}", 1)).toBe(true)
+    expect(shouldAutoSkipClosingCharacter(key("}"), "{}", 0)).toBe(false)
+    expect(isPotentialEditKey(key("backspace"))).toBe(true)
+    expect(isPotentialEditKey(key("a", { meta: true }))).toBe(false)
+  })
+})


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extracts the monolithic CodeEditor.ts into focused modules: folds, highlighting, key handling, offsets, and styles. Adds an `onValidationChange` callback so consumers get real-time validation state without calling back into the editor directly. Drops dead code and simplifies the main class.

### How did you verify your code works?

Added unit tests for `codeEditorFolds`, `codeEditorKeys`, and the new validation callback behavior in CodeEditor. Full suite passes: `bun test`, `bun run lint`, `bun run typecheck`.

### Screenshots / recordings

N/A — internal refactor, no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved code editor folding for JSON and YAML, including fold-all and unfold-all shortcuts.
  * Enhanced syntax highlighting and support for accurate cursor positioning with Unicode text.
  * Validation errors now update immediately across request bodies and YAML editing overlays.
  * Preserved automatic bracket and quote pairing behavior.

* **Tests**
  * Added coverage for folding, keyboard shortcuts, syntax validation updates, and editor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->