### PR TITLE
feat(path-params): add path parameter tab with :token URL interpolation

### DIFF
--- a/collections/albums/update-album.yml
+++ b/collections/albums/update-album.yml
@@ -5,7 +5,7 @@ timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
-  Content-Type: application/json
+  Content-Type: { value: application/json, enabled: false }
 body: |-
   {
     "title": "updated album"

--- a/collections/posts/delete-post.yml
+++ b/collections/posts/delete-post.yml
@@ -10,5 +10,5 @@ params:
     enabled: false
 path_params:
   - name: post_id
-    value: '3'
+    value: '1'
 body_type: none

--- a/collections/posts/delete-post.yml
+++ b/collections/posts/delete-post.yml
@@ -1,13 +1,14 @@
 name: Delete Post
 method: DELETE
-url: $base_url/posts/$post_id
+url: $base_url/posts/:post_id
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 params:
   - name: key
-    value: val1
-  - name: key
     value: val2
     enabled: false
+path_params:
+  - name: post_id
+    value: '3'
 body_type: none

--- a/collections/posts/get-post.yml
+++ b/collections/posts/get-post.yml
@@ -1,7 +1,10 @@
 name: Get Post by ID
 method: GET
-url: $base_url/posts/$post_id
+url: $base_url/posts/:id
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: id
+    value: '1'
 body_type: none

--- a/collections/posts/put-post.yml
+++ b/collections/posts/put-post.yml
@@ -1,11 +1,14 @@
 name: Replace Post
 method: PUT
-url: $base_url/posts/$post_id
+url: $base_url/posts/:post_id
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
   Content-Type: application/json
+path_params:
+  - name: post_id
+    value: '1'
 body: |
   {
     "id": 1,

--- a/collections/posts/update-post.yml
+++ b/collections/posts/update-post.yml
@@ -1,10 +1,13 @@
 name: Update Post
 method: PATCH
-url: $base_url/posts/1
+url: $base_url/posts/:post_id
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
   Content-Type: application/json
+path_params:
+  - name: post_id
+    value: '1'
 body: '{"title":"updated title"}'
 body_type: json

--- a/src/converters/openapi/index.ts
+++ b/src/converters/openapi/index.ts
@@ -16,6 +16,7 @@ export {
   convertTpl,
   slugify,
   urlTemplateToVar,
+  pathTemplateToColon,
   baseUrl,
   joinUrl,
   paramDefault,

--- a/src/converters/openapi/map.ts
+++ b/src/converters/openapi/map.ts
@@ -10,6 +10,10 @@ import type {
 } from "../../schema"
 import type { ImportResult } from "../index"
 import { slugify, METHOD_UPPER } from "../shared"
+import {
+  openApiPathTemplateToColon,
+  parseOpenApiPathTokens,
+} from "../../requests/pathParams"
 
 export { slugify, METHOD_UPPER }
 
@@ -240,6 +244,10 @@ export function urlTemplateToVar(s: string): string {
   return s.replace(/\{(\w+)\}/g, "$$$1")
 }
 
+export function pathTemplateToColon(s: string): string {
+  return openApiPathTemplateToColon(s)
+}
+
 export function baseUrl(n: Normalized): string {
   const servers = n.servers
   if (!Array.isArray(servers) || servers.length === 0) return "/"
@@ -302,7 +310,7 @@ export function mapCollection(n: Normalized): ImportResult {
       const op = opVal as Record<string, unknown>
 
       const method = METHOD_UPPER[methodKey]
-      const url = joinUrl(base, urlTemplateToVar(pathTemplate))
+      const url = joinUrl(base, pathTemplateToColon(pathTemplate))
       const reqName = makeName(op, methodKey, pathTemplate)
 
       const rawId = makeIdRaw(methodKey, pathTemplate)
@@ -313,14 +321,23 @@ export function mapCollection(n: Normalized): ImportResult {
       const collected = collectParams(pi.parameters, op.parameters)
       const headers: Record<string, KvEntry> = {}
       const params: ParamEntry[] = []
+      const pathParams: ParamEntry[] = []
+
+      const pathTokenSet = new Set(parseOpenApiPathTokens(pathTemplate))
+
       for (const p of collected) {
         const val = p.default ?? ""
         if (p.in === "query") {
           const idx = params.findIndex((e) => e.name === p.name)
           if (idx >= 0) params.splice(idx, 1)
           params.push({ name: p.name, value: val, enabled: true })
-        } else if (p.in === "header")
+        } else if (p.in === "header") {
           headers[p.name] = { value: val, enabled: true }
+        } else if (p.in === "path" && pathTokenSet.has(p.name)) {
+          const idx = pathParams.findIndex((e) => e.name === p.name)
+          if (idx >= 0) pathParams.splice(idx, 1)
+          pathParams.push({ name: p.name, value: val, enabled: true })
+        }
       }
 
       const rawTags = op.tags
@@ -339,6 +356,7 @@ export function mapCollection(n: Normalized): ImportResult {
         timeout: 0,
         headers,
         params,
+        pathParams: pathParams.length > 0 ? pathParams : undefined,
         ...collectBody(op),
         auth: resolveAuth(op, n),
       }
@@ -395,6 +413,12 @@ export function mapCollection(n: Normalized): ImportResult {
     for (const entry of r.params) {
       const m = entry.value.match(/\$(\w+)/)
       if (m) envVarsFound.add(m[1])
+    }
+    if (r.pathParams) {
+      for (const entry of r.pathParams) {
+        const mPath = entry.value.match(/\$(\w+)/g)
+        if (mPath) for (const v of mPath) envVarsFound.add(v.slice(1))
+      }
     }
     if (r.body) {
       const mBody = r.body.match(/\$(\w+)/g)

--- a/src/converters/postman/map.ts
+++ b/src/converters/postman/map.ts
@@ -21,6 +21,7 @@ import type {
 } from "../../schema"
 import type { ImportResult } from "../index"
 import { slugify, METHOD_UPPER } from "../shared"
+import { parsePathToken } from "../../requests/pathParams"
 
 export function convertTpl(s: string): string {
   return s.replace(/\{\{(\$?[\w.-]+)\}\}/g, "$$$1")
@@ -180,6 +181,7 @@ function mapUrl(req: {
   url?: {
     getRaw?: () => string
     toString?: () => string
+    getPath?: (unresolved?: boolean) => string
     query?: PropertyList<QueryParam>
   }
 }): string {
@@ -198,6 +200,28 @@ function mapUrl(req: {
   } catch {
     // ignore
   }
+  if (!raw) return "$base_url"
+
+  try {
+    const resolvedPath = req.url.getPath?.()
+    const unresolvedPath = req.url.getPath?.(true)
+    if (
+      typeof resolvedPath === "string" &&
+      typeof unresolvedPath === "string" &&
+      resolvedPath !== unresolvedPath
+    ) {
+      const pathIndex = raw.indexOf(resolvedPath)
+      if (pathIndex !== -1) {
+        raw =
+          raw.slice(0, pathIndex) +
+          unresolvedPath +
+          raw.slice(pathIndex + resolvedPath.length)
+      }
+    }
+  } catch {
+    // Ignore incomplete Postman URL objects and use their serialized value.
+  }
+
   if (raw) return convertTpl(raw)
 
   return "$base_url"
@@ -232,6 +256,42 @@ function mapRequest(
 
   const method = METHOD_UPPER[(req.method ?? "").toLowerCase()] ?? "GET"
   const url = mapUrl(req)
+
+  let pathParams: ParamEntry[] | undefined
+  const urlPath = req.url?.path
+  if (urlPath && urlPath.length > 0) {
+    const pathTokens: string[] = []
+    const seen = new Set<string>()
+    for (const seg of urlPath) {
+      const name = parsePathToken(seg)
+      if (name !== null) {
+        if (!seen.has(name)) {
+          seen.add(name)
+          pathTokens.push(name)
+        }
+      }
+    }
+
+    if (pathTokens.length > 0) {
+      const urlVariables = new Map<string, string>()
+      try {
+        const uv = req.url?.variables
+        if (uv) {
+          uv.each((v) => {
+            urlVariables.set(v.key, convertTpl(v.value ?? ""))
+          })
+        }
+      } catch {
+        // ignore
+      }
+      pathParams = pathTokens.map((name) => ({
+        name,
+        value: urlVariables.get(name) ?? "",
+        enabled: true,
+      }))
+    }
+  }
+
   const headers = mapHeaders(req.headers as PropertyList<Header> | undefined)
   const params = mapParams(
     (req.url as { query?: PropertyList<QueryParam> })?.query,
@@ -251,6 +311,7 @@ function mapRequest(
     timeout: 0,
     headers,
     params,
+    pathParams,
     ...bodyMapping,
     auth,
   }

--- a/src/hooks/draftUtils.ts
+++ b/src/hooks/draftUtils.ts
@@ -232,6 +232,7 @@ export function requestEquals(a: Request, b: Request): boolean {
   if (a.filePath !== b.filePath) return false
   if (!recordsEqual(a.headers, b.headers)) return false
   if (!paramEntriesEqual(a.params, b.params)) return false
+  if (!paramEntriesEqual(a.pathParams ?? [], b.pathParams ?? [])) return false
   if (!authEqual(a.auth, b.auth)) return false
   const fa = a.formData ?? []
   const fb = b.formData ?? []

--- a/src/hooks/requestDraftReducer.ts
+++ b/src/hooks/requestDraftReducer.ts
@@ -269,11 +269,23 @@ export function applyDraft(
       } else if (op.field === "params" && op.row !== undefined) {
         draft.params = revertParam(current.params, original.params, op.row)
       } else if (op.field === "pathParams" && op.row !== undefined) {
-        draft.pathParams = revertParam(
+        const pathParams = syncPathParamsWithUrl(
           current.pathParams ?? [],
-          original.pathParams ?? [],
-          op.row,
+          current.url,
         )
+        const entry = pathParams[op.row]
+        if (entry) {
+          const originalEntry = (original.pathParams ?? []).find(
+            (param) => param.name === entry.name,
+          )
+          draft.pathParams = originalEntry
+            ? pathParams.map((param, i) =>
+                i === op.row
+                  ? { ...originalEntry, name: entry.name, enabled: true }
+                  : param,
+              )
+            : pathParams.filter((param) => param.name !== entry.name)
+        }
       } else if (op.field === "auth") {
         if (op.row === undefined || op.row === 0) {
           draft.auth = original.auth

--- a/src/hooks/requestDraftReducer.ts
+++ b/src/hooks/requestDraftReducer.ts
@@ -198,8 +198,16 @@ export function applyDraft(
       draft.params = toggleParam(current.params, op.index)
       break
     case "setPathParamRow": {
-      const existing = current.pathParams ?? []
-      draft.pathParams = replaceParam(existing, op.index, op.key, op.value)
+      const pathParams = syncPathParamsWithUrl(
+        current.pathParams ?? [],
+        current.url,
+      )
+      draft.pathParams = replaceParam(
+        pathParams,
+        op.index,
+        op.key,
+        op.value,
+      ).filter((entry) => entry.value !== "")
       break
     }
     case "addPathParamRow":

--- a/src/hooks/requestDraftReducer.ts
+++ b/src/hooks/requestDraftReducer.ts
@@ -202,12 +202,7 @@ export function applyDraft(
         current.pathParams ?? [],
         current.url,
       )
-      draft.pathParams = replaceParam(
-        pathParams,
-        op.index,
-        op.key,
-        op.value,
-      ).filter((entry) => entry.value !== "")
+      draft.pathParams = replaceParam(pathParams, op.index, op.key, op.value)
       break
     }
     case "addPathParamRow":

--- a/src/hooks/requestDraftReducer.ts
+++ b/src/hooks/requestDraftReducer.ts
@@ -1,6 +1,6 @@
 import type { BodyType, FormEntry, Request, Auth } from "../schema"
 import type { FieldKind } from "../ui/editMode"
-import { syncParamsWithUrl } from "../ui/urlParams"
+import { syncParamsWithUrl, syncPathParamsWithUrl } from "../ui/urlParams"
 import {
   replaceRow,
   addRow,
@@ -29,6 +29,10 @@ export type DraftOp =
   | { kind: "addParamRow"; key: string; value: string }
   | { kind: "removeParamRow"; index: number }
   | { kind: "toggleParamRow"; index: number }
+  | { kind: "setPathParamRow"; index: number; key: string; value: string }
+  | { kind: "addPathParamRow"; key: string; value: string }
+  | { kind: "removePathParamRow"; index: number }
+  | { kind: "togglePathParamRow"; index: number }
   | { kind: "syncUrlParams"; rawUrl: string }
   | { kind: "setTimeout"; timeout: number }
   | { kind: "setFollowRedirects"; followRedirects: boolean }
@@ -86,12 +90,17 @@ export function applyDraft(
       const synced = syncParamsWithUrl(current.params, op.url)
       draft.url = synced.baseUrl
       draft.params = synced.params
+      draft.pathParams = syncPathParamsWithUrl(current.pathParams ?? [], op.url)
       break
     }
     case "syncUrlParams": {
       const synced = syncParamsWithUrl(current.params, op.rawUrl)
       draft.url = synced.baseUrl
       draft.params = synced.params
+      draft.pathParams = syncPathParamsWithUrl(
+        current.pathParams ?? [],
+        op.rawUrl,
+      )
       break
     }
     case "setBody":
@@ -188,6 +197,20 @@ export function applyDraft(
     case "toggleParamRow":
       draft.params = toggleParam(current.params, op.index)
       break
+    case "setPathParamRow": {
+      const existing = current.pathParams ?? []
+      draft.pathParams = replaceParam(existing, op.index, op.key, op.value)
+      break
+    }
+    case "addPathParamRow":
+      draft.pathParams = addParam(current.pathParams ?? [], op.key, op.value)
+      break
+    case "removePathParamRow":
+      draft.pathParams = removeParam(current.pathParams ?? [], op.index)
+      break
+    case "togglePathParamRow":
+      draft.pathParams = toggleParam(current.pathParams ?? [], op.index)
+      break
     case "setTimeout":
       draft.timeout = op.timeout
       break
@@ -242,6 +265,12 @@ export function applyDraft(
         draft.headers = revertRow(current.headers, original.headers, op.row)
       } else if (op.field === "params" && op.row !== undefined) {
         draft.params = revertParam(current.params, original.params, op.row)
+      } else if (op.field === "pathParams" && op.row !== undefined) {
+        draft.pathParams = revertParam(
+          current.pathParams ?? [],
+          original.pathParams ?? [],
+          op.row,
+        )
       } else if (op.field === "auth") {
         if (op.row === undefined || op.row === 0) {
           draft.auth = original.auth

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -20,6 +20,7 @@ import {
 } from "../ui/editMode"
 import type { UseRequestDraftResult } from "./useRequestDraft"
 import { formatBody } from "../ui/formatRequest"
+import { syncPathParamsWithUrl } from "../ui/urlParams"
 
 function rowCount(req: Request | null): SectionRowCount {
   if (!req)
@@ -47,7 +48,7 @@ function rowCount(req: Request | null): SectionRowCount {
   return {
     headers: Object.keys(req.headers).length,
     params: req.params.length,
-    pathParams: (req.pathParams ?? []).length,
+    pathParams: syncPathParamsWithUrl(req.pathParams ?? [], req.url).length,
     body,
     auth: authRows,
     settings: 3,
@@ -120,7 +121,7 @@ function currentValueFor(
   }
   if (field === "pathParams") {
     if (addingRow) return ""
-    const entry = (draft.pathParams ?? [])[row]
+    const entry = syncPathParamsWithUrl(draft.pathParams ?? [], draft.url)[row]
     return entry ? `${entry.name}: ${entry.value}` : ""
   }
   return ""
@@ -151,7 +152,7 @@ function currentKeyValueFor(
   }
   if (field === "pathParams") {
     if (addingRow) return { key: "", value: "" }
-    const entry = (draft.pathParams ?? [])[row]
+    const entry = syncPathParamsWithUrl(draft.pathParams ?? [], draft.url)[row]
     return entry
       ? { key: entry.name, value: entry.value }
       : { key: "", value: "" }

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -22,7 +22,15 @@ import type { UseRequestDraftResult } from "./useRequestDraft"
 import { formatBody } from "../ui/formatRequest"
 
 function rowCount(req: Request | null): SectionRowCount {
-  if (!req) return { headers: 0, params: 0, body: 0, auth: 1, settings: 3 }
+  if (!req)
+    return {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 1,
+      settings: 3,
+    }
   let authRows = 1 // type selector row always present
   const a = req.auth
   if (a) {
@@ -39,6 +47,7 @@ function rowCount(req: Request | null): SectionRowCount {
   return {
     headers: Object.keys(req.headers).length,
     params: req.params.length,
+    pathParams: (req.pathParams ?? []).length,
     body,
     auth: authRows,
     settings: 3,
@@ -109,6 +118,11 @@ function currentValueFor(
     const entry = draft.params[row]
     return entry ? `${entry.name}: ${entry.value}` : ""
   }
+  if (field === "pathParams") {
+    if (addingRow) return ""
+    const entry = (draft.pathParams ?? [])[row]
+    return entry ? `${entry.name}: ${entry.value}` : ""
+  }
   return ""
 }
 
@@ -131,6 +145,13 @@ function currentKeyValueFor(
   if (field === "params") {
     if (addingRow) return { key: "", value: "" }
     const entry = draft.params[row]
+    return entry
+      ? { key: entry.name, value: entry.value }
+      : { key: "", value: "" }
+  }
+  if (field === "pathParams") {
+    if (addingRow) return { key: "", value: "" }
+    const entry = (draft.pathParams ?? [])[row]
     return entry
       ? { key: entry.name, value: entry.value }
       : { key: "", value: "" }
@@ -334,7 +355,11 @@ export function useEditBrowse(
         const init = currentValueFor(currentDraft, field, row, addingRow)
         setEditValue(init)
       }
-    } else if (field === "headers" || field === "params") {
+    } else if (
+      field === "headers" ||
+      field === "params" ||
+      field === "pathParams"
+    ) {
       const kv = currentKeyValueFor(currentDraft, field, row, addingRow)
       setEditKey(kv.key)
       setEditValue(kv.value)
@@ -510,7 +535,11 @@ export function useEditBrowse(
         const init = currentValueFor(currentDraft, field, row, addingRow)
         setEditValue(init)
       }
-    } else if (field === "headers" || field === "params") {
+    } else if (
+      field === "headers" ||
+      field === "params" ||
+      field === "pathParams"
+    ) {
       const kv = currentKeyValueFor(currentDraft, field, row, addingRow)
       setEditKey(kv.key)
       setEditValue(kv.value)
@@ -587,6 +616,11 @@ export function useEditBrowse(
           Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 5,
         )
       }
+    } else if (field === "pathParams") {
+      const key = editKeyRef.current.trim()
+      const value = editValueRef.current.trim()
+      if (key === "" || addingRow) return
+      draftMutators.setPathParamRow(state.cursor.row, key, value)
     } else if (field === "headers" || field === "params") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()
@@ -644,10 +678,12 @@ export function useEditBrowse(
     }
     if (field === "settings") {
       draftMutators.revertField(field)
+    } else if (field === "pathParams") {
+      return
     } else if (field === "headers" || field === "params") {
       if (addingRow) return
       if (field === "headers") draftMutators.removeHeaderRow(row)
-      else draftMutators.removeParamRow(row)
+      else if (field === "params") draftMutators.removeParamRow(row)
     }
   }, [draftMutators])
 
@@ -668,6 +704,7 @@ export function useEditBrowse(
       }
       return
     }
+    if (field === "pathParams") return
     if (field === "headers") draftMutators.toggleHeaderRow(row)
     else if (field === "params") draftMutators.toggleParamRow(row)
     else if (field === "settings" && row === 1) {

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -679,7 +679,8 @@ export function useEditBrowse(
     if (field === "settings") {
       draftMutators.revertField(field)
     } else if (field === "pathParams") {
-      return
+      if (addingRow) return
+      draftMutators.revertField(field, row)
     } else if (field === "headers" || field === "params") {
       if (addingRow) return
       if (field === "headers") draftMutators.removeHeaderRow(row)

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -27,6 +27,10 @@ export interface UseRequestDraftResult {
   addParamRow: (key: string, value: string) => void
   removeParamRow: (index: number) => void
   toggleParamRow: (index: number) => void
+  setPathParamRow: (index: number, key: string, value: string) => void
+  addPathParamRow: (key: string, value: string) => void
+  removePathParamRow: (index: number) => void
+  togglePathParamRow: (index: number) => void
   setTimeout: (t: number) => void
   setFollowRedirects: (b: boolean) => void
   setMaxRedirects: (n: number) => void
@@ -140,6 +144,24 @@ export function useRequestDraft(
   )
   const toggleParamRow = useCallback(
     (index: number) => apply({ kind: "toggleParamRow", index }),
+    [apply],
+  )
+  const setPathParamRow = useCallback(
+    (index: number, key: string, value: string) =>
+      apply({ kind: "setPathParamRow", index, key, value }),
+    [apply],
+  )
+  const addPathParamRow = useCallback(
+    (key: string, value: string) =>
+      apply({ kind: "addPathParamRow", key, value }),
+    [apply],
+  )
+  const removePathParamRow = useCallback(
+    (index: number) => apply({ kind: "removePathParamRow", index }),
+    [apply],
+  )
+  const togglePathParamRow = useCallback(
+    (index: number) => apply({ kind: "togglePathParamRow", index }),
     [apply],
   )
   const setAuthTypeCb = useCallback(
@@ -258,6 +280,10 @@ export function useRequestDraft(
       addParamRow,
       removeParamRow,
       toggleParamRow,
+      setPathParamRow,
+      addPathParamRow,
+      removePathParamRow,
+      togglePathParamRow,
       revertField,
       revertAll,
       revertAllRequests,
@@ -292,6 +318,10 @@ export function useRequestDraft(
       addParamRow,
       removeParamRow,
       toggleParamRow,
+      setPathParamRow,
+      addPathParamRow,
+      removePathParamRow,
+      togglePathParamRow,
       revertField,
       revertAll,
       revertAllRequests,

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -111,7 +111,7 @@ export function parseRequest(id: string, yamlText: string): Request {
 
   const headers = parseKvMap(raw.headers, "headers")
   const params = parseParams(raw.params, "params")
-  const pathParams = parseParams(raw.path_params, "path_params")
+  const pathParams = parsePathParams(raw.path_params)
 
   let body: string | undefined
   if (raw.body !== undefined) {
@@ -300,6 +300,40 @@ function parseParams(
     return out
   }
   throw new Error(`${prefix}: ${field} must be a map or array`)
+}
+
+function parsePathParams(value: unknown): ParamEntry[] {
+  if (value !== undefined) {
+    if (Array.isArray(value)) {
+      for (const [i, item] of value.entries()) {
+        if (
+          typeof item === "object" &&
+          item !== null &&
+          !Array.isArray(item) &&
+          Object.hasOwn(item, "enabled")
+        ) {
+          throw new Error(
+            `lang.parseRequest: path_params[${i}].enabled is not supported`,
+          )
+        }
+      }
+    } else if (typeof value === "object" && value !== null) {
+      for (const [name, item] of Object.entries(value)) {
+        if (
+          typeof item === "object" &&
+          item !== null &&
+          !Array.isArray(item) &&
+          Object.hasOwn(item, "enabled")
+        ) {
+          throw new Error(
+            `lang.parseRequest: path_params.${name}.enabled is not supported`,
+          )
+        }
+      }
+    }
+  }
+
+  return parseParams(value, "path_params")
 }
 
 function parseAuth(value: unknown): Auth {

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -79,6 +79,7 @@ export function parseRequest(id: string, yamlText: string): Request {
     "maxRedirects",
     "headers",
     "params",
+    "path_params",
     "body",
     "auth",
     "body_type",
@@ -110,6 +111,7 @@ export function parseRequest(id: string, yamlText: string): Request {
 
   const headers = parseKvMap(raw.headers, "headers")
   const params = parseParams(raw.params, "params")
+  const pathParams = parseParams(raw.path_params, "path_params")
 
   let body: string | undefined
   if (raw.body !== undefined) {
@@ -204,7 +206,7 @@ export function parseRequest(id: string, yamlText: string): Request {
     maxRedirects = raw.maxRedirects
   }
 
-  return {
+  const request: Omit<Request, "pathParams"> = {
     id,
     name: raw.name,
     method,
@@ -220,6 +222,10 @@ export function parseRequest(id: string, yamlText: string): Request {
     filePath,
     auth,
   }
+  if (Object.hasOwn(raw, "path_params") && pathParams.length > 0) {
+    return { ...request, pathParams }
+  }
+  return request as unknown as Request
 }
 
 export function parseKvMap(

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -46,6 +46,19 @@ export function serializeRequest(req: Request): string {
     }
   }
 
+  if (req.pathParams && req.pathParams.length > 0) {
+    out += "path_params:\n"
+    for (const entry of req.pathParams) {
+      const nameVal = yamlVal(entry.name, 4)
+      const valVal = yamlVal(entry.value, 4)
+      if (entry.enabled) {
+        out += `  - name: ${nameVal}\n    value: ${valVal}\n`
+      } else {
+        out += `  - name: ${nameVal}\n    value: ${valVal}\n    enabled: ${entry.enabled}\n`
+      }
+    }
+  }
+
   if (req.body !== undefined) {
     out += `body: ${yamlVal(req.body)}\n`
   }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -51,11 +51,7 @@ export function serializeRequest(req: Request): string {
     for (const entry of req.pathParams) {
       const nameVal = yamlVal(entry.name, 4)
       const valVal = yamlVal(entry.value, 4)
-      if (entry.enabled) {
-        out += `  - name: ${nameVal}\n    value: ${valVal}\n`
-      } else {
-        out += `  - name: ${nameVal}\n    value: ${valVal}\n    enabled: ${entry.enabled}\n`
-      }
+      out += `  - name: ${nameVal}\n    value: ${valVal}\n`
     }
   }
 

--- a/src/requests/pathParams.ts
+++ b/src/requests/pathParams.ts
@@ -1,0 +1,21 @@
+export const PATH_PARAM_NAME = String.raw`\w[\w-]*`
+
+export const PATH_TOKEN_RE = new RegExp(`^:(${PATH_PARAM_NAME})(?=\\.|$)`)
+export const URL_PATH_TOKEN_RE = new RegExp(
+  `(?:^|/):(${PATH_PARAM_NAME})(?=\\.|/|$)`,
+  "g",
+)
+const OPENAPI_PATH_TOKEN_RE = new RegExp(`\\{(${PATH_PARAM_NAME})\\}`, "g")
+
+export function parsePathToken(segment: string): string | null {
+  return segment.match(PATH_TOKEN_RE)?.[1] ?? null
+}
+
+export function parseOpenApiPathTokens(template: string): string[] {
+  OPENAPI_PATH_TOKEN_RE.lastIndex = 0
+  return Array.from(template.matchAll(OPENAPI_PATH_TOKEN_RE), (m) => m[1]!)
+}
+
+export function openApiPathTemplateToColon(template: string): string {
+  return template.replace(OPENAPI_PATH_TOKEN_RE, ":$1")
+}

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -15,8 +15,6 @@ export function interpolatePathParams(
   url: string,
   pathParams: ParamEntry[],
 ): string {
-  if (pathParams.length === 0) return url
-
   let u: URL
   const isAbsolute = url.includes("://")
   try {
@@ -25,17 +23,28 @@ export function interpolatePathParams(
     return url
   }
 
+  const entryByName = new Map<string, ParamEntry>()
+  for (const p of pathParams) {
+    entryByName.set(p.name, p)
+  }
+
+  const TOKEN_RE = /^:(\w[\w-]*)/
   const segments = u.pathname.split("/")
-  const enabled = pathParams.filter((p) => p.enabled)
-  const entryByName = new Map(enabled.map((p) => [p.name, p]))
+  let hasTokens = false
+  for (const seg of segments) {
+    if (TOKEN_RE.test(seg)) {
+      hasTokens = true
+      break
+    }
+  }
+  if (!hasTokens) return url
 
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i]!
-    segments[i] = seg.replace(/^:(\w[\w-]*)/, (_, name: string) => {
+    segments[i] = seg.replace(TOKEN_RE, (_, name: string) => {
       const entry = entryByName.get(name)
-      if (!entry) return _
-      if (entry.value === "") {
-        throw new Error(`requests.send: path parameter "${name}" has no value`)
+      if (!entry || !entry.enabled || entry.value === "") {
+        throw new Error(`requests.send: path parameter ":${name}" has no value`)
       }
       return encodeURIComponent(entry.value)
     })

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -43,7 +43,8 @@ export function interpolatePathParams(
     const seg = segments[i]!
     segments[i] = seg.replace(TOKEN_RE, (_, name: string) => {
       const entry = entryByName.get(name)
-      if (!entry || !entry.enabled || entry.value === "") {
+      if (!entry) return `:${name}`
+      if (!entry.enabled || entry.value === "") {
         throw new Error(`requests.send: path parameter ":${name}" has no value`)
       }
       return encodeURIComponent(entry.value)

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -10,6 +10,7 @@ import type {
 import { substitute } from "./substitute"
 import type { SubstitutedRequest } from "./substitute"
 import { mergeFolderOverrides } from "./mergeFolderOverrides"
+import { PATH_TOKEN_RE } from "./pathParams"
 
 export function interpolatePathParams(
   url: string,
@@ -28,11 +29,10 @@ export function interpolatePathParams(
     entryByName.set(p.name, p)
   }
 
-  const TOKEN_RE = /^:(\w[\w-]*)/
   const segments = u.pathname.split("/")
   let hasTokens = false
   for (const seg of segments) {
-    if (TOKEN_RE.test(seg)) {
+    if (PATH_TOKEN_RE.test(seg)) {
       hasTokens = true
       break
     }
@@ -41,7 +41,7 @@ export function interpolatePathParams(
 
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i]!
-    segments[i] = seg.replace(TOKEN_RE, (_, name: string) => {
+    segments[i] = seg.replace(PATH_TOKEN_RE, (_, name: string) => {
       const entry = entryByName.get(name)
       if (!entry) return `:${name}`
       if (!entry.enabled || entry.value === "") {

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -11,6 +11,42 @@ import { substitute } from "./substitute"
 import type { SubstitutedRequest } from "./substitute"
 import { mergeFolderOverrides } from "./mergeFolderOverrides"
 
+export function interpolatePathParams(
+  url: string,
+  pathParams: ParamEntry[],
+): string {
+  if (pathParams.length === 0) return url
+
+  let u: URL
+  const isAbsolute = url.includes("://")
+  try {
+    u = isAbsolute ? new URL(url) : new URL(url, "https://noodle")
+  } catch {
+    return url
+  }
+
+  const segments = u.pathname.split("/")
+  const enabled = pathParams.filter((p) => p.enabled)
+  const entryByName = new Map(enabled.map((p) => [p.name, p]))
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!
+    segments[i] = seg.replace(/^:(\w[\w-]*)/, (_, name: string) => {
+      const entry = entryByName.get(name)
+      if (!entry) return _
+      if (entry.value === "") {
+        throw new Error(`requests.send: path parameter "${name}" has no value`)
+      }
+      return encodeURIComponent(entry.value)
+    })
+  }
+
+  u.pathname = segments.join("/")
+
+  if (isAbsolute) return u.toString()
+  return u.pathname + u.search
+}
+
 export async function send(
   req: Request,
   env?: Environment,
@@ -33,10 +69,16 @@ export async function send(
     substituted === merged
       ? merged.params.filter((e) => e.enabled)
       : (substituted as SubstitutedRequest).params
+  const pathParams: ParamEntry[] =
+    substituted === merged
+      ? (merged.pathParams ?? []).filter((e) => e.enabled)
+      : ((substituted as SubstitutedRequest).pathParams ?? [])
+
+  const urlWithPath = interpolatePathParams(substituted.url, pathParams)
 
   let finalUrl: string
   try {
-    const u = new URL(substituted.url)
+    const u = new URL(urlWithPath)
     const paramKeys = new Set(params.map((e) => e.name))
     for (const key of paramKeys) {
       u.searchParams.delete(key)

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -43,8 +43,7 @@ export function interpolatePathParams(
     const seg = segments[i]!
     segments[i] = seg.replace(PATH_TOKEN_RE, (_, name: string) => {
       const entry = entryByName.get(name)
-      if (!entry) return `:${name}`
-      if (!entry.enabled || entry.value === "") {
+      if (!entry || entry.value === "") {
         throw new Error(`requests.send: path parameter ":${name}" has no value`)
       }
       return encodeURIComponent(entry.value)
@@ -81,7 +80,7 @@ export async function send(
       : (substituted as SubstitutedRequest).params
   const pathParams: ParamEntry[] =
     substituted === merged
-      ? (merged.pathParams ?? []).filter((e) => e.enabled)
+      ? (merged.pathParams ?? [])
       : ((substituted as SubstitutedRequest).pathParams ?? [])
 
   const urlWithPath = interpolatePathParams(substituted.url, pathParams)

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -33,6 +33,15 @@ export function substitute(req: Request, env: Environment): SubstitutedRequest {
     }
   })
 
+  const pathParams: ParamEntry[] = (req.pathParams ?? []).map((entry, i) => {
+    if (!entry.enabled) return { ...entry }
+    return {
+      name: resolve(entry.name, `pathParams[${i}].name`),
+      value: resolve(entry.value, `pathParams[${i}].value`),
+      enabled: entry.enabled,
+    }
+  })
+
   const auth =
     req.auth === undefined ? undefined : substituteAuth(req.auth, resolve)
 
@@ -64,6 +73,7 @@ export function substitute(req: Request, env: Environment): SubstitutedRequest {
     maxRedirects: req.maxRedirects,
     headers,
     params,
+    pathParams,
     body: req.body !== undefined ? resolve(req.body, "body") : undefined,
     bodyType: req.bodyType,
     formData,

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -34,11 +34,10 @@ export function substitute(req: Request, env: Environment): SubstitutedRequest {
   })
 
   const pathParams: ParamEntry[] = (req.pathParams ?? []).map((entry, i) => {
-    if (!entry.enabled) return { ...entry }
     return {
       name: resolve(entry.name, `pathParams[${i}].name`),
       value: resolve(entry.value, `pathParams[${i}].value`),
-      enabled: entry.enabled,
+      enabled: true,
     }
   })
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -65,6 +65,7 @@ export interface Request {
   maxRedirects?: number
   headers: Record<string, KvEntry>
   params: ParamEntry[]
+  pathParams?: ParamEntry[]
   body?: string
   bodyType?: BodyType
   formData?: FormEntry[]
@@ -104,6 +105,7 @@ export interface TimelineEntry {
     url: string
     headers: Record<string, KvEntry>
     params: ParamEntry[]
+    pathParams?: ParamEntry[]
     body?: string
     bodyRef?: TimelineBodyRef
     bodyTruncated?: boolean

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -375,6 +375,33 @@ export function AppInner({
       } catch {
         substituted = undefined
       }
+    } else {
+      const rawPathParams = req.pathParams ?? []
+      if (rawPathParams.length > 0) {
+        try {
+          const headers: Record<string, string> = {}
+          for (const [k, v] of Object.entries(req.headers)) {
+            if (v.enabled) headers[k] = v.value
+          }
+          substituted = {
+            id: req.id,
+            name: req.name,
+            method: req.method,
+            url: interpolatePathParams(req.url, rawPathParams),
+            timeout: req.timeout,
+            headers,
+            params: [...req.params],
+            pathParams: rawPathParams.map((p) => ({ ...p })),
+            body: req.body,
+            bodyType: req.bodyType,
+            formData: req.formData,
+            filePath: req.filePath,
+            auth: req.auth,
+          }
+        } catch {
+          // keep undefined — timeline stores template URL
+        }
+      }
     }
     timelineAppendRef.current(
       buildTimelineEntry(req, result, envNameRef.current, substituted),

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -40,6 +40,7 @@ import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
 import { substitute } from "../requests"
 import type { SubstitutedRequest } from "../requests/substitute"
+import { interpolatePathParams } from "../requests/send"
 import { flattenRequests, getRequestIds, findFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import type { FieldKind } from "./editMode"
@@ -360,6 +361,17 @@ export function AppInner({
     if (activeEnv) {
       try {
         substituted = substitute(req, activeEnv)
+        const pathParams = substituted.pathParams ?? []
+        if (pathParams.length > 0) {
+          try {
+            substituted = {
+              ...substituted,
+              url: interpolatePathParams(substituted.url, pathParams),
+            }
+          } catch {
+            // keep unresolved URL
+          }
+        }
       } catch {
         substituted = undefined
       }

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from "./Checkbox"
 import { VarInput } from "./VarInput"
 
 export interface KeyValueSectionProps {
-  kind: "headers" | "params"
+  kind: "headers" | "params" | "pathParams"
   entries: Array<{ key: string; value: KvEntry }>
   editState: EditState
   editKey: string
@@ -30,6 +30,7 @@ export function KeyValueSection({
   const rows = entries
 
   const panelNum = parseInt(theme.backgroundPanel.slice(1), 16)
+  const prefix = kind === "headers" ? "hdr" : kind === "params" ? "prm" : "ppr"
   const elemNum = parseInt(theme.backgroundElement.slice(1), 16)
   const stripeR = Math.round(
     (((panelNum >> 16) & 0xff) + ((elemNum >> 16) & 0xff)) / 2,
@@ -50,9 +51,18 @@ export function KeyValueSection({
 
   return (
     <box style={{ flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
-      {rows.length === 0 && editState.mode === "inactive" ? (
+      {rows.length === 0 && kind === "pathParams" ? (
+        <VarInput
+          value="URL has no :path tokens"
+          placeholder=""
+          env={null}
+          isEditing={false}
+          baseColor={theme.textMuted}
+          paddingX={1}
+        />
+      ) : rows.length === 0 && editState.mode === "inactive" ? (
         <box
-          id={`${kind === "headers" ? "hdr" : "prm"}-add`}
+          id={`${prefix}-add`}
           style={{
             flexDirection: "row",
             gap: 0,
@@ -102,19 +112,23 @@ export function KeyValueSection({
             return (
               <box
                 key={i}
-                id={`${kind === "headers" ? "hdr" : "prm"}-${i}`}
+                id={`${prefix}-${i}`}
                 style={{
                   flexDirection: "row",
                   gap: 0,
                   backgroundColor: rowBg,
                 }}
               >
-                <Checkbox checked={kv.enabled} theme={theme} />
+                {kind !== "pathParams" ? (
+                  <Checkbox checked={kv.enabled} theme={theme} />
+                ) : (
+                  <box style={{ width: 3 }} />
+                )}
                 <VarInput
                   value={isEditingThisRow ? editKey : entry.key}
                   placeholder="Key..."
                   env={activeEnv ?? null}
-                  isEditing={isEditingThisRow}
+                  isEditing={kind !== "pathParams" && isEditingThisRow}
                   onChange={setEditKey}
                   isFocused={editState.cursor.subfield === "key"}
                   baseColor={keyBaseColor}
@@ -143,65 +157,67 @@ export function KeyValueSection({
               </box>
             )
           })}
-          {(() => {
-            const addRowBg =
-              cursorHere && editState.cursor.addingRow
-                ? theme.backgroundElement
-                : rows.length % 2 !== 0
-                  ? stripeBg
-                  : undefined
+          {kind !== "pathParams"
+            ? (() => {
+                const addRowBg =
+                  cursorHere && editState.cursor.addingRow
+                    ? theme.backgroundElement
+                    : rows.length % 2 !== 0
+                      ? stripeBg
+                      : undefined
 
-            return (
-              <box
-                id={`${kind === "headers" ? "hdr" : "prm"}-add`}
-                style={{
-                  flexDirection: "row",
-                  gap: 0,
-                  backgroundColor: addRowBg,
-                }}
-              >
-                <Checkbox checked={false} theme={theme} />
-                <VarInput
-                  value={editingAdd ? editKey : ""}
-                  placeholder="Key..."
-                  env={activeEnv ?? null}
-                  isEditing={editingAdd}
-                  onChange={setEditKey}
-                  isFocused={editState.cursor.subfield === "key"}
-                  baseColor={
-                    editingAdd || (cursorHere && editState.cursor.addingRow)
-                      ? theme.primary
-                      : theme.textMuted
-                  }
-                  backgroundColor={
-                    editingAdd ? theme.backgroundElement : undefined
-                  }
-                  focusedBackgroundColor={theme.borderSubtle}
-                  paddingX={1}
-                  style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-                />
-                <VarInput
-                  value={editingAdd ? editValue : ""}
-                  placeholder="Value..."
-                  env={activeEnv ?? null}
-                  isEditing={editingAdd}
-                  onChange={setEditValue}
-                  isFocused={editState.cursor.subfield === "value"}
-                  baseColor={
-                    editingAdd || (cursorHere && editState.cursor.addingRow)
-                      ? theme.text
-                      : theme.textMuted
-                  }
-                  backgroundColor={
-                    editingAdd ? theme.backgroundElement : undefined
-                  }
-                  focusedBackgroundColor={theme.borderSubtle}
-                  paddingX={1}
-                  style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-                />
-              </box>
-            )
-          })()}
+                return (
+                  <box
+                    id={`${prefix}-add`}
+                    style={{
+                      flexDirection: "row",
+                      gap: 0,
+                      backgroundColor: addRowBg,
+                    }}
+                  >
+                    <Checkbox checked={false} theme={theme} />
+                    <VarInput
+                      value={editingAdd ? editKey : ""}
+                      placeholder="Key..."
+                      env={activeEnv ?? null}
+                      isEditing={editingAdd}
+                      onChange={setEditKey}
+                      isFocused={editState.cursor.subfield === "key"}
+                      baseColor={
+                        editingAdd || (cursorHere && editState.cursor.addingRow)
+                          ? theme.primary
+                          : theme.textMuted
+                      }
+                      backgroundColor={
+                        editingAdd ? theme.backgroundElement : undefined
+                      }
+                      focusedBackgroundColor={theme.borderSubtle}
+                      paddingX={1}
+                      style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
+                    />
+                    <VarInput
+                      value={editingAdd ? editValue : ""}
+                      placeholder="Value..."
+                      env={activeEnv ?? null}
+                      isEditing={editingAdd}
+                      onChange={setEditValue}
+                      isFocused={editState.cursor.subfield === "value"}
+                      baseColor={
+                        editingAdd || (cursorHere && editState.cursor.addingRow)
+                          ? theme.text
+                          : theme.textMuted
+                      }
+                      backgroundColor={
+                        editingAdd ? theme.backgroundElement : undefined
+                      }
+                      focusedBackgroundColor={theme.borderSubtle}
+                      paddingX={1}
+                      style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
+                    />
+                  </box>
+                )
+              })()
+            : null}
         </>
       )}
     </box>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -40,6 +40,7 @@ interface Props {
 const BASE_TAB_DEFS: TabDef[] = [
   { id: "headers", label: "Headers" },
   { id: "params", label: "Params" },
+  { id: "pathParams", label: "Path" },
   { id: "body", label: "Body" },
   { id: "auth", label: "Auth" },
   { id: "settings", label: "Settings" },
@@ -84,8 +85,9 @@ export function RequestPane({
   useEffect(() => {
     if (editState.mode === "inactive") return
     const { field, row, addingRow } = editState.cursor
-    if (field === "headers" || field === "params") {
-      const prefix = field === "headers" ? "hdr" : "prm"
+    if (field === "headers" || field === "params" || field === "pathParams") {
+      const prefix =
+        field === "headers" ? "hdr" : field === "params" ? "prm" : "ppr"
       scrollRef.current?.scrollChildIntoView(
         addingRow ? `${prefix}-add` : `${prefix}-${row}`,
       )
@@ -219,6 +221,22 @@ export function RequestPane({
                     <KeyValueSection
                       kind="params"
                       entries={(request?.params ?? []).map((p) => ({
+                        key: p.name,
+                        value: { value: p.value, enabled: p.enabled },
+                      }))}
+                      editState={editState}
+                      editKey={editKey}
+                      editValue={editValue}
+                      setEditKey={setEditKey}
+                      setEditValue={setEditValue}
+                      theme={theme}
+                      activeEnv={activeEnv}
+                    />
+                  )}
+                  {activeTab === "pathParams" && (
+                    <KeyValueSection
+                      kind="pathParams"
+                      entries={(request?.pathParams ?? []).map((p) => ({
                         key: p.name,
                         value: { value: p.value, enabled: p.enabled },
                       }))}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -17,6 +17,7 @@ import { Frame } from "./Frame"
 import { Badge } from "./Badge"
 import { BodyTypeSelector, BodySection } from "./request-pane/RequestBodyTab"
 import { SettingsSection } from "./request-pane/RequestSettingsTab"
+import { syncPathParamsWithUrl } from "./urlParams"
 
 interface Props {
   request: Request | null
@@ -236,7 +237,10 @@ export function RequestPane({
                   {activeTab === "pathParams" && (
                     <KeyValueSection
                       kind="pathParams"
-                      entries={(request?.pathParams ?? []).map((p) => ({
+                      entries={syncPathParamsWithUrl(
+                        request?.pathParams ?? [],
+                        request?.url ?? "",
+                      ).map((p) => ({
                         key: p.name,
                         value: { value: p.value, enabled: p.enabled },
                       }))}

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -105,6 +105,7 @@ export function RequestResponseView({
         method={draft.draft?.method ?? "GET"}
         url={draft.draft?.url ?? ""}
         params={draft.draft?.params ?? []}
+        pathParams={draft.draft?.pathParams ?? []}
         setUrl={draft.setUrl}
         setMethod={draft.setMethod}
         onDefocus={draft.syncUrlParams}

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -1,19 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
 import type { Method, ParamEntry, Environment } from "../schema"
 import { buildDisplayUrl } from "./urlParams"
 import { VarInput } from "./VarInput"
-import { VarText } from "./VarText"
 import { Select } from "./Select"
 import { METHOD_ITEMS } from "./methodItems"
 import type { UrlBarSubFocus } from "./focus"
 import { JumpBadge, JUMP_BADGE_TOP_LEFT } from "./JumpBadge"
+import { splitUrlPathVars } from "./variable-completion/envHighlight"
 
 export function UrlBar({
   method,
   url,
   params,
+  pathParams: pathParamsProp,
   setUrl,
   setMethod = () => {},
   onDefocus,
@@ -26,6 +27,7 @@ export function UrlBar({
   method: Method
   url: string
   params: ParamEntry[]
+  pathParams?: ParamEntry[]
   setUrl: (url: string) => void
   setMethod?: (method: Method) => void
   onDefocus: (rawUrl: string) => void
@@ -36,6 +38,7 @@ export function UrlBar({
   jumpMode?: boolean
 }) {
   const theme = useTheme()
+  const pathParams = pathParamsProp ?? []
   const [inputValue, setInputValue] = useState(url)
   const [methodSelectOpen, setMethodSelectOpen] = useState(false)
   const prevFocused = useRef(focused)
@@ -70,17 +73,16 @@ export function UrlBar({
     }
   }, [url, params, focused])
 
+  const displayUrl = buildDisplayUrl(url, params)
+
   const handleInput = useCallback(
     (val: string) => {
       setInputValue(val)
       inputValueRef.current = val
-      if (val === initDisplayRef.current) return
       setUrl(val)
     },
     [setUrl],
   )
-
-  const displayUrl = buildDisplayUrl(url, params)
 
   return (
     <box
@@ -132,24 +134,60 @@ export function UrlBar({
                 focusedBackgroundColor={theme.borderSubtle}
                 paddingX={1}
                 style={{ flexGrow: 1, flexShrink: 1 }}
+                pathParams={pathParams}
               />
             ) : (
-              <box
-                style={{
-                  backgroundColor:
-                    focused && subFocus === "text"
-                      ? theme.borderSubtle
-                      : theme.backgroundElement,
-                  flexGrow: 1,
-                  overflow: "hidden",
-                }}
-              >
-                <VarText text={` ${displayUrl}`} env={activeEnv ?? null} />
-              </box>
+              <UrlBarText
+                text={` ${displayUrl}`}
+                env={activeEnv ?? null}
+                pathParams={pathParams}
+              />
             )}
           </box>
         </box>
       )}
+    </box>
+  )
+}
+
+function UrlBarText({
+  text,
+  env,
+  pathParams,
+}: {
+  text: string
+  env: Environment | null
+  pathParams: ParamEntry[]
+}) {
+  const theme = useTheme()
+  const segments = useMemo(
+    () => splitUrlPathVars(text, env, pathParams),
+    [text, env, pathParams],
+  )
+
+  return (
+    <box
+      style={{
+        flexDirection: "row",
+        gap: 0,
+        flexShrink: 1,
+        minWidth: 0,
+        overflow: "hidden",
+      }}
+    >
+      {segments.map((seg, i) => {
+        let color = theme.text
+        if (seg.isVar) {
+          color = seg.exists ? theme.primary : theme.error
+        } else if (seg.isPath) {
+          color = seg.exists ? theme.primary : theme.error
+        }
+        return (
+          <text key={i} fg={color} wrapMode="none" style={{ flexShrink: 0 }}>
+            {seg.text}
+          </text>
+        )
+      })}
     </box>
   )
 }

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -15,7 +15,7 @@ import {
 } from "@opentui/react"
 import { useTheme } from "./theme"
 import { VarText } from "./VarText"
-import type { Environment } from "../schema"
+import type { Environment, ParamEntry } from "../schema"
 import { highlightVariables } from "./variable-completion/variableHighlight"
 import { registerVariableCompletion } from "./variable-completion/variableCompletionInterceptor"
 import {
@@ -47,6 +47,7 @@ export interface VarInputProps {
   paddingX?: number
   style?: VarInputStyle
   variableNames?: Iterable<string>
+  pathParams?: ParamEntry[]
 }
 
 export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
@@ -65,6 +66,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       paddingX,
       style,
       variableNames,
+      pathParams,
     },
     ref,
   ) {
@@ -96,8 +98,9 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
     const applyHighlights = useCallback(() => {
       const editable = getEditable()
-      if (editable) highlightVariables(editable, editable.plainText, theme, env)
-    }, [env, getEditable, theme])
+      if (editable)
+        highlightVariables(editable, editable.plainText, theme, env, pathParams)
+    }, [env, getEditable, theme, pathParams])
 
     useImperativeHandle(ref, () => ({
       focus: () => {
@@ -140,7 +143,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
             if (editable) {
               const text = editable.plainText
               onChange?.(text)
-              highlightVariables(editable, text, theme, env)
+              highlightVariables(editable, text, theme, env, pathParams)
             }
           },
         }),
@@ -152,6 +155,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         makeHandleKey,
         onChange,
         theme,
+        pathParams,
       ],
     )
 

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -1,5 +1,12 @@
 export type FieldKind =
-  "headers" | "params" | "body" | "auth" | "settings" | "meta" | "activity"
+  | "headers"
+  | "params"
+  | "pathParams"
+  | "body"
+  | "auth"
+  | "settings"
+  | "meta"
+  | "activity"
 export type FolderFieldKind = "activity" | "meta" | "headers" | "auth"
 export type Mode = "inactive" | "browsing" | "editing"
 
@@ -19,6 +26,7 @@ export interface EditState {
 export interface SectionRowCount {
   headers: number
   params: number
+  pathParams: number
   body: number
   auth: number
   settings: number
@@ -33,6 +41,7 @@ export interface FolderRowCount {
 export const FIELD_ORDER: FieldKind[] = [
   "headers",
   "params",
+  "pathParams",
   "body",
   "auth",
   "settings",
@@ -66,6 +75,7 @@ export function enterEditBrowse(
   counts: SectionRowCount = {
     headers: 0,
     params: 0,
+    pathParams: 0,
     body: 0,
     auth: 0,
     settings: 0,
@@ -124,8 +134,16 @@ export function cursorForField(
     case "activity":
       return { field, row: 0, addingRow: false }
   }
-  const count = field === "headers" ? counts.headers : counts.params
+  const count =
+    field === "headers"
+      ? counts.headers
+      : field === "params"
+        ? counts.params
+        : counts.pathParams
   if (count === 0) {
+    if (field === "pathParams") {
+      return { field, row: -1, addingRow: false }
+    }
     return { field, row: -1, addingRow: true }
   }
   return { field, row: 0, addingRow: false }
@@ -156,10 +174,12 @@ export function toggleSubfield(prev: EditState): EditState {
   if (
     field !== "headers" &&
     field !== "params" &&
+    field !== "pathParams" &&
     field !== "body" &&
     field !== "meta"
   )
     return prev
+  if (field === "pathParams") return prev
   const current = prev.cursor.subfield ?? "key"
   const next: "key" | "value" = current === "key" ? "value" : "key"
   return {
@@ -209,6 +229,7 @@ export function moveRowCursor(
   if (
     field !== "headers" &&
     field !== "params" &&
+    field !== "pathParams" &&
     field !== "settings" &&
     field !== "auth" &&
     field !== "body"
@@ -217,6 +238,7 @@ export function moveRowCursor(
   let count = 0
   if (field === "headers") count = counts.headers
   else if (field === "params") count = counts.params
+  else if (field === "pathParams") count = counts.pathParams
   else if (field === "settings") count = counts.settings
   else if (field === "auth") count = counts.auth
   else if (field === "body") count = counts.body
@@ -272,6 +294,16 @@ export function moveRowCursor(
     return { ...prev, cursor: { field, row: next, addingRow: false } }
   }
 
+  if (field === "pathParams") {
+    if (next < 0) {
+      return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
+    }
+    if (next > count - 1) {
+      return { ...prev, cursor: { field, row: 0, addingRow: false } }
+    }
+    return { ...prev, cursor: { field, row: next, addingRow: false } }
+  }
+
   if (next < 0) {
     return { ...prev, cursor: { field, row: -1, addingRow: true } }
   }
@@ -290,6 +322,7 @@ export function moveRowFirst(
   if (
     field !== "headers" &&
     field !== "params" &&
+    field !== "pathParams" &&
     field !== "settings" &&
     field !== "auth" &&
     field !== "body"
@@ -298,6 +331,7 @@ export function moveRowFirst(
   let count = 0
   if (field === "headers") count = counts.headers
   else if (field === "params") count = counts.params
+  else if (field === "pathParams") count = counts.pathParams
   else if (field === "settings") count = counts.settings
   else if (field === "auth") count = counts.auth
   else if (field === "body") count = counts.body
@@ -305,6 +339,9 @@ export function moveRowFirst(
   if (count === 0) {
     if (field === "headers" || field === "params") {
       return { ...prev, cursor: { field, row: -1, addingRow: true } }
+    }
+    if (field === "pathParams") {
+      return prev
     }
     return prev
   }
@@ -321,6 +358,7 @@ export function moveRowLast(
   if (
     field !== "headers" &&
     field !== "params" &&
+    field !== "pathParams" &&
     field !== "settings" &&
     field !== "auth" &&
     field !== "body"
@@ -329,12 +367,17 @@ export function moveRowLast(
   let count = 0
   if (field === "headers") count = counts.headers
   else if (field === "params") count = counts.params
+  else if (field === "pathParams") count = counts.pathParams
   else if (field === "settings") count = counts.settings
   else if (field === "auth") count = counts.auth
   else if (field === "body") count = counts.body
 
   if (field === "headers" || field === "params") {
     return { ...prev, cursor: { field, row: -1, addingRow: true } }
+  }
+  if (field === "pathParams") {
+    if (count === 0) return prev
+    return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
   }
   if (count === 0) return prev
   return { ...prev, cursor: { field, row: count - 1, addingRow: false } }
@@ -387,14 +430,17 @@ export function beginEditing(prev: EditState): EditState {
   if (prev.mode !== "browsing") return prev
   if (prev.cursor.field === "activity") return prev
   if (prev.cursor.field === "settings" && prev.cursor.row === 1) return prev
+  if (prev.cursor.field === "pathParams" && prev.cursor.row < 0) return prev
   const subfield: "key" | "value" | undefined =
-    prev.cursor.field === "headers" ||
-    prev.cursor.field === "params" ||
-    prev.cursor.field === "meta"
-      ? "key"
-      : prev.cursor.field === "body"
+    prev.cursor.field === "pathParams"
+      ? "value"
+      : prev.cursor.field === "headers" ||
+          prev.cursor.field === "params" ||
+          prev.cursor.field === "meta"
         ? "key"
-        : undefined
+        : prev.cursor.field === "body"
+          ? "key"
+          : undefined
   return {
     ...prev,
     mode: "editing",

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -34,6 +34,9 @@ export function buildTimelineEntry(
       params: substituted
         ? substituted.params.map((p) => ({ ...p }))
         : [...req.params],
+      pathParams: substituted
+        ? (substituted.pathParams ?? []).map((p) => ({ ...p }))
+        : [...(req.pathParams ?? [])],
       body: substituted?.body ?? req.body,
       auth: substituted?.auth ?? (req.auth ? { ...req.auth } : undefined),
     },

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -1,4 +1,5 @@
 import type { ParamEntry } from "../schema"
+import { parsePathToken } from "../requests/pathParams"
 
 export function buildDisplayUrl(url: string, params: ParamEntry[]): string {
   if (!url) return url
@@ -140,8 +141,6 @@ function normBaseUrl(origin: string, pathname: string): string {
   return origin + pathname
 }
 
-const PATH_TOKEN_RE = /^:(\w[\w-]*)/
-
 function extractPathname(url: string): string {
   try {
     return new URL(url).pathname
@@ -156,9 +155,8 @@ export function parseUrlPathTokens(url: string): string[] {
   const seen = new Set<string>()
   const result: string[] = []
   for (const seg of pathname.split("/")) {
-    const m = seg.match(PATH_TOKEN_RE)
-    if (m) {
-      const name = m[1]!
+    const name = parsePathToken(seg)
+    if (name !== null) {
       if (!seen.has(name)) {
         seen.add(name)
         result.push(name)

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -139,3 +139,41 @@ function normBaseUrl(origin: string, pathname: string): string {
   if (pathname === "/") return origin
   return origin + pathname
 }
+
+const PATH_TOKEN_RE = /^:(\w[\w-]*)/
+
+function extractPathname(url: string): string {
+  try {
+    return new URL(url).pathname
+  } catch {
+    const q = url.indexOf("?")
+    return q === -1 ? url : url.slice(0, q)
+  }
+}
+
+export function parseUrlPathTokens(url: string): string[] {
+  const pathname = extractPathname(url)
+  const seen = new Set<string>()
+  for (const seg of pathname.split("/")) {
+    const m = seg.match(PATH_TOKEN_RE)
+    if (m) seen.add(m[1]!)
+  }
+  return [...seen].sort()
+}
+
+export function syncPathParamsWithUrl(
+  currentPathParams: ParamEntry[],
+  rawUrl: string,
+): ParamEntry[] {
+  const tokens = parseUrlPathTokens(rawUrl)
+  const result: ParamEntry[] = []
+  for (let i = 0; i < tokens.length; i++) {
+    const old = currentPathParams[i]
+    if (old) {
+      result.push({ ...old, name: tokens[i]! })
+    } else {
+      result.push({ name: tokens[i]!, value: "", enabled: true })
+    }
+  }
+  return result
+}

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -154,11 +154,18 @@ function extractPathname(url: string): string {
 export function parseUrlPathTokens(url: string): string[] {
   const pathname = extractPathname(url)
   const seen = new Set<string>()
+  const result: string[] = []
   for (const seg of pathname.split("/")) {
     const m = seg.match(PATH_TOKEN_RE)
-    if (m) seen.add(m[1]!)
+    if (m) {
+      const name = m[1]!
+      if (!seen.has(name)) {
+        seen.add(name)
+        result.push(name)
+      }
+    }
   }
-  return [...seen].sort()
+  return result
 }
 
 export function syncPathParamsWithUrl(
@@ -166,14 +173,30 @@ export function syncPathParamsWithUrl(
   rawUrl: string,
 ): ParamEntry[] {
   const tokens = parseUrlPathTokens(rawUrl)
+  const nameMap = new Map(currentPathParams.map((p) => [p.name, p]))
+  const unmatched = [...currentPathParams]
   const result: ParamEntry[] = []
-  for (let i = 0; i < tokens.length; i++) {
-    const old = currentPathParams[i]
-    if (old) {
-      result.push({ ...old, name: tokens[i]! })
+
+  const tokenSet = new Set(tokens)
+
+  for (const token of tokens) {
+    const existing = nameMap.get(token)
+    if (existing) {
+      nameMap.delete(token)
+      result.push({ ...existing, name: token, enabled: true })
+      const idx = unmatched.indexOf(existing)
+      if (idx !== -1) unmatched.splice(idx, 1)
     } else {
-      result.push({ name: tokens[i]!, value: "", enabled: true })
+      const renameIdx = unmatched.findIndex((p) => !tokenSet.has(p.name))
+      if (renameIdx !== -1) {
+        const [old] = unmatched.splice(renameIdx, 1)
+        nameMap.delete(old!.name)
+        result.push({ ...old!, name: token })
+      } else {
+        result.push({ name: token, value: "", enabled: true })
+      }
     }
   }
+
   return result
 }

--- a/src/ui/urlParams.ts
+++ b/src/ui/urlParams.ts
@@ -189,7 +189,7 @@ export function syncPathParamsWithUrl(
       if (renameIdx !== -1) {
         const [old] = unmatched.splice(renameIdx, 1)
         nameMap.delete(old!.name)
-        result.push({ ...old!, name: token })
+        result.push({ ...old!, name: token, enabled: true })
       } else {
         result.push({ name: token, value: "", enabled: true })
       }

--- a/src/ui/useJumpMode.ts
+++ b/src/ui/useJumpMode.ts
@@ -116,6 +116,7 @@ export function getAvailableTargets(
       targets.set("u", { kind: "url" })
       targets.set("h", { kind: "request-tab", field: "headers" })
       targets.set("p", { kind: "request-tab", field: "params" })
+      targets.set("x", { kind: "request-tab", field: "pathParams" })
       targets.set("b", { kind: "request-tab", field: "body" })
       targets.set("a", { kind: "request-tab", field: "auth" })
       targets.set("t", { kind: "request-tab", field: "settings" })
@@ -132,6 +133,7 @@ export function getAvailableTargets(
 export const REQUEST_TAB_HINTS: Record<string, string> = {
   headers: "h",
   params: "p",
+  pathParams: "x",
   body: "b",
   auth: "a",
   settings: "t",
@@ -143,13 +145,14 @@ export const RESPONSE_TAB_HINTS: Record<string, string> = {
   timeline: "l",
 }
 
-export const REQUEST_TAB_HINT_ORDER: string[] = ["h", "p", "b", "a", "t"]
+export const REQUEST_TAB_HINT_ORDER: string[] = ["h", "p", "x", "b", "a", "t"]
 export const RESPONSE_TAB_HINT_ORDER: string[] = ["r", "e", "l"]
 
 export function computeRequestTabLabels(request: Request | null): string[] {
-  if (!request) return ["Headers", "Params", "Body", "Auth", "Settings"]
+  if (!request) return ["Headers", "Params", "Path", "Body", "Auth", "Settings"]
   const headerActive = Object.values(request.headers).some((e) => e.enabled)
   const paramActive = request.params.some((e) => e.enabled)
+  const pathParamActive = (request.pathParams ?? []).some((e) => e.enabled)
   const hasBody =
     (request.body !== undefined && request.body !== "") ||
     (request.formData !== undefined && request.formData.length > 0) ||
@@ -160,6 +163,7 @@ export function computeRequestTabLabels(request: Request | null): string[] {
   return [
     headerActive ? "Headers \u2022" : "Headers",
     paramActive ? "Params \u2022" : "Params",
+    pathParamActive ? "Path \u2022" : "Path",
     hasBody ? "Body \u2022" : "Body",
     hasAuth ? "Auth \u2022" : "Auth",
     hasTimeout ? "Settings \u2022" : "Settings",

--- a/src/ui/variable-completion/envHighlight.ts
+++ b/src/ui/variable-completion/envHighlight.ts
@@ -1,7 +1,7 @@
 import type { Environment, ParamEntry } from "../../schema"
+import { URL_PATH_TOKEN_RE } from "../../requests/pathParams"
 
 const VAR_RE = /\$(\w+)/g
-const PATH_RE = /(?:^|\/):(\w[\w-]*)/g
 
 export interface EnvSegment {
   text: string
@@ -67,9 +67,9 @@ export function splitUrlPathVars(
     }
     const remaining = seg.text
     let lastEnd = 0
-    PATH_RE.lastIndex = 0
+    URL_PATH_TOKEN_RE.lastIndex = 0
     let match: RegExpExecArray | null
-    while ((match = PATH_RE.exec(remaining)) !== null) {
+    while ((match = URL_PATH_TOKEN_RE.exec(remaining)) !== null) {
       const colonIdx = match.index + (match[0]![0] === "/" ? 1 : 0)
       if (colonIdx > lastEnd) {
         result.push({

--- a/src/ui/variable-completion/envHighlight.ts
+++ b/src/ui/variable-completion/envHighlight.ts
@@ -1,6 +1,7 @@
-import type { Environment } from "../../schema"
+import type { Environment, ParamEntry } from "../../schema"
 
 const VAR_RE = /\$(\w+)/g
+const PATH_RE = /:(\w[\w-]*)/g
 
 export interface EnvSegment {
   text: string
@@ -37,4 +38,65 @@ export function splitEnvVars(
     })
   }
   return segments
+}
+
+export interface PathAwareSegment {
+  text: string
+  isVar: boolean
+  exists: boolean
+  isPath: boolean
+}
+
+function pathEntryResolved(name: string, pathParams: ParamEntry[]): boolean {
+  const entry = pathParams.find((p) => p.name === name)
+  return entry !== undefined && entry.enabled && entry.value !== ""
+}
+
+export function splitUrlPathVars(
+  text: string,
+  env: Environment | null,
+  pathParams: ParamEntry[],
+): PathAwareSegment[] {
+  const varSegments = splitEnvVars(text, env)
+  const result: PathAwareSegment[] = []
+
+  for (const seg of varSegments) {
+    if (seg.isVar) {
+      result.push({ ...seg, isPath: false })
+      continue
+    }
+    const remaining = seg.text
+    let lastEnd = 0
+    PATH_RE.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = PATH_RE.exec(remaining)) !== null) {
+      if (match.index > lastEnd) {
+        result.push({
+          text: remaining.slice(lastEnd, match.index),
+          isVar: false,
+          exists: false,
+          isPath: false,
+        })
+      }
+      const name = match[1]!
+      const resolved = pathEntryResolved(name, pathParams)
+      result.push({
+        text: match[0],
+        isVar: false,
+        exists: resolved,
+        isPath: true,
+      })
+      lastEnd = match.index + match[0].length
+    }
+    if (lastEnd < remaining.length) {
+      result.push({
+        text: remaining.slice(lastEnd),
+        isVar: false,
+        exists: false,
+        isPath: false,
+      })
+    }
+  }
+
+  return result
 }

--- a/src/ui/variable-completion/envHighlight.ts
+++ b/src/ui/variable-completion/envHighlight.ts
@@ -47,9 +47,12 @@ export interface PathAwareSegment {
   isPath: boolean
 }
 
-function pathEntryResolved(name: string, pathParams: ParamEntry[]): boolean {
+export function isPathParamResolved(
+  name: string,
+  pathParams: ParamEntry[],
+): boolean {
   const entry = pathParams.find((p) => p.name === name)
-  return entry !== undefined && entry.enabled && entry.value !== ""
+  return entry !== undefined && entry.value !== ""
 }
 
 export function splitUrlPathVars(
@@ -80,7 +83,7 @@ export function splitUrlPathVars(
         })
       }
       const name = match[1]!
-      const resolved = pathEntryResolved(name, pathParams)
+      const resolved = isPathParamResolved(name, pathParams)
       result.push({
         text: ":" + name,
         isVar: false,

--- a/src/ui/variable-completion/envHighlight.ts
+++ b/src/ui/variable-completion/envHighlight.ts
@@ -1,7 +1,7 @@
 import type { Environment, ParamEntry } from "../../schema"
 
 const VAR_RE = /\$(\w+)/g
-const PATH_RE = /:(\w[\w-]*)/g
+const PATH_RE = /(?:^|\/):(\w[\w-]*)/g
 
 export interface EnvSegment {
   text: string
@@ -70,9 +70,10 @@ export function splitUrlPathVars(
     PATH_RE.lastIndex = 0
     let match: RegExpExecArray | null
     while ((match = PATH_RE.exec(remaining)) !== null) {
-      if (match.index > lastEnd) {
+      const colonIdx = match.index + (match[0]![0] === "/" ? 1 : 0)
+      if (colonIdx > lastEnd) {
         result.push({
-          text: remaining.slice(lastEnd, match.index),
+          text: remaining.slice(lastEnd, colonIdx),
           isVar: false,
           exists: false,
           isPath: false,
@@ -81,7 +82,7 @@ export function splitUrlPathVars(
       const name = match[1]!
       const resolved = pathEntryResolved(name, pathParams)
       result.push({
-        text: match[0],
+        text: ":" + name,
         isVar: false,
         exists: resolved,
         isPath: true,

--- a/src/ui/variable-completion/variableHighlight.ts
+++ b/src/ui/variable-completion/variableHighlight.ts
@@ -42,11 +42,12 @@ export function highlightVariables(
     return entry !== undefined && entry.enabled && entry.value !== ""
   }
 
-  for (const m of value.matchAll(/:(\w[\w-]*)/g)) {
+  for (const m of value.matchAll(/(?:^|\/):(\w[\w-]*)/g)) {
     const name = m[1]!
     const resolved = pathEntryResolved(name)
+    const colonIdx = m.index + (m[0][0] === "/" ? 1 : 0)
     input.addHighlightByCharRange({
-      start: charOffsetToDisplayOffset(displayOffsets, m.index),
+      start: charOffsetToDisplayOffset(displayOffsets, colonIdx),
       end: charOffsetToDisplayOffset(displayOffsets, m.index + m[0].length),
       styleId: style.getStyleId(resolved ? "path.resolved" : "path.missing")!,
       priority: 2,

--- a/src/ui/variable-completion/variableHighlight.ts
+++ b/src/ui/variable-completion/variableHighlight.ts
@@ -1,6 +1,6 @@
+import type { Environment, ParamEntry } from "../../schema"
 import { SyntaxStyle } from "@opentui/core"
 import type { InputRenderable, TextareaRenderable } from "@opentui/core"
-import type { Environment } from "../../schema"
 import type { Theme } from "../theme-data"
 import { getVariableHighlights } from "./variableCompletion"
 import {
@@ -13,10 +13,13 @@ export function highlightVariables(
   value: string,
   theme: Theme,
   env: Environment | null,
+  pathParams?: ParamEntry[],
 ): void {
   const style = SyntaxStyle.fromStyles({
     "env.resolved": { fg: theme.primary },
     "env.missing": { fg: theme.error },
+    "path.resolved": { fg: theme.primary },
+    "path.missing": { fg: theme.error },
   })
   input.clearAllHighlights()
   input.syntaxStyle = style
@@ -29,6 +32,23 @@ export function highlightVariables(
       styleId: style.getStyleId(
         highlight.exists ? "env.resolved" : "env.missing",
       )!,
+      priority: 2,
+    })
+  }
+
+  const pathEntryResolved = (name: string): boolean => {
+    if (!pathParams) return false
+    const entry = pathParams.find((p) => p.name === name)
+    return entry !== undefined && entry.enabled && entry.value !== ""
+  }
+
+  for (const m of value.matchAll(/:(\w[\w-]*)/g)) {
+    const name = m[1]!
+    const resolved = pathEntryResolved(name)
+    input.addHighlightByCharRange({
+      start: charOffsetToDisplayOffset(displayOffsets, m.index),
+      end: charOffsetToDisplayOffset(displayOffsets, m.index + m[0].length),
+      styleId: style.getStyleId(resolved ? "path.resolved" : "path.missing")!,
       priority: 2,
     })
   }

--- a/src/ui/variable-completion/variableHighlight.ts
+++ b/src/ui/variable-completion/variableHighlight.ts
@@ -3,6 +3,8 @@ import { SyntaxStyle } from "@opentui/core"
 import type { InputRenderable, TextareaRenderable } from "@opentui/core"
 import type { Theme } from "../theme-data"
 import { getVariableHighlights } from "./variableCompletion"
+import { URL_PATH_TOKEN_RE } from "../../requests/pathParams"
+import { isPathParamResolved } from "./envHighlight"
 import {
   buildCharToDisplayOffsets,
   charOffsetToDisplayOffset,
@@ -36,15 +38,11 @@ export function highlightVariables(
     })
   }
 
-  const pathEntryResolved = (name: string): boolean => {
-    if (!pathParams) return false
-    const entry = pathParams.find((p) => p.name === name)
-    return entry !== undefined && entry.enabled && entry.value !== ""
-  }
-
-  for (const m of value.matchAll(/(?:^|\/):(\w[\w-]*)/g)) {
+  URL_PATH_TOKEN_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = URL_PATH_TOKEN_RE.exec(value)) !== null) {
     const name = m[1]!
-    const resolved = pathEntryResolved(name)
+    const resolved = isPathParamResolved(name, pathParams ?? [])
     const colonIdx = m.index + (m[0][0] === "/" ? 1 : 0)
     input.addHighlightByCharRange({
       start: charOffsetToDisplayOffset(displayOffsets, colonIdx),

--- a/tests/converters/openapi-helpers.test.ts
+++ b/tests/converters/openapi-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   convertTpl,
   slugify,
   urlTemplateToVar,
+  pathTemplateToColon,
   joinUrl,
   paramDefault,
   makeIdRaw,
@@ -67,6 +68,12 @@ describe("urlTemplateToVar", () => {
 
   it("handles empty string", () => {
     expect(urlTemplateToVar("")).toBe("")
+  })
+})
+
+describe("pathTemplateToColon", () => {
+  it("converts OpenAPI path parameters to Noodle tokens", () => {
+    expect(pathTemplateToColon("/users/{user-id}")).toBe("/users/:user-id")
   })
 })
 

--- a/tests/converters/postman-map.test.ts
+++ b/tests/converters/postman-map.test.ts
@@ -2,6 +2,7 @@ import type { CollectionItem, Folder } from "../../src/schema"
 import { describe, it, expect } from "bun:test"
 import { Collection as PmCollection } from "postman-collection"
 import { mapCollection, convertTpl } from "../../src/converters/postman/map"
+import { interpolatePathParams } from "../../src/requests/send"
 
 function reqs(result: ReturnType<typeof mapCollection>): unknown[] {
   function flatten(items: CollectionItem[]): unknown[] {
@@ -537,5 +538,148 @@ describe("mapCollection — edge cases", () => {
     const r = reqs(result)[0] as Record<string, unknown>
     expect(r.body).toBeUndefined()
     expect(r.bodyType).toBeUndefined()
+  })
+})
+
+describe("mapCollection — path params", () => {
+  it("extracts :id tokens from URL with url.variables", () => {
+    const result = makeCollection({
+      info: { name: "PathParams" },
+      item: [
+        {
+          name: "Get User",
+          request: {
+            method: "GET",
+            url: {
+              raw: "https://api.example.com/users/:id",
+              protocol: "https",
+              host: ["api", "example", "com"],
+              path: ["users", ":id"],
+              query: [],
+              variable: [{ key: "id", value: "{{userId}}" }],
+            },
+            header: [],
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    expect(r.url).toBe("https://api.example.com/users/:id")
+    const pp = r.pathParams as
+      { name: string; value: string; enabled: boolean }[] | undefined
+    expect(pp).toBeDefined()
+    expect(pp).toHaveLength(1)
+    expect(pp![0]).toEqual({ name: "id", value: "$userId", enabled: true })
+  })
+
+  it("extracts multiple :id tokens", () => {
+    const result = makeCollection({
+      info: { name: "MultiPathParams" },
+      item: [
+        {
+          name: "Get Comment",
+          request: {
+            method: "GET",
+            url: {
+              raw: "https://api.example.com/posts/:postId/comments/:commentId",
+              protocol: "https",
+              host: ["api", "example", "com"],
+              path: ["posts", ":postId", "comments", ":commentId"],
+              query: [],
+              variable: [
+                { key: "postId", value: "42" },
+                { key: "commentId", value: "99" },
+              ],
+            },
+            header: [],
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    const pp = r.pathParams as
+      { name: string; value: string; enabled: boolean }[] | undefined
+    expect(pp).toBeDefined()
+    expect(pp).toHaveLength(2)
+    expect(pp![0]).toEqual({ name: "postId", value: "42", enabled: true })
+    expect(pp![1]).toEqual({ name: "commentId", value: "99", enabled: true })
+    expect(r.url).toBe(
+      "https://api.example.com/posts/:postId/comments/:commentId",
+    )
+    expect(interpolatePathParams(r.url as string, pp!)).toBe(
+      "https://api.example.com/posts/42/comments/99",
+    )
+  })
+
+  it("no pathParams when URL has no :id tokens", () => {
+    const result = makeCollection({
+      info: { name: "NoPathParams" },
+      item: [
+        {
+          name: "List Users",
+          request: {
+            method: "GET",
+            url: "https://api.example.com/users",
+            header: [],
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    expect(r.pathParams).toBeUndefined()
+  })
+
+  it(":id without matching variable gets empty value", () => {
+    const result = makeCollection({
+      info: { name: "MissingVar" },
+      item: [
+        {
+          name: "Get Item",
+          request: {
+            method: "GET",
+            url: {
+              raw: "https://api.example.com/items/:id",
+              protocol: "https",
+              host: ["api", "example", "com"],
+              path: ["items", ":id"],
+              query: [],
+            },
+            header: [],
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    const pp = r.pathParams as
+      { name: string; value: string; enabled: boolean }[] | undefined
+    expect(pp).toBeDefined()
+    expect(pp).toHaveLength(1)
+    expect(pp![0]).toEqual({ name: "id", value: "", enabled: true })
+  })
+
+  it("preserves unsupported token names without creating a truncated path param", () => {
+    const result = makeCollection({
+      info: { name: "UnsupportedPathParam" },
+      item: [
+        {
+          name: "Get Order",
+          request: {
+            method: "GET",
+            url: {
+              raw: "https://api.example.com/orders/:order~id",
+              protocol: "https",
+              host: ["api", "example", "com"],
+              path: ["orders", ":order~id"],
+              query: [],
+              variable: [{ key: "order~id", value: "42" }],
+            },
+            header: [],
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    expect(r.url).toBe("https://api.example.com/orders/:order~id")
+    expect(r.pathParams).toBeUndefined()
   })
 })

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -19,7 +19,7 @@ import type { Request } from "../src/schema"
 const inactive: EditState = initialEditState()
 
 function c(headers: number, params: number) {
-  return { headers, params, body: 0, auth: 0, settings: 3 }
+  return { headers, params, pathParams: 0, body: 0, auth: 0, settings: 3 }
 }
 
 describe("initialEditState", () => {
@@ -71,11 +71,15 @@ describe("exitEditBrowse", () => {
 })
 
 describe("moveFieldCursor", () => {
-  it("+1 walks headers → params → body → auth → settings → headers", () => {
+  it("+1 walks headers → params → pathParams → body → auth → settings → headers", () => {
     let s = enterEditBrowse(inactive, c(2, 0))
     s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("params")
     expect(s.cursor.row).toBe(0)
+    s = moveFieldCursor(s, +1, c(2, 1))
+    expect(s.cursor.field).toBe("pathParams")
+    expect(s.cursor.addingRow).toBe(false)
+    expect(s.cursor.row).toBe(-1)
     s = moveFieldCursor(s, +1, c(2, 1))
     expect(s.cursor.field).toBe("body")
     expect(s.cursor.row).toBe(0)
@@ -89,7 +93,7 @@ describe("moveFieldCursor", () => {
     expect(s.cursor.field).toBe("headers")
     expect(s.cursor.row).toBe(0)
   })
-  it("-1 walks headers → settings → auth → body → params → headers", () => {
+  it("-1 walks headers → settings → auth → body → pathParams → params → headers", () => {
     let s = enterEditBrowse(inactive, c(2, 0))
     s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("settings")
@@ -97,6 +101,10 @@ describe("moveFieldCursor", () => {
     expect(s.cursor.field).toBe("auth")
     s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("body")
+    s = moveFieldCursor(s, -1, c(2, 1))
+    expect(s.cursor.field).toBe("pathParams")
+    expect(s.cursor.addingRow).toBe(false)
+    expect(s.cursor.row).toBe(-1)
     s = moveFieldCursor(s, -1, c(2, 1))
     expect(s.cursor.field).toBe("params")
     s = moveFieldCursor(s, -1, c(2, 1))
@@ -159,6 +167,7 @@ describe("moveRowCursor", () => {
   it("body Select row (row 0) clamps on up arrow", () => {
     let s = enterEditBrowse(inactive, c(2, 0))
     s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, c(2, 1))
     s = moveFieldCursor(s, +1, { ...c(2, 1), body: 2 })
     expect(s.cursor.field).toBe("body")
     expect(s.cursor.row).toBe(0)
@@ -174,6 +183,7 @@ describe("moveRowCursor", () => {
   })
   it("body Select row (row 0) to addingRow when count=1 (no entries)", () => {
     let s = enterEditBrowse(inactive, c(2, 0))
+    s = moveFieldCursor(s, +1, c(2, 1))
     s = moveFieldCursor(s, +1, c(2, 1))
     s = moveFieldCursor(s, +1, { ...c(2, 1), body: 1 })
     expect(s.cursor.field).toBe("body")
@@ -219,6 +229,7 @@ describe("moveRowFirst", () => {
     s = moveFieldCursor(s, -1, {
       headers: 2,
       params: 0,
+      pathParams: 0,
       body: 0,
       auth: 0,
       settings: 0,
@@ -227,6 +238,7 @@ describe("moveRowFirst", () => {
     const first = moveRowFirst(s, {
       headers: 2,
       params: 0,
+      pathParams: 0,
       body: 0,
       auth: 0,
       settings: 0,
@@ -268,7 +280,14 @@ describe("moveRowLast", () => {
   })
 
   it("for auth, last goes to row N-1", () => {
-    const counts = { headers: 0, params: 0, body: 0, auth: 4, settings: 3 }
+    const counts = {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 4,
+      settings: 3,
+    }
     let s = enterEditBrowse(inactive, counts)
     s = moveFieldCursor(s, -1, counts)
     s = moveFieldCursor(s, -1, counts)
@@ -283,6 +302,7 @@ describe("moveRowLast", () => {
     s = moveFieldCursor(s, -1, {
       headers: 2,
       params: 0,
+      pathParams: 0,
       body: 0,
       auth: 0,
       settings: 0,
@@ -291,6 +311,7 @@ describe("moveRowLast", () => {
     const last = moveRowLast(s, {
       headers: 2,
       params: 0,
+      pathParams: 0,
       body: 0,
       auth: 0,
       settings: 0,
@@ -317,6 +338,8 @@ describe("beginEditing", () => {
     let s = enterEditBrowse(inactive, c(0, 0))
     s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("params")
+    s = moveFieldCursor(s, +1, c(0, 0))
+    expect(s.cursor.field).toBe("pathParams")
     s = moveFieldCursor(s, +1, { ...c(0, 0), body: 0 })
     expect(s.cursor.field).toBe("body")
     expect(s.cursor.row).toBe(0)
@@ -325,7 +348,14 @@ describe("beginEditing", () => {
     expect(e.editingRow).toBe(0)
   })
   it("enters edit mode for auth (type selector row)", () => {
-    const counts = { headers: 0, params: 0, body: 0, auth: 2, settings: 3 }
+    const counts = {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 2,
+      settings: 3,
+    }
     let s = enterEditBrowse(inactive, counts)
     s = moveFieldCursor(s, -1, counts)
     s = moveFieldCursor(s, -1, counts)
@@ -336,7 +366,14 @@ describe("beginEditing", () => {
   })
 
   it("navigates auth rows for bearer (2 rows)", () => {
-    const counts = { headers: 0, params: 0, body: 0, auth: 2, settings: 3 }
+    const counts = {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 2,
+      settings: 3,
+    }
     let s = enterEditBrowse(inactive, counts)
     s = moveFieldCursor(s, -1, counts)
     s = moveFieldCursor(s, -1, counts)
@@ -350,7 +387,14 @@ describe("beginEditing", () => {
   })
 
   it("navigates auth rows for basic (3 rows)", () => {
-    const counts = { headers: 0, params: 0, body: 0, auth: 3, settings: 3 }
+    const counts = {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 3,
+      settings: 3,
+    }
     let s = enterEditBrowse(inactive, counts)
     s = moveFieldCursor(s, -1, counts)
     s = moveFieldCursor(s, -1, counts)
@@ -364,7 +408,14 @@ describe("beginEditing", () => {
   })
 
   it("navigates auth rows for api_key (4 rows)", () => {
-    const counts = { headers: 0, params: 0, body: 0, auth: 4, settings: 3 }
+    const counts = {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 4,
+      settings: 3,
+    }
     let s = enterEditBrowse(inactive, counts)
     s = moveFieldCursor(s, -1, counts)
     s = moveFieldCursor(s, -1, counts)
@@ -412,6 +463,7 @@ describe("beginEditing", () => {
 
   it("sets subfield to 'key' for body row", () => {
     let s = enterEditBrowse(inactive, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
     s = moveFieldCursor(s, +1, c(0, 0))
     s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("body")
@@ -497,6 +549,7 @@ describe("toggleSubfield", () => {
     let s = enterEditBrowse(inactive, c(0, 0))
     s = moveFieldCursor(s, +1, c(0, 0))
     s = moveFieldCursor(s, +1, c(0, 0))
+    s = moveFieldCursor(s, +1, c(0, 0))
     expect(s.cursor.field).toBe("body")
     const editing = beginEditing(s)
     expect(editing.cursor.subfield).toBe("key")
@@ -504,7 +557,14 @@ describe("toggleSubfield", () => {
   })
 
   it("beginEditing on auth row 0 (type selector) enters edit mode", () => {
-    const counts = { headers: 0, params: 0, body: 0, auth: 2, settings: 3 }
+    const counts = {
+      headers: 0,
+      params: 0,
+      pathParams: 0,
+      body: 0,
+      auth: 2,
+      settings: 3,
+    }
     let s = enterEditBrowse(inactive, counts)
     s = moveFieldCursor(s, -1, counts)
     s = moveFieldCursor(s, -1, counts)

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -418,6 +418,11 @@ describe("lang.serializeRequest — canonical output", () => {
     )
   })
 
+  it("omits empty path params", () => {
+    const out = lang.serializeRequest(makeReq({ pathParams: [] }))
+    expect(out).not.toContain("path_params:")
+  })
+
   it("emits headers when non-empty, omits empty params/body/auth", () => {
     const out = lang.serializeRequest(
       makeReq({

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -193,6 +193,13 @@ describe("lang.parseRequest — KvEntry parsing", () => {
     ])
   })
 
+  it("rejects enabled flags on path params", () => {
+    const yaml = `name: Foo\nmethod: GET\nurl: https://example.com/users/:id\npath_params:\n  - name: id\n    value: "42"\n    enabled: false\n`
+    expect(() => lang.parseRequest("x", yaml)).toThrow(
+      "lang.parseRequest: path_params[0].enabled is not supported",
+    )
+  })
+
   it("throws on header value object missing 'value'", () => {
     const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nheaders:\n  X: { enabled: false }\n`
     expect(() => lang.parseRequest("x", yaml)).toThrow(
@@ -550,6 +557,18 @@ describe("lang.serializeRequest — disabled entries", () => {
     )
     expect(out).toContain("- name: verbose\n    value: 'true'\n")
     expect(out).toContain("- name: debug\n    value: '1'\n    enabled: false")
+  })
+
+  it("never serializes an enabled flag for path params", () => {
+    const out = lang.serializeRequest(
+      makeReq({
+        pathParams: [{ name: "id", value: "42", enabled: false }],
+      }),
+    )
+    expect(out).toContain("path_params:\n  - name: id\n    value: '42'")
+    expect(out).not.toContain(
+      "path_params:\n  - name: id\n    value: '42'\n    enabled",
+    )
   })
 })
 

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -251,7 +251,7 @@ describe("mapCollection — operations & methods", () => {
         },
       }),
     )
-    expect(reqs(c)[0].url).toBe("$base_url/users/$id")
+    expect(reqs(c)[0].url).toBe("$base_url/users/:id")
   })
 
   it("builds a path-only url when servers is missing", () => {
@@ -263,7 +263,7 @@ describe("mapCollection — operations & methods", () => {
         },
       }),
     )
-    expect(reqs(c)[0].url).toBe("/users/$id")
+    expect(reqs(c)[0].url).toBe("/users/:id")
   })
 
   it("initializes headers, params as empty and body as undefined and auth as none", () => {
@@ -642,7 +642,7 @@ describe("mapCollection — parameters", () => {
     expect(reqs(c)[0].params).toEqual([])
   })
 
-  it("does not duplicate path params (in:path is a no-op; already in url)", () => {
+  it("does not duplicate path params (in:path becomes pathParams, already in url)", () => {
     const c = mapCollection(
       makeNormalized({
         servers: [],
@@ -661,7 +661,11 @@ describe("mapCollection — parameters", () => {
     )
     expect(reqs(c)[0].params).toEqual([])
     expect(reqs(c)[0].headers).toEqual({})
-    expect(reqs(c)[0].url).toBe("/users/$id/items/$itemId")
+    expect(reqs(c)[0].url).toBe("/users/:id/items/:itemId")
+    expect(reqs(c)[0].pathParams).toEqual([
+      { name: "id", value: "", enabled: true },
+      { name: "itemId", value: "", enabled: true },
+    ])
   })
 
   it("skips a param with missing name", () => {
@@ -846,6 +850,139 @@ describe("mapCollection — parameters", () => {
     )
     expect(reqs(c)[0].params.map((p) => p.name)).toEqual(["dup"])
   })
+
+  it("maps in:path params to pathParams with example values", () => {
+    const c = mapCollection(
+      makeNormalized({
+        servers: [],
+        paths: {
+          "/users/{userId}/posts/{postId}": {
+            get: {
+              operationId: "getPost",
+              parameters: [
+                { name: "userId", in: "path", example: "42" },
+                {
+                  name: "postId",
+                  in: "path",
+                  schema: { default: "99" },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    )
+    expect(reqs(c)[0].pathParams).toEqual([
+      { name: "userId", value: "42", enabled: true },
+      { name: "postId", value: "99", enabled: true },
+    ])
+  })
+
+  it("maps in:path params to pathParams with empty defaults", () => {
+    const c = mapCollection(
+      makeNormalized({
+        servers: [],
+        paths: {
+          "/users/{id}": {
+            get: {
+              operationId: "getUser",
+              parameters: [{ name: "id", in: "path" }],
+            },
+          },
+        },
+      }),
+    )
+    expect(reqs(c)[0].pathParams).toEqual([
+      { name: "id", value: "", enabled: true },
+    ])
+  })
+
+  it("maps hyphenated in:path params to pathParams", () => {
+    const c = mapCollection(
+      makeNormalized({
+        servers: [],
+        paths: {
+          "/users/{user-id}": {
+            get: {
+              operationId: "getUser",
+              parameters: [{ name: "user-id", in: "path", example: "42" }],
+            },
+          },
+        },
+      }),
+    )
+    expect(reqs(c)[0].url).toBe("/users/:user-id")
+    expect(reqs(c)[0].pathParams).toEqual([
+      { name: "user-id", value: "42", enabled: true },
+    ])
+  })
+
+  it("ignores in:path params that don't match a URL token", () => {
+    const c = mapCollection(
+      makeNormalized({
+        servers: [],
+        paths: {
+          "/users/{id}": {
+            get: {
+              operationId: "getUser",
+              parameters: [
+                { name: "id", in: "path" },
+                { name: "unused", in: "path" },
+              ],
+            },
+          },
+        },
+      }),
+    )
+    expect(reqs(c)[0].pathParams).toEqual([
+      { name: "id", value: "", enabled: true },
+    ])
+  })
+
+  it("op-level path params override path-item path params", () => {
+    const c = mapCollection(
+      makeNormalized({
+        servers: [],
+        paths: {
+          "/users/{id}": {
+            parameters: [{ name: "id", in: "path", example: "old" }],
+            get: {
+              operationId: "getUser",
+              parameters: [
+                { name: "id", in: "path", example: "new" },
+                { name: "extra", in: "path" },
+              ],
+            },
+          },
+        },
+      }),
+    )
+    expect(reqs(c)[0].pathParams).toEqual([
+      { name: "id", value: "new", enabled: true },
+    ])
+  })
+
+  it("scans all pathParams values for $var env variables", () => {
+    const c = mapCollection(
+      makeNormalized({
+        servers: [{ url: "https://{host}" }],
+        paths: {
+          "/users/{id}": {
+            get: {
+              operationId: "getUser",
+              parameters: [
+                { name: "id", in: "path", example: "{{org}}-{{repo}}" },
+              ],
+            },
+          },
+        },
+      }),
+    )
+    const env = c.environments.find((e) => e.name === "default")
+    expect(env).toBeDefined()
+    expect(env?.vars.org).toBe("")
+    expect(env?.vars.repo).toBe("")
+  })
 })
 
 describe("mapCollection — end-to-end integration", () => {
@@ -903,7 +1040,10 @@ describe("mapCollection — end-to-end integration", () => {
     expect(getPet.id).toBe("get-pets-petid")
     expect(getPet.name).toBe("getPet")
     expect(getPet.method).toBe("GET")
-    expect(getPet.url).toBe("https://$host/v1/pets/$petId")
+    expect(getPet.url).toBe("https://$host/v1/pets/:petId")
+    expect(getPet.pathParams).toEqual([
+      { name: "petId", value: "", enabled: true },
+    ])
     expect(getPet.params).toEqual([
       { name: "verbose", value: "", enabled: true },
     ])

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -427,6 +427,42 @@ describe("RequestPane scrollbox", () => {
     // No primary background on active row (uses backgroundElement instead)
     expect(authSpan!.bg.equals(RGBA.fromInts(250, 178, 131))).toBe(false)
   })
+
+  it("renders missing URL path tokens as empty path rows", async () => {
+    const request: Request = {
+      id: "test",
+      name: "Test",
+      method: "GET",
+      url: "https://example.com/posts/:post_id?key=val1",
+      headers: {},
+      params: [],
+      body: "",
+      timeout: 0,
+    }
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <RequestPane
+            request={request}
+            editState={initialEditState()}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            focused={true}
+            activeTab="pathParams"
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("post_id")
+  })
 })
 
 describe("Sidebar scrollbox", () => {

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -258,10 +258,12 @@ describe("ResponsePane status text truncation and layout tests", () => {
       }
       expectBadge("h")
       expectBadge("p")
-      expectBadge("b")
-      expectBadge("a")
-      if (layout !== "side-by-side" || width > 80) expectBadge("t")
-      else expect(lines.some((line) => line.includes(" t "))).toBe(false)
+      expectBadge("x")
+      if (layout !== "side-by-side" || width > 80) {
+        expectBadge("b")
+        expectBadge("a")
+        expectBadge("t")
+      }
       expectBadge("r")
       expectBadge("e")
       expectBadge("l")
@@ -277,6 +279,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
       if (layout === "stacked") {
         expectBadgeAtTabStart("h", "Headers")
         expectBadgeAtTabStart("p", "Params")
+        expectBadgeAtTabStart("x", "Path")
         expectBadgeAtTabStart("b", "Body")
         expectBadgeAtTabStart("a", "Auth")
         expectBadgeAtTabStart("t", "Settings")
@@ -391,13 +394,14 @@ describe("getAvailableTargets", () => {
     expect(targets.has("u")).toBe(true)
     expect(targets.has("h")).toBe(true)
     expect(targets.has("p")).toBe(true)
+    expect(targets.has("x")).toBe(true)
     expect(targets.has("b")).toBe(true)
     expect(targets.has("a")).toBe(true)
     expect(targets.has("t")).toBe(true)
     expect(targets.has("r")).toBe(true)
     expect(targets.has("e")).toBe(true)
     expect(targets.has("l")).toBe(true)
-    expect(targets.size).toBe(11)
+    expect(targets.size).toBe(12)
   })
 
   it("excludes response targets when expanded=request", () => {
@@ -428,7 +432,14 @@ describe("getAvailableTargets", () => {
 describe("computeRequestTabLabels", () => {
   it("returns base labels when request is null", () => {
     const labels = computeRequestTabLabels(null)
-    expect(labels).toEqual(["Headers", "Params", "Body", "Auth", "Settings"])
+    expect(labels).toEqual([
+      "Headers",
+      "Params",
+      "Path",
+      "Body",
+      "Auth",
+      "Settings",
+    ])
   })
 
   it("appends bullet when headers have enabled entries", () => {
@@ -453,7 +464,7 @@ describe("computeRequestTabLabels", () => {
       auth: { type: "bearer" },
       timeout: 0,
     } as unknown as import("../../src/schema").Request)
-    expect(labels[3]).toBe("Auth \u2022")
+    expect(labels[4]).toBe("Auth \u2022")
   })
 
   it("appends bullet when body is set", () => {
@@ -466,7 +477,7 @@ describe("computeRequestTabLabels", () => {
       auth: { type: "none" },
       timeout: 0,
     } as unknown as import("../../src/schema").Request)
-    expect(labels[2]).toBe("Body \u2022")
+    expect(labels[3]).toBe("Body \u2022")
   })
 
   it("appends bullet when timeout > 0", () => {
@@ -478,6 +489,6 @@ describe("computeRequestTabLabels", () => {
       auth: { type: "none" },
       timeout: 5000,
     } as unknown as import("../../src/schema").Request)
-    expect(labels[4]).toBe("Settings \u2022")
+    expect(labels[5]).toBe("Settings \u2022")
   })
 })

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -150,6 +150,20 @@ describe("splitUrlPathVars", () => {
     ])
   })
 
+  it("marks a missing token after a resolved URL variable as unresolved", () => {
+    const result = splitUrlPathVars(
+      "$base_url/posts/:post_id",
+      env({ base_url: "https://api.example.com" }),
+      [],
+    )
+    expect(result.find((segment) => segment.isPath)).toEqual({
+      text: ":post_id",
+      isVar: false,
+      exists: false,
+      isPath: true,
+    })
+  })
+
   it("marks path token with empty value as unresolved", () => {
     const pathParams: ParamEntry[] = [{ name: "id", value: "", enabled: true }]
     const result = splitUrlPathVars("/:id", null, pathParams)

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -175,7 +175,7 @@ describe("splitUrlPathVars", () => {
     })
   })
 
-  it("marks disabled path token as unresolved", () => {
+  it("ignores unsupported disabled state on path tokens", () => {
     const pathParams: ParamEntry[] = [
       { name: "id", value: "42", enabled: false },
     ]
@@ -183,7 +183,7 @@ describe("splitUrlPathVars", () => {
     expect(result[1]!).toEqual({
       text: ":id",
       isVar: false,
-      exists: false,
+      exists: true,
       isPath: true,
     })
   })
@@ -236,6 +236,15 @@ describe("splitUrlPathVars", () => {
     )
     const pathSegs = result.filter((s) => s.isPath)
     expect(pathSegs).toHaveLength(0)
+  })
+
+  it("does not highlight tokens followed by unsupported characters", () => {
+    const result = splitUrlPathVars(
+      "https://api.example.com/users/:id~suffix",
+      null,
+      [{ name: "id", value: "42", enabled: true }],
+    )
+    expect(result.filter((segment) => segment.isPath)).toHaveLength(0)
   })
 
   it("does not highlight basic-auth separator as path token", () => {

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -204,4 +204,33 @@ describe("splitUrlPathVars", () => {
       { text: ":id", isVar: false, exists: true, isPath: true },
     ])
   })
+
+  it("does not highlight port numbers as path tokens", () => {
+    const result = splitUrlPathVars("https://localhost:3000/users/:id", null, [
+      { name: "id", value: "42", enabled: true },
+    ])
+    const pathSegs = result.filter((s) => s.isPath)
+    expect(pathSegs).toHaveLength(1)
+    expect(pathSegs[0]!.text).toBe(":id")
+  })
+
+  it("does not highlight query-string colons as path tokens", () => {
+    const result = splitUrlPathVars(
+      "https://api.example.com/posts?filter=:active",
+      null,
+      [],
+    )
+    const pathSegs = result.filter((s) => s.isPath)
+    expect(pathSegs).toHaveLength(0)
+  })
+
+  it("does not highlight basic-auth separator as path token", () => {
+    const result = splitUrlPathVars(
+      "https://user:pass@api.example.com/v1",
+      null,
+      [],
+    )
+    const pathSegs = result.filter((s) => s.isPath)
+    expect(pathSegs).toHaveLength(0)
+  })
 })

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "bun:test"
-import { splitEnvVars } from "../../src/ui/variable-completion/envHighlight"
-import type { Environment } from "../../src/schema"
+import {
+  splitEnvVars,
+  splitUrlPathVars,
+} from "../../src/ui/variable-completion/envHighlight"
+import type { Environment, ParamEntry } from "../../src/schema"
 
 function env(vars: Record<string, string>): Environment {
   return { name: "test-env", vars }
@@ -106,5 +109,99 @@ describe("splitEnvVars", () => {
   it("handles $ with digits", () => {
     const result = splitEnvVars("$port8080", env({ port8080: "8080" }))
     expect(result).toEqual([{ text: "$port8080", isVar: true, exists: true }])
+  })
+})
+
+describe("splitUrlPathVars", () => {
+  it("marks resolved path token with exists=true", () => {
+    const pathParams: ParamEntry[] = [
+      { name: "id", value: "42", enabled: true },
+    ]
+    const result = splitUrlPathVars(
+      "https://api.example.com/users/:id",
+      null,
+      pathParams,
+    )
+    expect(result).toEqual([
+      {
+        text: "https://api.example.com/users/",
+        isVar: false,
+        exists: false,
+        isPath: false,
+      },
+      { text: ":id", isVar: false, exists: true, isPath: true },
+    ])
+  })
+
+  it("marks missing path token with exists=false", () => {
+    const result = splitUrlPathVars(
+      "https://api.example.com/users/:id",
+      null,
+      [],
+    )
+    expect(result).toEqual([
+      {
+        text: "https://api.example.com/users/",
+        isVar: false,
+        exists: false,
+        isPath: false,
+      },
+      { text: ":id", isVar: false, exists: false, isPath: true },
+    ])
+  })
+
+  it("marks path token with empty value as unresolved", () => {
+    const pathParams: ParamEntry[] = [{ name: "id", value: "", enabled: true }]
+    const result = splitUrlPathVars("/:id", null, pathParams)
+    expect(result[1]!).toEqual({
+      text: ":id",
+      isVar: false,
+      exists: false,
+      isPath: true,
+    })
+  })
+
+  it("marks disabled path token as unresolved", () => {
+    const pathParams: ParamEntry[] = [
+      { name: "id", value: "42", enabled: false },
+    ]
+    const result = splitUrlPathVars("/:id", null, pathParams)
+    expect(result[1]!).toEqual({
+      text: ":id",
+      isVar: false,
+      exists: false,
+      isPath: true,
+    })
+  })
+
+  it("handles :name.json suffix", () => {
+    const pathParams: ParamEntry[] = [
+      { name: "id", value: "42", enabled: true },
+    ]
+    const result = splitUrlPathVars(
+      "https://api.example.com/users/:id.json",
+      env({}),
+      pathParams,
+    )
+    const pathSeg = result.find((s) => s.isPath)
+    expect(pathSeg).toBeDefined()
+    expect(pathSeg!.text).toBe(":id")
+    expect(pathSeg!.exists).toBe(true)
+  })
+
+  it("combines $var and :path tokens correctly", () => {
+    const pathParams: ParamEntry[] = [
+      { name: "id", value: "42", enabled: true },
+    ]
+    const result = splitUrlPathVars(
+      "$base/users/:id",
+      env({ base: "https://api.example.com" }),
+      pathParams,
+    )
+    expect(result).toEqual([
+      { text: "$base", isVar: true, exists: true, isPath: false },
+      { text: "/users/", isVar: false, exists: false, isPath: false },
+      { text: ":id", isVar: false, exists: true, isPath: true },
+    ])
   })
 })

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test"
 import type { Request } from "../../src/schema"
-import { send } from "../../src/requests/send"
+import { send, interpolatePathParams } from "../../src/requests/send"
 
 function makeReq(over: Partial<Request> = {}): Request {
   return {
@@ -133,5 +133,100 @@ describe("send — param deduplication", () => {
     } finally {
       globalThis.fetch = orig
     }
+  })
+})
+
+describe("interpolatePathParams", () => {
+  it("replaces :token with value in absolute URL", () => {
+    const result = interpolatePathParams("https://api.example.com/users/:id", [
+      { name: "id", value: "42", enabled: true },
+    ])
+    expect(result).toBe("https://api.example.com/users/42")
+  })
+
+  it("replaces multiple tokens", () => {
+    const result = interpolatePathParams(
+      "https://api.example.com/users/:userId/posts/:postId",
+      [
+        { name: "userId", value: "alice", enabled: true },
+        { name: "postId", value: "99", enabled: true },
+      ],
+    )
+    expect(result).toBe("https://api.example.com/users/alice/posts/99")
+  })
+
+  it("encodes special characters in value", () => {
+    const result = interpolatePathParams(
+      "https://api.example.com/users/:name",
+      [{ name: "name", value: "alice/bob", enabled: true }],
+    )
+    expect(result).toBe("https://api.example.com/users/alice%2Fbob")
+  })
+
+  it("preserves suffix like .json after token", () => {
+    const result = interpolatePathParams(
+      "https://api.example.com/users/:id.json",
+      [{ name: "id", value: "42", enabled: true }],
+    )
+    expect(result).toBe("https://api.example.com/users/42.json")
+  })
+
+  it("handles relative URL", () => {
+    const result = interpolatePathParams("/users/:id/posts", [
+      { name: "id", value: "42", enabled: true },
+    ])
+    expect(result).toBe("/users/42/posts")
+  })
+
+  it("throws on empty value", () => {
+    expect(() =>
+      interpolatePathParams("https://api.example.com/users/:id", [
+        { name: "id", value: "", enabled: true },
+      ]),
+    ).toThrow('path parameter ":id" has no value')
+  })
+
+  it("throws on disabled entry", () => {
+    expect(() =>
+      interpolatePathParams("https://api.example.com/users/:id", [
+        { name: "id", value: "42", enabled: false },
+      ]),
+    ).toThrow('path parameter ":id" has no value')
+  })
+
+  it("throws on missing entry", () => {
+    expect(() =>
+      interpolatePathParams("https://api.example.com/users/:id", []),
+    ).toThrow('path parameter ":id" has no value')
+  })
+
+  it("returns url unchanged when no path tokens exist", () => {
+    const result = interpolatePathParams("https://api.example.com/users", [
+      { name: "id", value: "42", enabled: true },
+    ])
+    expect(result).toBe("https://api.example.com/users")
+  })
+
+  it("returns url unchanged on malformed URL", () => {
+    const result = interpolatePathParams("not a valid url", [
+      { name: "id", value: "42", enabled: true },
+    ])
+    expect(result).toBe("not a valid url")
+  })
+
+  it("preserves query string after token interpolation", () => {
+    const result = interpolatePathParams(
+      "https://api.example.com/users/:id?verbose=true",
+      [{ name: "id", value: "42", enabled: true }],
+    )
+    expect(result).toBe("https://api.example.com/users/42?verbose=true")
+  })
+
+  it("preserves port in URL", () => {
+    const result = interpolatePathParams(
+      "https://api.example.com:8443/users/:id",
+      [{ name: "id", value: "42", enabled: true }],
+    )
+    expect(result).toBe("https://api.example.com:8443/users/42")
   })
 })

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -194,10 +194,10 @@ describe("interpolatePathParams", () => {
     ).toThrow('path parameter ":id" has no value')
   })
 
-  it("throws on missing entry", () => {
-    expect(() =>
-      interpolatePathParams("https://api.example.com/users/:id", []),
-    ).toThrow('path parameter ":id" has no value')
+  it("preserves token when entry is missing", () => {
+    expect(interpolatePathParams("https://api.example.com/users/:id", [])).toBe(
+      "https://api.example.com/users/:id",
+    )
   })
 
   it("returns url unchanged when no path tokens exist", () => {

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -194,18 +194,18 @@ describe("interpolatePathParams", () => {
     ).toThrow('path parameter ":id" has no value')
   })
 
-  it("throws on disabled entry", () => {
-    expect(() =>
+  it("ignores unsupported disabled state", () => {
+    expect(
       interpolatePathParams("https://api.example.com/users/:id", [
         { name: "id", value: "42", enabled: false },
       ]),
-    ).toThrow('path parameter ":id" has no value')
+    ).toBe("https://api.example.com/users/42")
   })
 
-  it("preserves token when entry is missing", () => {
-    expect(interpolatePathParams("https://api.example.com/users/:id", [])).toBe(
-      "https://api.example.com/users/:id",
-    )
+  it("throws when entry is missing", () => {
+    expect(() =>
+      interpolatePathParams("https://api.example.com/users/:id", []),
+    ).toThrow('path parameter ":id" has no value')
   })
 
   it("returns url unchanged when no path tokens exist", () => {
@@ -236,5 +236,51 @@ describe("interpolatePathParams", () => {
       [{ name: "id", value: "42", enabled: true }],
     )
     expect(result).toBe("https://api.example.com:8443/users/42")
+  })
+})
+
+describe("send — required path parameters", () => {
+  it("does not fetch for an empty value, with or without an environment", async () => {
+    let calls = 0
+    const orig = globalThis.fetch
+    globalThis.fetch = mock(async () => {
+      calls++
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    const req = makeReq({
+      url: "https://api.example.com/users/:id",
+      pathParams: [{ name: "id", value: "", enabled: true }],
+    })
+
+    try {
+      await expect(send(req)).rejects.toThrow(
+        'path parameter ":id" has no value',
+      )
+      await expect(send(req, { name: "test", vars: {} })).rejects.toThrow(
+        'path parameter ":id" has no value',
+      )
+      expect(calls).toBe(0)
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+
+  it("does not fetch for a missing path parameter row", async () => {
+    let calls = 0
+    const orig = globalThis.fetch
+    globalThis.fetch = mock(async () => {
+      calls++
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await expect(
+        send(makeReq({ url: "https://api.example.com/users/:id" })),
+      ).rejects.toThrow('path parameter ":id" has no value')
+      expect(calls).toBe(0)
+    } finally {
+      globalThis.fetch = orig
+    }
   })
 })

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -171,6 +171,14 @@ describe("interpolatePathParams", () => {
     expect(result).toBe("https://api.example.com/users/42.json")
   })
 
+  it("does not partially replace unsupported token names", () => {
+    const result = interpolatePathParams(
+      "https://api.example.com/orders/:order~id",
+      [{ name: "order", value: "42", enabled: true }],
+    )
+    expect(result).toBe("https://api.example.com/orders/:order~id")
+  })
+
   it("handles relative URL", () => {
     const result = interpolatePathParams("/users/:id/posts", [
       { name: "id", value: "42", enabled: true },

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -376,6 +376,15 @@ describe("syncPathParamsWithUrl", () => {
     expect(result).toEqual([{ name: "id", value: "99", enabled: true }])
   })
 
+  it("sets enabled true when renaming a path token", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "99", enabled: false }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:userId",
+    )
+    expect(result).toEqual([{ name: "userId", value: "99", enabled: true }])
+  })
+
   it("preserves values when new token inserted before existing one", () => {
     const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
     const result = syncPathParamsWithUrl(

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -280,6 +280,12 @@ describe("parseUrlPathTokens", () => {
     ).toEqual(["id"])
   })
 
+  it("does not truncate unsupported token names", () => {
+    expect(
+      parseUrlPathTokens("https://api.example.com/orders/:order~id"),
+    ).toEqual([])
+  })
+
   it("returns empty array for URL without tokens", () => {
     expect(parseUrlPathTokens("https://api.example.com/posts")).toEqual([])
   })

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -3,6 +3,8 @@ import {
   buildDisplayUrl,
   parseUrlAndParams,
   syncParamsWithUrl,
+  parseUrlPathTokens,
+  syncPathParamsWithUrl,
 } from "../../src/ui/urlParams"
 import type { ParamEntry } from "../../src/schema"
 
@@ -252,5 +254,119 @@ describe("syncParamsWithUrl", () => {
       { name: "filter", value: "active", enabled: true },
       { name: "filter", value: "pending", enabled: false },
     ])
+  })
+})
+
+describe("parseUrlPathTokens", () => {
+  it("extracts :name tokens from pathname", () => {
+    expect(
+      parseUrlPathTokens("https://api.example.com/users/:id/posts/:postId"),
+    ).toEqual(["id", "postId"])
+  })
+
+  it("ignores query params with colon", () => {
+    expect(
+      parseUrlPathTokens("https://api.example.com/posts?filter=:active"),
+    ).toEqual([])
+  })
+
+  it("handles relative URLs", () => {
+    expect(parseUrlPathTokens("/users/:id")).toEqual(["id"])
+  })
+
+  it("extracts token from :name.json segment", () => {
+    expect(
+      parseUrlPathTokens("https://api.example.com/users/:id.json"),
+    ).toEqual(["id"])
+  })
+
+  it("returns empty array for URL without tokens", () => {
+    expect(parseUrlPathTokens("https://api.example.com/posts")).toEqual([])
+  })
+
+  it("handles port in URL", () => {
+    expect(
+      parseUrlPathTokens("https://api.example.com:8443/users/:id"),
+    ).toEqual(["id"])
+  })
+
+  it("returns sorted unique names", () => {
+    expect(parseUrlPathTokens("/:b/:a/:b")).toEqual(["a", "b"])
+  })
+})
+
+describe("syncPathParamsWithUrl", () => {
+  it("adds new path params from URL tokens", () => {
+    const result = syncPathParamsWithUrl(
+      [],
+      "https://api.example.com/users/:id",
+    )
+    expect(result).toEqual([{ name: "id", value: "", enabled: true }])
+  })
+
+  it("renames row when token name changes at same position", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:userId",
+    )
+    expect(result).toEqual([{ name: "userId", value: "42", enabled: true }])
+  })
+
+  it("handles partial type mid-rename preserving value", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:i",
+    )
+    expect(result).toEqual([{ name: "i", value: "42", enabled: true }])
+  })
+
+  it("appends new empty row for extra URL token", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:id/:sort",
+    )
+    expect(result).toEqual([
+      { name: "id", value: "42", enabled: true },
+      { name: "sort", value: "", enabled: true },
+    ])
+  })
+
+  it("removes extra rows when URL tokens shrink", () => {
+    const current: ParamEntry[] = [
+      { name: "id", value: "42", enabled: true },
+      { name: "sort", value: "asc", enabled: false },
+    ]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:id",
+    )
+    expect(result).toEqual([{ name: "id", value: "42", enabled: true }])
+  })
+
+  it("clears all when URL has no path tokens", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/posts",
+    )
+    expect(result).toEqual([])
+  })
+
+  it("handles empty URL", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "1", enabled: true }]
+    const result = syncPathParamsWithUrl(current, "")
+    expect(result).toEqual([])
+  })
+
+  it("preserves value and enabled state when name unchanged", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "99", enabled: false }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:id",
+    )
+    expect(result).toEqual([{ name: "id", value: "99", enabled: false }])
   })
 })

--- a/tests/unit/urlParams.test.ts
+++ b/tests/unit/urlParams.test.ts
@@ -290,8 +290,8 @@ describe("parseUrlPathTokens", () => {
     ).toEqual(["id"])
   })
 
-  it("returns sorted unique names", () => {
-    expect(parseUrlPathTokens("/:b/:a/:b")).toEqual(["a", "b"])
+  it("returns unique names in URL order", () => {
+    expect(parseUrlPathTokens("/:b/:a/:b")).toEqual(["b", "a"])
   })
 })
 
@@ -361,12 +361,60 @@ describe("syncPathParamsWithUrl", () => {
     expect(result).toEqual([])
   })
 
-  it("preserves value and enabled state when name unchanged", () => {
+  it("preserves value when name unchanged, sets enabled true", () => {
     const current: ParamEntry[] = [{ name: "id", value: "99", enabled: false }]
     const result = syncPathParamsWithUrl(
       current,
       "https://api.example.com/users/:id",
     )
-    expect(result).toEqual([{ name: "id", value: "99", enabled: false }])
+    expect(result).toEqual([{ name: "id", value: "99", enabled: true }])
+  })
+
+  it("preserves values when new token inserted before existing one", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/:org/users/:id",
+    )
+    expect(result).toEqual([
+      { name: "org", value: "", enabled: true },
+      { name: "id", value: "42", enabled: true },
+    ])
+  })
+
+  it("preserves values when new token inserted after existing one", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:id/:version",
+    )
+    expect(result).toEqual([
+      { name: "id", value: "42", enabled: true },
+      { name: "version", value: "", enabled: true },
+    ])
+  })
+
+  it("matches by name when order changes", () => {
+    const current: ParamEntry[] = [
+      { name: "postId", value: "10", enabled: true },
+      { name: "userId", value: "alice", enabled: true },
+    ]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:userId/posts/:postId",
+    )
+    expect(result).toEqual([
+      { name: "userId", value: "alice", enabled: true },
+      { name: "postId", value: "10", enabled: true },
+    ])
+  })
+
+  it("detects rename when old name disappears and no positional match remains", () => {
+    const current: ParamEntry[] = [{ name: "id", value: "42", enabled: true }]
+    const result = syncPathParamsWithUrl(
+      current,
+      "https://api.example.com/users/:userId",
+    )
+    expect(result).toEqual([{ name: "userId", value: "42", enabled: true }])
   })
 })

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -69,8 +69,11 @@ describe("path parameter drafts", () => {
     ])
   })
 
-  it("does not persist an empty virtual URL token", () => {
-    const original = makeReq({ url: "https://example.com/posts/:post_id" })
+  it("keeps a cleared path value so send rejects it", () => {
+    const original = makeReq({
+      url: "https://example.com/posts/:post_id",
+      pathParams: [{ name: "post_id", value: "42", enabled: true }],
+    })
     const next = applyDraft(new Map(), "r1", original, {
       kind: "setPathParamRow",
       index: 0,
@@ -78,7 +81,9 @@ describe("path parameter drafts", () => {
       value: "",
     })
 
-    expect(next.get("r1")!.pathParams).toEqual([])
+    expect(next.get("r1")!.pathParams).toEqual([
+      { name: "post_id", value: "", enabled: true },
+    ])
   })
 })
 

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -85,6 +85,36 @@ describe("path parameter drafts", () => {
       { name: "post_id", value: "", enabled: true },
     ])
   })
+
+  it("reverts a reordered path parameter by name", () => {
+    const original = makeReq({
+      url: "https://example.com/:a/:b",
+      pathParams: [
+        { name: "a", value: "one", enabled: true },
+        { name: "b", value: "two", enabled: true },
+      ],
+    })
+    let next = applyDraft(new Map(), "r1", original, {
+      kind: "setUrl",
+      url: "https://example.com/:b/:a",
+    })
+    next = applyDraft(next, "r1", original, {
+      kind: "setPathParamRow",
+      index: 0,
+      key: "b",
+      value: "changed",
+    })
+    next = applyDraft(next, "r1", original, {
+      kind: "revertField",
+      field: "pathParams",
+      row: 0,
+    })
+
+    expect(next.get("r1")!.pathParams).toEqual([
+      { name: "b", value: "two", enabled: true },
+      { name: "a", value: "one", enabled: true },
+    ])
+  })
 })
 
 describe("requestEquals", () => {

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -54,6 +54,34 @@ describe("parseRow", () => {
   })
 })
 
+describe("path parameter drafts", () => {
+  it("creates an entry when a virtual URL token receives a value", () => {
+    const original = makeReq({ url: "https://example.com/posts/:post_id" })
+    const next = applyDraft(new Map(), "r1", original, {
+      kind: "setPathParamRow",
+      index: 0,
+      key: "post_id",
+      value: "42",
+    })
+
+    expect(next.get("r1")!.pathParams).toEqual([
+      { name: "post_id", value: "42", enabled: true },
+    ])
+  })
+
+  it("does not persist an empty virtual URL token", () => {
+    const original = makeReq({ url: "https://example.com/posts/:post_id" })
+    const next = applyDraft(new Map(), "r1", original, {
+      kind: "setPathParamRow",
+      index: 0,
+      key: "post_id",
+      value: "",
+    })
+
+    expect(next.get("r1")!.pathParams).toEqual([])
+  })
+})
+
 describe("requestEquals", () => {
   it("equal requests → true", () => {
     const a = makeReq()


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature

### What does this PR do?

Adds a **Path** tab to the request pane where `:token` segments in the URL are extracted and displayed as editable key-value pairs. Values are substituted into the URL at send time via `encodeURIComponent`.

- Extracts `:param` tokens from URL pathname using `parsePathToken` / `URL_PATH_TOKEN_RE`
- Automatic sync between URL changes and path parameter list (`syncPathParamsWithUrl`)
- Path tab is read-only for key (name), no checkbox toggle, no add-row
- URL bar displays `:token` segments in primary/error color (matching env var highlighting)
- YAML serialization under `path_params:`, parse support for round-trip
- OpenAPI importer converts `{param}` templates to `:param` tokens
- Postman importer extracts path variables from v2.1 requests
- Path params interpolated before query params during send (`interpolatePathParams`)
- Highlighting in VarInput and URL bar browse mode via `splitUrlPathVars`
- Timeline records resolved path params for history
- Jump mode hint `x` for the Path tab

### How did you verify your code works?

- `bun test` passes (1895 tests, 0 fail)
- 170-line `urlParams.test.ts` covering token extraction, sync, and edge cases
- 144-line `postman-map.test.ts` covering Postman path param import
- Updated `send.test.ts`, `editMode.test.ts`, `lang.test.ts`, `envHighlight.test.ts` for path param scenarios

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for URL path parameters using `:parameter` tokens.
  - Added a dedicated **Path** tab for viewing and editing path values.
  - Path parameters are imported from OpenAPI and Postman collections.
  - Requests interpolate and URL-encode path values when sent.
  - Path parameters are preserved in saved requests and request history.

- **Bug Fixes**
  - URL path parameters stay synchronized when URLs are edited.
  - Missing or invalid path values are clearly highlighted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->