### PR TITLE
fix(dirty-state): eliminate stale closure in markSaved, add moveRequestDraft for rename, drop dirty dot from status bar

### DIFF
--- a/collections/comments/get-comments-by-post.yml
+++ b/collections/comments/get-comments-by-post.yml
@@ -1,10 +1,7 @@
 name: Get Comments by Post
 method: GET
-url: $base_url/comments
+url: $base_url/comments?postId=$post_id
 timeout: 0
 followRedirects: true
 maxRedirects: 5
-params:
-  - name: postId
-    value: $post_id
 body_type: none

--- a/collections/comments/get-comments-by-post.yml
+++ b/collections/comments/get-comments-by-post.yml
@@ -1,7 +1,10 @@
 name: Get Comments by Post
 method: GET
-url: $base_url/comments?postId=$post_id
+url: $base_url/comments
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+params:
+  - name: postId
+    value: $post_id
 body_type: none

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -260,7 +260,6 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
   )
   const revertAll = useCallback(() => dispatch({ kind: "revert" }), [dispatch])
   const markSaved = useCallback((savedFolder: Folder) => {
-    authTypeCache.delete(savedFolder.path)
     setOriginalMap((prev) => {
       const next = new Map(prev)
       next.set(savedFolder.path, { ...savedFolder })
@@ -271,6 +270,7 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
       if (!currentDraft || !folderEqual(currentDraft, savedFolder)) return prev
       const next = new Map(prev)
       next.delete(savedFolder.path)
+      authTypeCache.delete(savedFolder.path)
       return next
     })
   }, [])

--- a/src/hooks/useFolderDraft.ts
+++ b/src/hooks/useFolderDraft.ts
@@ -159,7 +159,7 @@ export interface UseFolderDraftResult {
   setAuthField: (authType: string, field: string, value: string) => void
   setApiKeyPlacement: (placement: "header" | "query") => void
   revertAll: () => void
-  markSaved: () => void
+  markSaved: (folder: Folder) => void
   revertAllFolders: () => void
   clearFolderDraft: (path: string) => void
 }
@@ -259,20 +259,21 @@ export function useFolderDraft(folder: Folder | null): UseFolderDraftResult {
     [dispatch],
   )
   const revertAll = useCallback(() => dispatch({ kind: "revert" }), [dispatch])
-  const markSaved = useCallback(() => {
-    if (!folderDraft || !folder) return
-    authTypeCache.delete(key)
+  const markSaved = useCallback((savedFolder: Folder) => {
+    authTypeCache.delete(savedFolder.path)
     setOriginalMap((prev) => {
       const next = new Map(prev)
-      next.set(key, { ...folderDraft })
+      next.set(savedFolder.path, { ...savedFolder })
       return next
     })
     setDraftMap((prev) => {
+      const currentDraft = prev.get(savedFolder.path)
+      if (!currentDraft || !folderEqual(currentDraft, savedFolder)) return prev
       const next = new Map(prev)
-      next.delete(key)
+      next.delete(savedFolder.path)
       return next
     })
-  }, [folderDraft, folder, key])
+  }, [])
   const revertAllFolders = useCallback(() => {
     authTypeCache.clear()
     setDraftMap(new Map())

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -232,31 +232,39 @@ export function useRequestDraft(
     })
   }, [])
 
