### PR TITLE
feat(jump-mode): add folder tab jump hints for m/h/a/y

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,16 +232,17 @@ Activated by `jump_mode` (default `g`). Shows `[letter]` hints on each focusable
 | Letter | Target |
 |--------|--------|
 | `s` | Sidebar pane |
-| `m` | URL bar method select |
+| `m` | URL bar method select / Folder General tab |
 | `u` | URL bar URL field |
-| `h` | Request Headers tab |
+| `h` | Request Headers tab / Folder Headers tab |
 | `p` | Request Params tab |
 | `b` | Request Body tab |
-| `a` | Request Auth tab |
+| `a` | Request Auth tab / Folder Auth tab |
 | `t` | Request Settings tab |
 | `r` | Response Body tab |
 | `e` | Response Headers tab |
 | `l` | Response Timeline tab |
+| `y` | Folder Activity tab |
 
 ### Browse mode (request pane focused, not editing)
 | Key | Action |

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -29,6 +29,7 @@ export interface UseFolderEditBrowseResult {
   isActive: boolean
   activeTab: FieldKind
   enterBrowse: () => void
+  enterBrowseAt: (field: FolderFieldKind) => void
   exitBrowse: () => void
   browseUp: () => void
   browseDown: () => void
@@ -200,6 +201,17 @@ export function useFolderEditBrowse(
       return enterFolderEditBrowse(prev, c, tab)
     })
   }, [activeTab])
