### PR TITLE
feat(network-tab): add network trace tab for live and persisted responses

### DIFF
--- a/src/hooks/useResponse.ts
+++ b/src/hooks/useResponse.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { Dispatch, SetStateAction } from "react"
-import type { Collection, Environment, Request, Response } from "../schema"
+import type {
+  Collection,
+  Environment,
+  NetworkEvent,
+  Request,
+  Response,
+} from "../schema"
 import { executor } from "../requests"
 import {
   startSend,
@@ -97,7 +103,20 @@ async function runSend(
   requestPath?: string,
 ): Promise<void> {
   try {
-    const res = await executor.send(req, env, signal, collection, requestPath)
+    const res = await executor.send(
+      req,
+      env,
+      signal,
+      collection,
+      requestPath,
+      (network: NetworkEvent[]) => {
+        setState((prev) =>
+          prev.status === "sending" && prev.request.id === req.id
+            ? { ...prev, network }
+            : prev,
+        )
+      },
+    )
     cacheRef.current.set(req.id, { status: "done", response: res })
     setState((prev) => finishSend(prev, req, res))
     onCompleteRef.current?.(req, { status: "done", response: res })

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,4 +1,10 @@
-import type { Collection, Environment, Request, Response } from "../schema"
+import type {
+  Collection,
+  Environment,
+  NetworkEvent,
+  Request,
+  Response,
+} from "../schema"
 import { send } from "./send"
 import { substitute } from "./substitute"
 
@@ -9,6 +15,7 @@ export interface RequestExecutor {
     signal?: AbortSignal,
     collection?: Collection,
     requestPath?: string,
+    onNetworkEvent?: (network: NetworkEvent[]) => void,
   ): Promise<Response>
 }
 

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -3,6 +3,9 @@ import type {
   Collection,
   Environment,
   KvEntry,
+  NetworkError,
+  NetworkEvent,
+  NetworkEventType,
   ParamEntry,
   Request,
   Response,
@@ -137,6 +140,7 @@ export async function send(
   }
 
   const start = performance.now()
+  const network: NetworkEvent[] = []
   let res: globalThis.Response
   let currentUrl = finalUrl
   let currentInit: RequestInit = { ...init, redirect: "manual" }
@@ -145,12 +149,31 @@ export async function send(
   const followRedirects = req.followRedirects ?? true
 
   while (true) {
+    recordNetworkEvent(
+      network,
+      start,
+      "request",
+      `${currentInit.method ?? substituted.method} ${networkUrl(currentUrl)}`,
+    )
     try {
       res = await fetch(currentUrl, currentInit)
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
-      throw new Error(`requests.send: fetch failed: ${msg}`, { cause: e })
+      if (e instanceof DOMException && e.name === "AbortError") throw e
+      throw networkFailure(
+        `requests.send: fetch failed: ${msg}`,
+        e,
+        network,
+        start,
+      )
     }
+
+    recordNetworkEvent(
+      network,
+      start,
+      "response",
+      `${res.status} ${res.statusText || "Response"} - ${[...res.headers].length} headers`,
+    )
 
     if (!followRedirects || ![301, 302, 303, 307, 308].includes(res.status)) {
       break
@@ -160,11 +183,32 @@ export async function send(
     if (!loc) break
 
     if (redirectCount >= maxRedirects) {
-      throw new Error(`requests.send: max redirects (${maxRedirects}) exceeded`)
+      throw networkFailure(
+        `requests.send: max redirects (${maxRedirects}) exceeded`,
+        undefined,
+        network,
+        start,
+      )
     }
     redirectCount++
 
-    currentUrl = new URL(loc, currentUrl).toString()
+    try {
+      currentUrl = new URL(loc, currentUrl).toString()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      throw networkFailure(
+        `requests.send: invalid redirect location: ${msg}`,
+        e,
+        network,
+        start,
+      )
+    }
+    recordNetworkEvent(
+      network,
+      start,
+      "redirect",
+      `${res.status} -> ${networkUrl(currentUrl)}`,
+    )
 
     if (
       res.status === 303 ||
@@ -189,10 +233,27 @@ export async function send(
     body = await res.text()
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
-    throw new Error(`requests.send: failed to read response body: ${msg}`, {
-      cause: e,
-    })
+    if (e instanceof DOMException && e.name === "AbortError") throw e
+    throw networkFailure(
+      `requests.send: failed to read response body: ${msg}`,
+      e,
+      network,
+      start,
+    )
   }
+
+  recordNetworkEvent(
+    network,
+    start,
+    "body",
+    `Body received - ${new TextEncoder().encode(body).length} bytes`,
+  )
+  recordNetworkEvent(
+    network,
+    start,
+    "complete",
+    `Completed in ${Math.round(performance.now() - start)}ms`,
+  )
 
   return {
     status: res.status,
@@ -200,6 +261,37 @@ export async function send(
     headers: headersToObject(res.headers),
     body,
     timeMs: performance.now() - start,
+    network,
+  }
+}
+
+function recordNetworkEvent(
+  network: NetworkEvent[],
+  start: number,
+  type: NetworkEventType,
+  message: string,
+): void {
+  network.push({ timeMs: performance.now() - start, type, message })
+}
+
+function networkFailure(
+  message: string,
+  cause: unknown,
+  network: NetworkEvent[],
+  start: number,
+): NetworkError {
+  recordNetworkEvent(network, start, "error", message)
+  const error = new Error(message, cause === undefined ? undefined : { cause })
+  ;(error as NetworkError).network = network
+  return error as NetworkError
+}
+
+function networkUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.origin}${parsed.pathname}${parsed.search ? "?..." : ""}`
+  } catch {
+    return url
   }
 }
 

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -65,6 +65,7 @@ export async function send(
   signal?: AbortSignal,
   collection?: Collection,
   requestPath?: string,
+  onNetworkEvent?: (network: NetworkEvent[]) => void,
 ): Promise<Response> {
   const merged =
     collection && requestPath
@@ -154,6 +155,7 @@ export async function send(
       start,
       "request",
       `${currentInit.method ?? substituted.method} ${networkUrl(currentUrl)}`,
+      onNetworkEvent,
     )
     try {
       res = await fetch(currentUrl, currentInit)
@@ -165,6 +167,7 @@ export async function send(
         e,
         network,
         start,
+        onNetworkEvent,
       )
     }
 
@@ -173,6 +176,7 @@ export async function send(
       start,
       "response",
       `${res.status} ${res.statusText || "Response"} - ${[...res.headers].length} headers`,
+      onNetworkEvent,
     )
 
     if (!followRedirects || ![301, 302, 303, 307, 308].includes(res.status)) {
@@ -188,6 +192,7 @@ export async function send(
         undefined,
         network,
         start,
+        onNetworkEvent,
       )
     }
     redirectCount++
@@ -201,6 +206,7 @@ export async function send(
         e,
         network,
         start,
+        onNetworkEvent,
       )
     }
     recordNetworkEvent(
@@ -208,6 +214,7 @@ export async function send(
       start,
       "redirect",
       `${res.status} -> ${networkUrl(currentUrl)}`,
+      onNetworkEvent,
     )
 
     if (
@@ -239,6 +246,7 @@ export async function send(
       e,
       network,
       start,
+      onNetworkEvent,
     )
   }
 
@@ -247,12 +255,14 @@ export async function send(
     start,
     "body",
     `Body received - ${new TextEncoder().encode(body).length} bytes`,
+    onNetworkEvent,
   )
   recordNetworkEvent(
     network,
     start,
     "complete",
     `Completed in ${Math.round(performance.now() - start)}ms`,
+    onNetworkEvent,
   )
 
   return {
@@ -270,8 +280,10 @@ function recordNetworkEvent(
   start: number,
   type: NetworkEventType,
   message: string,
+  onNetworkEvent?: (network: NetworkEvent[]) => void,
 ): void {
   network.push({ timeMs: performance.now() - start, type, message })
+  onNetworkEvent?.(network.map((event) => ({ ...event })))
 }
 
 function networkFailure(
@@ -279,8 +291,9 @@ function networkFailure(
   cause: unknown,
   network: NetworkEvent[],
   start: number,
+  onNetworkEvent?: (network: NetworkEvent[]) => void,
 ): NetworkError {
-  recordNetworkEvent(network, start, "error", message)
+  recordNetworkEvent(network, start, "error", message, onNetworkEvent)
   const error = new Error(message, cause === undefined ? undefined : { cause })
   ;(error as NetworkError).network = network
   return error as NetworkError

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -85,6 +85,20 @@ export interface Response {
   headers: Record<string, string>
   body: string
   timeMs: number
+  network?: NetworkEvent[]
+}
+
+export type NetworkEventType =
+  "request" | "redirect" | "response" | "body" | "complete" | "error"
+
+export interface NetworkEvent {
+  timeMs: number
+  type: NetworkEventType
+  message: string
+}
+
+export interface NetworkError extends Error {
+  network?: NetworkEvent[]
 }
 
 export interface Environment {
@@ -98,6 +112,7 @@ export interface TimelineEntry {
   id?: string
   timestamp: number
   envName?: string
+  network?: NetworkEvent[]
   request: {
     id: string
     name: string

--- a/src/ui/NetworkTab.tsx
+++ b/src/ui/NetworkTab.tsx
@@ -1,0 +1,64 @@
+import type { NetworkEvent } from "../schema"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import type { RefObject } from "react"
+import { useTheme } from "./theme"
+
+function eventColor(event: NetworkEvent, theme: ReturnType<typeof useTheme>) {
+  if (event.type === "error") return theme.error
+  if (event.type === "redirect") return theme.warning
+  if (event.type === "response" || event.type === "complete")
+    return theme.success
+  if (event.type === "request") return theme.primary
+  return theme.textMuted
+}
+
+export function NetworkTab({
+  events,
+  emptyMessage = "Send a request to see network activity.",
+  height,
+  scrollRef,
+}: {
+  events?: NetworkEvent[]
+  emptyMessage?: string
+  height?: number
+  scrollRef?: RefObject<ScrollBoxRenderable | null>
+}) {
+  const theme = useTheme()
+  const rows = events?.map((event, index) => (
+    <box key={index} style={{ flexDirection: "row", gap: 1 }}>
+      <text fg={theme.textMuted} style={{ width: 7 }}>
+        {`${Math.round(event.timeMs)}ms`}
+      </text>
+      <text fg={eventColor(event, theme)}>{event.message}</text>
+    </box>
+  ))
+
+  return (
+    <box
+      style={{
+        flexDirection: "column",
+        flexGrow: height === undefined ? 1 : 0,
+        minHeight: 0,
+        ...(height !== undefined && { height }),
+      }}
+    >
+      {!events?.length ? (
+        <text fg={theme.textMuted}>{emptyMessage}</text>
+      ) : (
+        <scrollbox
+          ref={scrollRef}
+          scrollY
+          contentOptions={{ flexDirection: "column" }}
+          scrollbarOptions={{ visible: false }}
+          style={{
+            flexGrow: 1,
+            minHeight: 0,
+            flexBasis: 0,
+          }}
+        >
+          {rows}
+        </scrollbox>
+      )}
+    </box>
+  )
+}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -4,7 +4,7 @@ import { useKeymap } from "@opentui/keymap/react"
 import type { InputRenderable, ScrollBoxRenderable } from "@opentui/core"
 import type { RefObject } from "react"
 import type { SendState } from "./sendState"
-import type { TimelineEntry } from "../schema"
+import type { NetworkError, TimelineEntry } from "../schema"
 import { formatHeaders, formatBody, formatSize, statusColor } from "./format"
 import { Tabs, type TabDef } from "./Tabs"
 import { useTheme } from "./theme"
@@ -21,7 +21,9 @@ import {
 
 import { HeaderTable } from "./HeaderTable"
 import { TimelineTab } from "./timeline/TimelineTab"
+import { NetworkTab } from "./NetworkTab"
 import { Badge } from "./Badge"
+import type { ResponseTabKind } from "./tabs/uiState"
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 const AUTO_RENDER_LIMIT = 5 * 1024 * 1024
@@ -29,6 +31,7 @@ const AUTO_RENDER_LIMIT = 5 * 1024 * 1024
 const TAB_DEFS: TabDef[] = [
   { id: "body", label: "Body" },
   { id: "headers", label: "Headers" },
+  { id: "network", label: "Network" },
   { id: "timeline", label: "Timeline" },
 ]
 
@@ -50,8 +53,8 @@ export function ResponsePane({
   state: SendState
   focused?: boolean
   timelineEntries?: TimelineEntry[]
-  initialTab?: "body" | "headers" | "timeline"
-  onTabChange?: (tab: "body" | "headers" | "timeline") => void
+  initialTab?: ResponseTabKind
+  onTabChange?: (tab: ResponseTabKind) => void
   onOpenTimelineEntry?: (entry: TimelineEntry) => void
   responseKey?: string | null
   responseQueryRef?: RefObject<ResponseQueryController | null>
@@ -65,10 +68,12 @@ export function ResponsePane({
   const keymap = useKeymap()
   const focusedRef = useRef(focused)
   focusedRef.current = focused
-  const isDoneRef = useRef(state.status === "done")
-  isDoneRef.current = state.status === "done"
+  const isSettledRef = useRef(
+    state.status === "done" || state.status === "error",
+  )
+  isSettledRef.current = state.status === "done" || state.status === "error"
 
-  const [activeTab, setActiveTab] = useState<"body" | "headers" | "timeline">(
+  const [activeTab, setActiveTab] = useState<ResponseTabKind>(
     initialTab ?? "body",
   )
   const tabs = useMemo(
@@ -102,18 +107,18 @@ export function ResponsePane({
 
   useKeyboard((key) => {
     if (!focusedRef.current) return
-    if (!isDoneRef.current) return
+    if (!isSettledRef.current) return
     if (keymap.getData("app.overlay") !== "none") return
     if (queryVisible) return
     if (key.name === "left")
       setActiveTab((prev) => {
-        const ids = ["body", "headers", "timeline"] as const
+        const ids = ["body", "headers", "network", "timeline"] as const
         const idx = ids.indexOf(prev)
         return ids[(idx - 1 + ids.length) % ids.length]
       })
     else if (key.name === "right")
       setActiveTab((prev) => {
-        const ids = ["body", "headers", "timeline"] as const
+        const ids = ["body", "headers", "network", "timeline"] as const
         const idx = ids.indexOf(prev)
         return ids[(idx + 1) % ids.length]
       })
@@ -219,6 +224,11 @@ export function ResponsePane({
   const borderColor = focused ? theme.primary : theme.borderSubtle
 
   const responseHeaders = isDone ? formatHeaders(state.response) : []
+  const networkEvents = isDone
+    ? state.response.network
+    : state.status === "error"
+      ? (state.error as NetworkError).network
+      : undefined
 
   const bodySize = useMemo(() => {
     if (state.status !== "done") return 0
@@ -361,6 +371,16 @@ export function ResponsePane({
                 </text>
               </box>
             </box>
+          ) : activeTab === "network" ? (
+            <NetworkTab
+              events={networkEvents}
+              scrollRef={scrollRef}
+              emptyMessage={
+                state.status === "error"
+                  ? "Request did not reach the network."
+                  : undefined
+              }
+            />
           ) : activeTab === "timeline" ? (
             <TimelineTab
               entries={timelineEntries ?? []}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -68,10 +68,8 @@ export function ResponsePane({
   const keymap = useKeymap()
   const focusedRef = useRef(focused)
   focusedRef.current = focused
-  const isSettledRef = useRef(
-    state.status === "done" || state.status === "error",
-  )
-  isSettledRef.current = state.status === "done" || state.status === "error"
+  const isActiveRef = useRef(state.status !== "idle")
+  isActiveRef.current = state.status !== "idle"
 
   const [activeTab, setActiveTab] = useState<ResponseTabKind>(
     initialTab ?? "body",
@@ -107,7 +105,7 @@ export function ResponsePane({
 
   useKeyboard((key) => {
     if (!focusedRef.current) return
-    if (!isSettledRef.current) return
+    if (!isActiveRef.current) return
     if (keymap.getData("app.overlay") !== "none") return
     if (queryVisible) return
     if (key.name === "left")
@@ -224,11 +222,14 @@ export function ResponsePane({
   const borderColor = focused ? theme.primary : theme.borderSubtle
 
   const responseHeaders = isDone ? formatHeaders(state.response) : []
-  const networkEvents = isDone
-    ? state.response.network
-    : state.status === "error"
-      ? (state.error as NetworkError).network
-      : undefined
+  const networkEvents =
+    state.status === "sending"
+      ? state.network
+      : isDone
+        ? state.response.network
+        : state.status === "error"
+          ? (state.error as NetworkError).network
+          : undefined
 
   const bodySize = useMemo(() => {
     if (state.status !== "done") return 0
@@ -356,7 +357,17 @@ export function ResponsePane({
     >
       <box style={{ flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
         <Tabs tabs={tabs} activeId={activeTab}>
-          {state.status === "sending" ? (
+          {activeTab === "network" ? (
+            <NetworkTab
+              events={networkEvents}
+              scrollRef={scrollRef}
+              emptyMessage={
+                state.status === "error"
+                  ? "Request did not reach the network."
+                  : undefined
+              }
+            />
+          ) : state.status === "sending" ? (
             <box
               style={{
                 flexGrow: 1,
@@ -371,16 +382,6 @@ export function ResponsePane({
                 </text>
               </box>
             </box>
-          ) : activeTab === "network" ? (
-            <NetworkTab
-              events={networkEvents}
-              scrollRef={scrollRef}
-              emptyMessage={
-                state.status === "error"
-                  ? "Request did not reach the network."
-                  : undefined
-              }
-            />
           ) : activeTab === "timeline" ? (
             <TimelineTab
               entries={timelineEntries ?? []}
@@ -472,6 +473,8 @@ export function ResponsePane({
             >
               <HeaderTable entries={responseHeaders} theme={theme} />
             </scrollbox>
+          ) : state.status === "error" ? (
+            <text fg={theme.textMuted}>No response headers available.</text>
           ) : (
             <Tips />
           )}

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -10,6 +10,7 @@ import { formatSize, statusColor } from "../format"
 import { methodColor } from "../formatRequest"
 import { JsonBodyViewer } from "../editor/JsonBodyViewer"
 import { HeaderTable } from "../HeaderTable"
+import { NetworkTab } from "../NetworkTab"
 import {
   entryMethod,
   entryStatus,
@@ -23,12 +24,13 @@ import {
 
 const AUTO_RENDER_LIMIT = 5 * 1024 * 1024
 
-const TAB_DEFS: TabDef[] = [
+const BASE_TAB_DEFS: TabDef[] = [
   { id: "request", label: "Request" },
   { id: "response", label: "Response" },
 ]
 
-type DetailTab = "request" | "response"
+type DetailTab = "request" | "response" | "network"
+type BodyTab = Exclude<DetailTab, "network">
 
 function formatJson(body: string): string {
   try {
@@ -40,7 +42,7 @@ function formatJson(body: string): string {
 
 function bodyInfo(
   entry: TimelineEntry,
-  tab: DetailTab,
+  tab: BodyTab,
 ): {
   body?: string
   ref?: TimelineBodyRef
@@ -90,7 +92,7 @@ export function TimelineDetailOverlay({
   onCopyBody?: (body: string) => void
   onExportBody?: (
     entry: TimelineEntry,
-    kind: DetailTab,
+    kind: BodyTab,
     body?: string,
   ) => Promise<void>
 }) {
@@ -106,7 +108,12 @@ export function TimelineDetailOverlay({
   )
   const bodyScrollRef = useRef<ScrollBoxRenderable | null>(null)
 
-  const info = entry ? bodyInfo(entry, activeTab) : null
+  const hasNetwork = (entry?.network?.length ?? 0) > 0
+  const tabs = hasNetwork
+    ? [...BASE_TAB_DEFS, { id: "network", label: "Network" }]
+    : BASE_TAB_DEFS
+  const info =
+    entry && activeTab !== "network" ? bodyInfo(entry, activeTab) : null
   const isLarge = (info?.size ?? 0) > AUTO_RENDER_LIMIT
 
   useEffect(() => {
@@ -161,12 +168,19 @@ export function TimelineDetailOverlay({
         key.stopPropagation()
         if (key.name === "escape") onClose()
         else if (key.name === "left" || key.name === "right") {
-          setActiveTab((prev) => (prev === "request" ? "response" : "request"))
+          setActiveTab((prev) => {
+            const ids: DetailTab[] = hasNetwork
+              ? ["request", "response", "network"]
+              : ["request", "response"]
+            const index = ids.indexOf(prev)
+            const direction = key.name === "left" ? -1 : 1
+            return ids[(index + direction + ids.length) % ids.length]!
+          })
           setLoadedBody(null)
           setBodyError(null)
           setShowLargeBody(false)
         } else if (key.name === "v" && isLarge) setShowLargeBody(true)
-        else if (key.name === "h") {
+        else if (key.name === "h" && activeTab !== "network") {
           const currentHeaders =
             activeTab === "request"
               ? buildDetailRequestHeaders(
@@ -179,7 +193,7 @@ export function TimelineDetailOverlay({
                     .map(([key, value]) => ({ key, value }))
                 : []
           onCopyHeaders(formatHeaderEntries(currentHeaders))
-        } else if (key.name === "b") {
+        } else if (key.name === "b" && activeTab !== "network") {
           const body = loadedBody ?? info?.body
           if (body !== undefined) onCopyBody(body)
           else if (info?.ref) {
@@ -189,7 +203,7 @@ export function TimelineDetailOverlay({
                 setBodyError("Unable to load the saved response body"),
               )
           }
-        } else if (key.name === "e") {
+        } else if (key.name === "e" && activeTab !== "network") {
           const exportBody = (body?: string) =>
             onExportBody(entry, activeTab, body).catch(() =>
               setBodyError("Failed to export timeline entry"),
@@ -238,9 +252,10 @@ export function TimelineDetailOverlay({
     onExportBody,
     onLoadBody,
     activeTab,
+    hasNetwork,
   ])
 
-  if (!visible || !entry || !info) return null
+  if (!visible || !entry) return null
 
   const method = entryMethod(entry)
   const status = entryStatus(entry)
@@ -268,166 +283,183 @@ export function TimelineDetailOverlay({
         }}
       >
         <Tabs
-          tabs={TAB_DEFS}
+          tabs={tabs}
           activeId={activeTab}
           rightChildren={<text fg={theme.textMuted}>esc</text>}
         >
-          <box
-            style={{
-              flexDirection: "column",
-              flexGrow: 1,
-              minHeight: 0,
-              paddingTop: 1,
-            }}
-          >
-            {activeTab === "request" ? (
-              <box style={{ flexDirection: "column", marginBottom: 1 }}>
-                <box style={{ flexDirection: "row", flexShrink: 0 }}>
-                  <text
-                    wrapMode="word"
-                    content={t`${fg(methodColor(method, theme))(shortMethod(method) + " ")}${fg(theme.text)(formatRequestUrl(entry))}`}
-                  />
+          {activeTab === "network" ? (
+            <NetworkTab
+              key="network"
+              events={entry.network}
+              scrollRef={bodyScrollRef}
+              height={Math.min(Math.max(entry.network?.length ?? 1, 1), 10)}
+            />
+          ) : (
+            <box
+              key="details"
+              style={{
+                flexDirection: "column",
+                flexGrow: 1,
+                minHeight: 0,
+                paddingTop: 1,
+              }}
+            >
+              {activeTab === "request" ? (
+                <box style={{ flexDirection: "column", marginBottom: 1 }}>
+                  <box style={{ flexDirection: "row", flexShrink: 0 }}>
+                    <text
+                      wrapMode="word"
+                      content={t`${fg(methodColor(method, theme))(shortMethod(method) + " ")}${fg(theme.text)(formatRequestUrl(entry))}`}
+                    />
+                  </box>
+                  <box style={{ flexDirection: "row", flexShrink: 0 }}>
+                    <text fg={theme.textMuted} wrapMode="none">
+                      {truncateUrl(formatRequestDisplayName(entry), 60)}
+                    </text>
+                  </box>
                 </box>
-                <box style={{ flexDirection: "row", flexShrink: 0 }}>
-                  <text fg={theme.textMuted} wrapMode="none">
-                    {truncateUrl(formatRequestDisplayName(entry), 60)}
+              ) : (
+                <box style={{ flexDirection: "column", marginBottom: 1 }}>
+                  {entry?.response
+                    ? (() => {
+                        const rawText = entry.response.statusText ?? ""
+                        const truncatedStatusText =
+                          rawText.length > 13
+                            ? `${rawText.slice(0, 13)}…`
+                            : rawText
+                        const statusStr = `${status}${truncatedStatusText !== "" ? ` ${truncatedStatusText}` : ""}`
+                        return (
+                          <box
+                            style={{
+                              flexDirection: "row",
+                              alignItems: "center",
+                            }}
+                          >
+                            <Badge bg={theme.backgroundElement} fg={theme.text}>
+                              {formatSize(entry.response.size)} in{" "}
+                              {entryTiming(entry)}
+                            </Badge>
+                            <Badge
+                              bg={statusColor(status!, theme)}
+                              fg={theme.background}
+                            >
+                              {statusStr}
+                            </Badge>
+                          </box>
+                        )
+                      })()
+                    : null}
+                  {entry?.error ? (
+                    <box
+                      border={["left", "right", "top", "bottom"]}
+                      borderColor={theme.error}
+                      style={{ padding: 1, marginTop: entry?.response ? 1 : 0 }}
+                    >
+                      <text fg={theme.error}>{entry.error.message}</text>
+                    </box>
+                  ) : null}
+                </box>
+              )}
+              <box style={{ height: 1 }}>
+                <text fg={theme.text}>Headers</text>
+              </box>
+              <box
+                border={["bottom"]}
+                borderColor={theme.borderSubtle}
+                style={{ height: 1 }}
+              />
+              <scrollbox
+                scrollY
+                height={Math.min(Math.max(headers.length, 1), headerHeight)}
+                verticalScrollbarOptions={{
+                  trackOptions: {
+                    backgroundColor: theme.background,
+                    foregroundColor: theme.borderActive,
+                  },
+                }}
+                style={{ flexShrink: 0 }}
+              >
+                <HeaderTable entries={headers} theme={theme} />
+              </scrollbox>
+              <box style={{ height: 1, marginTop: 1 }}>
+                <text fg={theme.text}>Body</text>
+              </box>
+              <box
+                border={["bottom"]}
+                borderColor={theme.borderSubtle}
+                style={{ height: 1 }}
+              />
+              {info!.truncated ? (
+                <text fg={theme.warning}>
+                  Saved body was truncated by an older Noodle version.
+                </text>
+              ) : loading ? (
+                <text fg={theme.textMuted}>Loading body…</text>
+              ) : bodyError ? (
+                <text fg={theme.error}>{bodyError}</text>
+              ) : isLarge && !showLargeBody ? (
+                <box style={{ flexDirection: "column" }}>
+                  <text
+                    fg={theme.warning}
+                  >{`Body is ${formatSize(info!.size)}. It was not rendered automatically.`}</text>
+                  <text fg={theme.textMuted}>
+                    v view raw · b copy · e export
                   </text>
                 </box>
-              </box>
-            ) : (
-              <box style={{ flexDirection: "column", marginBottom: 1 }}>
-                {entry?.response
-                  ? (() => {
-                      const rawText = entry.response.statusText ?? ""
-                      const truncatedStatusText =
-                        rawText.length > 13
-                          ? `${rawText.slice(0, 13)}…`
-                          : rawText
-                      const statusStr = `${status}${truncatedStatusText !== "" ? ` ${truncatedStatusText}` : ""}`
-                      return (
-                        <box
-                          style={{
-                            flexDirection: "row",
-                            alignItems: "center",
-                          }}
-                        >
-                          <Badge bg={theme.backgroundElement} fg={theme.text}>
-                            {formatSize(entry.response.size)} in{" "}
-                            {entryTiming(entry)}
-                          </Badge>
-                          <Badge
-                            bg={statusColor(status!, theme)}
-                            fg={theme.background}
-                          >
-                            {statusStr}
-                          </Badge>
-                        </box>
-                      )
-                    })()
-                  : null}
-                {entry?.error ? (
-                  <box
-                    border={["left", "right", "top", "bottom"]}
-                    borderColor={theme.error}
-                    style={{ padding: 1, marginTop: entry?.response ? 1 : 0 }}
-                  >
-                    <text fg={theme.error}>{entry.error.message}</text>
-                  </box>
-                ) : null}
-              </box>
-            )}
-            <box style={{ height: 1 }}>
-              <text fg={theme.text}>Headers</text>
+              ) : renderedBody ? (
+                (() => {
+                  const bodyLines = renderedBody.split("\n").length
+                  const computedBodyHeight = Math.min(
+                    Math.max(bodyLines, 1),
+                    10,
+                  )
+                  return (
+                    <scrollbox
+                      ref={bodyScrollRef}
+                      scrollY
+                      height={computedBodyHeight}
+                      verticalScrollbarOptions={{
+                        trackOptions: {
+                          backgroundColor: theme.background,
+                          foregroundColor: theme.borderActive,
+                        },
+                      }}
+                      style={{ flexShrink: 0 }}
+                    >
+                      <JsonBodyViewer
+                        body={renderedBody}
+                        theme={theme}
+                        highlightPriority={highlightPriority}
+                      />
+                    </scrollbox>
+                  )
+                })()
+              ) : (
+                <text fg={theme.textMuted}>
+                  {entry.response ? "(empty body)" : "No response"}
+                </text>
+              )}
             </box>
-            <box
-              border={["bottom"]}
-              borderColor={theme.borderSubtle}
-              style={{ height: 1 }}
-            />
-            <scrollbox
-              scrollY
-              height={Math.min(Math.max(headers.length, 1), headerHeight)}
-              verticalScrollbarOptions={{
-                trackOptions: {
-                  backgroundColor: theme.background,
-                  foregroundColor: theme.borderActive,
-                },
-              }}
-              style={{ flexShrink: 0 }}
-            >
-              <HeaderTable entries={headers} theme={theme} />
-            </scrollbox>
-            <box style={{ height: 1, marginTop: 1 }}>
-              <text fg={theme.text}>Body</text>
-            </box>
-            <box
-              border={["bottom"]}
-              borderColor={theme.borderSubtle}
-              style={{ height: 1 }}
-            />
-            {info.truncated ? (
-              <text fg={theme.warning}>
-                Saved body was truncated by an older Noodle version.
-              </text>
-            ) : loading ? (
-              <text fg={theme.textMuted}>Loading body…</text>
-            ) : bodyError ? (
-              <text fg={theme.error}>{bodyError}</text>
-            ) : isLarge && !showLargeBody ? (
-              <box style={{ flexDirection: "column" }}>
-                <text
-                  fg={theme.warning}
-                >{`Body is ${formatSize(info.size)}. It was not rendered automatically.`}</text>
-                <text fg={theme.textMuted}>v view raw · b copy · e export</text>
-              </box>
-            ) : renderedBody ? (
-              (() => {
-                const bodyLines = renderedBody.split("\n").length
-                const computedBodyHeight = Math.min(Math.max(bodyLines, 1), 10)
-                return (
-                  <scrollbox
-                    ref={bodyScrollRef}
-                    scrollY
-                    height={computedBodyHeight}
-                    verticalScrollbarOptions={{
-                      trackOptions: {
-                        backgroundColor: theme.background,
-                        foregroundColor: theme.borderActive,
-                      },
-                    }}
-                    style={{ flexShrink: 0 }}
-                  >
-                    <JsonBodyViewer
-                      body={renderedBody}
-                      theme={theme}
-                      highlightPriority={highlightPriority}
-                    />
-                  </scrollbox>
-                )
-              })()
-            ) : (
-              <text fg={theme.textMuted}>
-                {entry.response ? "(empty body)" : "No response"}
-              </text>
-            )}
-          </box>
+          )}
         </Tabs>
-        <box
-          style={{
-            flexDirection: "row",
-            justifyContent: "flex-end",
-            marginTop: 1,
-          }}
-        >
-          <text fg={theme.text}>h</text>
-          <text fg={theme.textMuted}> copy headers </text>
-          <text fg={theme.textMuted}>· </text>
-          <text fg={theme.text}>b</text>
-          <text fg={theme.textMuted}> copy body </text>
-          <text fg={theme.textMuted}>· </text>
-          <text fg={theme.text}>e</text>
-          <text fg={theme.textMuted}> export</text>
-        </box>
+        {activeTab !== "network" && (
+          <box
+            style={{
+              flexDirection: "row",
+              justifyContent: "flex-end",
+              marginTop: 1,
+            }}
+          >
+            <text fg={theme.text}>h</text>
+            <text fg={theme.textMuted}> copy headers </text>
+            <text fg={theme.textMuted}>· </text>
+            <text fg={theme.text}>b</text>
+            <text fg={theme.textMuted}> copy body </text>
+            <text fg={theme.textMuted}>· </text>
+            <text fg={theme.text}>e</text>
+            <text fg={theme.textMuted}> export</text>
+          </box>
+        )}
       </box>
     </Overlay>
   )

--- a/src/ui/sendState.ts
+++ b/src/ui/sendState.ts
@@ -1,14 +1,14 @@
-import type { Request, Response } from "../schema"
+import type { NetworkEvent, Request, Response } from "../schema"
 
 export type SendState =
   | { status: "idle" }
-  | { status: "sending"; request: Request }
+  | { status: "sending"; request: Request; network: NetworkEvent[] }
   | { status: "done"; response: Response }
   | { status: "error"; request: Request; error: Error }
 
 export function startSend(state: SendState, req: Request): SendState {
   if (state.status === "sending") return state
-  return { status: "sending", request: req }
+  return { status: "sending", request: req, network: [] }
 }
 
 export function finishSend(

--- a/src/ui/tabs/uiState.ts
+++ b/src/ui/tabs/uiState.ts
@@ -3,7 +3,7 @@ import { join } from "node:path"
 import * as yaml from "js-yaml"
 import type { FieldKind } from "../editMode"
 
-export type ResponseTabKind = "body" | "headers" | "timeline"
+export type ResponseTabKind = "body" | "headers" | "network" | "timeline"
 
 export interface TabPrefs {
   requestTab: FieldKind

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -1,4 +1,5 @@
 import type { TimelineEntry, Method } from "../../schema"
+import type { NetworkError } from "../../schema"
 import type { Request } from "../../schema"
 import type { SendCompleteResult } from "../../hooks/useResponse"
 import type { SubstitutedRequest } from "../../requests/substitute"
@@ -18,6 +19,12 @@ export function buildTimelineEntry(
     id: randomUUID(),
     timestamp: Date.now(),
     envName,
+    network:
+      result.status === "done"
+        ? result.response.network?.map((event) => ({ ...event }))
+        : (result.error as NetworkError).network?.map((event) => ({
+            ...event,
+          })),
     request: {
       id: req.id,
       name: req.name,

--- a/src/ui/useJumpMode.ts
+++ b/src/ui/useJumpMode.ts
@@ -140,6 +140,7 @@ export function getAvailableTargets(
     if (expanded !== "request") {
       targets.set("r", { kind: "response-tab", tab: "body" })
       targets.set("e", { kind: "response-tab", tab: "headers" })
+      targets.set("n", { kind: "response-tab", tab: "network" })
       targets.set("l", { kind: "response-tab", tab: "timeline" })
     }
   }
@@ -158,11 +159,12 @@ export const REQUEST_TAB_HINTS: Record<string, string> = {
 export const RESPONSE_TAB_HINTS: Record<string, string> = {
   body: "r",
   headers: "e",
+  network: "n",
   timeline: "l",
 }
 
 export const REQUEST_TAB_HINT_ORDER: string[] = ["h", "p", "x", "b", "a", "t"]
-export const RESPONSE_TAB_HINT_ORDER: string[] = ["r", "e", "l"]
+export const RESPONSE_TAB_HINT_ORDER: string[] = ["r", "e", "n", "l"]
 export const FOLDER_TAB_HINT_ORDER: string[] = ["m", "h", "a", "y"]
 
 export function computeRequestTabLabels(request: Request | null): string[] {

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -153,6 +153,63 @@ describe("ResponsePane scrollbox", () => {
     expect(queryController.current?.canOpen()).toBe(true)
   })
 
+  it("scrolls the network trace", async () => {
+    const state = {
+      status: "done" as const,
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "ok",
+        timeMs: 12,
+        network: Array.from({ length: 20 }, (_, i) => ({
+          timeMs: i,
+          type: "request" as const,
+          message: `event ${i}`,
+        })),
+      },
+    } satisfies SendState
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ResponsePane state={state} focused initialTab="network" />
+      </KeymapProvider>,
+      { width: 80, height: 16 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("event 0")
+    await act(async () => mockInput.pressKey("END"))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("event 19")
+  })
+
+  it("renders trace events after a failed request", async () => {
+    const error = Object.assign(new Error("offline"), {
+      network: [
+        { timeMs: 0, type: "request" as const, message: "GET example" },
+        { timeMs: 2, type: "error" as const, message: "offline" },
+      ],
+    })
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ResponsePane
+          state={{ status: "error", request: makeRequest(1), error }}
+          focused
+          initialTab="network"
+        />
+      </KeymapProvider>,
+      { width: 80, height: 16 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("GET example")
+  })
+
   it("shows JSONPath errors in the filter bar", async () => {
     const state = {
       status: "done" as const,

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -186,6 +186,31 @@ describe("ResponsePane scrollbox", () => {
     expect(captureCharFrame()).toContain("event 19")
   })
 
+  it("shows network activity while sending", async () => {
+    const state = {
+      status: "sending" as const,
+      request: makeRequest(1),
+      network: [
+        { timeMs: 0, type: "request" as const, message: "GET example" },
+      ],
+    } satisfies SendState
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ResponsePane state={state} focused initialTab="body" />
+      </KeymapProvider>,
+      { width: 80, height: 16 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Sending")
+    await act(async () => mockInput.pressKey("ARROW_RIGHT"))
+    await act(async () => mockInput.pressKey("ARROW_RIGHT"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("GET example")
+  })
+
   it("renders trace events after a failed request", async () => {
     const error = Object.assign(new Error("offline"), {
       network: [
@@ -208,6 +233,28 @@ describe("ResponsePane scrollbox", () => {
     )
     await renderOnce()
     expect(captureCharFrame()).toContain("GET example")
+  })
+
+  it("shows no response headers after a failed request", async () => {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ResponsePane
+          state={{
+            status: "error",
+            request: makeRequest(1),
+            error: new Error("offline"),
+          }}
+          focused
+          initialTab="headers"
+        />
+      </KeymapProvider>,
+      { width: 80, height: 16 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("No response headers available.")
   })
 
   it("shows JSONPath errors in the filter bar", async () => {

--- a/tests/sendState.test.ts
+++ b/tests/sendState.test.ts
@@ -41,6 +41,7 @@ describe("startSend", () => {
     expect(next.status).toBe("sending")
     if (next.status !== "sending") throw new Error("narrow")
     expect(next.request).toEqual(makeReq())
+    expect(next.network).toEqual([])
   })
 
   it("transitions done → sending (re-send works)", () => {
@@ -65,7 +66,11 @@ describe("startSend", () => {
   })
 
   it("is a no-op when already sending (returns same reference)", () => {
-    const sending: SendState = { status: "sending", request: makeReq() }
+    const sending: SendState = {
+      status: "sending",
+      request: makeReq(),
+      network: [],
+    }
     const next = startSend(sending, makeReq())
     expect(next).toBe(sending)
   })
@@ -73,7 +78,11 @@ describe("startSend", () => {
 
 describe("finishSend", () => {
   it("transitions to done with response", () => {
-    const sending: SendState = { status: "sending", request: makeReq() }
+    const sending: SendState = {
+      status: "sending",
+      request: makeReq(),
+      network: [],
+    }
     const res = makeRes({ status: 201, statusText: "Created" })
     const next = finishSend(sending, makeReq(), res)
     expect(next.status).toBe("done")
@@ -85,7 +94,11 @@ describe("finishSend", () => {
 
 describe("failSend", () => {
   it("transitions to error with request and error", () => {
-    const sending: SendState = { status: "sending", request: makeReq() }
+    const sending: SendState = {
+      status: "sending",
+      request: makeReq(),
+      network: [],
+    }
     const err = new Error("fetch failed")
     const next = failSend(sending, makeReq(), err)
     expect(next.status).toBe("error")
@@ -102,12 +115,20 @@ describe("immutability", () => {
     expect(idle.status).toBe("idle")
   })
   it("finishSend does not mutate input state", () => {
-    const sending: SendState = { status: "sending", request: makeReq() }
+    const sending: SendState = {
+      status: "sending",
+      request: makeReq(),
+      network: [],
+    }
     finishSend(sending, makeReq(), makeRes())
     expect(sending.status).toBe("sending")
   })
   it("failSend does not mutate input state", () => {
-    const sending: SendState = { status: "sending", request: makeReq() }
+    const sending: SendState = {
+      status: "sending",
+      request: makeReq(),
+      network: [],
+    }
     failSend(sending, makeReq(), new Error("boom"))
     expect(sending.status).toBe("sending")
   })

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -257,6 +257,21 @@ describe("saveTimelineEntry", () => {
     expect(result[0].response).toBeUndefined()
   })
 
+  it("persists network activity", async () => {
+    await saveTimelineEntry(
+      dir,
+      "network",
+      makeEntry({
+        network: [
+          { timeMs: 0, type: "request", message: "GET https://example.com" },
+          { timeMs: 5, type: "complete", message: "Completed in 5ms" },
+        ],
+      }),
+    )
+    const result = await loadTimeline(dir, "network")
+    expect(result[0]?.network?.[1]?.message).toBe("Completed in 5ms")
+  })
+
   it("isolates entries per request id", async () => {
     await saveTimelineEntry(dir, "req-a", makeEntry({ timestamp: 1 }))
     await saveTimelineEntry(dir, "req-b", makeEntry({ timestamp: 2 }))

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -258,18 +258,23 @@ describe("saveTimelineEntry", () => {
   })
 
   it("persists network activity", async () => {
+    const network = [
+      {
+        timeMs: 0,
+        type: "request" as const,
+        message: "GET https://example.com",
+      },
+      { timeMs: 5, type: "complete" as const, message: "Completed in 5ms" },
+    ]
     await saveTimelineEntry(
       dir,
       "network",
       makeEntry({
-        network: [
-          { timeMs: 0, type: "request", message: "GET https://example.com" },
-          { timeMs: 5, type: "complete", message: "Completed in 5ms" },
-        ],
+        network,
       }),
     )
     const result = await loadTimeline(dir, "network")
-    expect(result[0]?.network?.[1]?.message).toBe("Completed in 5ms")
+    expect(result[0]?.network).toEqual(network)
   })
 
   it("isolates entries per request id", async () => {

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -533,6 +533,58 @@ describe("buildTimelineEntry", () => {
     expect(entry.envName).toBe("dev")
   })
 
+  it("copies network activity into the saved entry", () => {
+    const req = {
+      id: "req-network",
+      name: "Network",
+      method: "GET" as const,
+      url: "https://api.example.com",
+      headers: {},
+      params: [],
+      auth: undefined,
+      timeout: 0,
+    }
+    const entry = buildTimelineEntry(req, {
+      status: "done",
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "",
+        timeMs: 5,
+        network: [{ timeMs: 0, type: "request", message: "GET example" }],
+      },
+    })
+    expect(entry.network).toEqual([
+      { timeMs: 0, type: "request", message: "GET example" },
+    ])
+  })
+
+  it("copies failed network activity into the saved entry", () => {
+    const req = {
+      id: "req-network-error",
+      name: "Network error",
+      method: "GET" as const,
+      url: "https://api.example.com",
+      headers: {},
+      params: [],
+      auth: undefined,
+      timeout: 0,
+    }
+    const error = Object.assign(new Error("offline"), {
+      network: [
+        { timeMs: 0, type: "request" as const, message: "GET example" },
+        { timeMs: 2, type: "error" as const, message: "offline" },
+      ],
+    })
+    const entry = buildTimelineEntry(req, {
+      status: "error",
+      request: req,
+      error,
+    })
+    expect(entry.network).toEqual(error.network)
+  })
+
   it("uses resolvedUrl when provided", () => {
     const req = {
       id: "req-3",

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -267,6 +267,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
       }
       expectBadge("r")
       expectBadge("e")
+      expectBadge("n")
       expectBadge("l")
 
       const expectBadgeAtTabStart = (hint: string, label: string) => {
@@ -286,6 +287,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
         expectBadgeAtTabStart("t", "Settings")
         expectBadgeAtTabStart("r", "Body")
         expectBadgeAtTabStart("e", "Headers")
+        expectBadgeAtTabStart("n", "Network")
         expectBadgeAtTabStart("l", "Timeline")
       }
     })
@@ -375,7 +377,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
     )
     await renderOnce()
     const spans = captureSpans().lines.flatMap((line) => line.spans)
-    for (const letter of ["r", "e", "l"]) {
+    for (const letter of ["r", "e", "n", "l"]) {
       expect(
         spans.some(
           (span) =>
@@ -411,8 +413,9 @@ describe("getAvailableTargets", () => {
     expect(targets.has("t")).toBe(true)
     expect(targets.has("r")).toBe(true)
     expect(targets.has("e")).toBe(true)
+    expect(targets.has("n")).toBe(true)
     expect(targets.has("l")).toBe(true)
-    expect(targets.size).toBe(12)
+    expect(targets.size).toBe(13)
   })
 
   it("excludes response targets when expanded=request", () => {
@@ -421,6 +424,7 @@ describe("getAvailableTargets", () => {
     expect(targets.has("b")).toBe(true)
     expect(targets.has("r")).toBe(false)
     expect(targets.has("e")).toBe(false)
+    expect(targets.has("n")).toBe(false)
     expect(targets.has("l")).toBe(false)
   })
 
@@ -428,6 +432,7 @@ describe("getAvailableTargets", () => {
     const targets = getAvailableTargets(true, "response", false)
     expect(targets.has("r")).toBe(true)
     expect(targets.has("e")).toBe(true)
+    expect(targets.has("n")).toBe(true)
     expect(targets.has("l")).toBe(true)
     expect(targets.has("h")).toBe(false)
     expect(targets.has("b")).toBe(false)

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -92,6 +92,29 @@ describe("TimelineDetailOverlay", () => {
     cleanup()
   })
 
+  it("scrolls persisted network activity", async () => {
+    const { renderOnce, captureCharFrame, host, cleanup } = await renderOverlay(
+      makeEntry({
+        network: Array.from({ length: 12 }, (_, i) => ({
+          timeMs: i,
+          type: "request" as const,
+          message: `event ${i}`,
+        })),
+      }),
+      () => {},
+    )
+    await renderOnce()
+    await act(async () => host.press("right"))
+    await act(async () => host.press("right"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Network")
+    expect(captureCharFrame()).toContain("event 0")
+    await act(async () => host.press("end"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("event 11")
+    cleanup()
+  })
+
   it("keeps a large body visible when scrolling past headers", async () => {
     const body = JSON.stringify(
       {

--- a/tests/unit/getContextualSegments.test.ts
+++ b/tests/unit/getContextualSegments.test.ts
@@ -267,6 +267,11 @@ describe("getContextualSegments", () => {
     expect(r.footer).toEqual([seg("f2", "expand")])
   })
 
+  it("response when done on network tab shows expand", () => {
+    const r = base({ focus: "response", sendState: done, tab: "network" })
+    expect(r.footer).toEqual([seg("f2", "expand")])
+  })
+
   it("response when done without tab shows expand", () => {
     const r = base({ focus: "response", sendState: done })
     expect(r.footer).toEqual([seg("f2", "expand")])

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock } from "bun:test"
-import type { Request } from "../../src/schema"
+import type { NetworkError, Request } from "../../src/schema"
 import { send, interpolatePathParams } from "../../src/requests/send"
 
 function makeReq(over: Partial<Request> = {}): Request {
@@ -132,6 +132,170 @@ describe("send — param deduplication", () => {
       ])
     } finally {
       globalThis.fetch = orig
+    }
+  })
+})
+
+describe("send — network trace", () => {
+  it("records request, response, body, and completion", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(
+      async () => new Response("ok", { status: 200 }),
+    ) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(
+        makeReq({ url: "https://api.example.com/users?token=secret" }),
+      )
+      expect(response.network?.map((event) => event.type)).toEqual([
+        "request",
+        "response",
+        "body",
+        "complete",
+      ])
+      expect(response.network?.[0]?.message).toBe(
+        "GET https://api.example.com/users?...",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("records redirect hops", async () => {
+    const originalFetch = globalThis.fetch
+    let calls = 0
+    globalThis.fetch = mock(async () => {
+      calls++
+      if (calls === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "/v2/users" },
+        })
+      }
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(
+        makeReq({ url: "https://api.example.com/users" }),
+      )
+      expect(response.network?.map((event) => event.type)).toEqual([
+        "request",
+        "response",
+        "redirect",
+        "request",
+        "response",
+        "body",
+        "complete",
+      ])
+      expect(response.network?.[2]?.message).toBe(
+        "302 -> https://api.example.com/v2/users",
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("attaches network activity to fetch errors", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(async () => {
+      throw new Error("offline")
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      let error: NetworkError | undefined
+      try {
+        await send(makeReq())
+      } catch (e) {
+        error = e as NetworkError
+      }
+      expect(error?.message).toBe("requests.send: fetch failed: offline")
+      expect(error?.network?.map((event) => event.type)).toEqual([
+        "request",
+        "error",
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("attaches network activity to invalid redirect locations", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://[invalid" },
+        }),
+    ) as unknown as typeof globalThis.fetch
+
+    try {
+      let error: NetworkError | undefined
+      try {
+        await send(makeReq())
+      } catch (e) {
+        error = e as NetworkError
+      }
+      expect(error?.message).toContain("invalid redirect location")
+      expect(error?.network?.map((event) => event.type)).toEqual([
+        "request",
+        "response",
+        "error",
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("attaches network activity when redirects exceed the limit", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "/again" },
+        }),
+    ) as unknown as typeof globalThis.fetch
+
+    try {
+      let error: NetworkError | undefined
+      try {
+        await send(makeReq({ maxRedirects: 0 }))
+      } catch (e) {
+        error = e as NetworkError
+      }
+      expect(error?.network?.map((event) => event.type)).toEqual([
+        "request",
+        "response",
+        "error",
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("attaches network activity to response body read errors", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(async () => {
+      const response = new Response("ok", { status: 200 })
+      await response.text()
+      return response
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      let error: NetworkError | undefined
+      try {
+        await send(makeReq())
+      } catch (e) {
+        error = e as NetworkError
+      }
+      expect(error?.network?.map((event) => event.type)).toEqual([
+        "request",
+        "response",
+        "error",
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
     }
   })
 })

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -161,6 +161,33 @@ describe("send — network trace", () => {
     }
   })
 
+  it("reports each network event before the request settles", async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(
+      async () => new Response("ok", { status: 200 }),
+    ) as unknown as typeof globalThis.fetch
+
+    try {
+      const snapshots: string[][] = []
+      await send(
+        makeReq(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        (network) => snapshots.push(network.map((event) => event.type)),
+      )
+      expect(snapshots).toEqual([
+        ["request"],
+        ["request", "response"],
+        ["request", "response", "body"],
+        ["request", "response", "body", "complete"],
+      ])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it("records redirect hops", async () => {
     const originalFetch = globalThis.fetch
     let calls = 0

--- a/tests/unit/statusBar.test.ts
+++ b/tests/unit/statusBar.test.ts
@@ -80,6 +80,7 @@ describe("statusBarText", () => {
           params: [],
           timeout: 0,
         },
+        network: [],
       },
       envLabel: "dev",
       saveState: { kind: "idle" },

--- a/tests/unit/uiState.test.ts
+++ b/tests/unit/uiState.test.ts
@@ -47,7 +47,7 @@ describe("uiState I/O", () => {
 
   itOnCI("loads multiple requests", async () => {
     const a: TabPrefs = { requestTab: "auth", responseTab: "body" }
-    const b: TabPrefs = { requestTab: "body", responseTab: "timeline" }
+    const b: TabPrefs = { requestTab: "body", responseTab: "network" }
     await saveUIState(
       tmpDir,
       new Map([


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a Network tab to the response pane showing a live trace of network activity (request, redirects, response, body, completion, errors), and persists that trace into saved timeline entries so it can be viewed in the timeline detail overlay. Failed requests (fetch errors, invalid redirects, redirect limits, body read errors) attach the trace to the thrown error. The tab is reachable via `Tab`-cycling, left/right arrows, and jump-mode hint `n`.

### How did you verify your code works?

- `bun test` passes (1921 tests)
- `bun run lint` passes
- `bun run typecheck` passes
- New unit tests cover trace recording (redirect hops, fetch/redirect/body-read errors), persistence, and overlay rendering

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network activity tracking for requests, redirects, responses, and errors.
  * Added a Network tab with timestamped activity for successful and failed requests.
  * Network activity is included in timelines and remains available after saving and reopening entries.
  * Request URLs in network messages redact query values for privacy.

* **Bug Fixes**
  * Network failures now include detailed activity history while preserving abort behavior.
  * Response headers are clearly marked unavailable when a request fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->