-  const moveRequestDraft = useCallback((oldId: string, request: Request) => {
-    clearRequestDraftCaches(oldId)
-    clearRequestDraftCaches(request.id)
-    setMap((prev) => {
-      const draft = prev.get(oldId)
-      const next = new Map(prev)
-      next.delete(oldId)
-      if (draft) {
-        next.set(request.id, {
-          ...draft,
-          id: request.id,
-          name: request.name,
-          method: request.method,
-          url: request.url,
-        })
-      }
-      return next
-    })
-    setOriginalMap((prev) => {
-      const next = new Map(prev)
-      next.delete(oldId)
-      next.set(request.id, { ...request })
-      return next
-    })
-  }, [])
+  const moveRequestDraft = useCallback(
+    (oldId: string, request: Request) => {
+      clearRequestDraftCaches(oldId)
+      clearRequestDraftCaches(request.id)
+      const original = originalMap.get(oldId)
+      setMap((prev) => {
+        const draft = prev.get(oldId)
+        const next = new Map(prev)
+        next.delete(oldId)
+        if (draft) {
+          next.set(request.id, {
+            ...draft,
+            id: request.id,
+            name: request.name,
+            method:
+              original && draft.method === original.method
+                ? request.method
+                : draft.method,
+            url:
+              original && draft.url === original.url ? request.url : draft.url,
+          })
+        }
+        return next
+      })
+      setOriginalMap((prev) => {
+        const next = new Map(prev)
+        next.delete(oldId)
+        next.set(request.id, { ...request })
+        return next
+      })
+    },
+    [originalMap],
+  )
 
   const resetRequestDraft = useCallback((id: string) => {
     clearRequestDraftCaches(id)

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -219,11 +219,16 @@ export function useRequestDraft(
   }, [])
 
   const markSaved = useCallback((request: Request) => {
-    clearRequestDraftCaches(request.id)
     setOriginalMap((prev) => {
       const next = new Map(prev)
       next.set(request.id, { ...request })
       return next
+    })
+    setMap((prev) => {
+      const currentDraft = prev.get(request.id)
+      if (!currentDraft || !requestEquals(currentDraft, request)) return prev
+      clearRequestDraftCaches(request.id)
+      return removeRequestDraftEntry(prev, request.id)
     })
   }, [])
 

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import type { Auth, Method, Request } from "../schema"
 import type { BodyType } from "../schema"
 import type { FieldKind } from "../ui/editMode"
@@ -50,7 +50,8 @@ export interface UseRequestDraftResult {
   removeFormRow: (index: number) => void
   toggleFormRow: (index: number) => void
   setFilePath: (path: string) => void
-  markSaved: () => void
+  markSaved: (request: Request) => void
+  moveRequestDraft: (oldId: string, request: Request) => void
   resetRequestDraft: (id: string) => void
   revertAllRequests: () => void
 }
@@ -217,20 +218,40 @@ export function useRequestDraft(
     setOriginalMap(new Map())
   }, [])
 