+
+  const enterBrowseAt = useCallback((field: FolderFieldKind) => {
+    setInactiveTab(field)
+    const c = folderRowCount(draftRef.current)
+    setEditState((prev) => {
+      if (prev.mode !== "inactive") {
+        return enterFolderEditBrowse(initialFolderEditState(), c, field)
+      }
+      return enterFolderEditBrowse(prev, c, field)
+    })
+  }, [])
 
   const enterAndEdit = useCallback(() => {
     const c = folderRowCount(draftRef.current)
@@ -391,6 +403,7 @@ export function useFolderEditBrowse(
       isActive: editState.mode !== "inactive",
       activeTab,
       enterBrowse,
+      enterBrowseAt,
       exitBrowse,
       browseUp,
       browseDown,
@@ -412,6 +425,7 @@ export function useFolderEditBrowse(
       editKey,
       activeTab,
       enterBrowse,
+      enterBrowseAt,
       exitBrowse,
       browseUp,
       browseDown,

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -6,6 +6,7 @@ import {
   exitEditBrowse,
   moveFolderFieldCursor,
   moveFolderRowCursor,
+  folderCursorForField,
   beginEditing,
   commitEditing,
   cancelEditing,
@@ -205,9 +206,15 @@ export function useFolderEditBrowse(
   const enterBrowseAt = useCallback((field: FolderFieldKind) => {
     setInactiveTab(field)
     const c = folderRowCount(draftRef.current)
+    setEditKey("")
     setEditState((prev) => {
       if (prev.mode !== "inactive") {
-        return enterFolderEditBrowse(initialFolderEditState(), c, field)
+        const canceled = prev.mode === "editing" ? cancelEditing(prev) : prev
+        return {
+          ...canceled,
+          cursor: folderCursorForField(field, c),
+          editingRow: -1,
+        }
       }
       return enterFolderEditBrowse(prev, c, field)
     })

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -705,6 +705,7 @@ export function AppInner({
     setFocus,
     setUrlbarSubFocus,
     ebRef,
+    folderEbRef,
     setTab,
     selectedIdRef,
     targetsRef: jumpTargetsRef,

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -11,6 +11,7 @@ import type { Theme } from "./theme"
 import { FullBorder } from "./borders"
 import { Frame } from "./Frame"
 import { Badge } from "./Badge"
+import { FOLDER_TAB_HINT_ORDER } from "./useJumpMode"
 
 interface FolderPaneProps {
   collectionDir: string
@@ -63,7 +64,10 @@ export function FolderPane({
         { id: "headers", label: "Headers" },
         { id: "auth", label: "Auth" },
         { id: "activity", label: "Activity" },
-      ]
+      ].map((tab, i) => ({
+        ...tab,
+        jumpHint: jumpMode ? FOLDER_TAB_HINT_ORDER[i] : undefined,
+      }))
     }
     const hasHeaders = Object.values(folder.overrides?.headers ?? {}).some(
       (e) => e.enabled,
@@ -76,8 +80,11 @@ export function FolderPane({
       { id: "headers", label: hasHeaders ? "Headers \u2022" : "Headers" },
       { id: "auth", label: hasAuth ? "Auth \u2022" : "Auth" },
       { id: "activity", label: "Activity" },
-    ]
-  }, [folder])
+    ].map((tab, i) => ({
+      ...tab,
+      jumpHint: jumpMode ? FOLDER_TAB_HINT_ORDER[i] : undefined,
+    }))
+  }, [folder, jumpMode])
 
   return (
     <Frame

--- a/src/ui/useJumpMode.ts
+++ b/src/ui/useJumpMode.ts
@@ -2,6 +2,10 @@ import { useEffect } from "react"
 import type { RefObject } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
+import type {
+  UseFolderEditBrowseResult,
+  FolderFieldKind,
+} from "../hooks/useFolderEditBrowse"
 import type { UseUIStateResult } from "./tabs/useUIState"
 import type { Focus, UrlBarSubFocus } from "./focus"
 import type { FieldKind } from "./editMode"
@@ -13,6 +17,7 @@ export type JumpTarget =
   | { kind: "method" }
   | { kind: "url" }
   | { kind: "request-tab"; field: FieldKind }
+  | { kind: "folder-tab"; field: FolderFieldKind }
   | { kind: "response-tab"; tab: ResponseTabKind }
 
 interface UseJumpModeOpts {
@@ -21,6 +26,7 @@ interface UseJumpModeOpts {
   setFocus: (f: Focus) => void
   setUrlbarSubFocus: (f: UrlBarSubFocus) => void
   ebRef: RefObject<UseEditBrowseResult>
+  folderEbRef: RefObject<UseFolderEditBrowseResult>
   setTab: UseUIStateResult["setTab"]
   selectedIdRef: RefObject<string | null>
   targetsRef: RefObject<Map<string, JumpTarget>>
@@ -35,6 +41,7 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
     setFocus,
     setUrlbarSubFocus,
     ebRef,
+    folderEbRef,
     setTab,
     selectedIdRef,
     targetsRef,
@@ -76,6 +83,10 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
             ebRef.current.enterBrowseAt(target.field)
             setFocus("request")
             break
+          case "folder-tab":
+            folderEbRef.current.enterBrowseAt(target.field)
+            setFocus("folder")
+            break
           case "response-tab": {
             const id = selectedIdRef.current
             if (id) setTab(id, "response", target.tab)
@@ -94,6 +105,7 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
     setFocus,
     setUrlbarSubFocus,
     ebRef,
+    folderEbRef,
     setTab,
     selectedIdRef,
   ])
@@ -107,6 +119,10 @@ export function getAvailableTargets(
   const targets = new Map<string, JumpTarget>()
   if (folderView) {
     targets.set("s", { kind: "sidebar" })
+    targets.set("m", { kind: "folder-tab", field: "meta" })
+    targets.set("h", { kind: "folder-tab", field: "headers" })
+    targets.set("a", { kind: "folder-tab", field: "auth" })
+    targets.set("y", { kind: "folder-tab", field: "activity" })
     return targets
   }
   targets.set("s", { kind: "sidebar" })
@@ -147,6 +163,7 @@ export const RESPONSE_TAB_HINTS: Record<string, string> = {
 
 export const REQUEST_TAB_HINT_ORDER: string[] = ["h", "p", "x", "b", "a", "t"]
 export const RESPONSE_TAB_HINT_ORDER: string[] = ["r", "e", "l"]
+export const FOLDER_TAB_HINT_ORDER: string[] = ["m", "h", "a", "y"]
 
 export function computeRequestTabLabels(request: Request | null): string[] {
   if (!request) return ["Headers", "Params", "Path", "Body", "Auth", "Settings"]

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -388,10 +388,14 @@ describe("ResponsePane status text truncation and layout tests", () => {
 })
 
 describe("getAvailableTargets", () => {
-  it("returns only sidebar in folder view", () => {
+  it("returns sidebar and folder tabs in folder view", () => {
     const targets = getAvailableTargets(true, null, true)
-    expect(targets.size).toBe(1)
+    expect(targets.size).toBe(5)
     expect(targets.get("s")).toEqual({ kind: "sidebar" })
+    expect(targets.get("m")).toEqual({ kind: "folder-tab", field: "meta" })
+    expect(targets.get("h")).toEqual({ kind: "folder-tab", field: "headers" })
+    expect(targets.get("a")).toEqual({ kind: "folder-tab", field: "auth" })
+    expect(targets.get("y")).toEqual({ kind: "folder-tab", field: "activity" })
   })
 
   it("returns sidebar + urlbar + all request/response tabs when not expanded", () => {

--- a/tests/unit/useFolderEditBrowse.test.tsx
+++ b/tests/unit/useFolderEditBrowse.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test"
+import { act, useEffect, useRef, useState } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { useFolderEditBrowse } from "../../src/hooks/useFolderEditBrowse"
+import type { UseFolderDraftResult } from "../../src/hooks/useFolderDraft"
+import type { UseEditBrowseResult } from "../../src/hooks/useEditBrowse"
+import type { Folder } from "../../src/schema"
+import { useJumpMode, type JumpTarget } from "../../src/ui/useJumpMode"
+import type { Focus } from "../../src/ui/focus"
+import { setupKeymap } from "./_helpers"
+
+const folder: Folder = {
+  id: "folder",
+  name: "Original",
+  path: "folder",
+  children: [],
+  overrides: {
+    headers: { Existing: { value: "value", enabled: true } },
+  },
+}
+
+function createDraftMutators(calls: string[]): UseFolderDraftResult {
+  const noop = () => {}
+  return {
+    folderDraft: folder,
+    isDirty: false,
+    dirtyPaths: new Set(),
+    originalFolder: folder,
+    setName: () => calls.push("setName"),
+    setSeq: noop,
+    setHeaderRow: () => calls.push("setHeaderRow"),
+    addHeaderRow: () => calls.push("addHeaderRow"),
+    removeHeaderRow: () => calls.push("removeHeaderRow"),
+    toggleHeaderRow: noop,
+    setAuthType: noop,
+    setAuthField: noop,
+    setApiKeyPlacement: noop,
+    revertAll: noop,
+    markSaved: noop,
+    revertAllFolders: noop,
+    clearFolderDraft: noop,
+  }
+}
+
+function JumpHarness({
+  onSnapshot,
+}: {
+  onSnapshot: (value: Snapshot) => void
+}) {
+  const calls = useRef<string[]>([])
+  const folderEb = useFolderEditBrowse(
+    folder,
+    createDraftMutators(calls.current),
+  )
+  const folderEbRef = useRef(folderEb)
+  folderEbRef.current = folderEb
+  const ebRef = useRef({} as UseEditBrowseResult)
+  const selectedIdRef = useRef<string | null>(null)
+  const targetsRef = useRef<Map<string, JumpTarget>>(
+    new Map([["h", { kind: "folder-tab", field: "headers" }]]),
+  )
+  const [jumpMode, setJumpMode] = useState(true)
+  const [focus, setFocus] = useState<Focus>("folder")
+
+  useEffect(() => {
+    folderEb.enterAndEdit()
+    folderEb.setEditKey("uncommitted-key")
+    folderEb.setEditValue("uncommitted-value")
+  }, [])
+
+  useJumpMode({
+    jumpMode,
+    setJumpMode,
+    setFocus,
+    setUrlbarSubFocus: () => {},
+    ebRef,
+    folderEbRef,
+    setTab: () => {},
+    selectedIdRef,
+    targetsRef,
+    triggerKey: "g",
+  })
+
+  useEffect(() => {
+    onSnapshot({
+      mode: folderEb.editState.mode,
+      field: folderEb.editState.cursor.field,
+      row: folderEb.editState.cursor.row,
+      editKey: folderEb.editKey,
+      editValue: folderEb.editValue,
+      focus,
+      jumpMode,
+      calls: calls.current,
+    })
+  }, [folderEb, focus, jumpMode, onSnapshot])
+
+  return null
+}
+
+interface Snapshot {
+  mode: string
+  field: string
+  row: number
+  editKey: string
+  editValue: string
+  focus: Focus
+  jumpMode: boolean
+  calls: string[]
+}
+
+describe("useFolderEditBrowse jump mode", () => {
+  it("cancels an active edit before jumping to another folder tab", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let snapshot: Snapshot | undefined
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <JumpHarness onSnapshot={(value) => (snapshot = value)} />
+      </KeymapProvider>,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await render.renderOnce()
+    expect(snapshot?.mode).toBe("editing")
+    expect(snapshot?.editKey).toBe("uncommitted-key")
+
+    await act(async () => host.press("h"))
+    await render.renderOnce()
+    await render.renderOnce()
+
+    expect(snapshot).toMatchObject({
+      mode: "browsing",
+      field: "headers",
+      row: 0,
+      editKey: "",
+      focus: "folder",
+      jumpMode: false,
+      calls: [],
+    })
+    cleanup()
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extends jump mode to the folder view — pressing `g` then `m`/h/a/y` jumps to the corresponding folder tab (meta, headers, auth, activity). Previously jump mode only showed a sidebar target in folder view.

### How did you verify your code works?

- Updated `getAvailableTargets` test to expect 5 targets (sidebar + 4 folder tabs) instead of 1.
- `bun test` — 1907 pass, 0 fail.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added jump-mode shortcuts for navigating folder tabs: Meta, Headers, Auth, and Activity.
  * Jumping to a folder tab now opens the relevant folder view and focuses the selected tab.
  * Added support for entering browse mode directly at a selected folder field.

* **Documentation**
  * Updated keyboard shortcut documentation for folder views.

* **Tests**
  * Updated folder-view navigation coverage to include all available folder tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->