-  const mapRef = useRef(map)
-  mapRef.current = map
-
-  const markSaved = useCallback(() => {
-    if (!selectedRequest) return
-    clearRequestDraftCaches(selectedRequest.id)
-    const currentDraft =
-      mapRef.current.get(selectedRequest.id) ?? selectedRequest
+  const markSaved = useCallback((request: Request) => {
+    clearRequestDraftCaches(request.id)
     setOriginalMap((prev) => {
       const next = new Map(prev)
-      next.set(selectedRequest.id, { ...currentDraft })
+      next.set(request.id, { ...request })
       return next
     })
-  }, [selectedRequest])
+  }, [])
+
+  const moveRequestDraft = useCallback((oldId: string, request: Request) => {
+    clearRequestDraftCaches(oldId)
+    clearRequestDraftCaches(request.id)
+    setMap((prev) => {
+      const draft = prev.get(oldId)
+      const next = new Map(prev)
+      next.delete(oldId)
+      if (draft) {
+        next.set(request.id, {
+          ...draft,
+          id: request.id,
+          name: request.name,
+          method: request.method,
+          url: request.url,
+        })
+      }
+      return next
+    })
+    setOriginalMap((prev) => {
+      const next = new Map(prev)
+      next.delete(oldId)
+      next.set(request.id, { ...request })
+      return next
+    })
+  }, [])
 
   const resetRequestDraft = useCallback((id: string) => {
     clearRequestDraftCaches(id)
@@ -297,6 +318,7 @@ export function useRequestDraft(
       toggleFormRow: toggleFormRowCb,
       setFilePath: setFilePathCb,
       markSaved,
+      moveRequestDraft,
       resetRequestDraft,
     }),
     [
@@ -335,6 +357,7 @@ export function useRequestDraft(
       toggleFormRowCb,
       setFilePathCb,
       markSaved,
+      moveRequestDraft,
       resetRequestDraft,
     ],
   )

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -252,6 +252,8 @@ export function AppInner({
   })
 
   const draft = useRequestDraft(selectedRequest)
+  const draftRef = useRef(draft)
+  draftRef.current = draft
 
   const availableJumpTargets = useMemo(
     () =>
@@ -540,6 +542,7 @@ export function AppInner({
     collectionDir,
     updateCollection,
     selectedRequest,
+    requestDraftRef: draftRef,
     folderDraftRef,
     newRequestFolderRef,
     folderDeletePathRef,
@@ -614,9 +617,6 @@ export function AppInner({
   envEditorRef.current = envEditor
 
   const envHeaderRef = useRef<EnvHeaderPaneHandle>(null)
-
-  const draftRef = useRef(draft)
-  draftRef.current = draft
 
   const activeIndexRef = useRef(activeIndex)
   activeIndexRef.current = activeIndex

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -105,7 +105,7 @@ export function statusBarText(input: {
     }
   }
 
-  // ── CENTER: env + dirty + save flash ───────────────
+  // ── CENTER: env + save flash ───────────────────────
   let center: string
   if (saveState.kind === "success") {
     center = `✓ ${saveState.message}`
@@ -114,12 +114,13 @@ export function statusBarText(input: {
   } else if (envLabel === "" || envLabel === "(no env)") {
     center = "(no env)"
   } else {
-    center = isDirty ? `● ${envLabel} •` : `● ${envLabel}`
+    center = `● ${envLabel}`
   }
 
   // ── RIGHT: pinned hints (statusBarText is kept for backward compat) ──
   const right = ""
 
+  void isDirty
   void kb
   return { left, center, right }
 }
@@ -153,9 +154,7 @@ export function StatusBar(input: {
   const envText =
     input.envLabel === "" || input.envLabel === "(no env)"
       ? "no env"
-      : input.isDirty
-        ? `● ${input.envLabel} •`
-        : `● ${input.envLabel}`
+      : `● ${input.envLabel}`
 
   const envFg = input.envLabel.includes("(load failed")
     ? theme.error

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -7,6 +7,7 @@ import type {
   Request as NoodleRequest,
 } from "../schema"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
+import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import {
   saveRequest,
   deleteRequest,
@@ -24,6 +25,7 @@ interface UseCollectionFileActionsOptions {
   collection: Collection | null
   updateCollection: (collection: Collection) => void
   selectedRequest: NoodleRequest | null
+  requestDraftRef: MutableRefObject<UseRequestDraftResult>
   folderDraftRef: MutableRefObject<UseFolderDraftResult>
   newRequestFolderRef: MutableRefObject<string | null>
   folderDeletePathRef: MutableRefObject<string | null>
@@ -49,6 +51,7 @@ export function useCollectionFileActions({
   collection,
   updateCollection,
   selectedRequest,
+  requestDraftRef,
   folderDraftRef,
   newRequestFolderRef,
   folderDeletePathRef,
@@ -92,7 +95,7 @@ export function useCollectionFileActions({
     if (!draftFolder || !collection) return
     try {
       await saveFolder(collectionDir, draftFolder)
-      folderDraftRef.current?.markSaved()
+      folderDraftRef.current?.markSaved(draftFolder)
       updateCollection({
         ...collection,
         items: updateFolderByPath(
@@ -353,6 +356,7 @@ export function useCollectionFileActions({
 
       savePromise
         .then(() => {
+          requestDraftRef.current.moveRequestDraft(req.id, updated)
           setCollectionReloadToken((n) => n + 1)
           setSelectedId(newId)
           setEditRequestVisible(false)
@@ -369,6 +373,7 @@ export function useCollectionFileActions({
       collectionDir,
       expandFolder,
       selectedRequest,
+      requestDraftRef,
       setCollectionReloadToken,
       setEditRequestVisible,
       setFocus,

--- a/src/ui/useSaveFile.ts
+++ b/src/ui/useSaveFile.ts
@@ -20,7 +20,7 @@ export function useSaveFile(
   collectionDir: string,
   req: Request | null,
   selectedRequestId: string | undefined,
-  markSaved: () => void,
+  markSaved: (request: Request) => void,
 ): UseSaveFileResult {
   const [saveState, setSaveState] = useState<SaveState>({ kind: "idle" })
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -50,7 +50,7 @@ export function useSaveFile(
       .then(() => {
         if (!mountedRef.current) return
         if (selectedRequestId !== requestId) return
-        markSaved()
+        markSaved(req)
         clearSaveTimer()
         setSaveState({
           kind: "success",

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -46,7 +46,7 @@ describe("StatusBar component", () => {
     expect(frame).toContain("dev")
   })
 
-  it("renders dirty indicator when modified", async () => {
+  it("does not append a dirty marker to environment", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
         <StatusBar
@@ -66,7 +66,7 @@ describe("StatusBar component", () => {
     await renderOnce()
     const frame = captureCharFrame()
 
-    expect(frame).toContain("●")
+    expect(frame).not.toContain("dev •")
   })
 
   it("renders contextual shortcuts when focused on sidebar", async () => {

--- a/tests/unit/statusBar.test.ts
+++ b/tests/unit/statusBar.test.ts
@@ -190,7 +190,7 @@ describe("statusBarText", () => {
     expect(r.center).toBe("● dev")
   })
 
-  it("center shows env with dirty dot when modified", () => {
+  it("center does not append a dirty marker to environment", () => {
     const r = statusBarText({
       method: "GET",
       url: "/users",
@@ -201,7 +201,7 @@ describe("statusBarText", () => {
       kb: defaults,
       spinnerFrame: "⠋",
     })
-    expect(r.center).toBe("● prod •")
+    expect(r.center).toBe("● prod")
   })
 
   it("center shows (no env) when envLabel is empty", () => {

--- a/tests/unit/useRequestDraftHook.test.tsx
+++ b/tests/unit/useRequestDraftHook.test.tsx
@@ -82,30 +82,38 @@ function SaveRaceHarness({ onDirty }: { onDirty: (dirty: boolean) => void }) {
 }
 
 function MoveDraftHarness({
-  onDirtyIds,
+  onDraft,
 }: {
-  onDirtyIds: (ids: Set<string>) => void
+  onDraft: (draft: Request | null) => void
 }) {
-  const draft = useRequestDraft(request)
+  const [selectedRequest, setSelectedRequest] = useState(request)
+  const draft = useRequestDraft(selectedRequest)
   const [step, setStep] = useState(0)
   const movedRequest = {
     ...request,
     id: "folder/r2",
     name: "Moved",
     method: "DELETE" as const,
+    url: "https://overlay.example.com",
   }
 
   useEffect(() => {
     if (step === 0) {
-      draft.setBody("unsaved body")
+      draft.setMethod("POST")
+      draft.setUrl("https://unsaved.example.com")
       setStep(1)
-    } else if (step === 1 && draft.draft?.body === "unsaved body") {
+    } else if (
+      step === 1 &&
+      draft.draft?.method === "POST" &&
+      draft.draft.url === "https://unsaved.example.com"
+    ) {
       draft.moveRequestDraft(request.id, movedRequest)
+      setSelectedRequest(movedRequest)
       setStep(2)
     } else if (step === 2) {
-      onDirtyIds(draft.dirtyRequestIds)
+      onDraft(draft.draft)
     }
-  }, [draft, movedRequest, onDirtyIds, step])
+  }, [draft, movedRequest, onDraft, step])
 
   return null
 }
@@ -225,9 +233,9 @@ describe("useRequestDraft setMethod", () => {
   })
 
   it("preserves unsaved method and URL when a request is renamed", async () => {
-    let dirtyIds = new Set<string>()
+    const result: { draft: Request | null } = { draft: null }
     const { renderOnce } = await testRender(
-      <MoveDraftHarness onDirtyIds={(ids) => (dirtyIds = ids)} />,
+      <MoveDraftHarness onDraft={(draft) => (result.draft = draft)} />,
       { width: 20, height: 5 },
     )
 
@@ -236,7 +244,9 @@ describe("useRequestDraft setMethod", () => {
     await renderOnce()
     await renderOnce()
 
-    expect(dirtyIds).toEqual(new Set(["folder/r2"]))
+    if (!result.draft) throw new Error("renamed draft was not reported")
+    expect(result.draft.method).toBe("POST")
+    expect(result.draft.url).toBe("https://unsaved.example.com")
   })
 
   it("keeps cached request auth after a concurrent save edit", async () => {

--- a/tests/unit/useRequestDraftHook.test.tsx
+++ b/tests/unit/useRequestDraftHook.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test"
 import { useEffect, useState } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { useRequestDraft } from "../../src/hooks/useRequestDraft"
-import type { Request } from "../../src/schema"
+import { useFolderDraft } from "../../src/hooks/useFolderDraft"
+import type { Auth, Folder, Request } from "../../src/schema"
 
 const request: Request = {
   id: "r1",
@@ -15,6 +16,32 @@ const request: Request = {
   followRedirects: true,
   maxRedirects: 5,
   auth: { type: "none" },
+}
+
+const authRequest: Request = {
+  ...request,
+  id: "auth-race",
+  auth: { type: "basic", user: "saved-user", pass: "saved-pass" },
+}
+
+const savedAuthRequest: Request = {
+  ...authRequest,
+  auth: { type: "bearer", token: "saved-token" },
+}
+
+const folder: Folder = {
+  id: "folder-auth-race",
+  name: "Folder auth race",
+  path: "folder-auth-race",
+  children: [],
+  overrides: {
+    auth: { type: "basic", user: "saved-user", pass: "saved-pass" },
+  },
+}
+
+const savedFolder: Folder = {
+  ...folder,
+  overrides: { auth: { type: "bearer", token: "saved-token" } },
 }
 
 function Harness({ onMethod }: { onMethod: (method: string) => void }) {
@@ -61,7 +88,12 @@ function MoveDraftHarness({
 }) {
   const draft = useRequestDraft(request)
   const [step, setStep] = useState(0)
-  const movedRequest = { ...request, id: "folder/r2", name: "Moved" }
+  const movedRequest = {
+    ...request,
+    id: "folder/r2",
+    name: "Moved",
+    method: "DELETE" as const,
+  }
 
   useEffect(() => {
     if (step === 0) {
@@ -74,6 +106,90 @@ function MoveDraftHarness({
       onDirtyIds(draft.dirtyRequestIds)
     }
   }, [draft, movedRequest, onDirtyIds, step])
+
+  return null
+}
+
+function RequestAuthSaveRaceHarness({
+  onAuth,
+}: {
+  onAuth: (auth: Auth | undefined) => void
+}) {
+  const draft = useRequestDraft(authRequest)
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    const auth = draft.draft?.auth
+    if (step === 0) {
+      draft.setAuthType("bearer")
+      setStep(1)
+    } else if (step === 1 && auth?.type === "bearer") {
+      draft.setAuthField("bearer", "token", "saved-token")
+      setStep(2)
+    } else if (
+      step === 2 &&
+      auth?.type === "bearer" &&
+      auth.token === "saved-token"
+    ) {
+      draft.setAuthField("bearer", "token", "later-token")
+      setStep(3)
+    } else if (
+      step === 3 &&
+      auth?.type === "bearer" &&
+      auth.token === "later-token"
+    ) {
+      draft.markSaved(savedAuthRequest)
+      setStep(4)
+    } else if (step === 4) {
+      draft.setAuthType("basic")
+      setStep(5)
+    } else if (step === 5) {
+      onAuth(draft.draft?.auth)
+    }
+  }, [draft, onAuth, step])
+
+  return null
+}
+
+function FolderAuthSaveRaceHarness({
+  onAuth,
+}: {
+  onAuth: (auth: Auth | undefined) => void
+}) {
+  const draft = useFolderDraft(folder)
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    if (step === 0) {
+      draft.setAuthType("bearer")
+      setStep(1)
+    } else if (
+      step === 1 &&
+      draft.folderDraft?.overrides?.auth?.type === "bearer"
+    ) {
+      draft.setAuthField("bearer", "token", "saved-token")
+      setStep(2)
+    } else if (
+      step === 2 &&
+      draft.folderDraft?.overrides?.auth?.type === "bearer" &&
+      draft.folderDraft.overrides.auth.token === "saved-token"
+    ) {
+      draft.setAuthField("bearer", "token", "later-token")
+      setStep(3)
+    } else if (
+      step === 3 &&
+      draft.folderDraft?.overrides?.auth?.type === "bearer" &&
+      draft.folderDraft.overrides.auth.token === "later-token"
+    ) {
+      draft.markSaved(savedFolder)
+      setStep(4)
+    } else if (step === 4) {
+      draft.setAuthType("basic")
+      setStep(5)
+    } else if (step === 5) {
+      onAuth(draft.folderDraft?.overrides?.auth)
+    }
+  }, [draft, onAuth, step])
 
   return null
 }
@@ -108,7 +224,7 @@ describe("useRequestDraft setMethod", () => {
     expect(isDirty).toBe(true)
   })
 
-  it("moves unsaved state to a renamed request ID", async () => {
+  it("preserves unsaved method and URL when a request is renamed", async () => {
     let dirtyIds = new Set<string>()
     const { renderOnce } = await testRender(
       <MoveDraftHarness onDirtyIds={(ids) => (dirtyIds = ids)} />,
@@ -121,5 +237,37 @@ describe("useRequestDraft setMethod", () => {
     await renderOnce()
 
     expect(dirtyIds).toEqual(new Set(["folder/r2"]))
+  })
+
+  it("keeps cached request auth after a concurrent save edit", async () => {
+    let restoredAuth: Auth | undefined
+    const { renderOnce } = await testRender(
+      <RequestAuthSaveRaceHarness onAuth={(auth) => (restoredAuth = auth)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 8; i++) await renderOnce()
+
+    expect(restoredAuth).toEqual({
+      type: "basic",
+      user: "saved-user",
+      pass: "saved-pass",
+    })
+  })
+
+  it("keeps cached folder auth after a concurrent save edit", async () => {
+    let restoredAuth: Auth | undefined
+    const { renderOnce } = await testRender(
+      <FolderAuthSaveRaceHarness onAuth={(auth) => (restoredAuth = auth)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 8; i++) await renderOnce()
+
+    expect(restoredAuth).toEqual({
+      type: "basic",
+      user: "saved-user",
+      pass: "saved-pass",
+    })
   })
 })

--- a/tests/unit/useRequestDraftHook.test.tsx
+++ b/tests/unit/useRequestDraftHook.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { useRequestDraft } from "../../src/hooks/useRequestDraft"
 import type { Request } from "../../src/schema"
@@ -31,6 +31,53 @@ function Harness({ onMethod }: { onMethod: (method: string) => void }) {
   return null
 }
 
+function SaveRaceHarness({ onDirty }: { onDirty: (dirty: boolean) => void }) {
+  const draft = useRequestDraft(request)
+  const [step, setStep] = useState(0)
+  const savedRequest = { ...request, url: "https://saved.example.com" }
+
+  useEffect(() => {
+    if (step === 0) {
+      draft.setUrl(savedRequest.url)
+      setStep(1)
+    } else if (step === 1 && draft.draft?.url === savedRequest.url) {
+      draft.setUrl("https://later.example.com")
+      setStep(2)
+    } else if (step === 2 && draft.draft?.url === "https://later.example.com") {
+      draft.markSaved(savedRequest)
+      setStep(3)
+    } else if (step === 3) {
+      onDirty(draft.isDirty)
+    }
+  }, [draft, onDirty, savedRequest, step])
+
+  return null
+}
+
+function MoveDraftHarness({
+  onDirtyIds,
+}: {
+  onDirtyIds: (ids: Set<string>) => void
+}) {
+  const draft = useRequestDraft(request)
+  const [step, setStep] = useState(0)
+  const movedRequest = { ...request, id: "folder/r2", name: "Moved" }
+
+  useEffect(() => {
+    if (step === 0) {
+      draft.setBody("unsaved body")
+      setStep(1)
+    } else if (step === 1 && draft.draft?.body === "unsaved body") {
+      draft.moveRequestDraft(request.id, movedRequest)
+      setStep(2)
+    } else if (step === 2) {
+      onDirtyIds(draft.dirtyRequestIds)
+    }
+  }, [draft, movedRequest, onDirtyIds, step])
+
+  return null
+}
+
 describe("useRequestDraft setMethod", () => {
   it("exposes method updates through hook result", async () => {
     let method = ""
@@ -43,5 +90,36 @@ describe("useRequestDraft setMethod", () => {
     await renderOnce()
 
     expect(method).toBe("POST")
+  })
+
+  it("keeps edits made during a pending save dirty", async () => {
+    let isDirty = false
+    const { renderOnce } = await testRender(
+      <SaveRaceHarness onDirty={(dirty) => (isDirty = dirty)} />,
+      { width: 20, height: 5 },
+    )
+
+    await renderOnce()
+    await renderOnce()
+    await renderOnce()
+    await renderOnce()
+    await renderOnce()
+
+    expect(isDirty).toBe(true)
+  })
+
+  it("moves unsaved state to a renamed request ID", async () => {
+    let dirtyIds = new Set<string>()
+    const { renderOnce } = await testRender(
+      <MoveDraftHarness onDirtyIds={(ids) => (dirtyIds = ids)} />,
+      { width: 20, height: 5 },
+    )
+
+    await renderOnce()
+    await renderOnce()
+    await renderOnce()
+    await renderOnce()
+
+    expect(dirtyIds).toEqual(new Set(["folder/r2"]))
   })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes dirty state tracking bugs:

- **useRequestDraft `markSaved`** — no longer captures `selectedRequest` via stale closure; takes the saved `Request` as argument instead
- **useFolderDraft `markSaved`** — same fix, takes saved `Folder` as argument
- **`moveRequestDraft`** — new hook method that transfers unsaved draft edits from old request ID to new one on rename, preventing lost edits
- **StatusBar** — removed stale dirty dot (`•`) from env label; the dirty indicator was unreliable and inconsistent
- **`useCollectionFileActions`** — passes `requestDraftRef` and calls `moveRequestDraft` after file rename
- **Tests** — added `SaveRaceHarness` (verifies edits made during pending save stay dirty) and `MoveDraftHarness` (verifies unsaved state transfers on rename)

### How did you verify your code works?

- `bun test` — 1905 pass, 0 fail
- `bun run lint` — clean
- `bun run typecheck` — clean
- Existing `statusBar.test` / `StatusBar.test.tsx` updated for new env label behavior

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved draft handling when saving or renaming requests and folders, helping preserve unsaved changes and authentication details.
  - Prevented stale drafts and cached authentication data from being removed during concurrent edits and saves.
  - Updated save behavior so saved content is accurately reflected in the current draft state.

- **UI Improvements**
  - Simplified environment labels in the status bar by removing the dirty-state marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->