### PR TITLE
feat(ui): full mouse support across the TUI

### DIFF
--- a/collections/.environments/production.env
+++ b/collections/.environments/production.env
@@ -1,6 +1,6 @@
 _color=warning
 base_url=https://jsonplaceholder.typicode.com
 post_id=1
-user_id=1
+user_id=2
 api_token=sdf7f7s8fdfs0d8fs0f
 x_api_key=s98df7s98f7sf7sfs87sdf

--- a/collections/albums/delete-album.yml
+++ b/collections/albums/delete-album.yml
@@ -1,7 +1,10 @@
 name: Delete Album
 method: DELETE
-url: $base_url/albums/1
+url: $base_url/albums/:albumId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: albumId
+    value: '1'
 body_type: none

--- a/collections/albums/get-album.yml
+++ b/collections/albums/get-album.yml
@@ -1,7 +1,10 @@
 name: Get Album by ID
 method: GET
-url: $base_url/albums/1
+url: $base_url/albums/:albumId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: albumId
+    value: '1'
 body_type: none

--- a/collections/albums/get-albums-by-user.yml
+++ b/collections/albums/get-albums-by-user.yml
@@ -1,7 +1,10 @@
 name: Get Albums by User
 method: GET
-url: $base_url/albums?userId=$user_id
+url: $base_url/albums
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+params:
+  - name: userId
+    value: $user_id
 body_type: none

--- a/collections/albums/update-album.yml
+++ b/collections/albums/update-album.yml
@@ -1,11 +1,14 @@
 name: Update Album
 method: PATCH
-url: $base_url/albums/1
+url: $base_url/albums/:albumId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
   Content-Type: { value: application/json, enabled: false }
+path_params:
+  - name: albumId
+    value: '1'
 body: |-
   {
     "title": "updated album"

--- a/collections/comments/delete-comment.yml
+++ b/collections/comments/delete-comment.yml
@@ -1,7 +1,10 @@
 name: Delete Comment
 method: DELETE
-url: $base_url/comments/1
+url: $base_url/comments/:commentId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: commentId
+    value: '1'
 body_type: none

--- a/collections/comments/get-comment.yml
+++ b/collections/comments/get-comment.yml
@@ -1,7 +1,10 @@
 name: Get Comment by ID
 method: GET
-url: $base_url/comments/1
+url: $base_url/comments/:commentId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: commentId
+    value: '1'
 body_type: none

--- a/collections/comments/get-comments-by-post.yml
+++ b/collections/comments/get-comments-by-post.yml
@@ -1,7 +1,10 @@
 name: Get Comments by Post
 method: GET
-url: $base_url/comments?postId=$post_id
+url: $base_url/comments
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+params:
+  - name: postId
+    value: $post_id
 body_type: none

--- a/collections/comments/update-comment.yml
+++ b/collections/comments/update-comment.yml
@@ -1,11 +1,14 @@
 name: Update Comment
 method: PATCH
-url: $base_url/comments/1
+url: $base_url/comments/:commentId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
   Content-Type: application/json
+path_params:
+  - name: commentId
+    value: '1'
 body: |-
   {
     "name": "updated comment"

--- a/collections/delayed-response.yml
+++ b/collections/delayed-response.yml
@@ -1,7 +1,10 @@
 name: Delayed Response
 method: GET
-url: https://httpbin.org/delay/2
+url: https://httpbin.org/delay/:delayTime
 timeout: 5000
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: delayTime
+    value: '2'
 body_type: none

--- a/collections/photos/delete-photo.yml
+++ b/collections/photos/delete-photo.yml
@@ -1,7 +1,10 @@
 name: Delete Photo
 method: DELETE
-url: $base_url/photos/1
+url: $base_url/photos/:photoId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: photoId
+    value: '1'
 body_type: none

--- a/collections/photos/get-photo.yml
+++ b/collections/photos/get-photo.yml
@@ -1,7 +1,10 @@
 name: Get Photo by ID
 method: GET
-url: $base_url/photos/1
+url: $base_url/photos/:photoId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: photoId
+    value: '1'
 body_type: none

--- a/collections/photos/get-photos-by-album.yml
+++ b/collections/photos/get-photos-by-album.yml
@@ -1,7 +1,10 @@
 name: Get Photos by Album
 method: GET
-url: $base_url/photos?albumId=1
+url: $base_url/photos
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+params:
+  - name: albumId
+    value: '1'
 body_type: none

--- a/collections/photos/update-photo.yml
+++ b/collections/photos/update-photo.yml
@@ -1,11 +1,14 @@
 name: Update Photo
 method: PATCH
-url: $base_url/photos/1
+url: $base_url/photos/:photoId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
   Content-Type: application/json
+path_params:
+  - name: photoId
+    value: '1'
 body: |-
   {
     "title": "updated photo title"

--- a/collections/posts/get-post.yml
+++ b/collections/posts/get-post.yml
@@ -1,10 +1,10 @@
 name: Get Post by ID
 method: GET
-url: $base_url/posts/:id
+url: $base_url/posts/:postId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 path_params:
-  - name: id
+  - name: postId
     value: '1'
 body_type: none

--- a/collections/posts/get-posts-by-user.yml
+++ b/collections/posts/get-posts-by-user.yml
@@ -6,5 +6,5 @@ followRedirects: true
 maxRedirects: 5
 params:
   - name: userId
-    value: '1'
+    value: $user_id
 body_type: none

--- a/collections/posts/put-post.yml
+++ b/collections/posts/put-post.yml
@@ -9,7 +9,7 @@ headers:
 path_params:
   - name: post_id
     value: '1'
-body: |
+body: |-
   {
     "id": 1,
     "title": "replaced title",

--- a/collections/todos/delete-todo.yml
+++ b/collections/todos/delete-todo.yml
@@ -1,7 +1,10 @@
 name: Delete Todo
 method: DELETE
-url: $base_url/todos/1
+url: $base_url/todos/:todoId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: todoId
+    value: '1'
 body_type: none

--- a/collections/todos/get-todo.yml
+++ b/collections/todos/get-todo.yml
@@ -1,7 +1,10 @@
 name: Get Todo by ID
 method: GET
-url: $base_url/todos/1
+url: $base_url/todos/:todoId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: todoId
+    value: '1'
 body_type: none

--- a/collections/todos/get-todos-by-user.yml
+++ b/collections/todos/get-todos-by-user.yml
@@ -1,7 +1,10 @@
 name: Get Todos by User
 method: GET
-url: $base_url/todos?userId=$user_id
+url: $base_url/todos
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+params:
+  - name: userId
+    value: $user_id
 body_type: none

--- a/collections/todos/update-todo.yml
+++ b/collections/todos/update-todo.yml
@@ -1,11 +1,14 @@
 name: Update Todo
 method: PATCH
-url: $base_url/todos/1
+url: $base_url/todos/:todoId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
 headers:
   Content-Type: application/json
+path_params:
+  - name: todoId
+    value: '1'
 body: |-
   {
     "completed": true

--- a/collections/users/get-user.yml
+++ b/collections/users/get-user.yml
@@ -1,7 +1,10 @@
 name: Get User by ID
 method: GET
-url: $base_url/users/1
+url: $base_url/users/:userId
 timeout: 0
 followRedirects: true
 maxRedirects: 5
+path_params:
+  - name: userId
+    value: '1'
 body_type: none

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import type { Dispatch, SetStateAction } from "react"
 import { filestore } from "../filestore"
 import { loadCollectionBrowse } from "../filestore"
 import type { Collection } from "../schema"
@@ -7,7 +8,7 @@ export interface UseCollectionResult {
   collection: Collection | null
   loading: boolean
   error: Error | null
-  updateCollection: (collection: Collection) => void
+  updateCollection: Dispatch<SetStateAction<Collection | null>>
 }
 
 export function useCollection(

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -216,7 +216,7 @@ export interface UseEditBrowseResult {
   toggleRow: () => void
   toggleFormRowType: () => void
   cycleInactiveTab: (delta: 1 | -1) => void
-  enterBrowseAt: (field: FieldKind) => void
+  enterBrowseAt: (field: FieldKind, row?: number) => void
   canEnterJsonBodyEditor: boolean
   isEditingJsonBody: boolean
   enterJsonBodyEditor: () => void
@@ -284,19 +284,23 @@ export function useEditBrowse(
     })
   }, [activeTab])
 
-  const enterBrowseAt = useCallback((field: FieldKind) => {
+  const enterBrowseAt = useCallback((field: FieldKind, row?: number) => {
     setInactiveTab(field)
     const c = rowCount(draftRef.current)
     setEditState((prev) => {
       if (prev.mode !== "inactive") {
+        const cursor = cursorForField(field, c)
         return {
           ...prev,
-          cursor: cursorForField(field, c),
+          cursor:
+            row === undefined ? cursor : { ...cursor, row, addingRow: false },
           mode: "browsing" as const,
           editingRow: -1,
         }
       }
-      return enterEditBrowse(prev, c, field)
+      const next = enterEditBrowse(prev, c, field)
+      if (row === undefined) return next
+      return { ...next, cursor: { ...next.cursor, row, addingRow: false } }
     })
   }, [])
 

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -217,6 +217,8 @@ export interface UseEditBrowseResult {
   toggleFormRowType: () => void
   cycleInactiveTab: (delta: 1 | -1) => void
   enterBrowseAt: (field: FieldKind, row?: number) => void
+  activateAt: (field: FieldKind, row: number, addingRow?: boolean) => void
+  toggleAt: (field: FieldKind, row: number) => void
   canEnterJsonBodyEditor: boolean
   isEditingJsonBody: boolean
   enterJsonBodyEditor: () => void
@@ -303,6 +305,74 @@ export function useEditBrowse(
       return { ...next, cursor: { ...next.cursor, row, addingRow: false } }
     })
   }, [])
+
+  const activateAt = useCallback(
+    (field: FieldKind, row: number, addingRow = false) => {
+      setInactiveTab(field)
+      const currentDraft = draftRef.current
+
+      if (
+        field === "body" &&
+        (currentDraft?.bodyType === "multipart" ||
+          currentDraft?.bodyType === "urlencoded")
+      ) {
+        const kv = currentKeyValueFor(currentDraft, field, row, addingRow)
+        setEditKey(kv.key)
+        setEditValue(kv.value)
+      } else if (
+        field === "headers" ||
+        field === "params" ||
+        field === "pathParams"
+      ) {
+        const kv = currentKeyValueFor(currentDraft, field, row, addingRow)
+        setEditKey(kv.key)
+        setEditValue(kv.value)
+      } else {
+        setEditValue(currentValueFor(currentDraft, field, row, addingRow))
+      }
+
+      setEditState((prev) => {
+        const browsed =
+          prev.mode === "inactive"
+            ? enterEditBrowse(prev, rowCount(currentDraft), field)
+            : cancelEditing(prev)
+        return beginEditing({
+          ...browsed,
+          mode: "browsing",
+          editingRow: -1,
+          cursor: { field, row, addingRow },
+        })
+      })
+    },
+    [],
+  )
+
+  const toggleAt = useCallback(
+    (field: FieldKind, row: number) => {
+      setInactiveTab(field)
+      setEditState((prev) => {
+        const browsed =
+          prev.mode === "inactive"
+            ? enterEditBrowse(prev, rowCount(draftRef.current), field)
+            : cancelEditing(prev)
+        return {
+          ...browsed,
+          mode: "browsing",
+          editingRow: -1,
+          cursor: { field, row, addingRow: false },
+        }
+      })
+
+      if (field === "headers") draftMutators.toggleHeaderRow(row)
+      else if (field === "params") draftMutators.toggleParamRow(row)
+      else if (field === "body") draftMutators.toggleFormRow(row - 1)
+      else if (field === "settings" && row === 1) {
+        const current = draftRef.current?.followRedirects ?? true
+        draftMutators.setFollowRedirects(!current)
+      }
+    },
+    [draftMutators],
+  )
 
   const enterAndEdit = useCallback(() => {
     if (activeTab === "activity") return
@@ -624,8 +694,9 @@ export function useEditBrowse(
     } else if (field === "pathParams") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()
-      if (key === "" || addingRow) return
-      draftMutators.setPathParamRow(state.cursor.row, key, value)
+      if (key !== "" && !addingRow) {
+        draftMutators.setPathParamRow(state.cursor.row, key, value)
+      }
     } else if (field === "headers" || field === "params") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()
@@ -776,6 +847,8 @@ export function useEditBrowse(
       toggleFormRowType,
       cycleInactiveTab,
       enterBrowseAt,
+      activateAt,
+      toggleAt,
       canEnterJsonBodyEditor,
       isEditingJsonBody,
       enterJsonBodyEditor,
@@ -789,6 +862,8 @@ export function useEditBrowse(
       activeTab,
       enterBrowse,
       enterBrowseAt,
+      activateAt,
+      toggleAt,
       exitBrowse,
       browseUp,
       browseDown,

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -373,19 +373,6 @@ export function useEnvironmentEditor({
     })
   }, [])
 
-  const activateVar = useCallback((row: number, addingRow = false) => {
-    const currentRow = addingRow ? undefined : draftRef.current?.varRows[row]
-    setEditKey(currentRow?.key ?? "")
-    setEditValue(currentRow?.value ?? "")
-    setEditState({
-      mode: "editing",
-      row,
-      addingRow,
-      subfield: "key",
-      editingRow: addingRow ? -1 : row,
-    })
-  }, [])
-
   const commitEdit = useCallback(() => {
     const state = editStateRef.current
     if (state.mode !== "editing") return
@@ -421,6 +408,23 @@ export function useEnvironmentEditor({
       editingRow: -1,
     })
   }, [])
+
+  const activateVar = useCallback(
+    (row: number, addingRow = false) => {
+      commitEdit()
+      const currentRow = addingRow ? undefined : draftRef.current?.varRows[row]
+      setEditKey(currentRow?.key ?? "")
+      setEditValue(currentRow?.value ?? "")
+      setEditState({
+        mode: "editing",
+        row,
+        addingRow,
+        subfield: "key",
+        editingRow: addingRow ? -1 : row,
+      })
+    },
+    [commitEdit],
+  )
 
   const cancelEdit = useCallback(() => {
     setEditState((prev) => {

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -70,6 +70,7 @@ export interface UseEnvironmentEditorResult {
   browseFirst: () => void
   browseLast: () => void
   enterEdit: () => void
+  activateVar: (row: number, addingRow?: boolean) => void
   commitEdit: () => void
   cancelEdit: () => void
   browseTab: () => void
@@ -372,6 +373,19 @@ export function useEnvironmentEditor({
     })
   }, [])
 
+  const activateVar = useCallback((row: number, addingRow = false) => {
+    const currentRow = addingRow ? undefined : draftRef.current?.varRows[row]
+    setEditKey(currentRow?.key ?? "")
+    setEditValue(currentRow?.value ?? "")
+    setEditState({
+      mode: "editing",
+      row,
+      addingRow,
+      subfield: "key",
+      editingRow: addingRow ? -1 : row,
+    })
+  }, [])
+
   const commitEdit = useCallback(() => {
     const state = editStateRef.current
     if (state.mode !== "editing") return
@@ -634,6 +648,7 @@ export function useEnvironmentEditor({
     browseFirst,
     browseLast,
     enterEdit,
+    activateVar,
     commitEdit,
     cancelEdit,
     browseTab,

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -411,16 +411,27 @@ export function useEnvironmentEditor({
 
   const activateVar = useCallback(
     (row: number, addingRow = false) => {
+      const targetId = addingRow
+        ? undefined
+        : draftRef.current?.varRows[row]?.id
       commitEdit()
-      const currentRow = addingRow ? undefined : draftRef.current?.varRows[row]
+      const resolvedRow = targetId
+        ? (draftRef.current?.varRows.findIndex(
+            (entry) => entry.id === targetId,
+          ) ?? -1)
+        : row
+      if (!addingRow && resolvedRow < 0) return
+      const currentRow = addingRow
+        ? undefined
+        : draftRef.current?.varRows[resolvedRow]
       setEditKey(currentRow?.key ?? "")
       setEditValue(currentRow?.value ?? "")
       setEditState({
         mode: "editing",
-        row,
+        row: resolvedRow,
         addingRow,
         subfield: "key",
-        editingRow: addingRow ? -1 : row,
+        editingRow: addingRow ? -1 : resolvedRow,
       })
     },
     [commitEdit],

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -228,6 +228,7 @@ export function useFolderEditBrowse(
 
   const activateAt = useCallback(
     (field: FolderFieldKind, row: number, addingRow = false) => {
+      if (field === "auth" && row === 0) return
       setInactiveTab(field)
       const currentFolder = draftRef.current
       const kv = folderCurrentKeyValueFor(currentFolder, field, row, addingRow)
@@ -268,7 +269,7 @@ export function useFolderEditBrowse(
           cursor: { field, row, addingRow: false },
         }
       })
-      if (field === "headers") draftMutators.toggleHeaderRow(row)
+      if (field === "headers" && row >= 0) draftMutators.toggleHeaderRow(row)
     },
     [draftMutators],
   )

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -45,6 +45,8 @@ export interface UseFolderEditBrowseResult {
   revertAll: () => void
   toggleRow: () => void
   cycleInactiveTab: (delta: 1 | -1) => void
+  activateAt: (field: FolderFieldKind, row: number, addingRow?: boolean) => void
+  toggleAt: (field: FolderFieldKind, row: number) => void
 }
 
 export interface UseFolderEditBrowseOptions {
@@ -223,6 +225,53 @@ export function useFolderEditBrowse(
       return { ...next, cursor: { ...next.cursor, row, addingRow: false } }
     })
   }, [])
+
+  const activateAt = useCallback(
+    (field: FolderFieldKind, row: number, addingRow = false) => {
+      setInactiveTab(field)
+      const currentFolder = draftRef.current
+      const kv = folderCurrentKeyValueFor(currentFolder, field, row, addingRow)
+      setEditKey(kv.key)
+      setEditValue(kv.value)
+      setEditState((prev) => {
+        const browsed =
+          prev.mode === "inactive"
+            ? enterFolderEditBrowse(prev, folderRowCount(currentFolder), field)
+            : cancelEditing(prev)
+        return beginEditing({
+          ...browsed,
+          mode: "browsing",
+          editingRow: -1,
+          cursor: { field, row, addingRow },
+        })
+      })
+    },
+    [],
+  )
+
+  const toggleAt = useCallback(
+    (field: FolderFieldKind, row: number) => {
+      setInactiveTab(field)
+      setEditState((prev) => {
+        const browsed =
+          prev.mode === "inactive"
+            ? enterFolderEditBrowse(
+                prev,
+                folderRowCount(draftRef.current),
+                field,
+              )
+            : cancelEditing(prev)
+        return {
+          ...browsed,
+          mode: "browsing",
+          editingRow: -1,
+          cursor: { field, row, addingRow: false },
+        }
+      })
+      if (field === "headers") draftMutators.toggleHeaderRow(row)
+    },
+    [draftMutators],
+  )
 
   const enterAndEdit = useCallback(() => {
     const c = folderRowCount(draftRef.current)
@@ -415,6 +464,8 @@ export function useFolderEditBrowse(
       activeTab,
       enterBrowse,
       enterBrowseAt,
+      activateAt,
+      toggleAt,
       exitBrowse,
       browseUp,
       browseDown,
@@ -437,6 +488,8 @@ export function useFolderEditBrowse(
       activeTab,
       enterBrowse,
       enterBrowseAt,
+      activateAt,
+      toggleAt,
       exitBrowse,
       browseUp,
       browseDown,

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -30,7 +30,7 @@ export interface UseFolderEditBrowseResult {
   isActive: boolean
   activeTab: FieldKind
   enterBrowse: () => void
-  enterBrowseAt: (field: FolderFieldKind) => void
+  enterBrowseAt: (field: FolderFieldKind, row?: number) => void
   exitBrowse: () => void
   browseUp: () => void
   browseDown: () => void
@@ -203,20 +203,24 @@ export function useFolderEditBrowse(
     })
   }, [activeTab])
 
-  const enterBrowseAt = useCallback((field: FolderFieldKind) => {
+  const enterBrowseAt = useCallback((field: FolderFieldKind, row?: number) => {
     setInactiveTab(field)
     const c = folderRowCount(draftRef.current)
     setEditKey("")
     setEditState((prev) => {
       if (prev.mode !== "inactive") {
         const canceled = prev.mode === "editing" ? cancelEditing(prev) : prev
+        const cursor = folderCursorForField(field, c)
         return {
           ...canceled,
-          cursor: folderCursorForField(field, c),
+          cursor:
+            row === undefined ? cursor : { ...cursor, row, addingRow: false },
           editingRow: -1,
         }
       }
-      return enterFolderEditBrowse(prev, c, field)
+      const next = enterFolderEditBrowse(prev, c, field)
+      if (row === undefined) return next
+      return { ...next, cursor: { ...next.cursor, row, addingRow: false } }
     })
   }, [])
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -175,6 +175,7 @@ export function AppInner({
     setSelectedId,
     revealRequest,
     revealFolder,
+    toggleFolder,
     expandFolder,
   } = useTreeNavigation(
     items,
@@ -455,6 +456,12 @@ export function AppInner({
     },
     [eb.enterBrowse, envEditor.enterBrowse, folderEb.enterBrowse],
   )
+
+  const focusUrlbar = useCallback((subFocus: UrlBarSubFocus) => {
+    setJumpMode(false)
+    setUrlbarSubFocus(subFocus)
+    setFocus("urlbar")
+  }, [])
 
   const {
     collectionSwitcherVisible,
@@ -940,6 +947,19 @@ export function AppInner({
             mode={mode}
             jumpMode={jumpMode}
             onPaneFocus={focusPane}
+            onUrlbarFocus={focusUrlbar}
+            onRequestSelect={(id) => {
+              revealRequest(id)
+              focusPane("sidebar")
+            }}
+            onFolderSelect={(path) => {
+              revealFolder(path)
+              focusPane("sidebar")
+            }}
+            onFolderToggle={(path) => {
+              toggleFolder(path)
+              focusPane("sidebar")
+            }}
           />
         ) : mode === "collection" ? (
           <EnvironmentEditorView

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -6,7 +6,11 @@ import { EnvironmentEditorView } from "./env-editor/EnvironmentEditorView"
 import { AppOverlays } from "./AppOverlays"
 import { useCollection } from "../hooks/useCollection"
 import { useTreeNavigation } from "../hooks/useTreeNavigation"
-import { deriveRequestParentFolder, getFolderPaths } from "./tree"
+import {
+  deriveRequestParentFolder,
+  getFolderPaths,
+  updateRequestById,
+} from "./tree"
 import { useResponse } from "../hooks/useResponse"
 import type { SendCompleteResult } from "../hooks/useResponse"
 import type { Request as NoodleRequest, Method } from "../schema"
@@ -260,6 +264,18 @@ export function AppInner({
   const draft = useRequestDraft(selectedRequest)
   const draftRef = useRef(draft)
   draftRef.current = draft
+  const markRequestSaved = useCallback(
+    (request: NoodleRequest) => {
+      if (collection) {
+        updateCollection({
+          ...collection,
+          items: updateRequestById(collection.items, request.id, request),
+        })
+      }
+      draft.markSaved(request)
+    },
+    [collection, draft.markSaved, updateCollection],
+  )
 
   const availableJumpTargets = useMemo(
     () =>
@@ -326,7 +342,7 @@ export function AppInner({
     collectionDir,
     draft.draft,
     selectedRequest?.id,
-    draft.markSaved,
+    markRequestSaved,
   )
 
   const doSaveRef = useRef(doSave)

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -336,9 +336,9 @@ export function AppInner({
   const {
     saveState,
     setSaveState,
+    savingRef,
     doSave,
     clearSaveTimer,
-    savingRef,
     saveTimerRef,
   } = useSaveFile(
     collectionDir,
@@ -476,8 +476,8 @@ export function AppInner({
         folderEb.commitEdit()
       }
       if (next === "urlbar") setUrlbarSubFocus("select")
-      if (next === "request") eb.enterBrowse()
-      if (next === "folder") folderEb.enterBrowse()
+      if (mode === "collection" && next === "request") eb.enterBrowse()
+      if (mode === "collection" && next === "folder") folderEb.enterBrowse()
       if (next === "env-vars") envEditor.enterBrowse()
       setFocus(next)
     },
@@ -488,6 +488,7 @@ export function AppInner({
       focus,
       folderEb.commitEdit,
       folderEb.enterBrowse,
+      mode,
     ],
   )
 
@@ -572,7 +573,6 @@ export function AppInner({
     setTimelineDetailEntry,
   } = useOverlayState({
     previewIndex,
-    saveState,
     collectionSwitcherVisible,
     collectionSwitchPending,
     updatePhase: updateFlow.phase,
@@ -612,6 +612,7 @@ export function AppInner({
     setCollectionReloadToken,
     setFocus,
     setSaveState,
+    savingRef,
     clearSaveTimer,
     saveTimerRef,
     setSelectedId,
@@ -691,7 +692,7 @@ export function AppInner({
   const handleEnvironmentActivate = useCallback(() => {
     eb.commitEdit()
     folderEb.commitEdit()
-    envEditor.openEditor(envState.activeEnv?.name)
+    envEditor.openEditor(envState.activeEnv?.name).catch(() => {})
     setView("env-editor")
     setFocus("env-sidebar")
   }, [eb.commitEdit, envEditor, envState.activeEnv?.name, folderEb.commitEdit])
@@ -809,9 +810,7 @@ export function AppInner({
   const overlayActions = useOverlayIntercepts({
     activeOverlay,
     cancelSendRef,
-    saveState,
     setSaveState,
-    doSave,
     envDeletePending,
     envDeletePendingRef,
     setEnvDeletePending,
@@ -1064,11 +1063,11 @@ export function AppInner({
         ) : null}
         <AppOverlays
           keybinds={keybinds}
+          activeOverlay={activeOverlay}
           helpVisible={helpVisible}
           setHelpVisible={setHelpVisible}
           aboutVisible={aboutVisible}
           setAboutVisible={setAboutVisible}
-          saveState={saveState}
           envDeletePending={envDeletePending}
           undoAllPending={undoAllPending}
           initPending={initPending}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -17,7 +17,10 @@ import { useFolderEditBrowse } from "../hooks/useFolderEditBrowse"
 import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
 import { type Focus, type UrlBarSubFocus } from "./focus"
-import { buildCommandPaletteCommands } from "./commands"
+import {
+  buildCommandPaletteCommands,
+  type CommandPaletteTarget,
+} from "./commands"
 import { useTheme } from "./theme"
 import { StatusBar } from "./StatusBar"
 import { Header } from "./Header"
@@ -138,6 +141,8 @@ export function AppInner({
     null,
   )
   const folderDeletePathRef = useRef<string | null>(null)
+  const [paletteTarget, setPaletteTarget] =
+    useState<CommandPaletteTarget | null>(null)
   const [jumpMode, setJumpMode] = useState(false)
   const jumpTargetsRef = useRef<Map<string, JumpTarget>>(new Map())
   const headerFieldRef = useRef<"name" | "color">("name")
@@ -554,6 +559,9 @@ export function AppInner({
     collectionSwitchPending,
     updatePhase: updateFlow.phase,
   })
+  useEffect(() => {
+    if (!commandPaletteVisible) setPaletteTarget(null)
+  }, [commandPaletteVisible])
   const overlayActive = useKeymapSync({
     focus,
     view,
@@ -888,6 +896,7 @@ export function AppInner({
         activeIndexRef,
         savingRef,
         doSaveRef,
+        folderSaveRef,
         focusedFolderPathRef,
         focusedFolderNameRef,
         folderDeletePathRef,
@@ -918,6 +927,7 @@ export function AppInner({
         setEnvDeletePending,
         onReloadCollection,
         triggerUpdateCheck,
+        paletteTarget,
       }),
     [
       keybinds,
@@ -928,6 +938,7 @@ export function AppInner({
       onReloadCollection,
       view,
       mode,
+      paletteTarget,
       triggerUpdateCheck,
     ],
   )
@@ -1007,6 +1018,20 @@ export function AppInner({
             onFolderToggle={(path) => {
               focusPane("sidebar")
               toggleFolder(path)
+            }}
+            onRequestContextMenu={(id) => {
+              if (!isCollection) return
+              focusPane("sidebar")
+              revealRequest(id)
+              setPaletteTarget("request")
+              setCommandPaletteVisible(true)
+            }}
+            onFolderContextMenu={(path) => {
+              if (!isCollection) return
+              focusPane("sidebar")
+              revealFolder(path)
+              setPaletteTarget("folder")
+              setCommandPaletteVisible(true)
             }}
           />
         ) : mode === "collection" ? (

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -448,20 +448,38 @@ export function AppInner({
   const focusPane = useCallback(
     (next: Focus) => {
       setJumpMode(false)
+      if (next !== focus) {
+        eb.commitEdit()
+        folderEb.commitEdit()
+      }
       if (next === "urlbar") setUrlbarSubFocus("select")
       if (next === "request") eb.enterBrowse()
       if (next === "folder") folderEb.enterBrowse()
       if (next === "env-vars") envEditor.enterBrowse()
       setFocus(next)
     },
-    [eb.enterBrowse, envEditor.enterBrowse, folderEb.enterBrowse],
+    [
+      eb.commitEdit,
+      eb.enterBrowse,
+      envEditor.enterBrowse,
+      focus,
+      folderEb.commitEdit,
+      folderEb.enterBrowse,
+    ],
   )
 
-  const focusUrlbar = useCallback((subFocus: UrlBarSubFocus) => {
-    setJumpMode(false)
-    setUrlbarSubFocus(subFocus)
-    setFocus("urlbar")
-  }, [])
+  const focusUrlbar = useCallback(
+    (subFocus: UrlBarSubFocus) => {
+      setJumpMode(false)
+      if (focus !== "urlbar") {
+        eb.commitEdit()
+        folderEb.commitEdit()
+      }
+      setUrlbarSubFocus(subFocus)
+      setFocus("urlbar")
+    },
+    [eb.commitEdit, focus, folderEb.commitEdit],
+  )
 
   const {
     collectionSwitcherVisible,
@@ -949,16 +967,16 @@ export function AppInner({
             onPaneFocus={focusPane}
             onUrlbarFocus={focusUrlbar}
             onRequestSelect={(id) => {
-              revealRequest(id)
               focusPane("sidebar")
+              revealRequest(id)
             }}
             onFolderSelect={(path) => {
-              revealFolder(path)
               focusPane("sidebar")
+              revealFolder(path)
             }}
             onFolderToggle={(path) => {
-              toggleFolder(path)
               focusPane("sidebar")
+              toggleFolder(path)
             }}
           />
         ) : mode === "collection" ? (

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -778,7 +778,7 @@ export function AppInner({
   })
 
   // ── Overlay intercepts ────────────────────────────────────────────
-  useOverlayIntercepts({
+  const overlayActions = useOverlayIntercepts({
     activeOverlay,
     cancelSendRef,
     saveState,
@@ -1029,6 +1029,8 @@ export function AppInner({
           undoAllPending={undoAllPending}
           initPending={initPending}
           collectionSwitchPending={collectionSwitchPending}
+          onConfirmDialog={overlayActions.onConfirm}
+          onCancelDialog={overlayActions.onCancel}
           commandPaletteVisible={commandPaletteVisible}
           commandPaletteCommands={commandPaletteCommands}
           setCommandPaletteVisible={setCommandPaletteVisible}
@@ -1062,8 +1064,10 @@ export function AppInner({
           saveTimerRef={saveTimerRef}
           newRequestVisible={newRequestVisible}
           newRequestRef={newRequestRef}
+          newRequestActions={overlayActions.newRequest}
           importCurlVisible={importCurlVisible}
           importCurlRef={importCurlRef}
+          importCurlActions={overlayActions.importCurl}
           importCurlInitialFolder={requestParentFolder ?? ""}
           activeEnv={envState.activeEnv}
           editRequestVisible={editRequestVisible}
@@ -1071,10 +1075,13 @@ export function AppInner({
           folderPaths={folderPaths}
           editRequestInitialFolder={editRequestInitialFolder}
           editRequestRef={editRequestRef}
+          editRequestActions={overlayActions.editRequest}
           cloneRequestVisible={cloneRequestVisible}
           cloneRequestRef={cloneRequestRef}
+          cloneRequestActions={overlayActions.cloneRequest}
           newFolderVisible={newFolderVisible}
           newFolderRef={newFolderRef}
+          newFolderActions={overlayActions.newFolder}
           folderDeletePending={folderDeletePending}
           requestDeletePending={requestDeletePending}
           timelineDetailEntry={timelineDetailEntry}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -444,6 +444,18 @@ export function AppInner({
     },
   })
 
+  const focusPane = useCallback(
+    (next: Focus) => {
+      setJumpMode(false)
+      if (next === "urlbar") setUrlbarSubFocus("select")
+      if (next === "request") eb.enterBrowse()
+      if (next === "folder") folderEb.enterBrowse()
+      if (next === "env-vars") envEditor.enterBrowse()
+      setFocus(next)
+    },
+    [eb.enterBrowse, envEditor.enterBrowse, folderEb.enterBrowse],
+  )
+
   const {
     collectionSwitcherVisible,
     setCollectionSwitcherVisible,
@@ -927,6 +939,7 @@ export function AppInner({
             onQueryVisibleChange={setQueryVisible}
             mode={mode}
             jumpMode={jumpMode}
+            onPaneFocus={focusPane}
           />
         ) : mode === "collection" ? (
           <EnvironmentEditorView
@@ -935,7 +948,7 @@ export function AppInner({
             envColors={envColors}
             focus={focus}
             envHeaderRef={envHeaderRef}
-            setFocus={setFocus}
+            onPaneFocus={focusPane}
             setEnvDeletePending={setEnvDeletePending}
           />
         ) : null}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -640,6 +640,34 @@ export function AppInner({
     ],
   )
 
+  const sendCommand =
+    view === "main" && mode === "collection" && !overlayActive && !jumpMode
+      ? paneMode === "browse" && focus === "request"
+        ? "browse.send"
+        : paneMode === "edit" && focus === "request" && eb.isEditingJsonBody
+          ? "edit.json-send"
+          : paneMode === "base" && focus !== "folder"
+            ? "request.send"
+            : undefined
+      : undefined
+
+  const handleHintActivate = useCallback(
+    (command: string) => {
+      keymap.dispatchCommand(command)
+    },
+    [keymap],
+  )
+
+  const handleAboutActivate = useCallback(() => {
+    setAboutVisible(true)
+  }, [setAboutVisible])
+
+  const handleEnvironmentActivate = useCallback(() => {
+    envEditor.openEditor(envState.activeEnv?.name)
+    setView("env-editor")
+    setFocus("env-header")
+  }, [envEditor, envState.activeEnv?.name])
+
   // ── Refs for keymap/intercepts ─────────────────────────────────────
   const trySendRef = useRef(trySend)
   trySendRef.current = trySend
@@ -916,6 +944,8 @@ export function AppInner({
     >
       <Header
         headerHints={hints.header}
+        onAboutActivate={handleAboutActivate}
+        onHintActivate={handleHintActivate}
         restartVersion={restartVersion}
         updateAvailable={updateAvailable}
       />
@@ -1079,6 +1109,13 @@ export function AppInner({
         collectionMode={mode}
         overlayActive={overlayActive}
         footerHints={hints.footer}
+        sendCommand={sendCommand}
+        onEnvironmentActivate={
+          view === "main" && mode === "collection" && !overlayActive
+            ? handleEnvironmentActivate
+            : undefined
+        }
+        onHintActivate={handleHintActivate}
       />
     </box>
   )

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -266,15 +266,17 @@ export function AppInner({
   draftRef.current = draft
   const markRequestSaved = useCallback(
     (request: NoodleRequest) => {
-      if (collection) {
-        updateCollection({
-          ...collection,
-          items: updateRequestById(collection.items, request.id, request),
-        })
-      }
+      updateCollection((current) =>
+        current
+          ? {
+              ...current,
+              items: updateRequestById(current.items, request.id, request),
+            }
+          : current,
+      )
       draft.markSaved(request)
     },
-    [collection, draft.markSaved, updateCollection],
+    [draft.markSaved, updateCollection],
   )
 
   const availableJumpTargets = useMemo(

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -665,7 +665,7 @@ export function AppInner({
   const handleEnvironmentActivate = useCallback(() => {
     envEditor.openEditor(envState.activeEnv?.name)
     setView("env-editor")
-    setFocus("env-header")
+    setFocus("env-sidebar")
   }, [envEditor, envState.activeEnv?.name])
 
   // ── Refs for keymap/intercepts ─────────────────────────────────────
@@ -1023,7 +1023,9 @@ export function AppInner({
         <AppOverlays
           keybinds={keybinds}
           helpVisible={helpVisible}
+          setHelpVisible={setHelpVisible}
           aboutVisible={aboutVisible}
+          setAboutVisible={setAboutVisible}
           saveState={saveState}
           envDeletePending={envDeletePending}
           undoAllPending={undoAllPending}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -671,10 +671,12 @@ export function AppInner({
   }, [setAboutVisible])
 
   const handleEnvironmentActivate = useCallback(() => {
+    eb.commitEdit()
+    folderEb.commitEdit()
     envEditor.openEditor(envState.activeEnv?.name)
     setView("env-editor")
     setFocus("env-sidebar")
-  }, [envEditor, envState.activeEnv?.name])
+  }, [eb.commitEdit, envEditor, envState.activeEnv?.name, folderEb.commitEdit])
 
   // ── Refs for keymap/intercepts ─────────────────────────────────────
   const trySendRef = useRef(trySend)
@@ -1008,15 +1010,12 @@ export function AppInner({
             onPaneFocus={focusPane}
             onUrlbarFocus={focusUrlbar}
             onRequestSelect={(id) => {
-              focusPane("sidebar")
               revealRequest(id)
             }}
             onFolderSelect={(path) => {
-              focusPane("sidebar")
               revealFolder(path)
             }}
             onFolderToggle={(path) => {
-              focusPane("sidebar")
               toggleFolder(path)
             }}
             onRequestContextMenu={(id) => {

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -55,6 +55,8 @@ interface AppOverlaysProps {
   undoAllPending: boolean
   initPending: boolean
   collectionSwitchPending: string | null
+  onConfirmDialog: () => void
+  onCancelDialog: () => void
   commandPaletteVisible: boolean
   commandPaletteCommands: CommandItem[]
   setCommandPaletteVisible: (visible: boolean) => void
@@ -88,8 +90,10 @@ interface AppOverlaysProps {
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
   newRequestVisible: boolean
   newRequestRef: RefObject<NewRequestOverlayHandle | null>
+  newRequestActions: { confirm: () => void; cancel: () => void }
   importCurlVisible: boolean
   importCurlRef: RefObject<ImportCurlOverlayHandle | null>
+  importCurlActions: { confirm: () => void; cancel: () => void }
   importCurlInitialFolder: string
   activeEnv: Environment | null
   editRequestVisible: boolean
@@ -97,10 +101,13 @@ interface AppOverlaysProps {
   folderPaths: FolderPathOption[]
   editRequestInitialFolder: string
   editRequestRef: RefObject<NewRequestOverlayHandle | null>
+  editRequestActions: { confirm: () => void; cancel: () => void }
   cloneRequestVisible: boolean
   cloneRequestRef: RefObject<CloneRequestOverlayHandle | null>
+  cloneRequestActions: { confirm: () => void; cancel: () => void }
   newFolderVisible: boolean
   newFolderRef: RefObject<NewFolderOverlayHandle | null>
+  newFolderActions: { confirm: () => void; cancel: () => void }
   folderDeletePending: string | null
   requestDeletePending: string | null
   timelineDetailEntry: TimelineEntry | null
@@ -132,6 +139,8 @@ export function AppOverlays({
   undoAllPending,
   initPending,
   collectionSwitchPending,
+  onConfirmDialog,
+  onCancelDialog,
   commandPaletteVisible,
   commandPaletteCommands,
   setCommandPaletteVisible,
@@ -165,8 +174,10 @@ export function AppOverlays({
   saveTimerRef,
   newRequestVisible,
   newRequestRef,
+  newRequestActions,
   importCurlVisible,
   importCurlRef,
+  importCurlActions,
   importCurlInitialFolder,
   activeEnv,
   editRequestVisible,
@@ -174,10 +185,13 @@ export function AppOverlays({
   folderPaths,
   editRequestInitialFolder,
   editRequestRef,
+  editRequestActions,
   cloneRequestVisible,
   cloneRequestRef,
+  cloneRequestActions,
   newFolderVisible,
   newFolderRef,
+  newFolderActions,
   folderDeletePending,
   requestDeletePending,
   timelineDetailEntry,
@@ -197,27 +211,40 @@ export function AppOverlays({
         <ConfirmOverlay
           visible
           message={`Save changes to ${saveState.requestId}?`}
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
         />
       )}
       {envDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete environment "${envDeletePending}"?`}
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
         />
       )}
       {undoAllPending && (
-        <ConfirmOverlay visible message="Discard all unsaved changes? (y/n)" />
+        <ConfirmOverlay
+          visible
+          message="Discard all unsaved changes? (y/n)"
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
+        />
       )}
       {initPending && (
         <ConfirmOverlay
           visible
           message={`Initialize collection in ${collectionDir}? (y/n)`}
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
         />
       )}
       {collectionSwitchPending !== null && (
         <ConfirmOverlay
           visible
           message={`Switch to "${collectionSwitchPending}" and discard unsaved changes?`}
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
         />
       )}
       {commandPaletteVisible && (
@@ -297,7 +324,13 @@ export function AppOverlays({
         />
       )}
       {newRequestVisible && (
-        <NewRequestOverlay visible ref={newRequestRef} activeEnv={activeEnv} />
+        <NewRequestOverlay
+          visible
+          ref={newRequestRef}
+          activeEnv={activeEnv}
+          onConfirm={newRequestActions.confirm}
+          onClose={newRequestActions.cancel}
+        />
       )}
       {importCurlVisible && (
         <ImportCurlOverlay
@@ -305,6 +338,8 @@ export function AppOverlays({
           ref={importCurlRef}
           folderPaths={folderPaths}
           initialFolderPath={importCurlInitialFolder}
+          onConfirm={importCurlActions.confirm}
+          onClose={importCurlActions.cancel}
         />
       )}
       {editRequestVisible && (
@@ -318,6 +353,8 @@ export function AppOverlays({
           initialFolderPath={editRequestInitialFolder}
           ref={editRequestRef}
           activeEnv={activeEnv}
+          onConfirm={editRequestActions.confirm}
+          onClose={editRequestActions.cancel}
         />
       )}
       {cloneRequestVisible && (
@@ -325,17 +362,33 @@ export function AppOverlays({
           visible
           initialName={selectedRequest ? `${selectedRequest.name} - Copy` : ""}
           ref={cloneRequestRef}
+          onConfirm={cloneRequestActions.confirm}
+          onClose={cloneRequestActions.cancel}
         />
       )}
-      {newFolderVisible && <NewFolderOverlay visible ref={newFolderRef} />}
+      {newFolderVisible && (
+        <NewFolderOverlay
+          visible
+          ref={newFolderRef}
+          onConfirm={newFolderActions.confirm}
+          onClose={newFolderActions.cancel}
+        />
+      )}
       {folderDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete folder "${folderDeletePending}" and all requests inside?`}
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
         />
       )}
       {requestDeletePending !== null && (
-        <ConfirmOverlay visible message={`Delete "${requestDeletePending}"?`} />
+        <ConfirmOverlay
+          visible
+          message={`Delete "${requestDeletePending}"?`}
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
+        />
       )}
       {updateConfirm !== null && (
         <ConfirmOverlay
@@ -345,6 +398,8 @@ export function AppOverlays({
               ? "Update Noodle via Homebrew?"
               : `Update Noodle to ${updateConfirm.version}?`
           }
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
         />
       )}
       {timelineDetailEntry !== null && (

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -40,6 +40,7 @@ import type { Keybinds } from "./keybind"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
 import { initialYamlEditorState, type YamlEditorState } from "./appState"
+import type { ActiveOverlay } from "./useOverlayState"
 
 interface FolderPathOption {
   id: string
@@ -52,7 +53,7 @@ interface AppOverlaysProps {
   setHelpVisible: (visible: boolean) => void
   aboutVisible: boolean
   setAboutVisible: (visible: boolean) => void
-  saveState: SaveState
+  activeOverlay: ActiveOverlay
   envDeletePending: string | null
   undoAllPending: boolean
   initPending: boolean
@@ -138,7 +139,7 @@ export function AppOverlays({
   setHelpVisible,
   aboutVisible,
   setAboutVisible,
-  saveState,
+  activeOverlay,
   envDeletePending,
   undoAllPending,
   initPending,
@@ -219,15 +220,7 @@ export function AppOverlays({
       {aboutVisible && (
         <AboutOverlay visible onClose={() => setAboutVisible(false)} />
       )}
-      {saveState.kind === "confirming" && (
-        <ConfirmOverlay
-          visible
-          message={`Save changes to ${saveState.requestId}?`}
-          onConfirm={onConfirmDialog}
-          onCancel={onCancelDialog}
-        />
-      )}
-      {envDeletePending !== null && (
+      {activeOverlay === "env-delete" && envDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete environment "${envDeletePending}"?`}
@@ -235,7 +228,7 @@ export function AppOverlays({
           onCancel={onCancelDialog}
         />
       )}
-      {undoAllPending && (
+      {activeOverlay === "undo-all" && undoAllPending && (
         <ConfirmOverlay
           visible
           message="Discard all unsaved changes? (y/n)"
@@ -243,7 +236,7 @@ export function AppOverlays({
           onCancel={onCancelDialog}
         />
       )}
-      {initPending && (
+      {activeOverlay === "init-confirm" && initPending && (
         <ConfirmOverlay
           visible
           message={`Initialize collection in ${collectionDir}? (y/n)`}
@@ -251,14 +244,15 @@ export function AppOverlays({
           onCancel={onCancelDialog}
         />
       )}
-      {collectionSwitchPending !== null && (
-        <ConfirmOverlay
-          visible
-          message={`Switch to "${collectionSwitchPending}" and discard unsaved changes?`}
-          onConfirm={onConfirmDialog}
-          onCancel={onCancelDialog}
-        />
-      )}
+      {activeOverlay === "collection-switch-confirm" &&
+        collectionSwitchPending !== null && (
+          <ConfirmOverlay
+            visible
+            message={`Switch to "${collectionSwitchPending}" and discard unsaved changes?`}
+            onConfirm={onConfirmDialog}
+            onCancel={onCancelDialog}
+          />
+        )}
       {commandPaletteVisible && (
         <CommandPaletteOverlay
           visible
@@ -386,7 +380,7 @@ export function AppOverlays({
           onClose={newFolderActions.cancel}
         />
       )}
-      {folderDeletePending !== null && (
+      {activeOverlay === "delete-folder" && folderDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete folder "${folderDeletePending}" and all requests inside?`}
@@ -394,7 +388,7 @@ export function AppOverlays({
           onCancel={onCancelDialog}
         />
       )}
-      {requestDeletePending !== null && (
+      {activeOverlay === "request-delete" && requestDeletePending !== null && (
         <ConfirmOverlay
           visible
           message={`Delete "${requestDeletePending}"?`}
@@ -402,7 +396,7 @@ export function AppOverlays({
           onCancel={onCancelDialog}
         />
       )}
-      {updateConfirm !== null && (
+      {activeOverlay === "update-confirm" && updateConfirm !== null && (
         <ConfirmOverlay
           visible
           message={

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -49,7 +49,9 @@ interface FolderPathOption {
 interface AppOverlaysProps {
   keybinds: Keybinds
   helpVisible: boolean
+  setHelpVisible: (visible: boolean) => void
   aboutVisible: boolean
+  setAboutVisible: (visible: boolean) => void
   saveState: SaveState
   envDeletePending: string | null
   undoAllPending: boolean
@@ -133,7 +135,9 @@ interface AppOverlaysProps {
 export function AppOverlays({
   keybinds,
   helpVisible,
+  setHelpVisible,
   aboutVisible,
+  setAboutVisible,
   saveState,
   envDeletePending,
   undoAllPending,
@@ -205,8 +209,16 @@ export function AppOverlays({
 }: AppOverlaysProps) {
   return (
     <>
-      {helpVisible && <HelpOverlay visible keybinds={keybinds} />}
-      {aboutVisible && <AboutOverlay visible />}
+      {helpVisible && (
+        <HelpOverlay
+          visible
+          keybinds={keybinds}
+          onClose={() => setHelpVisible(false)}
+        />
+      )}
+      {aboutVisible && (
+        <AboutOverlay visible onClose={() => setAboutVisible(false)} />
+      )}
       {saveState.kind === "confirming" && (
         <ConfirmOverlay
           visible

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -109,6 +109,7 @@ export interface AuthEditorProps {
   onActivateRow?: (row: number) => void
   idPrefix?: string
   showInherit?: boolean
+  interactive?: boolean
 }
 
 export function AuthEditor({
@@ -126,6 +127,7 @@ export function AuthEditor({
   onActivateRow,
   idPrefix = "auth",
   showInherit = false,
+  interactive = true,
 }: AuthEditorProps) {
   const [typeSelectOpen, setTypeSelectOpen] = useState(false)
   const [placementSelectOpen, setPlacementSelectOpen] = useState(false)
@@ -170,6 +172,7 @@ export function AuthEditor({
           badge={false}
           onOpenChange={handleTypeSelectOpen}
           onActivate={() => onFocusRow?.(0)}
+          interactive={interactive}
         />
       </box>
 
@@ -254,6 +257,7 @@ export function AuthEditor({
                     badge={false}
                     onOpenChange={handlePlacementSelectOpen}
                     onActivate={() => onFocusRow?.(def.row)}
+                    interactive={interactive}
                   />
                 </box>
               ) : (

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { MouseButton } from "@opentui/core"
 import type { Auth, Environment } from "../schema"
 import type { EditState } from "./editMode"
 import { Select, type SelectItem } from "./Select"
@@ -105,6 +106,7 @@ export interface AuthEditorProps {
   onApiKeyPlacementChange: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
   onFocusRow?: (row: number) => void
+  onActivateRow?: (row: number) => void
   idPrefix?: string
   showInherit?: boolean
 }
@@ -121,6 +123,7 @@ export function AuthEditor({
   onApiKeyPlacementChange,
   onSelectOpenChange,
   onFocusRow,
+  onActivateRow,
   idPrefix = "auth",
   showInherit = false,
 }: AuthEditorProps) {
@@ -205,6 +208,15 @@ export function AuthEditor({
                 backgroundColor: isActive ? theme.backgroundElement : undefined,
                 paddingLeft: 1,
               }}
+              onMouseDown={
+                !isEditingRow && !def.isPlacement && onActivateRow
+                  ? (event) => {
+                      if (event.button !== MouseButton.LEFT) return
+                      onActivateRow(def.row)
+                      event.stopPropagation()
+                    }
+                  : undefined
+              }
             >
               {isEditingRow && !def.isPlacement ? (
                 <>

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -129,6 +129,7 @@ export function AuthEditor({
 }: AuthEditorProps) {
   const [typeSelectOpen, setTypeSelectOpen] = useState(false)
   const [placementSelectOpen, setPlacementSelectOpen] = useState(false)
+  const [hoveredField, setHoveredField] = useState<string | null>(null)
 
   const { type, fieldDefs } = getAuthRows(auth)
   const authItems = showInherit
@@ -182,6 +183,8 @@ export function AuthEditor({
           editState.cursor.field === "auth" &&
           editState.cursor.row === def.row
         const fieldValue = getFieldValue(auth, def.field)
+        const canHoverField =
+          !isEditingRow && !def.isPlacement && onActivateRow !== undefined
         const displayValue = def.isSecret
           ? maskIfSecret(fieldValue, true)
           : fieldValue
@@ -205,7 +208,10 @@ export function AuthEditor({
                 flexDirection:
                   isEditingRow && !def.isPlacement ? "row" : undefined,
                 gap: isEditingRow && !def.isPlacement ? 1 : undefined,
-                backgroundColor: isActive ? theme.backgroundElement : undefined,
+                backgroundColor:
+                  isActive || (canHoverField && hoveredField === def.field)
+                    ? theme.backgroundElement
+                    : undefined,
                 paddingLeft: 1,
               }}
               onMouseDown={
@@ -216,6 +222,12 @@ export function AuthEditor({
                       event.stopPropagation()
                     }
                   : undefined
+              }
+              onMouseOver={
+                canHoverField ? () => setHoveredField(def.field) : undefined
+              }
+              onMouseOut={
+                canHoverField ? () => setHoveredField(null) : undefined
               }
             >
               {isEditingRow && !def.isPlacement ? (

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -104,6 +104,7 @@ export interface AuthEditorProps {
   onAuthTypeChange: (t: Auth["type"]) => void
   onApiKeyPlacementChange: (placement: "header" | "query") => void
   onSelectOpenChange?: (open: boolean) => void
+  onFocusRow?: (row: number) => void
   idPrefix?: string
   showInherit?: boolean
 }
@@ -119,6 +120,7 @@ export function AuthEditor({
   onAuthTypeChange,
   onApiKeyPlacementChange,
   onSelectOpenChange,
+  onFocusRow,
   idPrefix = "auth",
   showInherit = false,
 }: AuthEditorProps) {
@@ -163,6 +165,7 @@ export function AuthEditor({
           focused={isTypeSelectorActive}
           badge={false}
           onOpenChange={handleTypeSelectOpen}
+          onActivate={() => onFocusRow?.(0)}
         />
       </box>
 
@@ -226,6 +229,7 @@ export function AuthEditor({
                     focused={isActive}
                     badge={false}
                     onOpenChange={handlePlacementSelectOpen}
+                    onActivate={() => onFocusRow?.(def.row)}
                   />
                 </box>
               ) : (

--- a/src/ui/FolderMetaTab.tsx
+++ b/src/ui/FolderMetaTab.tsx
@@ -1,5 +1,6 @@
 import type { Environment } from "../schema"
 import { MouseButton } from "@opentui/core"
+import { useState } from "react"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { LeftBar } from "./borders"
@@ -25,6 +26,7 @@ export function FolderMetaTab({
   activeEnv,
   onActivate,
 }: FolderMetaTabProps) {
+  const [hovered, setHovered] = useState(false)
   const inEdit = editState.mode === "editing"
   const cursorHere = editState.cursor.field === "meta"
   const editingRow = inEdit && cursorHere ? editState.cursor.row : -1
@@ -44,7 +46,10 @@ export function FolderMetaTab({
         style={{
           flexDirection: nameEditing ? "row" : undefined,
           gap: nameEditing ? 1 : undefined,
-          backgroundColor: nameActive ? theme.backgroundElement : undefined,
+          backgroundColor:
+            nameActive || (hovered && !nameEditing && onActivate)
+              ? theme.backgroundElement
+              : undefined,
           paddingLeft: 1,
         }}
         onMouseDown={
@@ -55,6 +60,12 @@ export function FolderMetaTab({
                 event.stopPropagation()
               }
             : undefined
+        }
+        onMouseOver={
+          !nameEditing && onActivate ? () => setHovered(true) : undefined
+        }
+        onMouseOut={
+          !nameEditing && onActivate ? () => setHovered(false) : undefined
         }
       >
         {nameEditing ? (

--- a/src/ui/FolderMetaTab.tsx
+++ b/src/ui/FolderMetaTab.tsx
@@ -1,4 +1,5 @@
 import type { Environment } from "../schema"
+import { MouseButton } from "@opentui/core"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { LeftBar } from "./borders"
@@ -12,6 +13,7 @@ export interface FolderMetaTabProps {
   browseActive: boolean
   theme: Theme
   activeEnv?: Environment | null
+  onActivate?: () => void
 }
 
 export function FolderMetaTab({
@@ -21,6 +23,7 @@ export function FolderMetaTab({
   browseActive,
   theme,
   activeEnv,
+  onActivate,
 }: FolderMetaTabProps) {
   const inEdit = editState.mode === "editing"
   const cursorHere = editState.cursor.field === "meta"
@@ -44,6 +47,15 @@ export function FolderMetaTab({
           backgroundColor: nameActive ? theme.backgroundElement : undefined,
           paddingLeft: 1,
         }}
+        onMouseDown={
+          !nameEditing && onActivate
+            ? (event) => {
+                if (event.button !== MouseButton.LEFT) return
+                onActivate()
+                event.stopPropagation()
+              }
+            : undefined
+        }
       >
         {nameEditing ? (
           <>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -32,6 +32,13 @@ interface FolderPaneProps {
   onPaneFocus?: () => void
   onTabChange?: (tab: FolderFieldKind) => void
   onAuthFocusRow?: (row: number) => void
+  onFieldActivate?: (
+    field: FolderFieldKind,
+    row: number,
+    addingRow?: boolean,
+  ) => void
+  onFieldToggle?: (field: FolderFieldKind, row: number) => void
+  onInteraction?: () => void
 }
 
 export function FolderPane({
@@ -53,6 +60,9 @@ export function FolderPane({
   onPaneFocus,
   onTabChange,
   onAuthFocusRow,
+  onFieldActivate,
+  onFieldToggle,
+  onInteraction,
 }: FolderPaneProps) {
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
@@ -127,7 +137,7 @@ export function FolderPane({
             tabs={tabs}
             activeId={activeTab}
             onChange={(tab) => {
-              if (inEdit) return
+              onInteraction?.()
               onPaneFocus?.()
               onTabChange?.(tab as FolderFieldKind)
             }}
@@ -152,6 +162,15 @@ export function FolderPane({
                   browseActive={browseActive}
                   theme={theme}
                   activeEnv={activeEnv}
+                  onActivate={
+                    onFieldActivate
+                      ? () => {
+                          onPaneFocus?.()
+                          onInteraction?.()
+                          onFieldActivate("meta", 0)
+                        }
+                      : undefined
+                  }
                 />
               )}
               {activeTab === "headers" && (
@@ -171,6 +190,24 @@ export function FolderPane({
                     setEditValue={setEditValue}
                     theme={theme}
                     activeEnv={activeEnv}
+                    onActivateRow={
+                      onFieldActivate
+                        ? (row, addingRow) => {
+                            onPaneFocus?.()
+                            onInteraction?.()
+                            onFieldActivate("headers", row, addingRow)
+                          }
+                        : undefined
+                    }
+                    onToggleRow={
+                      onFieldToggle
+                        ? (row) => {
+                            onPaneFocus?.()
+                            onInteraction?.()
+                            onFieldToggle("headers", row)
+                          }
+                        : undefined
+                    }
                   />
                 </box>
               )}
@@ -192,7 +229,20 @@ export function FolderPane({
                       onApiKeyPlacementChange ?? (() => {})
                     }
                     onSelectOpenChange={onSelectOpenChange}
-                    onFocusRow={onAuthFocusRow}
+                    onFocusRow={(row) => {
+                      onInteraction?.()
+                      onPaneFocus?.()
+                      onAuthFocusRow?.(row)
+                    }}
+                    onActivateRow={
+                      onFieldActivate
+                        ? (row) => {
+                            onPaneFocus?.()
+                            onInteraction?.()
+                            onFieldActivate("auth", row)
+                          }
+                        : undefined
+                    }
                     showInherit={false}
                   />
                 </box>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -29,6 +29,7 @@ interface FolderPaneProps {
   activeEnv: Environment | null
   theme: Theme
   jumpMode?: boolean
+  onPaneFocus?: () => void
 }
 
 export function FolderPane({
@@ -47,6 +48,7 @@ export function FolderPane({
   activeEnv,
   theme,
   jumpMode = false,
+  onPaneFocus,
 }: FolderPaneProps) {
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
@@ -113,6 +115,7 @@ export function FolderPane({
           </Badge>
         )
       }
+      onPaneFocus={onPaneFocus}
     >
       {folder ? (
         <>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -31,6 +31,7 @@ interface FolderPaneProps {
   jumpMode?: boolean
   onPaneFocus?: () => void
   onTabChange?: (tab: FolderFieldKind) => void
+  onAuthFocusRow?: (row: number) => void
 }
 
 export function FolderPane({
@@ -51,6 +52,7 @@ export function FolderPane({
   jumpMode = false,
   onPaneFocus,
   onTabChange,
+  onAuthFocusRow,
 }: FolderPaneProps) {
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
@@ -190,6 +192,7 @@ export function FolderPane({
                       onApiKeyPlacementChange ?? (() => {})
                     }
                     onSelectOpenChange={onSelectOpenChange}
+                    onFocusRow={onAuthFocusRow}
                     showInherit={false}
                   />
                 </box>

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import type { Folder, Environment, Auth } from "../schema"
-import type { EditState, FieldKind } from "./editMode"
+import type { EditState, FieldKind, FolderFieldKind } from "./editMode"
 import { Tabs } from "./Tabs"
 import { FolderMetaTab } from "./FolderMetaTab"
 import { FolderActivityTab } from "./FolderActivityTab"
@@ -30,6 +30,7 @@ interface FolderPaneProps {
   theme: Theme
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onTabChange?: (tab: FolderFieldKind) => void
 }
 
 export function FolderPane({
@@ -49,6 +50,7 @@ export function FolderPane({
   theme,
   jumpMode = false,
   onPaneFocus,
+  onTabChange,
 }: FolderPaneProps) {
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
@@ -119,7 +121,15 @@ export function FolderPane({
     >
       {folder ? (
         <>
-          <Tabs tabs={tabs} activeId={activeTab}>
+          <Tabs
+            tabs={tabs}
+            activeId={activeTab}
+            onChange={(tab) => {
+              if (inEdit) return
+              onPaneFocus?.()
+              onTabChange?.(tab as FolderFieldKind)
+            }}
+          >
             <scrollbox
               scrollY
               style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -39,6 +39,7 @@ interface FolderPaneProps {
   ) => void
   onFieldToggle?: (field: FolderFieldKind, row: number) => void
   onInteraction?: () => void
+  interactive?: boolean
 }
 
 export function FolderPane({
@@ -63,6 +64,7 @@ export function FolderPane({
   onFieldActivate,
   onFieldToggle,
   onInteraction,
+  interactive = true,
 }: FolderPaneProps) {
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
@@ -229,6 +231,7 @@ export function FolderPane({
                       onApiKeyPlacementChange ?? (() => {})
                     }
                     onSelectOpenChange={onSelectOpenChange}
+                    interactive={interactive}
                     onFocusRow={(row) => {
                       onInteraction?.()
                       onPaneFocus?.()

--- a/src/ui/FormEditor.tsx
+++ b/src/ui/FormEditor.tsx
@@ -1,4 +1,5 @@
 import type { FormEntry, Environment } from "../schema"
+import { MouseButton } from "@opentui/core"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { Checkbox } from "./Checkbox"
@@ -17,6 +18,8 @@ export interface FormEditorProps {
   browseActive: boolean
   theme: Theme
   activeEnv?: Environment | null
+  onActivateRow?: (row: number, addingRow: boolean) => void
+  onToggleRow?: (row: number) => void
 }
 
 export function FormEditor({
@@ -29,6 +32,8 @@ export function FormEditor({
   browseActive,
   theme,
   activeEnv,
+  onActivateRow,
+  onToggleRow,
 }: FormEditorProps) {
   const rows = request.formData ?? []
 
@@ -67,6 +72,15 @@ export function FormEditor({
                 ? theme.backgroundElement
                 : undefined,
           }}
+          onMouseDown={
+            onActivateRow
+              ? (event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  onActivateRow(-1, true)
+                  event.stopPropagation()
+                }
+              : undefined
+          }
         >
           <Checkbox checked={false} theme={theme} />
           <VarInput
@@ -125,8 +139,29 @@ export function FormEditor({
                   gap: 0,
                   backgroundColor: rowBg,
                 }}
+                onMouseDown={
+                  !isEditingThisRow && onActivateRow
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(i, false)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
               >
-                <Checkbox checked={entry.enabled} theme={theme} />
+                <box
+                  onMouseDown={
+                    onToggleRow
+                      ? (event) => {
+                          if (event.button !== MouseButton.LEFT) return
+                          onToggleRow(i)
+                          event.stopPropagation()
+                        }
+                      : undefined
+                  }
+                >
+                  <Checkbox checked={entry.enabled} theme={theme} />
+                </box>
                 <VarInput
                   value={isEditingThisRow ? editKey : displayKey}
                   placeholder="Key..."
@@ -176,6 +211,15 @@ export function FormEditor({
                   gap: 0,
                   backgroundColor: addRowBg,
                 }}
+                onMouseDown={
+                  onActivateRow
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(-1, true)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
               >
                 <Checkbox checked={false} theme={theme} />
                 <VarInput

--- a/src/ui/FormEditor.tsx
+++ b/src/ui/FormEditor.tsx
@@ -1,5 +1,6 @@
 import type { FormEntry, Environment } from "../schema"
 import { MouseButton } from "@opentui/core"
+import { useState } from "react"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { Checkbox } from "./Checkbox"
@@ -36,6 +37,7 @@ export function FormEditor({
   onToggleRow,
 }: FormEditorProps) {
   const rows = request.formData ?? []
+  const [hoveredRow, setHoveredRow] = useState<number | "add" | null>(null)
 
   const panelNum = parseInt(theme.backgroundPanel.slice(1), 16)
   const elemNum = parseInt(theme.backgroundElement.slice(1), 16)
@@ -70,7 +72,9 @@ export function FormEditor({
             backgroundColor:
               cursorHere && editState.cursor.addingRow
                 ? theme.backgroundElement
-                : undefined,
+                : hoveredRow === "add" && onActivateRow
+                  ? theme.backgroundElement
+                  : undefined,
           }}
           onMouseDown={
             onActivateRow
@@ -81,6 +85,8 @@ export function FormEditor({
                 }
               : undefined
           }
+          onMouseOver={onActivateRow ? () => setHoveredRow("add") : undefined}
+          onMouseOut={onActivateRow ? () => setHoveredRow(null) : undefined}
         >
           <Checkbox checked={false} theme={theme} />
           <VarInput
@@ -112,6 +118,9 @@ export function FormEditor({
               !editState.cursor.addingRow &&
               editState.cursor.row - 1 === i
             const dimmed = (inEdit && !isEditingThisRow) || !entry.enabled
+            const canHoverRow =
+              !isEditingThisRow &&
+              (onActivateRow !== undefined || onToggleRow !== undefined)
 
             const displayKey =
               entry.type === "file" ? `[F] ${entry.name}` : entry.name
@@ -124,7 +133,9 @@ export function FormEditor({
                 ? theme.text
                 : theme.textMuted
             const rowBg =
-              cursorOnThisRow || isEditingThisRow
+              cursorOnThisRow ||
+              isEditingThisRow ||
+              (canHoverRow && hoveredRow === i)
                 ? theme.backgroundElement
                 : i % 2 !== 0
                   ? stripeBg
@@ -148,6 +159,8 @@ export function FormEditor({
                       }
                     : undefined
                 }
+                onMouseOver={canHoverRow ? () => setHoveredRow(i) : undefined}
+                onMouseOut={canHoverRow ? () => setHoveredRow(null) : undefined}
               >
                 <box
                   onMouseDown={
@@ -199,9 +212,11 @@ export function FormEditor({
             const addRowBg =
               cursorHere && editState.cursor.addingRow
                 ? theme.backgroundElement
-                : rows.length % 2 !== 0
-                  ? stripeBg
-                  : undefined
+                : hoveredRow === "add" && onActivateRow
+                  ? theme.backgroundElement
+                  : rows.length % 2 !== 0
+                    ? stripeBg
+                    : undefined
 
             return (
               <box
@@ -219,6 +234,12 @@ export function FormEditor({
                         event.stopPropagation()
                       }
                     : undefined
+                }
+                onMouseOver={
+                  onActivateRow ? () => setHoveredRow("add") : undefined
+                }
+                onMouseOut={
+                  onActivateRow ? () => setHoveredRow(null) : undefined
                 }
               >
                 <Checkbox checked={false} theme={theme} />

--- a/src/ui/Frame.tsx
+++ b/src/ui/Frame.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react"
-import type { BorderCharacters } from "@opentui/core"
+import { MouseButton, type BorderCharacters } from "@opentui/core"
 
 export interface FrameProps {
   children?: ReactNode
@@ -16,6 +16,7 @@ export interface FrameProps {
   titleAlignment?: "left" | "center" | "right"
   bottomTitle?: string
   bottomTitleAlignment?: "left" | "center" | "right"
+  onPaneFocus?: () => void
 }
 
 export function Frame({
@@ -33,6 +34,7 @@ export function Frame({
   titleAlignment,
   bottomTitle,
   bottomTitleAlignment,
+  onPaneFocus,
 }: FrameProps) {
   return (
     <box
@@ -45,6 +47,13 @@ export function Frame({
       titleAlignment={titleAlignment}
       bottomTitle={bottomTitle}
       bottomTitleAlignment={bottomTitleAlignment}
+      onMouseDown={
+        onPaneFocus
+          ? (event) => {
+              if (event.button === MouseButton.LEFT) onPaneFocus()
+            }
+          : undefined
+      }
     >
       {children}
       {titleLeft ? (

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,4 +1,4 @@
-import { TextAttributes } from "@opentui/core"
+import { MouseButton, TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
 import pkg from "../../package.json" with { type: "json" }
 import { useTheme } from "./theme"
@@ -6,10 +6,14 @@ import type { HintSegment } from "./keybindingHints"
 
 export function Header({
   headerHints,
+  onAboutActivate,
+  onHintActivate,
   restartVersion,
   updateAvailable,
 }: {
   headerHints: HintSegment[]
+  onAboutActivate?: () => void
+  onHintActivate?: (command: string) => void
   restartVersion?: string | null
   updateAvailable?: string | null
 }) {
@@ -32,10 +36,17 @@ export function Header({
       }}
     >
       <box style={{ flexDirection: "row" }}>
-        <text fg={theme.primary} attributes={TextAttributes.BOLD}>
-          Noodle
-        </text>
-        {showVersion && <text fg={theme.textMuted}> v{pkg.version}</text>}
+        <box
+          style={{ flexDirection: "row" }}
+          onMouseDown={(event) => {
+            if (event.button === MouseButton.LEFT) onAboutActivate?.()
+          }}
+        >
+          <text fg={theme.primary} attributes={TextAttributes.BOLD}>
+            Noodle
+          </text>
+          {showVersion && <text fg={theme.textMuted}> v{pkg.version}</text>}
+        </box>
         {showVersion && updateAvailable != null && (
           <text fg={theme.warning}> {"✨"} Update available</text>
         )}
@@ -46,7 +57,15 @@ export function Header({
       {showHints && headerHints.length > 0 && (
         <box style={{ flexDirection: "row" }}>
           {headerHints.map((hint, i) => (
-            <box key={i} style={{ flexDirection: "row" }}>
+            <box
+              key={i}
+              style={{ flexDirection: "row" }}
+              onMouseDown={(event) => {
+                if (event.button === MouseButton.LEFT && hint.command) {
+                  onHintActivate?.(hint.command)
+                }
+              }}
+            >
               <text fg={theme.text}>{hint.key}</text>
               {showHintLabels && hint.word ? (
                 <text fg={theme.textMuted}> {hint.word}</text>

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -49,7 +49,10 @@ export function Header({
               : undefined,
           }}
           onMouseDown={(event) => {
-            if (event.button === MouseButton.LEFT) onAboutActivate?.()
+            if (event.button === MouseButton.LEFT) {
+              setHoveringAbout(false)
+              onAboutActivate?.()
+            }
           }}
           onMouseOver={
             onAboutActivate ? () => setHoveringAbout(true) : undefined
@@ -58,10 +61,18 @@ export function Header({
             onAboutActivate ? () => setHoveringAbout(false) : undefined
           }
         >
-          <text fg={theme.primary} attributes={TextAttributes.BOLD}>
+          <text
+            fg={theme.primary}
+            attributes={TextAttributes.BOLD}
+            selectable={false}
+          >
             Noodle
           </text>
-          {showVersion && <text fg={theme.textMuted}> v{pkg.version}</text>}
+          {showVersion && (
+            <text fg={theme.textMuted} selectable={false}>
+              {` v${pkg.version}`}
+            </text>
+          )}
         </box>
         {showVersion && updateAvailable != null && (
           <text fg={theme.warning}> {"✨"} Update available</text>
@@ -86,6 +97,7 @@ export function Header({
               }}
               onMouseDown={(event) => {
                 if (event.button === MouseButton.LEFT && hint.command) {
+                  setHoveredHint(null)
                   onHintActivate?.(hint.command)
                 }
               }}
@@ -100,9 +112,13 @@ export function Header({
                   : undefined
               }
             >
-              <text fg={theme.text}>{hint.key}</text>
+              <text fg={theme.text} selectable={false}>
+                {hint.key}
+              </text>
               {showHintLabels && hint.word ? (
-                <text fg={theme.textMuted}> {hint.word}</text>
+                <text fg={theme.textMuted} selectable={false}>
+                  {` ${hint.word}`}
+                </text>
               ) : null}
             </box>
           ))}

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -26,6 +26,28 @@ export function Header({
   const showVersion = termWidth >= 45
   const showHints = termWidth >= 35
   const showHintLabels = termWidth >= 60
+  const status = showVersion
+    ? updateAvailable != null
+      ? " ✨ Update available"
+      : restartVersion
+        ? " ✨ Restart to update"
+        : ""
+    : ""
+  const titleWidth = 8 + (showVersion ? ` v${pkg.version}`.length : 0)
+  const availableHintWidth = termWidth - 2 - titleWidth - status.length
+  let usedHintWidth = 0
+  const visibleHints = showHints
+    ? headerHints.filter((hint) => {
+        const width =
+          hint.key.length +
+          (showHintLabels && hint.word ? hint.word.length + 1 : 0) +
+          2 +
+          (usedHintWidth === 0 ? 0 : 1)
+        if (usedHintWidth + width > availableHintWidth) return false
+        usedHintWidth += width
+        return true
+      })
+    : []
 
   return (
     <box
@@ -74,54 +96,52 @@ export function Header({
             </text>
           )}
         </box>
-        {showVersion && updateAvailable != null && (
-          <text fg={theme.warning}> {"✨"} Update available</text>
-        )}
-        {showVersion && restartVersion && (
-          <text fg={theme.warning}> ✨ Restart to update</text>
-        )}
+        {showVersion && status && <text fg={theme.warning}>{status}</text>}
       </box>
-      {showHints && headerHints.length > 0 && (
+      {visibleHints.length > 0 && (
         <box style={{ flexDirection: "row", gap: 1 }}>
-          {headerHints.map((hint, i) => (
-            <box
-              key={i}
-              style={{
-                flexDirection: "row",
-                paddingLeft: 1,
-                paddingRight: 1,
-                backgroundColor:
-                  hint.command && onHintActivate && hoveredHint === i
-                    ? theme.backgroundElement
-                    : undefined,
-              }}
-              onMouseDown={(event) => {
-                if (event.button === MouseButton.LEFT && hint.command) {
-                  setHoveredHint(null)
-                  onHintActivate?.(hint.command)
+          {visibleHints.map((hint) => {
+            const i = headerHints.indexOf(hint)
+            return (
+              <box
+                key={i}
+                style={{
+                  flexDirection: "row",
+                  paddingLeft: 1,
+                  paddingRight: 1,
+                  backgroundColor:
+                    hint.command && onHintActivate && hoveredHint === i
+                      ? theme.backgroundElement
+                      : undefined,
+                }}
+                onMouseDown={(event) => {
+                  if (event.button === MouseButton.LEFT && hint.command) {
+                    setHoveredHint(null)
+                    onHintActivate?.(hint.command)
+                  }
+                }}
+                onMouseOver={
+                  hint.command && onHintActivate
+                    ? () => setHoveredHint(i)
+                    : undefined
                 }
-              }}
-              onMouseOver={
-                hint.command && onHintActivate
-                  ? () => setHoveredHint(i)
-                  : undefined
-              }
-              onMouseOut={
-                hint.command && onHintActivate
-                  ? () => setHoveredHint(null)
-                  : undefined
-              }
-            >
-              <text fg={theme.text} selectable={false}>
-                {hint.key}
-              </text>
-              {showHintLabels && hint.word ? (
-                <text fg={theme.textMuted} selectable={false}>
-                  {` ${hint.word}`}
+                onMouseOut={
+                  hint.command && onHintActivate
+                    ? () => setHoveredHint(null)
+                    : undefined
+                }
+              >
+                <text fg={theme.text} selectable={false}>
+                  {hint.key}
                 </text>
-              ) : null}
-            </box>
-          ))}
+                {showHintLabels && hint.word ? (
+                  <text fg={theme.textMuted} selectable={false}>
+                    {` ${hint.word}`}
+                  </text>
+                ) : null}
+              </box>
+            )
+          })}
         </box>
       )}
     </box>

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,5 +1,6 @@
 import { MouseButton, TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
+import { useState } from "react"
 import pkg from "../../package.json" with { type: "json" }
 import { useTheme } from "./theme"
 import type { HintSegment } from "./keybindingHints"
@@ -18,6 +19,8 @@ export function Header({
   updateAvailable?: string | null
 }) {
   const theme = useTheme()
+  const [hoveringAbout, setHoveringAbout] = useState(false)
+  const [hoveredHint, setHoveredHint] = useState<number | null>(null)
   const { width: termWidth = 100 } = useTerminalDimensions()
 
   const showVersion = termWidth >= 45
@@ -37,10 +40,23 @@ export function Header({
     >
       <box style={{ flexDirection: "row" }}>
         <box
-          style={{ flexDirection: "row" }}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor: hoveringAbout
+              ? theme.backgroundElement
+              : undefined,
+          }}
           onMouseDown={(event) => {
             if (event.button === MouseButton.LEFT) onAboutActivate?.()
           }}
+          onMouseOver={
+            onAboutActivate ? () => setHoveringAbout(true) : undefined
+          }
+          onMouseOut={
+            onAboutActivate ? () => setHoveringAbout(false) : undefined
+          }
         >
           <text fg={theme.primary} attributes={TextAttributes.BOLD}>
             Noodle
@@ -55,24 +71,39 @@ export function Header({
         )}
       </box>
       {showHints && headerHints.length > 0 && (
-        <box style={{ flexDirection: "row" }}>
+        <box style={{ flexDirection: "row", gap: 1 }}>
           {headerHints.map((hint, i) => (
             <box
               key={i}
-              style={{ flexDirection: "row" }}
+              style={{
+                flexDirection: "row",
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor:
+                  hint.command && onHintActivate && hoveredHint === i
+                    ? theme.backgroundElement
+                    : undefined,
+              }}
               onMouseDown={(event) => {
                 if (event.button === MouseButton.LEFT && hint.command) {
                   onHintActivate?.(hint.command)
                 }
               }}
+              onMouseOver={
+                hint.command && onHintActivate
+                  ? () => setHoveredHint(i)
+                  : undefined
+              }
+              onMouseOut={
+                hint.command && onHintActivate
+                  ? () => setHoveredHint(null)
+                  : undefined
+              }
             >
               <text fg={theme.text}>{hint.key}</text>
               {showHintLabels && hint.word ? (
                 <text fg={theme.textMuted}> {hint.word}</text>
               ) : null}
-              {i < headerHints.length - 1 && (
-                <text fg={theme.textMuted}> · </text>
-              )}
             </box>
           ))}
         </box>

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -1,5 +1,6 @@
 import type { KvEntry, Environment } from "../schema"
 import { MouseButton } from "@opentui/core"
+import { useState } from "react"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { Checkbox } from "./Checkbox"
@@ -33,6 +34,7 @@ export function KeyValueSection({
   onToggleRow,
 }: KeyValueSectionProps) {
   const rows = entries
+  const [hoveredRow, setHoveredRow] = useState<number | "add" | null>(null)
 
   const panelNum = parseInt(theme.backgroundPanel.slice(1), 16)
   const prefix = kind === "headers" ? "hdr" : kind === "params" ? "prm" : "ppr"
@@ -71,6 +73,10 @@ export function KeyValueSection({
           style={{
             flexDirection: "row",
             gap: 0,
+            backgroundColor:
+              hoveredRow === "add" && onActivateRow
+                ? theme.backgroundElement
+                : undefined,
           }}
           onMouseDown={
             onActivateRow
@@ -81,6 +87,8 @@ export function KeyValueSection({
                 }
               : undefined
           }
+          onMouseOver={onActivateRow ? () => setHoveredRow("add") : undefined}
+          onMouseOut={onActivateRow ? () => setHoveredRow(null) : undefined}
         >
           <Checkbox checked={false} theme={theme} />
           <VarInput
@@ -113,11 +121,17 @@ export function KeyValueSection({
               !editState.cursor.addingRow &&
               editState.cursor.row === i
             const dimmed = (inEdit && !isEditingThisRow) || !kv.enabled
+            const canHoverRow =
+              !isEditingThisRow &&
+              (onActivateRow !== undefined ||
+                (kind !== "pathParams" && onToggleRow !== undefined))
 
             const keyBaseColor = dimmed ? theme.textMuted : theme.primary
             const valueBaseColor = dimmed ? theme.textMuted : theme.text
             const rowBg =
-              cursorOnThisRow || isEditingThisRow
+              cursorOnThisRow ||
+              isEditingThisRow ||
+              (canHoverRow && hoveredRow === i)
                 ? theme.backgroundElement
                 : i % 2 !== 0
                   ? stripeBg
@@ -141,6 +155,8 @@ export function KeyValueSection({
                       }
                     : undefined
                 }
+                onMouseOver={canHoverRow ? () => setHoveredRow(i) : undefined}
+                onMouseOut={canHoverRow ? () => setHoveredRow(null) : undefined}
               >
                 {kind !== "pathParams" ? (
                   <box
@@ -197,9 +213,11 @@ export function KeyValueSection({
                 const addRowBg =
                   cursorHere && editState.cursor.addingRow
                     ? theme.backgroundElement
-                    : rows.length % 2 !== 0
-                      ? stripeBg
-                      : undefined
+                    : hoveredRow === "add" && onActivateRow
+                      ? theme.backgroundElement
+                      : rows.length % 2 !== 0
+                        ? stripeBg
+                        : undefined
 
                 return (
                   <box
@@ -217,6 +235,12 @@ export function KeyValueSection({
                             event.stopPropagation()
                           }
                         : undefined
+                    }
+                    onMouseOver={
+                      onActivateRow ? () => setHoveredRow("add") : undefined
+                    }
+                    onMouseOut={
+                      onActivateRow ? () => setHoveredRow(null) : undefined
                     }
                   >
                     <Checkbox checked={false} theme={theme} />

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -1,4 +1,5 @@
 import type { KvEntry, Environment } from "../schema"
+import { MouseButton } from "@opentui/core"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { Checkbox } from "./Checkbox"
@@ -14,6 +15,8 @@ export interface KeyValueSectionProps {
   setEditValue: (v: string) => void
   theme: Theme
   activeEnv?: Environment | null
+  onActivateRow?: (row: number, addingRow: boolean) => void
+  onToggleRow?: (row: number) => void
 }
 
 export function KeyValueSection({
@@ -26,6 +29,8 @@ export function KeyValueSection({
   setEditValue,
   theme,
   activeEnv,
+  onActivateRow,
+  onToggleRow,
 }: KeyValueSectionProps) {
   const rows = entries
 
@@ -67,6 +72,15 @@ export function KeyValueSection({
             flexDirection: "row",
             gap: 0,
           }}
+          onMouseDown={
+            onActivateRow
+              ? (event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  onActivateRow(-1, true)
+                  event.stopPropagation()
+                }
+              : undefined
+          }
         >
           <Checkbox checked={false} theme={theme} />
           <VarInput
@@ -118,9 +132,30 @@ export function KeyValueSection({
                   gap: 0,
                   backgroundColor: rowBg,
                 }}
+                onMouseDown={
+                  !isEditingThisRow && onActivateRow
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(i, false)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
               >
                 {kind !== "pathParams" ? (
-                  <Checkbox checked={kv.enabled} theme={theme} />
+                  <box
+                    onMouseDown={
+                      onToggleRow
+                        ? (event) => {
+                            if (event.button !== MouseButton.LEFT) return
+                            onToggleRow(i)
+                            event.stopPropagation()
+                          }
+                        : undefined
+                    }
+                  >
+                    <Checkbox checked={kv.enabled} theme={theme} />
+                  </box>
                 ) : (
                   <box style={{ width: 3 }} />
                 )}
@@ -174,6 +209,15 @@ export function KeyValueSection({
                       gap: 0,
                       backgroundColor: addRowBg,
                     }}
+                    onMouseDown={
+                      onActivateRow
+                        ? (event) => {
+                            if (event.button !== MouseButton.LEFT) return
+                            onActivateRow(-1, true)
+                            event.stopPropagation()
+                          }
+                        : undefined
+                    }
                   >
                     <Checkbox checked={false} theme={theme} />
                     <VarInput

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -230,7 +230,7 @@ export function KeyValueSection({
                       backgroundColor: addRowBg,
                     }}
                     onMouseDown={
-                      onActivateRow
+                      onActivateRow && !editingAdd
                         ? (event) => {
                             if (event.button !== MouseButton.LEFT) return
                             onActivateRow(-1, true)
@@ -239,10 +239,14 @@ export function KeyValueSection({
                         : undefined
                     }
                     onMouseOver={
-                      onActivateRow ? () => setHoveredRow("add") : undefined
+                      onActivateRow && !editingAdd
+                        ? () => setHoveredRow("add")
+                        : undefined
                     }
                     onMouseOut={
-                      onActivateRow ? () => setHoveredRow(null) : undefined
+                      onActivateRow && !editingAdd
+                        ? () => setHoveredRow(null)
+                        : undefined
                     }
                   >
                     <Checkbox checked={false} theme={theme} />
@@ -263,6 +267,7 @@ export function KeyValueSection({
                       }
                       focusedBackgroundColor={theme.borderSubtle}
                       paddingX={1}
+                      stopMousePropagation={editingAdd}
                       style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
                     />
                     <VarInput
@@ -282,6 +287,7 @@ export function KeyValueSection({
                       }
                       focusedBackgroundColor={theme.borderSubtle}
                       paddingX={1}
+                      stopMousePropagation={editingAdd}
                       style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
                     />
                   </box>

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -188,6 +188,7 @@ export function KeyValueSection({
                   }
                   focusedBackgroundColor={theme.borderSubtle}
                   paddingX={1}
+                  stopMousePropagation={isEditingThisRow}
                   style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
                 />
                 <VarInput
@@ -203,6 +204,7 @@ export function KeyValueSection({
                   }
                   focusedBackgroundColor={theme.borderSubtle}
                   paddingX={1}
+                  stopMousePropagation={isEditingThisRow}
                   style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
                 />
               </box>

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -47,6 +47,10 @@ interface MainViewProps {
   jumpMode?: boolean
   onQueryVisibleChange?: (v: boolean) => void
   onPaneFocus?: (focus: Focus) => void
+  onUrlbarFocus?: (subFocus: UrlBarSubFocus) => void
+  onRequestSelect?: (id: string) => void
+  onFolderSelect?: (path: string) => void
+  onFolderToggle?: (path: string) => void
 }
 
 export function MainView({
@@ -82,6 +86,10 @@ export function MainView({
   jumpMode = false,
   onQueryVisibleChange,
   onPaneFocus = () => {},
+  onUrlbarFocus,
+  onRequestSelect,
+  onFolderSelect,
+  onFolderToggle,
 }: MainViewProps) {
   const theme = useTheme()
 
@@ -109,6 +117,9 @@ export function MainView({
         dirtyFolderPaths={folderDraft.dirtyPaths}
         jumpMode={jumpMode}
         onPaneFocus={() => onPaneFocus("sidebar")}
+        onRequestSelect={onRequestSelect}
+        onFolderSelect={onFolderSelect}
+        onFolderToggle={onFolderToggle}
       />
       <box
         style={{
@@ -143,6 +154,7 @@ export function MainView({
             theme={theme}
             jumpMode={jumpMode}
             onPaneFocus={() => onPaneFocus("folder")}
+            onTabChange={folderEb.enterBrowseAt}
           />
         ) : (
           <RequestResponseView
@@ -167,6 +179,8 @@ export function MainView({
             jumpMode={jumpMode}
             onQueryVisibleChange={onQueryVisibleChange}
             onPaneFocus={onPaneFocus}
+            onUrlbarFocus={onUrlbarFocus}
+            onRequestTabChange={eb.enterBrowseAt}
           />
         )}
       </box>

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -169,6 +169,7 @@ export function MainView({
             onFieldToggle={
               mode === "collection" ? folderEb.toggleAt : undefined
             }
+            interactive={mode === "collection"}
           />
         ) : (
           <RequestResponseView

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -155,6 +155,7 @@ export function MainView({
             jumpMode={jumpMode}
             onPaneFocus={() => onPaneFocus("folder")}
             onTabChange={folderEb.enterBrowseAt}
+            onAuthFocusRow={(row) => folderEb.enterBrowseAt("auth", row)}
           />
         ) : (
           <RequestResponseView
@@ -181,6 +182,13 @@ export function MainView({
             onPaneFocus={onPaneFocus}
             onUrlbarFocus={onUrlbarFocus}
             onRequestTabChange={eb.enterBrowseAt}
+            onRequestBodyTypeFocus={() => eb.enterBrowseAt("body")}
+            onRequestAuthFocusRow={(row) => eb.enterBrowseAt("auth", row)}
+            onRequestJsonEditorFocus={() => {
+              if (eb.isEditingJsonBody) return
+              eb.enterBrowseAt("body")
+              eb.enterJsonBodyEditor()
+            }}
           />
         )}
       </box>

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -51,6 +51,8 @@ interface MainViewProps {
   onRequestSelect?: (id: string) => void
   onFolderSelect?: (path: string) => void
   onFolderToggle?: (path: string) => void
+  onRequestContextMenu?: (id: string) => void
+  onFolderContextMenu?: (path: string) => void
 }
 
 export function MainView({
@@ -90,6 +92,8 @@ export function MainView({
   onRequestSelect,
   onFolderSelect,
   onFolderToggle,
+  onRequestContextMenu,
+  onFolderContextMenu,
 }: MainViewProps) {
   const theme = useTheme()
 
@@ -120,6 +124,8 @@ export function MainView({
         onRequestSelect={onRequestSelect}
         onFolderSelect={onFolderSelect}
         onFolderToggle={onFolderToggle}
+        onRequestContextMenu={onRequestContextMenu}
+        onFolderContextMenu={onFolderContextMenu}
       />
       <box
         style={{

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -1,7 +1,7 @@
 import { Sidebar } from "./Sidebar"
 import { FolderPane } from "./FolderPane"
 import { useTheme } from "./theme"
-import type { CollectionItem, Environment } from "../schema"
+import type { BodyType, CollectionItem, Environment } from "../schema"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
@@ -156,6 +156,13 @@ export function MainView({
             onPaneFocus={() => onPaneFocus("folder")}
             onTabChange={folderEb.enterBrowseAt}
             onAuthFocusRow={(row) => folderEb.enterBrowseAt("auth", row)}
+            onInteraction={folderEb.commitEdit}
+            onFieldActivate={
+              mode === "collection" ? folderEb.activateAt : undefined
+            }
+            onFieldToggle={
+              mode === "collection" ? folderEb.toggleAt : undefined
+            }
           />
         ) : (
           <RequestResponseView
@@ -184,11 +191,26 @@ export function MainView({
             onRequestTabChange={eb.enterBrowseAt}
             onRequestBodyTypeFocus={() => eb.enterBrowseAt("body")}
             onRequestAuthFocusRow={(row) => eb.enterBrowseAt("auth", row)}
-            onRequestJsonEditorFocus={() => {
-              if (eb.isEditingJsonBody) return
-              eb.enterBrowseAt("body")
-              eb.enterJsonBodyEditor()
-            }}
+            onRequestInteraction={eb.commitEdit}
+            onRequestBodyEditorFocus={
+              mode === "collection"
+                ? (bodyType: BodyType) => {
+                    if (bodyType === "json") {
+                      if (eb.isEditingJsonBody) return
+                      eb.enterBrowseAt("body")
+                      eb.enterJsonBodyEditor()
+                    } else {
+                      eb.activateAt("body", 1)
+                    }
+                  }
+                : undefined
+            }
+            onRequestFieldActivate={
+              mode === "collection" ? eb.activateAt : undefined
+            }
+            onRequestFieldToggle={
+              mode === "collection" ? eb.toggleAt : undefined
+            }
           />
         )}
       </box>

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -46,6 +46,7 @@ interface MainViewProps {
   mode?: "collection" | "browse" | "empty" | "invalid"
   jumpMode?: boolean
   onQueryVisibleChange?: (v: boolean) => void
+  onPaneFocus?: (focus: Focus) => void
 }
 
 export function MainView({
@@ -80,6 +81,7 @@ export function MainView({
   mode = "collection",
   jumpMode = false,
   onQueryVisibleChange,
+  onPaneFocus = () => {},
 }: MainViewProps) {
   const theme = useTheme()
 
@@ -106,6 +108,7 @@ export function MainView({
         dirtyRequestIds={draft.dirtyRequestIds}
         dirtyFolderPaths={folderDraft.dirtyPaths}
         jumpMode={jumpMode}
+        onPaneFocus={() => onPaneFocus("sidebar")}
       />
       <box
         style={{
@@ -139,6 +142,7 @@ export function MainView({
             activeEnv={activeEnv}
             theme={theme}
             jumpMode={jumpMode}
+            onPaneFocus={() => onPaneFocus("folder")}
           />
         ) : (
           <RequestResponseView
@@ -162,6 +166,7 @@ export function MainView({
             responseBodyForCopyRef={responseBodyForCopyRef}
             jumpMode={jumpMode}
             onQueryVisibleChange={onQueryVisibleChange}
+            onPaneFocus={onPaneFocus}
           />
         )}
       </box>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -18,6 +18,7 @@ import { Badge } from "./Badge"
 import { BodyTypeSelector, BodySection } from "./request-pane/RequestBodyTab"
 import { SettingsSection } from "./request-pane/RequestSettingsTab"
 import { syncPathParamsWithUrl } from "./urlParams"
+import type { CodeEditorRenderable } from "./editor/CodeEditor"
 
 interface Props {
   request: Request | null
@@ -88,7 +89,10 @@ export function RequestPane({
   const inEdit = editState.mode === "editing"
   const browseActive = editState.mode === "browsing"
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const bodyEditorRef = useRef<CodeEditorRenderable | null>(null)
   const keymap = useKeymap()
+  const isJsonBody =
+    activeTab === "body" && (request?.bodyType ?? "json") === "json"
 
   const focusedRef = useRef(focused)
   focusedRef.current = focused
@@ -97,8 +101,13 @@ export function RequestPane({
     if (!focusedRef.current) return
     if (keymap.getData("app.overlay") !== "none") return
     if (editState.mode !== "browsing") return
-    if (key.name === "pagedown") scrollRef.current?.scrollBy(1, "viewport")
-    else if (key.name === "pageup") scrollRef.current?.scrollBy(-1, "viewport")
+    if (key.name === "pagedown") {
+      if (isJsonBody) bodyEditorRef.current?.scrollByViewport(1)
+      else scrollRef.current?.scrollBy(1, "viewport")
+    } else if (key.name === "pageup") {
+      if (isJsonBody) bodyEditorRef.current?.scrollByViewport(-1)
+      else scrollRef.current?.scrollBy(-1, "viewport")
+    }
   })
 
   useEffect(() => {
@@ -135,9 +144,6 @@ export function RequestPane({
       jumpHint: jumpMode ? REQUEST_TAB_HINT_ORDER[i] : undefined,
     }))
   }, [request, jumpMode])
-  const isJsonBody =
-    activeTab === "body" && (request?.bodyType ?? "json") === "json"
-
   return (
     <Frame
       style={{
@@ -238,6 +244,9 @@ export function RequestPane({
                     if (!inEdit) onInteraction?.()
                     onPaneFocus?.()
                     onBodyEditorFocus?.(request.bodyType ?? "json")
+                  }}
+                  onEditorRef={(editor) => {
+                    bodyEditorRef.current = editor
                   }}
                 />
               ) : (

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -37,6 +37,7 @@ interface Props {
   onSelectOpenChange?: (open: boolean) => void
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onTabChange?: (tab: FieldKind) => void
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -66,6 +67,7 @@ export function RequestPane({
   onSelectOpenChange,
   jumpMode = false,
   onPaneFocus,
+  onTabChange,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -153,7 +155,15 @@ export function RequestPane({
     >
       {request ? (
         <>
-          <Tabs tabs={tabs} activeId={activeTab}>
+          <Tabs
+            tabs={tabs}
+            activeId={activeTab}
+            onChange={(tab) => {
+              if (inEdit) return
+              onPaneFocus?.()
+              onTabChange?.(tab as FieldKind)
+            }}
+          >
             <box
               style={{
                 flexDirection: "column",

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -36,6 +36,7 @@ interface Props {
   onBodyChange?: (body: string) => void
   onSelectOpenChange?: (open: boolean) => void
   jumpMode?: boolean
+  onPaneFocus?: () => void
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -64,6 +65,7 @@ export function RequestPane({
   onBodyChange,
   onSelectOpenChange,
   jumpMode = false,
+  onPaneFocus,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -147,6 +149,7 @@ export function RequestPane({
           </Badge>
         )
       }
+      onPaneFocus={onPaneFocus}
     >
       {request ? (
         <>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -40,7 +40,10 @@ interface Props {
   onTabChange?: (tab: FieldKind) => void
   onBodyTypeFocus?: () => void
   onAuthFocusRow?: (row: number) => void
-  onJsonEditorFocus?: () => void
+  onBodyEditorFocus?: (bodyType: BodyType) => void
+  onFieldActivate?: (field: FieldKind, row: number, addingRow?: boolean) => void
+  onFieldToggle?: (field: FieldKind, row: number) => void
+  onInteraction?: () => void
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -73,7 +76,10 @@ export function RequestPane({
   onTabChange,
   onBodyTypeFocus,
   onAuthFocusRow,
-  onJsonEditorFocus,
+  onBodyEditorFocus,
+  onFieldActivate,
+  onFieldToggle,
+  onInteraction,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -165,7 +171,7 @@ export function RequestPane({
             tabs={tabs}
             activeId={activeTab}
             onChange={(tab) => {
-              if (inEdit) return
+              onInteraction?.()
               onPaneFocus?.()
               onTabChange?.(tab as FieldKind)
             }}
@@ -185,7 +191,11 @@ export function RequestPane({
                   browseActive={browseActive}
                   onBodyTypeChange={onBodyTypeChange ?? (() => {})}
                   onSelectOpenChange={onSelectOpenChange}
-                  onActivate={onBodyTypeFocus}
+                  onActivate={() => {
+                    onInteraction?.()
+                    onPaneFocus?.()
+                    onBodyTypeFocus?.()
+                  }}
                 />
               )}
               {isJsonBody ? (
@@ -201,9 +211,30 @@ export function RequestPane({
                   theme={theme}
                   activeEnv={activeEnv}
                   onBodyChange={onBodyChange ?? (() => {})}
+                  onFormRowActivate={
+                    onFieldActivate
+                      ? (row, addingRow) => {
+                          onPaneFocus?.()
+                          onFieldActivate(
+                            "body",
+                            addingRow ? -1 : row + 1,
+                            addingRow,
+                          )
+                        }
+                      : undefined
+                  }
+                  onFormRowToggle={
+                    onFieldToggle
+                      ? (row) => {
+                          onPaneFocus?.()
+                          onFieldToggle("body", row + 1)
+                        }
+                      : undefined
+                  }
                   onEditorActivate={() => {
+                    if (!inEdit) onInteraction?.()
                     onPaneFocus?.()
-                    onJsonEditorFocus?.()
+                    onBodyEditorFocus?.(request.bodyType ?? "json")
                   }}
                 />
               ) : (
@@ -225,9 +256,32 @@ export function RequestPane({
                       theme={theme}
                       activeEnv={activeEnv}
                       onBodyChange={onBodyChange ?? (() => {})}
+                      onFormRowActivate={
+                        onFieldActivate
+                          ? (row, addingRow) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldActivate(
+                                "body",
+                                addingRow ? -1 : row + 1,
+                                addingRow,
+                              )
+                            }
+                          : undefined
+                      }
+                      onFormRowToggle={
+                        onFieldToggle
+                          ? (row) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldToggle("body", row + 1)
+                            }
+                          : undefined
+                      }
                       onEditorActivate={() => {
+                        if (!inEdit) onInteraction?.()
                         onPaneFocus?.()
-                        onJsonEditorFocus?.()
+                        onBodyEditorFocus?.(request.bodyType ?? "json")
                       }}
                     />
                   )}
@@ -244,6 +298,24 @@ export function RequestPane({
                       setEditValue={setEditValue}
                       theme={theme}
                       activeEnv={activeEnv}
+                      onActivateRow={
+                        onFieldActivate
+                          ? (row, addingRow) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldActivate("headers", row, addingRow)
+                            }
+                          : undefined
+                      }
+                      onToggleRow={
+                        onFieldToggle
+                          ? (row) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldToggle("headers", row)
+                            }
+                          : undefined
+                      }
                     />
                   )}
                   {activeTab === "params" && (
@@ -260,6 +332,24 @@ export function RequestPane({
                       setEditValue={setEditValue}
                       theme={theme}
                       activeEnv={activeEnv}
+                      onActivateRow={
+                        onFieldActivate
+                          ? (row, addingRow) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldActivate("params", row, addingRow)
+                            }
+                          : undefined
+                      }
+                      onToggleRow={
+                        onFieldToggle
+                          ? (row) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldToggle("params", row)
+                            }
+                          : undefined
+                      }
                     />
                   )}
                   {activeTab === "pathParams" && (
@@ -279,6 +369,15 @@ export function RequestPane({
                       setEditValue={setEditValue}
                       theme={theme}
                       activeEnv={activeEnv}
+                      onActivateRow={
+                        onFieldActivate
+                          ? (row, addingRow) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldActivate("pathParams", row, addingRow)
+                            }
+                          : undefined
+                      }
                     />
                   )}
                   {activeTab === "auth" && (
@@ -295,7 +394,20 @@ export function RequestPane({
                         onApiKeyPlacementChange ?? (() => {})
                       }
                       onSelectOpenChange={handleSelectOpenChange}
-                      onFocusRow={onAuthFocusRow}
+                      onFocusRow={(row) => {
+                        onInteraction?.()
+                        onPaneFocus?.()
+                        onAuthFocusRow?.(row)
+                      }}
+                      onActivateRow={
+                        onFieldActivate
+                          ? (row) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldActivate("auth", row)
+                            }
+                          : undefined
+                      }
                       showInherit={true}
                     />
                   )}
@@ -308,6 +420,24 @@ export function RequestPane({
                       browseActive={browseActive}
                       theme={theme}
                       activeEnv={activeEnv}
+                      onActivateRow={
+                        onFieldActivate
+                          ? (row) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldActivate("settings", row)
+                            }
+                          : undefined
+                      }
+                      onToggleRow={
+                        onFieldToggle
+                          ? (row) => {
+                              onInteraction?.()
+                              onPaneFocus?.()
+                              onFieldToggle("settings", row)
+                            }
+                          : undefined
+                      }
                     />
                   )}
                 </scrollbox>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -38,6 +38,9 @@ interface Props {
   jumpMode?: boolean
   onPaneFocus?: () => void
   onTabChange?: (tab: FieldKind) => void
+  onBodyTypeFocus?: () => void
+  onAuthFocusRow?: (row: number) => void
+  onJsonEditorFocus?: () => void
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -68,6 +71,9 @@ export function RequestPane({
   jumpMode = false,
   onPaneFocus,
   onTabChange,
+  onBodyTypeFocus,
+  onAuthFocusRow,
+  onJsonEditorFocus,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -179,6 +185,7 @@ export function RequestPane({
                   browseActive={browseActive}
                   onBodyTypeChange={onBodyTypeChange ?? (() => {})}
                   onSelectOpenChange={onSelectOpenChange}
+                  onActivate={onBodyTypeFocus}
                 />
               )}
               {isJsonBody ? (
@@ -194,6 +201,10 @@ export function RequestPane({
                   theme={theme}
                   activeEnv={activeEnv}
                   onBodyChange={onBodyChange ?? (() => {})}
+                  onEditorActivate={() => {
+                    onPaneFocus?.()
+                    onJsonEditorFocus?.()
+                  }}
                 />
               ) : (
                 <scrollbox
@@ -214,6 +225,10 @@ export function RequestPane({
                       theme={theme}
                       activeEnv={activeEnv}
                       onBodyChange={onBodyChange ?? (() => {})}
+                      onEditorActivate={() => {
+                        onPaneFocus?.()
+                        onJsonEditorFocus?.()
+                      }}
                     />
                   )}
                   {activeTab === "headers" && (
@@ -280,6 +295,7 @@ export function RequestPane({
                         onApiKeyPlacementChange ?? (() => {})
                       }
                       onSelectOpenChange={handleSelectOpenChange}
+                      onFocusRow={onAuthFocusRow}
                       showInherit={true}
                     />
                   )}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -1,4 +1,4 @@
-import type { ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useKeymap } from "@opentui/keymap/react"
 import { useCallback, useEffect, useMemo, useRef } from "react"
@@ -244,6 +244,14 @@ export function RequestPane({
                 <scrollbox
                   ref={scrollRef}
                   scrollY
+                  onMouseDown={
+                    activeTab === "params" || activeTab === "pathParams"
+                      ? (event) => {
+                          if (event.button === MouseButton.LEFT)
+                            onInteraction?.()
+                        }
+                      : undefined
+                  }
                   style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
                 >
                   {activeTab === "body" && (

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -44,6 +44,7 @@ interface Props {
   onFieldActivate?: (field: FieldKind, row: number, addingRow?: boolean) => void
   onFieldToggle?: (field: FieldKind, row: number) => void
   onInteraction?: () => void
+  interactive?: boolean
 }
 
 const BASE_TAB_DEFS: TabDef[] = [
@@ -80,6 +81,7 @@ export function RequestPane({
   onFieldActivate,
   onFieldToggle,
   onInteraction,
+  interactive = true,
 }: Props) {
   const theme = useTheme()
   const title = "Request"
@@ -191,6 +193,7 @@ export function RequestPane({
                   browseActive={browseActive}
                   onBodyTypeChange={onBodyTypeChange ?? (() => {})}
                   onSelectOpenChange={onSelectOpenChange}
+                  interactive={interactive}
                   onActivate={() => {
                     onInteraction?.()
                     onPaneFocus?.()
@@ -394,6 +397,7 @@ export function RequestPane({
                         onApiKeyPlacementChange ?? (() => {})
                       }
                       onSelectOpenChange={handleSelectOpenChange}
+                      interactive={interactive}
                       onFocusRow={(row) => {
                         onInteraction?.()
                         onPaneFocus?.()

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -10,6 +10,7 @@ import type { ResponseTabKind } from "./tabs/uiState"
 import type { SendState } from "./sendState"
 import type { RefObject } from "react"
 import type { ResponseQueryController } from "./responseQuery"
+import type { FieldKind } from "./editMode"
 
 interface RequestResponseViewProps {
   draft: UseRequestDraftResult
@@ -33,6 +34,8 @@ interface RequestResponseViewProps {
   jumpMode?: boolean
   onQueryVisibleChange?: (v: boolean) => void
   onPaneFocus?: (focus: Focus) => void
+  onUrlbarFocus?: (subFocus: UrlBarSubFocus) => void
+  onRequestTabChange?: (tab: FieldKind) => void
 }
 
 export function RequestResponseView({
@@ -57,6 +60,8 @@ export function RequestResponseView({
   jumpMode = false,
   onQueryVisibleChange,
   onPaneFocus = () => {},
+  onUrlbarFocus,
+  onRequestTabChange,
 }: RequestResponseViewProps) {
   const content = (
     <>
@@ -79,6 +84,7 @@ export function RequestResponseView({
           onSelectOpenChange={setSelectOpen}
           jumpMode={jumpMode}
           onPaneFocus={() => onPaneFocus("request")}
+          onTabChange={onRequestTabChange}
         />
       )}
       {expanded !== "request" && (
@@ -119,6 +125,7 @@ export function RequestResponseView({
         activeEnv={activeEnv}
         jumpMode={jumpMode && draft.draft !== null && expanded !== "response"}
         onPaneFocus={() => onPaneFocus("urlbar")}
+        onSubFocus={onUrlbarFocus}
       />
       <box
         key={layout}

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -32,6 +32,7 @@ interface RequestResponseViewProps {
   responseBodyForCopyRef?: RefObject<string | null>
   jumpMode?: boolean
   onQueryVisibleChange?: (v: boolean) => void
+  onPaneFocus?: (focus: Focus) => void
 }
 
 export function RequestResponseView({
@@ -55,6 +56,7 @@ export function RequestResponseView({
   responseBodyForCopyRef,
   jumpMode = false,
   onQueryVisibleChange,
+  onPaneFocus = () => {},
 }: RequestResponseViewProps) {
   const content = (
     <>
@@ -76,6 +78,7 @@ export function RequestResponseView({
           onBodyChange={draft.setBody}
           onSelectOpenChange={setSelectOpen}
           jumpMode={jumpMode}
+          onPaneFocus={() => onPaneFocus("request")}
         />
       )}
       {expanded !== "request" && (
@@ -94,6 +97,7 @@ export function RequestResponseView({
           expanded={expanded}
           jumpMode={jumpMode && draft.draft !== null}
           onQueryVisibleChange={onQueryVisibleChange}
+          onPaneFocus={() => onPaneFocus("response")}
         />
       )}
     </>
@@ -114,6 +118,7 @@ export function RequestResponseView({
         subFocus={urlbarSubFocus}
         activeEnv={activeEnv}
         jumpMode={jumpMode && draft.draft !== null && expanded !== "response"}
+        onPaneFocus={() => onPaneFocus("urlbar")}
       />
       <box
         key={layout}

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -107,6 +107,7 @@ export function RequestResponseView({
           onFieldActivate={onRequestFieldActivate}
           onFieldToggle={onRequestFieldToggle}
           onInteraction={onRequestInteraction}
+          interactive={urlbarInteractive}
         />
       )}
       {expanded !== "request" && (

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -1,7 +1,7 @@
 import { UrlBar } from "./UrlBar"
 import { RequestPane } from "./RequestPane"
 import { ResponsePane } from "./ResponsePane"
-import type { Environment, TimelineEntry } from "../schema"
+import type { BodyType, Environment, TimelineEntry } from "../schema"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseEditBrowseResult } from "../hooks/useEditBrowse"
 import type { Focus } from "./focus"
@@ -38,7 +38,14 @@ interface RequestResponseViewProps {
   onRequestTabChange?: (tab: FieldKind) => void
   onRequestBodyTypeFocus?: () => void
   onRequestAuthFocusRow?: (row: number) => void
-  onRequestJsonEditorFocus?: () => void
+  onRequestBodyEditorFocus?: (bodyType: BodyType) => void
+  onRequestFieldActivate?: (
+    field: FieldKind,
+    row: number,
+    addingRow?: boolean,
+  ) => void
+  onRequestFieldToggle?: (field: FieldKind, row: number) => void
+  onRequestInteraction?: () => void
 }
 
 export function RequestResponseView({
@@ -67,7 +74,10 @@ export function RequestResponseView({
   onRequestTabChange,
   onRequestBodyTypeFocus,
   onRequestAuthFocusRow,
-  onRequestJsonEditorFocus,
+  onRequestBodyEditorFocus,
+  onRequestFieldActivate,
+  onRequestFieldToggle,
+  onRequestInteraction,
 }: RequestResponseViewProps) {
   const content = (
     <>
@@ -93,7 +103,10 @@ export function RequestResponseView({
           onTabChange={onRequestTabChange}
           onBodyTypeFocus={onRequestBodyTypeFocus}
           onAuthFocusRow={onRequestAuthFocusRow}
-          onJsonEditorFocus={onRequestJsonEditorFocus}
+          onBodyEditorFocus={onRequestBodyEditorFocus}
+          onFieldActivate={onRequestFieldActivate}
+          onFieldToggle={onRequestFieldToggle}
+          onInteraction={onRequestInteraction}
         />
       )}
       {expanded !== "request" && (

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -36,6 +36,9 @@ interface RequestResponseViewProps {
   onPaneFocus?: (focus: Focus) => void
   onUrlbarFocus?: (subFocus: UrlBarSubFocus) => void
   onRequestTabChange?: (tab: FieldKind) => void
+  onRequestBodyTypeFocus?: () => void
+  onRequestAuthFocusRow?: (row: number) => void
+  onRequestJsonEditorFocus?: () => void
 }
 
 export function RequestResponseView({
@@ -62,6 +65,9 @@ export function RequestResponseView({
   onPaneFocus = () => {},
   onUrlbarFocus,
   onRequestTabChange,
+  onRequestBodyTypeFocus,
+  onRequestAuthFocusRow,
+  onRequestJsonEditorFocus,
 }: RequestResponseViewProps) {
   const content = (
     <>
@@ -85,6 +91,9 @@ export function RequestResponseView({
           jumpMode={jumpMode}
           onPaneFocus={() => onPaneFocus("request")}
           onTabChange={onRequestTabChange}
+          onBodyTypeFocus={onRequestBodyTypeFocus}
+          onAuthFocusRow={onRequestAuthFocusRow}
+          onJsonEditorFocus={onRequestJsonEditorFocus}
         />
       )}
       {expanded !== "request" && (

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useKeyboard } from "@opentui/react"
 import { useKeymap } from "@opentui/keymap/react"
-import type { InputRenderable, ScrollBoxRenderable } from "@opentui/core"
+import {
+  MouseButton,
+  type InputRenderable,
+  type ScrollBoxRenderable,
+} from "@opentui/core"
 import type { RefObject } from "react"
 import type { SendState } from "./sendState"
 import type { NetworkError, TimelineEntry } from "../schema"
@@ -397,6 +401,7 @@ export function ResponsePane({
               entries={timelineEntries ?? []}
               focused={focused}
               onOpenEntry={onOpenTimelineEntry}
+              onPaneFocus={onPaneFocus}
               layout={layout}
               expanded={expanded}
             />
@@ -460,7 +465,18 @@ export function ResponsePane({
                       <text
                         fg={theme.warning}
                       >{`Body is ${formatSize(bodySize)}. It was not rendered automatically.`}</text>
-                      <text fg={theme.textMuted}>v view raw · ctrl+b copy</text>
+                      <box
+                        onMouseDown={(event) => {
+                          if (event.button !== MouseButton.LEFT) return
+                          onPaneFocus?.()
+                          setShowLargeBody(true)
+                          event.stopPropagation()
+                        }}
+                      >
+                        <text fg={theme.textMuted}>
+                          v view raw · ctrl+b copy
+                        </text>
+                      </box>
                     </box>
                   ) : displayedBody === "" ? (
                     <text fg={theme.textMuted}>(no body)</text>

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -359,7 +359,14 @@ export function ResponsePane({
       onPaneFocus={onPaneFocus}
     >
       <box style={{ flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
-        <Tabs tabs={tabs} activeId={activeTab}>
+        <Tabs
+          tabs={tabs}
+          activeId={activeTab}
+          onChange={(tab) => {
+            onPaneFocus?.()
+            setActiveTab(tab as ResponseTabKind)
+          }}
+        >
           {activeTab === "network" ? (
             <NetworkTab
               events={networkEvents}

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -93,6 +93,7 @@ export function ResponsePane({
   const [spinnerIdx, setSpinnerIdx] = useState(0)
   const [queryVisible, setQueryVisible] = useState(false)
   const [query, setQuery] = useState("")
+  const [hoveringRawBody, setHoveringRawBody] = useState(false)
   const [settledQuery, setSettledQuery] = useState("")
   const [showLargeBody, setShowLargeBody] = useState(false)
   const [highlightPriority, setHighlightPriority] = useState<"start" | "end">(
@@ -471,6 +472,13 @@ export function ResponsePane({
                           onPaneFocus?.()
                           setShowLargeBody(true)
                           event.stopPropagation()
+                        }}
+                        onMouseOver={() => setHoveringRawBody(true)}
+                        onMouseOut={() => setHoveringRawBody(false)}
+                        style={{
+                          backgroundColor: hoveringRawBody
+                            ? theme.backgroundElement
+                            : undefined,
                         }}
                       >
                         <text fg={theme.textMuted}>

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -49,6 +49,7 @@ export function ResponsePane({
   expanded,
   jumpMode = false,
   onQueryVisibleChange,
+  onPaneFocus,
 }: {
   state: SendState
   focused?: boolean
@@ -63,6 +64,7 @@ export function ResponsePane({
   expanded?: "request" | "response" | null
   jumpMode?: boolean
   onQueryVisibleChange?: (v: boolean) => void
+  onPaneFocus?: () => void
 }) {
   const theme = useTheme()
   const keymap = useKeymap()
@@ -354,6 +356,7 @@ export function ResponsePane({
       customBorderChars={FullBorder.customBorderChars}
       borderColor={borderColor}
       titleRight={headerRight}
+      onPaneFocus={onPaneFocus}
     >
       <box style={{ flexDirection: "column", flexGrow: 1, minHeight: 0 }}>
         <Tabs tabs={tabs} activeId={activeTab}>

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -34,6 +34,7 @@ export interface SelectProps {
   badge?: boolean
   onOpenChange?: (open: boolean) => void
   onActivate?: () => void
+  interactive?: boolean
   triggerPriority?: number
 }
 
@@ -50,6 +51,7 @@ export function Select({
   badge = false,
   onOpenChange,
   onActivate,
+  interactive = true,
   triggerPriority = 50,
 }: SelectProps) {
   const theme = useTheme()
@@ -70,8 +72,8 @@ export function Select({
   const safeInitialIndex = currentIndex >= 0 ? currentIndex : 0
 
   useEffect(() => {
-    if (!focused && open) setOpen(false)
-  }, [focused, open])
+    if ((!focused || !interactive) && open) setOpen(false)
+  }, [focused, interactive, open])
 
   useEffect(() => {
     onOpenChange?.(open)
@@ -92,7 +94,7 @@ export function Select({
   }, [highlightIndex, open, items])
 
   useEffect(() => {
-    if (open || !focused) return
+    if (open || !focused || !interactive) return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -106,7 +108,7 @@ export function Select({
       { priority: triggerPriority },
     )
     return dispose
-  }, [open, focused, keymap, triggerPriority])
+  }, [open, focused, interactive, keymap, triggerPriority])
 
   useEffect(() => {
     if (!open) return
@@ -241,13 +243,17 @@ export function Select({
         <box
           ref={triggerRef}
           height={1}
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onActivate?.()
-            setOpen((wasOpen) => !wasOpen)
-          }}
-          onMouseOver={() => setHovered(true)}
-          onMouseOut={() => setHovered(false)}
+          onMouseDown={
+            interactive
+              ? (event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  onActivate?.()
+                  setOpen((wasOpen) => !wasOpen)
+                }
+              : undefined
+          }
+          onMouseOver={interactive ? () => setHovered(true) : undefined}
+          onMouseOut={interactive ? () => setHovered(false) : undefined}
           style={{
             flexDirection: "row",
             justifyContent: "space-between",

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -60,6 +60,7 @@ export function Select({
   const [open, setOpen] = useState(false)
   const [uid] = useState(() => `s-${nextSelectId++}-`)
   const [highlightIndex, setHighlightIndex] = useState(0)
+  const [hovered, setHovered] = useState(false)
   const contrastColor = useMemo(() => contrastOnPrimary(theme), [theme])
 
   const currentIndex = useMemo(
@@ -173,7 +174,7 @@ export function Select({
       : selectedBadgeBg
     : open
       ? theme.primary
-      : visualFocused
+      : visualFocused || hovered
         ? theme.borderSubtle
         : theme.backgroundElement
 
@@ -245,6 +246,8 @@ export function Select({
             onActivate?.()
             setOpen(true)
           }}
+          onMouseOver={() => setHovered(true)}
+          onMouseOut={() => setHovered(false)}
           style={{
             flexDirection: "row",
             justifyContent: "space-between",
@@ -310,6 +313,9 @@ export function Select({
                           event.preventDefault()
                           event.stopPropagation()
                         }}
+                        onMouseOver={
+                          item.disabled ? undefined : () => setHighlightIndex(i)
+                        }
                         style={{
                           flexDirection: "row",
                           gap: 1,

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -244,7 +244,7 @@ export function Select({
           onMouseDown={(event) => {
             if (event.button !== MouseButton.LEFT) return
             onActivate?.()
-            setOpen(true)
+            setOpen((wasOpen) => !wasOpen)
           }}
           onMouseOver={() => setHovered(true)}
           onMouseOut={() => setHovered(false)}
@@ -359,20 +359,38 @@ export function Select({
                     dropdownWidth
                   : triggerRef.current.x
               return createPortal(
-                <box
-                  style={{
-                    position: "absolute",
-                    top: triggerRef.current.y + 1,
-                    left: x,
-                    width: dropdownWidth,
-                    zIndex: 10000,
-                    backgroundColor: theme.background,
-                    borderStyle: "single",
-                    borderColor: theme.primary,
-                  }}
-                >
-                  {renderList(scrollRef)}
-                </box>,
+                <>
+                  <box
+                    onMouseDown={(event) => {
+                      if (event.button !== MouseButton.LEFT) return
+                      setOpen(false)
+                      event.preventDefault()
+                      event.stopPropagation()
+                    }}
+                    style={{
+                      position: "absolute",
+                      left: 0,
+                      top: 0,
+                      width: "100%",
+                      height: "100%",
+                      zIndex: 10001,
+                    }}
+                  />
+                  <box
+                    style={{
+                      position: "absolute",
+                      top: triggerRef.current.y + 1,
+                      left: x,
+                      width: dropdownWidth,
+                      zIndex: 10002,
+                      backgroundColor: theme.background,
+                      borderStyle: "single",
+                      borderColor: theme.primary,
+                    }}
+                  >
+                    {renderList(scrollRef)}
+                  </box>
+                </>,
                 root,
                 null,
               )

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, isValidElement } from "react"
 import type { ReactNode } from "react"
 import {
+  MouseButton,
   TextAttributes,
   type ScrollBoxRenderable,
   type BoxRenderable,
@@ -237,6 +238,9 @@ export function Select({
         <box
           ref={triggerRef}
           height={1}
+          onMouseDown={(event) => {
+            if (event.button === MouseButton.LEFT) setOpen(true)
+          }}
           style={{
             flexDirection: "row",
             justifyContent: "space-between",
@@ -291,6 +295,17 @@ export function Select({
                         key={item.id}
                         id={`${uid}${item.id}`}
                         opacity={item.disabled ? 0.4 : 1}
+                        onMouseDown={(event) => {
+                          if (
+                            event.button !== MouseButton.LEFT ||
+                            item.disabled
+                          )
+                            return
+                          onChange?.(item.id)
+                          setOpen(false)
+                          event.preventDefault()
+                          event.stopPropagation()
+                        }}
                         style={{
                           flexDirection: "row",
                           gap: 1,

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -33,6 +33,7 @@ export interface SelectProps {
   dropdownAlign?: "left" | "right"
   badge?: boolean
   onOpenChange?: (open: boolean) => void
+  onActivate?: () => void
   triggerPriority?: number
 }
 
@@ -48,6 +49,7 @@ export function Select({
   dropdownAlign = "left",
   badge = false,
   onOpenChange,
+  onActivate,
   triggerPriority = 50,
 }: SelectProps) {
   const theme = useTheme()
@@ -239,7 +241,9 @@ export function Select({
           ref={triggerRef}
           height={1}
           onMouseDown={(event) => {
-            if (event.button === MouseButton.LEFT) setOpen(true)
+            if (event.button !== MouseButton.LEFT) return
+            onActivate?.()
+            setOpen(true)
           }}
           style={{
             flexDirection: "row",

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, ScrollBoxRenderable } from "@opentui/core"
 import { useEffect, useRef } from "react"
 import type { CollectionItem, Method } from "../schema"
 import { methodColor } from "./formatRequest"
@@ -37,6 +37,9 @@ export function Sidebar({
   dirtyFolderPaths,
   jumpMode = false,
   onPaneFocus,
+  onRequestSelect,
+  onFolderSelect,
+  onFolderToggle,
 }: {
   items: CollectionItem[]
   loading: boolean
@@ -51,6 +54,9 @@ export function Sidebar({
   dirtyFolderPaths?: Set<string>
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onRequestSelect?: (id: string) => void
+  onFolderSelect?: (path: string) => void
+  onFolderToggle?: (path: string) => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -195,9 +201,24 @@ export function Sidebar({
                   border={[...LeftBar.border]}
                   customBorderChars={LeftBar.customBorderChars}
                   borderColor={isCursor ? theme.primary : theme.backgroundPanel}
+                  onMouseDown={(event) => {
+                    if (event.button !== MouseButton.LEFT) return
+                    onFolderSelect?.(node.id)
+                    onPaneFocus?.()
+                    event.stopPropagation()
+                  }}
                 >
                   <box style={{ flexDirection: "row" }}>
-                    <text fg={theme.textMuted}>{chevron} </text>
+                    <box
+                      onMouseDown={(event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onFolderToggle?.(node.id)
+                        onPaneFocus?.()
+                        event.stopPropagation()
+                      }}
+                    >
+                      <text fg={theme.textMuted}>{chevron} </text>
+                    </box>
                     <text fg={theme.textMuted} wrapMode="none">
                       {truncName(node.name, 20)}
                     </text>
@@ -222,6 +243,12 @@ export function Sidebar({
                 border={[...LeftBar.border]}
                 customBorderChars={LeftBar.customBorderChars}
                 borderColor={isCursor ? theme.primary : theme.backgroundPanel}
+                onMouseDown={(event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  onRequestSelect?.(node.id)
+                  onPaneFocus?.()
+                  event.stopPropagation()
+                }}
               >
                 <box style={{ flexDirection: "row" }}>
                   <text

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -40,6 +40,8 @@ export function Sidebar({
   onRequestSelect,
   onFolderSelect,
   onFolderToggle,
+  onRequestContextMenu,
+  onFolderContextMenu,
 }: {
   items: CollectionItem[]
   loading: boolean
@@ -57,6 +59,8 @@ export function Sidebar({
   onRequestSelect?: (id: string) => void
   onFolderSelect?: (path: string) => void
   onFolderToggle?: (path: string) => void
+  onRequestContextMenu?: (id: string) => void
+  onFolderContextMenu?: (path: string) => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -210,9 +214,14 @@ export function Sidebar({
                   customBorderChars={LeftBar.customBorderChars}
                   borderColor={isCursor ? theme.primary : theme.backgroundPanel}
                   onMouseDown={(event) => {
-                    if (event.button !== MouseButton.LEFT) return
-                    onFolderSelect?.(node.id)
-                    onPaneFocus?.()
+                    if (event.button === MouseButton.RIGHT) {
+                      onFolderContextMenu?.(node.id)
+                    } else if (event.button === MouseButton.LEFT) {
+                      onFolderSelect?.(node.id)
+                      onPaneFocus?.()
+                    } else {
+                      return
+                    }
                     event.stopPropagation()
                   }}
                   onMouseOver={
@@ -275,9 +284,14 @@ export function Sidebar({
                 customBorderChars={LeftBar.customBorderChars}
                 borderColor={isCursor ? theme.primary : theme.backgroundPanel}
                 onMouseDown={(event) => {
-                  if (event.button !== MouseButton.LEFT) return
-                  onRequestSelect?.(node.id)
-                  onPaneFocus?.()
+                  if (event.button === MouseButton.RIGHT) {
+                    onRequestContextMenu?.(node.id)
+                  } else if (event.button === MouseButton.LEFT) {
+                    onRequestSelect?.(node.id)
+                    onPaneFocus?.()
+                  } else {
+                    return
+                  }
                   event.stopPropagation()
                 }}
                 onMouseOver={

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -36,6 +36,7 @@ export function Sidebar({
   dirtyRequestIds,
   dirtyFolderPaths,
   jumpMode = false,
+  onPaneFocus,
 }: {
   items: CollectionItem[]
   loading: boolean
@@ -49,6 +50,7 @@ export function Sidebar({
   dirtyRequestIds?: Set<string>
   dirtyFolderPaths?: Set<string>
   jumpMode?: boolean
+  onPaneFocus?: () => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -88,6 +90,7 @@ export function Sidebar({
           </Badge>
         )
       }
+      onPaneFocus={onPaneFocus}
     >
       {jumpMode && <JumpBadge letter="s" style={JUMP_BADGE_TOP_INDENT} />}
       {loading ? (

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { MouseButton, ScrollBoxRenderable } from "@opentui/core"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import type { CollectionItem, Method } from "../schema"
 import { methodColor } from "./formatRequest"
 import { useTheme } from "./theme"
@@ -60,6 +60,8 @@ export function Sidebar({
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null)
+  const [hoveredToggle, setHoveredToggle] = useState<string | null>(null)
 
   useEffect(() => {
     if (cursorIndex >= 0 && visibleItems.length > 0) {
@@ -183,6 +185,11 @@ export function Sidebar({
         >
           {visibleItems.map((node, i) => {
             const isCursor = i === cursorIndex
+            const canSelectItem =
+              node.type === "folder"
+                ? onFolderSelect !== undefined
+                : onRequestSelect !== undefined
+            const isHovered = canSelectItem && hoveredItem === node.id
             if (node.type === "folder") {
               const chevron = node.expanded ? "\u25BE" : "\u25B8"
               const isFolderDirty = dirtyFolderPaths?.has(node.id)
@@ -194,9 +201,10 @@ export function Sidebar({
                     flexDirection: "row",
                     justifyContent: "space-between",
                     paddingLeft: node.depth * 2,
-                    backgroundColor: isCursor
-                      ? theme.backgroundElement
-                      : undefined,
+                    backgroundColor:
+                      isCursor || isHovered
+                        ? theme.backgroundElement
+                        : undefined,
                   }}
                   border={[...LeftBar.border]}
                   customBorderChars={LeftBar.customBorderChars}
@@ -207,6 +215,12 @@ export function Sidebar({
                     onPaneFocus?.()
                     event.stopPropagation()
                   }}
+                  onMouseOver={
+                    onFolderSelect ? () => setHoveredItem(node.id) : undefined
+                  }
+                  onMouseOut={
+                    onFolderSelect ? () => setHoveredItem(null) : undefined
+                  }
                 >
                   <box style={{ flexDirection: "row" }}>
                     <box
@@ -216,8 +230,26 @@ export function Sidebar({
                         onPaneFocus?.()
                         event.stopPropagation()
                       }}
+                      onMouseOver={
+                        onFolderToggle
+                          ? () => setHoveredToggle(node.id)
+                          : undefined
+                      }
+                      onMouseOut={
+                        onFolderToggle
+                          ? () => setHoveredToggle(null)
+                          : undefined
+                      }
                     >
-                      <text fg={theme.textMuted}>{chevron} </text>
+                      <text
+                        fg={
+                          hoveredToggle === node.id
+                            ? theme.primary
+                            : theme.textMuted
+                        }
+                      >
+                        {chevron}{" "}
+                      </text>
                     </box>
                     <text fg={theme.textMuted} wrapMode="none">
                       {truncName(node.name, 20)}
@@ -236,9 +268,8 @@ export function Sidebar({
                   flexDirection: "row",
                   justifyContent: "space-between",
                   paddingLeft: (node.depth + 1) * 2,
-                  backgroundColor: isCursor
-                    ? theme.backgroundElement
-                    : undefined,
+                  backgroundColor:
+                    isCursor || isHovered ? theme.backgroundElement : undefined,
                 }}
                 border={[...LeftBar.border]}
                 customBorderChars={LeftBar.customBorderChars}
@@ -249,6 +280,12 @@ export function Sidebar({
                   onPaneFocus?.()
                   event.stopPropagation()
                 }}
+                onMouseOver={
+                  onRequestSelect ? () => setHoveredItem(node.id) : undefined
+                }
+                onMouseOut={
+                  onRequestSelect ? () => setHoveredItem(null) : undefined
+                }
               >
                 <box style={{ flexDirection: "row" }}>
                   <text

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { MouseButton } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
 import { useTheme } from "./theme"
 import type { Keybinds } from "./keybind"
@@ -14,11 +15,8 @@ export interface StatusBarSections {
   right: string
 }
 
-function fitSegments(
-  segments: Array<{ key: string; word: string }>,
-  maxChars: number,
-): Array<{ key: string; word: string }> {
-  const visible: Array<{ key: string; word: string }> = []
+function fitSegments(segments: HintSegment[], maxChars: number): HintSegment[] {
+  const visible: HintSegment[] = []
   let usedChars = 0
 
   for (const seg of segments) {
@@ -141,6 +139,9 @@ export function StatusBar(input: {
   collectionMode?: CollectionMode
   overlayActive?: boolean
   footerHints: HintSegment[]
+  sendCommand?: string
+  onEnvironmentActivate?: () => void
+  onHintActivate?: (command: string) => void
 }) {
   const theme = useTheme()
 
@@ -167,7 +168,7 @@ export function StatusBar(input: {
 
   const isEnvEditor = view === "env-editor"
 
-  const jumpSegments = [
+  const jumpSegments: HintSegment[] = [
     { key: "Type key", word: "to jump" },
     { key: "Esc", word: "dismiss" },
   ]
@@ -178,8 +179,15 @@ export function StatusBar(input: {
     view === "main" &&
     collectionMode === "collection" &&
     !overlayActive &&
-    !jumpMode
-      ? [{ key: displayKey(input.kb.request_send), word: "send" }]
+    !jumpMode &&
+    input.sendCommand
+      ? [
+          {
+            key: displayKey(input.kb.request_send),
+            word: "send",
+            command: input.sendCommand,
+          },
+        ]
       : []
 
   let sendWidth = 0
@@ -211,7 +219,14 @@ export function StatusBar(input: {
         paddingRight: 1,
       }}
     >
-      <box style={{ flexDirection: "row" }}>
+      <box
+        style={{ flexDirection: "row" }}
+        onMouseDown={(event) => {
+          if (event.button === MouseButton.LEFT && !isEnvEditor) {
+            input.onEnvironmentActivate?.()
+          }
+        }}
+      >
         {isEnvEditor ? (
           <Badge bg={theme.backgroundElement} fg={theme.info}>
             {input.envStats || "Env Editor"}
@@ -222,7 +237,15 @@ export function StatusBar(input: {
       </box>
       <box style={{ flexDirection: "row", alignItems: "center" }}>
         {allSegments.map((seg, i) => (
-          <box key={i} style={{ flexDirection: "row" }}>
+          <box
+            key={i}
+            style={{ flexDirection: "row" }}
+            onMouseDown={(event) => {
+              if (event.button === MouseButton.LEFT && seg.command) {
+                input.onHintActivate?.(seg.command)
+              }
+            }}
+          >
             <text fg={theme.text}>{seg.key}</text>
             {seg.word ? <text fg={theme.textMuted}> {seg.word}</text> : null}
             {i < allSegments.length - 1 && (

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -249,6 +249,7 @@ export function StatusBar(input: {
         }}
         onMouseDown={(event) => {
           if (event.button === MouseButton.LEFT && !isEnvEditor) {
+            setHoveringEnvironment(false)
             input.onEnvironmentActivate?.()
           }
         }}
@@ -264,9 +265,13 @@ export function StatusBar(input: {
         }
       >
         {isEnvEditor ? (
-          <text fg={theme.info}>{input.envStats || "Env Editor"}</text>
+          <text fg={theme.info} selectable={false}>
+            {input.envStats || "Env Editor"}
+          </text>
         ) : (
-          <text fg={envFg}>{envText}</text>
+          <text fg={envFg} selectable={false}>
+            {envText}
+          </text>
         )}
       </box>
       <box
@@ -290,6 +295,7 @@ export function StatusBar(input: {
             }}
             onMouseDown={(event) => {
               if (event.button === MouseButton.LEFT && seg.command) {
+                setHoveredSegment(null)
                 input.onHintActivate?.(seg.command)
               }
             }}
@@ -304,8 +310,14 @@ export function StatusBar(input: {
                 : undefined
             }
           >
-            <text fg={theme.text}>{seg.key}</text>
-            {seg.word ? <text fg={theme.textMuted}> {seg.word}</text> : null}
+            <text fg={theme.text} selectable={false}>
+              {seg.key}
+            </text>
+            {seg.word ? (
+              <text fg={theme.textMuted} selectable={false}>
+                {` ${seg.word}`}
+              </text>
+            ) : null}
           </box>
         ))}
       </box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { MouseButton } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
+import { useState } from "react"
 import { useTheme } from "./theme"
 import type { Keybinds } from "./keybind"
 import { displayKey } from "./keybind"
@@ -9,13 +10,20 @@ import { Badge } from "./Badge"
 import type { HintSegment } from "./keybindingHints"
 import type { CollectionMode } from "../app/main"
 
+const HINT_HORIZONTAL_PADDING = 2
+const HINT_ITEM_GAP = 1
+
 export interface StatusBarSections {
   left: string
   center: string
   right: string
 }
 
-function fitSegments(segments: HintSegment[], maxChars: number): HintSegment[] {
+function fitSegments(
+  segments: HintSegment[],
+  maxChars: number,
+  trailingGap = 0,
+): HintSegment[] {
   const visible: HintSegment[] = []
   let usedChars = 0
 
@@ -23,7 +31,8 @@ function fitSegments(segments: HintSegment[], maxChars: number): HintSegment[] {
     const segLen =
       seg.key.length +
       (seg.word ? 1 + seg.word.length : 0) +
-      (visible.length > 0 ? 3 : 0)
+      HINT_HORIZONTAL_PADDING +
+      (visible.length > 0 ? HINT_ITEM_GAP : trailingGap)
     if (usedChars + segLen > maxChars) break
     visible.push(seg)
     usedChars += segLen
@@ -144,6 +153,8 @@ export function StatusBar(input: {
   onHintActivate?: (command: string) => void
 }) {
   const theme = useTheme()
+  const [hoveringEnvironment, setHoveringEnvironment] = useState(false)
+  const [hoveredSegment, setHoveredSegment] = useState<number | null>(null)
 
   const view = input.view ?? "main"
   const jumpMode = input.jumpMode ?? false
@@ -192,7 +203,11 @@ export function StatusBar(input: {
 
   let sendWidth = 0
   for (const seg of sendSegment) {
-    sendWidth += seg.key.length + (seg.word ? 1 + seg.word.length : 0) + 3
+    sendWidth +=
+      seg.key.length +
+      (seg.word ? 1 + seg.word.length : 0) +
+      HINT_HORIZONTAL_PADDING +
+      (sendWidth > 0 ? HINT_ITEM_GAP : 0)
   }
 
   const segments = jumpMode ? jumpSegments : contextual
@@ -203,7 +218,11 @@ export function StatusBar(input: {
   const maxShortcutChars = Math.max(0, termWidth - leftWidth - sendWidth)
   const visibleSegments = jumpMode
     ? segments
-    : fitSegments(segments, maxShortcutChars)
+    : fitSegments(
+        segments,
+        maxShortcutChars,
+        sendSegment.length > 0 ? HINT_ITEM_GAP : 0,
+      )
 
   const allSegments = [...visibleSegments, ...sendSegment]
 
@@ -220,12 +239,30 @@ export function StatusBar(input: {
       }}
     >
       <box
-        style={{ flexDirection: "row" }}
+        style={{
+          flexDirection: "row",
+          paddingLeft: !isEnvEditor ? 1 : undefined,
+          paddingRight: !isEnvEditor ? 1 : undefined,
+          backgroundColor:
+            !isEnvEditor && hoveringEnvironment
+              ? theme.backgroundElement
+              : undefined,
+        }}
         onMouseDown={(event) => {
           if (event.button === MouseButton.LEFT && !isEnvEditor) {
             input.onEnvironmentActivate?.()
           }
         }}
+        onMouseOver={
+          !isEnvEditor && input.onEnvironmentActivate
+            ? () => setHoveringEnvironment(true)
+            : undefined
+        }
+        onMouseOut={
+          !isEnvEditor && input.onEnvironmentActivate
+            ? () => setHoveringEnvironment(false)
+            : undefined
+        }
       >
         {isEnvEditor ? (
           <Badge bg={theme.backgroundElement} fg={theme.info}>
@@ -235,22 +272,43 @@ export function StatusBar(input: {
           <text fg={envFg}>{envText}</text>
         )}
       </box>
-      <box style={{ flexDirection: "row", alignItems: "center" }}>
+      <box
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          gap: HINT_ITEM_GAP,
+        }}
+      >
         {allSegments.map((seg, i) => (
           <box
             key={i}
-            style={{ flexDirection: "row" }}
+            style={{
+              flexDirection: "row",
+              paddingLeft: 1,
+              paddingRight: 1,
+              backgroundColor:
+                seg.command && input.onHintActivate && hoveredSegment === i
+                  ? theme.backgroundElement
+                  : undefined,
+            }}
             onMouseDown={(event) => {
               if (event.button === MouseButton.LEFT && seg.command) {
                 input.onHintActivate?.(seg.command)
               }
             }}
+            onMouseOver={
+              seg.command && input.onHintActivate
+                ? () => setHoveredSegment(i)
+                : undefined
+            }
+            onMouseOut={
+              seg.command && input.onHintActivate
+                ? () => setHoveredSegment(null)
+                : undefined
+            }
           >
             <text fg={theme.text}>{seg.key}</text>
             {seg.word ? <text fg={theme.textMuted}> {seg.word}</text> : null}
-            {i < allSegments.length - 1 && (
-              <text fg={theme.textMuted}> · </text>
-            )}
           </box>
         ))}
       </box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -6,7 +6,6 @@ import type { Keybinds } from "./keybind"
 import { displayKey } from "./keybind"
 import type { SendState } from "./sendState"
 import type { SaveState } from "./saveState"
-import { Badge } from "./Badge"
 import type { HintSegment } from "./keybindingHints"
 import type { CollectionMode } from "../app/main"
 
@@ -265,9 +264,7 @@ export function StatusBar(input: {
         }
       >
         {isEnvEditor ? (
-          <Badge bg={theme.backgroundElement} fg={theme.info}>
-            {input.envStats || "Env Editor"}
-          </Badge>
+          <text fg={theme.info}>{input.envStats || "Env Editor"}</text>
         ) : (
           <text fg={envFg}>{envText}</text>
         )}

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -1,5 +1,5 @@
 import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
-import { useEffect, useRef, type ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
 import { JumpBadge } from "./JumpBadge"
 import { useTheme } from "./theme"
 
@@ -25,6 +25,7 @@ export function Tabs({
   const theme = useTheme()
   const tabScrollRef = useRef<ScrollBoxRenderable | null>(null)
   const badgeScrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
   const hasJumpHint = tabs.some((t) => t.jumpHint)
   const scrollTabs = (delta: number) => {
     tabScrollRef.current?.scrollBy({ x: delta, y: 0 })
@@ -178,6 +179,7 @@ export function Tabs({
           >
             {tabs.map((tab) => {
               const isActive = tab.id === activeId
+              const isHovered = onChange !== undefined && hoveredId === tab.id
               return (
                 <box
                   id={`tab-${tab.id}`}
@@ -198,6 +200,10 @@ export function Tabs({
                     onChange?.(tab.id)
                     event.stopPropagation()
                   }}
+                  onMouseOver={
+                    onChange ? () => setHoveredId(tab.id) : undefined
+                  }
+                  onMouseOut={onChange ? () => setHoveredId(null) : undefined}
                   style={{
                     flexDirection: "column",
                     flexBasis: "auto",
@@ -211,7 +217,15 @@ export function Tabs({
                       paddingRight: 2,
                     }}
                   >
-                    <text fg={isActive ? theme.primary : theme.textMuted}>
+                    <text
+                      fg={
+                        isActive
+                          ? theme.primary
+                          : isHovered
+                            ? theme.text
+                            : theme.textMuted
+                      }
+                    >
                       {tab.label}
                     </text>
                   </box>

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -1,4 +1,4 @@
-import type { ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
 import { useEffect, useRef, type ReactNode } from "react"
 import { JumpBadge } from "./JumpBadge"
 import { useTheme } from "./theme"
@@ -14,11 +14,13 @@ export function Tabs({
   activeId,
   children,
   rightChildren,
+  onChange,
 }: {
   tabs: TabDef[]
   activeId: string
   children: ReactNode
   rightChildren?: ReactNode
+  onChange?: (id: string) => void
 }) {
   const theme = useTheme()
   const tabScrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -189,6 +191,11 @@ export function Tabs({
                       amount
                     scrollTabs(delta)
                     event.preventDefault()
+                    event.stopPropagation()
+                  }}
+                  onMouseDown={(event) => {
+                    if (event.button !== MouseButton.LEFT) return
+                    onChange?.(tab.id)
                     event.stopPropagation()
                   }}
                   style={{

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { createPortal, useRenderer } from "@opentui/react"
 import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
 
@@ -13,6 +14,7 @@ export function showToast(message: string, variant?: ToastVariant) {
 
 export function Toast() {
   const theme = useTheme()
+  const renderer = useRenderer()
   const [state, setState] = useState<{
     message: string
     variant: ToastVariant
@@ -32,11 +34,14 @@ export function Toast() {
 
   if (!state) return null
 
-  return (
+  return createPortal(
     <box
-      position="absolute"
-      bottom={2}
-      right={2}
+      style={{
+        position: "absolute",
+        bottom: 2,
+        right: 2,
+        zIndex: 10003,
+      }}
       paddingLeft={2}
       paddingRight={2}
       paddingTop={1}
@@ -47,6 +52,8 @@ export function Toast() {
       borderColor={theme.primary}
     >
       <text fg={theme.text}>{state.message}</text>
-    </box>
+    </box>,
+    renderer.root,
+    null,
   )
 }

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { MouseButton } from "@opentui/core"
 import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
 import type { Method, ParamEntry, Environment } from "../schema"
@@ -23,6 +24,7 @@ export function UrlBar({
   activeEnv,
   subFocus = "select",
   jumpMode = false,
+  onPaneFocus,
 }: {
   method: Method
   url: string
@@ -36,6 +38,7 @@ export function UrlBar({
   activeEnv?: Environment | null
   subFocus?: UrlBarSubFocus
   jumpMode?: boolean
+  onPaneFocus?: () => void
 }) {
   const theme = useTheme()
   const pathParams = pathParamsProp ?? []
@@ -95,6 +98,13 @@ export function UrlBar({
       border={[...FullBorder.border]}
       customBorderChars={FullBorder.customBorderChars}
       borderColor={focused ? theme.primary : theme.borderSubtle}
+      onMouseDown={
+        onPaneFocus
+          ? (event) => {
+              if (event.button === MouseButton.LEFT) onPaneFocus()
+            }
+          : undefined
+      }
     >
       {!displayUrl ? (
         <box

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -25,6 +25,7 @@ export function UrlBar({
   subFocus = "select",
   jumpMode = false,
   onPaneFocus,
+  onSubFocus,
 }: {
   method: Method
   url: string
@@ -39,6 +40,7 @@ export function UrlBar({
   subFocus?: UrlBarSubFocus
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onSubFocus?: (subFocus: UrlBarSubFocus) => void
 }) {
   const theme = useTheme()
   const pathParams = pathParamsProp ?? []
@@ -131,7 +133,14 @@ export function UrlBar({
               onOpenChange={setMethodSelectOpen}
             />
           </box>
-          <box style={{ flexGrow: 1, flexShrink: 1, position: "relative" }}>
+          <box
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT) return
+              onSubFocus?.("text")
+              event.stopPropagation()
+            }}
+            style={{ flexGrow: 1, flexShrink: 1, position: "relative" }}
+          >
             {jumpMode && <JumpBadge letter="u" style={JUMP_BADGE_TOP_LEFT} />}
             {focused && subFocus === "text" && interactive ? (
               <VarInput

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -131,6 +131,7 @@ export function UrlBar({
               badge
               maxDropdownHeight={10}
               onOpenChange={setMethodSelectOpen}
+              interactive={interactive}
             />
           </box>
           <box

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -48,6 +48,7 @@ export interface VarInputProps {
   style?: VarInputStyle
   variableNames?: Iterable<string>
   pathParams?: ParamEntry[]
+  stopMousePropagation?: boolean
 }
 
 export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
@@ -67,6 +68,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       style,
       variableNames,
       pathParams,
+      stopMousePropagation = false,
     },
     ref,
   ) {
@@ -206,6 +208,11 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       if (useTextarea) {
         return (
           <box
+            onMouseDown={
+              stopMousePropagation
+                ? (event) => event.stopPropagation()
+                : undefined
+            }
             style={{
               flexGrow: style?.flexGrow,
             }}
@@ -239,6 +246,11 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
       return (
         <box
+          onMouseDown={
+            stopMousePropagation
+              ? (event) => event.stopPropagation()
+              : undefined
+          }
           style={{
             flexGrow: style?.flexGrow,
             flexShrink: style?.flexShrink,

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -208,6 +208,8 @@ export function newFolder(): boolean {
 
 export function saveFolder(c: CommandActionsConfig): boolean {
   if (!c.focusedFolderPathRef.current) return false
+  const d = c.folderDraftRef.current
+  if (c.savingRef.current || !d.folderDraft || !d.isDirty) return false
   c.folderSaveRef.current()
   return true
 }

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -32,17 +32,20 @@ export interface CommandActionsConfig {
   activeIndexRef: RefObject<number>
   savingRef: RefObject<boolean>
   doSaveRef: RefObject<() => void>
+  folderSaveRef: RefObject<() => void>
   focusedFolderPathRef: RefObject<string | null>
   focusedFolderNameRef: RefObject<string | null>
   folderDeletePathRef: RefObject<string | null>
 }
 
 export function sendRequest(c: CommandActionsConfig): boolean {
+  if (c.focusedFolderPathRef.current) return false
   c.trySendRef.current?.()
   return true
 }
 
 export function saveRequest(c: CommandActionsConfig): boolean {
+  if (c.focusedFolderPathRef.current) return false
   const d = c.draftRef.current
   if (!c.savingRef.current && d.draft && d.isDirty) {
     c.doSaveRef.current()
@@ -105,6 +108,7 @@ export function newRequest(): boolean {
 }
 
 export function cloneRequest(c: CommandActionsConfig): boolean {
+  if (c.focusedFolderPathRef.current) return false
   const sid = c.selectedIdRef.current
   if (!sid) return false
   const col = c.collectionRef.current
@@ -199,6 +203,12 @@ export function deleteEnvironment(c: CommandActionsConfig): {
 }
 
 export function newFolder(): boolean {
+  return true
+}
+
+export function saveFolder(c: CommandActionsConfig): boolean {
+  if (!c.focusedFolderPathRef.current) return false
+  c.folderSaveRef.current()
   return true
 }
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -312,7 +312,7 @@ export function buildCommandPaletteCommands(
       run: () => {
         if (!openEnvironmentEditor(c)) return false
         setView("env-editor")
-        setFocus("env-header")
+        setFocus("env-sidebar")
         return true
       },
     },

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -14,6 +14,8 @@ import type { SendState } from "./sendState"
 import type { ResponseQueryController } from "./responseQuery"
 import {
   saveRequest,
+  saveFolder,
+  editRequestOverlay,
   getEditRequestYamlFile,
   getEditFolderYamlFile,
   cloneRequest,
@@ -38,6 +40,8 @@ import {
   type CommandActionsConfig,
 } from "./commandActions"
 
+export type CommandPaletteTarget = "request" | "folder"
+
 export interface CommandBuilderContext {
   keybinds: Keybinds
   collectionDir: string
@@ -57,6 +61,7 @@ export interface CommandBuilderContext {
   activeIndexRef: RefObject<number>
   savingRef: RefObject<boolean>
   doSaveRef: RefObject<() => void>
+  folderSaveRef: RefObject<() => void>
   focusedFolderPathRef: RefObject<string | null>
   focusedFolderNameRef: RefObject<string | null>
   folderDeletePathRef: RefObject<string | null>
@@ -112,6 +117,7 @@ export interface CommandBuilderContext {
   ) => void
   onReloadCollection: () => void
   triggerUpdateCheck: () => void
+  paletteTarget: CommandPaletteTarget | null
 }
 
 function toConfig(ctx: CommandBuilderContext): CommandActionsConfig {
@@ -133,6 +139,7 @@ function toConfig(ctx: CommandBuilderContext): CommandActionsConfig {
     activeIndexRef: ctx.activeIndexRef,
     savingRef: ctx.savingRef,
     doSaveRef: ctx.doSaveRef,
+    folderSaveRef: ctx.folderSaveRef,
     focusedFolderPathRef: ctx.focusedFolderPathRef,
     focusedFolderNameRef: ctx.focusedFolderNameRef,
     folderDeletePathRef: ctx.folderDeletePathRef,
@@ -171,6 +178,7 @@ export function buildCommandPaletteCommands(
     setEnvDeletePending,
     getCollectionMode,
     triggerUpdateCheck,
+    paletteTarget,
   } = ctx
 
   const c = toConfig(ctx)
@@ -226,7 +234,7 @@ export function buildCommandPaletteCommands(
       keybinding: displayKey(keybinds.request_edit_overlay),
       run: () => {
         if (mode !== "collection") return false
-        if (!cloneRequest(c)) return false
+        if (!editRequestOverlay(c)) return false
         setEditRequestVisible(true)
         return true
       },
@@ -435,6 +443,17 @@ export function buildCommandPaletteCommands(
     },
   ]
 
+  const folderSaveCommand: CommandItem = {
+    id: "folder.save",
+    label: "Save Folder",
+    section: "Folder",
+    keybinding: displayKey(keybinds.request_save),
+    run: () => {
+      if (mode !== "collection") return false
+      return saveFolder(c)
+    },
+  }
+
   const mainOnlyCommands: CommandItem[] = [
     {
       id: "pane.expand",
@@ -533,6 +552,53 @@ export function buildCommandPaletteCommands(
       },
     },
   ]
+
+  if (paletteTarget === "request") {
+    if (mode !== "collection") return []
+    return [
+      ...requestCommands.filter((command) =>
+        [
+          "request.generate-client-code",
+          "request.send",
+          "request.save",
+          "request.edit-overlay",
+          "request.clone",
+          "request.delete",
+        ].includes(command.id),
+      ),
+      ...workspaceCommands
+        .filter((command) => command.id === "workspace.edit-yaml")
+        .map((command) => ({
+          ...command,
+          label: "Edit Request YAML",
+          section: "Request",
+        })),
+    ]
+  }
+
+  if (paletteTarget === "folder") {
+    if (mode !== "collection") return []
+    return [
+      folderSaveCommand,
+      ...requestCommands
+        .filter((command) => command.id === "request.new")
+        .map((command) => ({ ...command, section: "Folder" })),
+      ...workspaceCommands
+        .filter((command) =>
+          ["folder.new", "folder.delete", "workspace.edit-yaml"].includes(
+            command.id,
+          ),
+        )
+        .map((command) => ({
+          ...command,
+          label:
+            command.id === "workspace.edit-yaml"
+              ? "Edit Folder YAML"
+              : command.label,
+          section: "Folder",
+        })),
+    ]
+  }
 
   if (view === "env-editor") {
     return [

--- a/src/ui/editor/CodeEditor.ts
+++ b/src/ui/editor/CodeEditor.ts
@@ -232,6 +232,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
   }
 
   scrollBy(delta: number): void {
+    if (delta === 0) return
     const move =
       delta < 0 ? this.moveCursorUp.bind(this) : this.moveCursorDown.bind(this)
     for (

--- a/src/ui/editor/CodeEditor.ts
+++ b/src/ui/editor/CodeEditor.ts
@@ -227,6 +227,22 @@ export class CodeEditorRenderable extends TextareaRenderable {
     this._foldManager.unfoldAll()
   }
 
+  scrollByViewport(delta: number): void {
+    this.scrollBy(delta * this.height)
+  }
+
+  scrollBy(delta: number): void {
+    const move =
+      delta < 0 ? this.moveCursorUp.bind(this) : this.moveCursorDown.bind(this)
+    for (
+      let step = 0;
+      step < Math.max(1, Math.round(Math.abs(delta)));
+      step++
+    ) {
+      move()
+    }
+  }
+
   override requestRender(): void {
     if (!this._renderSuppressed) super.requestRender()
   }

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -44,6 +44,7 @@ export function YamlEditorOverlay({
   const [editorInstance, setEditorInstance] =
     useState<CodeEditorRenderable | null>(null)
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
+  const hoveredFoldLineRef = useRef<number | null>(null)
   const [content, setContent] = useState<string | null>(null)
   const [draftContent, setDraftContent] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
@@ -198,14 +199,46 @@ export function YamlEditorOverlay({
     }
   }, [visible, content])
 
-  const handleFoldsChange = useCallback(() => {
-    const ed = editorRef.current
-    const ln = lineNumberRef.current
-    if (ed && ln) {
-      ln.setLineSigns(new Map([...RESERVED_FOLD_SIGN, ...ed.getFoldSigns()]))
+  const syncFoldSigns = useCallback(
+    (hoveredFoldLine?: number) => {
+      const ed = editorRef.current
+      const ln = lineNumberRef.current
+      if (!ed || !ln) return
+      const signs = ed.getFoldSigns()
+      const sign =
+        hoveredFoldLine === undefined ? undefined : signs.get(hoveredFoldLine)
+      if (sign && hoveredFoldLine !== undefined) {
+        signs.set(hoveredFoldLine, { ...sign, beforeColor: theme.primary })
+      }
+      ln.setLineSigns(new Map([...RESERVED_FOLD_SIGN, ...signs]))
       ln.setHideLineNumbers(ed.getHiddenLineNumbers())
-    }
-  }, [])
+    },
+    [theme.primary],
+  )
+
+  const handleFoldsChange = useCallback(() => {
+    hoveredFoldLineRef.current = null
+    syncFoldSigns()
+  }, [syncFoldSigns])
+
+  const updateFoldHover = useCallback(
+    (event: { x: number; y: number }) => {
+      const editor = editorRef.current
+      const lineNumbers = lineNumberRef.current
+      const displayLine =
+        editor && lineNumbers && event.x === lineNumbers.x
+          ? editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
+          : undefined
+      const hoveredFoldLine =
+        displayLine !== undefined && editor?.getFoldSigns().has(displayLine)
+          ? displayLine
+          : null
+      if (hoveredFoldLine === hoveredFoldLineRef.current) return
+      hoveredFoldLineRef.current = hoveredFoldLine
+      syncFoldSigns(hoveredFoldLine ?? undefined)
+    },
+    [syncFoldSigns],
+  )
 
   if (!visible) return null
 
@@ -253,6 +286,27 @@ export function YamlEditorOverlay({
             fg={theme.textMuted}
             bg={theme.backgroundPanel}
             lineSigns={RESERVED_FOLD_SIGN}
+            onMouseMove={updateFoldHover}
+            onMouseOut={() => {
+              if (hoveredFoldLineRef.current === null) return
+              hoveredFoldLineRef.current = null
+              syncFoldSigns()
+            }}
+            onMouseDown={(event) => {
+              const editor = editorRef.current
+              if (event.button !== MouseButton.LEFT || !editor) return
+              if (event.x >= editor.x) return
+              const displayLine =
+                editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
+              if (
+                displayLine === undefined ||
+                !editor.getFoldSigns().has(displayLine)
+              )
+                return
+              editor.toggleFold(displayLine)
+              event.preventDefault()
+              event.stopPropagation()
+            }}
             style={{ flexGrow: 1, minHeight: 0 }}
             width="100%"
           >

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -5,6 +5,7 @@ import { basename, dirname } from "node:path"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { useTheme } from "../theme"
 import { Overlay } from "../overlays/Overlay"
+import { EscapeClose } from "../overlays/EscapeClose"
 import type { CodeEditorRenderable } from "./CodeEditor"
 import { ValidationNotice } from "./ValidationNotice"
 import { lang } from "../../lang"
@@ -216,7 +217,7 @@ export function YamlEditorOverlay({
             ? `${requestName}/folder.yml`
             : `${requestName}.yml`}
         </text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={handleClose} />
       </box>
       {readError ? (
         <box

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -1,4 +1,8 @@
-import { type LineNumberRenderable, type LineSign } from "@opentui/core"
+import {
+  MouseButton,
+  type LineNumberRenderable,
+  type LineSign,
+} from "@opentui/core"
 import { useEffect, useRef, useState, useCallback, useMemo } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 import { basename, dirname } from "node:path"
@@ -45,6 +49,9 @@ export function YamlEditorOverlay({
   const [validationError, setValidationError] = useState<string | null>(null)
   const [readError, setReadError] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
+    null,
+  )
   const mountedRef = useRef(true)
 
   useEffect(() => {
@@ -300,11 +307,44 @@ export function YamlEditorOverlay({
             gap: 1,
           }}
         >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}>save</text>
-          <text fg={theme.textMuted}> · </text>
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}>close</text>
+          <box
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT) return
+              handleSave()
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseOver={() => setHoveredAction("save")}
+            onMouseOut={() => setHoveredAction(null)}
+            style={{
+              flexDirection: "row",
+              paddingX: 1,
+              backgroundColor:
+                hoveredAction === "save" ? theme.backgroundElement : undefined,
+            }}
+          >
+            <text fg={theme.text}>^S</text>
+            <text fg={theme.textMuted}> save</text>
+          </box>
+          <box
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT) return
+              handleClose()
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseOver={() => setHoveredAction("close")}
+            onMouseOut={() => setHoveredAction(null)}
+            style={{
+              flexDirection: "row",
+              paddingX: 1,
+              backgroundColor:
+                hoveredAction === "close" ? theme.backgroundElement : undefined,
+            }}
+          >
+            <text fg={theme.text}>esc</text>
+            <text fg={theme.textMuted}> close</text>
+          </box>
         </box>
       </box>
     </Overlay>

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -4,8 +4,8 @@ import { useTheme } from "../theme"
 import { FullBorder } from "../borders"
 import { Checkbox } from "../Checkbox"
 import { VarInput } from "../VarInput"
-import { ScrollBoxRenderable } from "@opentui/core"
-import { useEffect, useRef } from "react"
+import { MouseButton, ScrollBoxRenderable } from "@opentui/core"
+import { useEffect, useRef, useState } from "react"
 import { Frame } from "../Frame"
 import { Badge } from "../Badge"
 
@@ -20,6 +20,8 @@ export function EnvEditorPane({
   error,
   focused: _focused,
   onPaneFocus,
+  onActivateRow,
+  onToggleRow,
 }: {
   draft: EnvDraft | null
   editState: EnvEditState
@@ -31,9 +33,12 @@ export function EnvEditorPane({
   error: string | null
   focused: boolean
   onPaneFocus?: () => void
+  onActivateRow?: (row: number, addingRow: boolean) => void
+  onToggleRow?: (row: number) => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const [hoveredRow, setHoveredRow] = useState<number | "add" | null>(null)
 
   const inEdit = editState?.mode === "editing"
   const inBrowse = editState?.mode === "browsing"
@@ -144,15 +149,22 @@ export function EnvEditorPane({
           const cursorOnThisRow =
             inBrowse && !editState.addingRow && editState.row === i
           const dimmed = (inEdit && !isEditingThisRow) || !row.enabled
+          const canHoverRow =
+            !isEditingThisRow &&
+            (onActivateRow !== undefined || onToggleRow !== undefined)
+          const canActivateRow =
+            !isEditingThisRow && onActivateRow !== undefined
 
           const keyBaseColor = dimmed ? theme.textMuted : theme.primary
           const valueBaseColor = dimmed ? theme.textMuted : theme.text
           const rowBg =
             cursorOnThisRow || isEditingThisRow
               ? theme.backgroundElement
-              : i % 2 !== 0
-                ? stripeBg
-                : undefined
+              : canHoverRow && hoveredRow === i
+                ? theme.backgroundElement
+                : i % 2 !== 0
+                  ? stripeBg
+                  : undefined
 
           return (
             <box
@@ -163,8 +175,31 @@ export function EnvEditorPane({
                 gap: 0,
                 backgroundColor: rowBg,
               }}
+              onMouseDown={
+                canActivateRow
+                  ? (event) => {
+                      if (event.button !== MouseButton.LEFT) return
+                      onActivateRow?.(i, false)
+                      event.stopPropagation()
+                    }
+                  : undefined
+              }
+              onMouseOver={canHoverRow ? () => setHoveredRow(i) : undefined}
+              onMouseOut={canHoverRow ? () => setHoveredRow(null) : undefined}
             >
-              <Checkbox checked={row.enabled} theme={theme} />
+              <box
+                onMouseDown={
+                  onToggleRow
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onToggleRow(i)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
+              >
+                <Checkbox checked={row.enabled} theme={theme} />
+              </box>
               <VarInput
                 value={isEditingThisRow ? editKey : row.key}
                 placeholder="Key..."
@@ -204,9 +239,11 @@ export function EnvEditorPane({
           const addRowBg =
             (inBrowse && editState.addingRow) || editingAdd
               ? theme.backgroundElement
-              : rows.length % 2 !== 0
-                ? stripeBg
-                : undefined
+              : hoveredRow === "add" && onActivateRow
+                ? theme.backgroundElement
+                : rows.length % 2 !== 0
+                  ? stripeBg
+                  : undefined
 
           return (
             <box
@@ -217,6 +254,25 @@ export function EnvEditorPane({
                 gap: 0,
                 backgroundColor: addRowBg,
               }}
+              onMouseDown={
+                !editingAdd && onActivateRow
+                  ? (event) => {
+                      if (event.button !== MouseButton.LEFT) return
+                      onActivateRow(-1, true)
+                      event.stopPropagation()
+                    }
+                  : undefined
+              }
+              onMouseOver={
+                !editingAdd && onActivateRow
+                  ? () => setHoveredRow("add")
+                  : undefined
+              }
+              onMouseOut={
+                !editingAdd && onActivateRow
+                  ? () => setHoveredRow(null)
+                  : undefined
+              }
             >
               <Checkbox checked={false} theme={theme} />
               <VarInput

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -19,6 +19,7 @@ export function EnvEditorPane({
   saving,
   error,
   focused: _focused,
+  onPaneFocus,
 }: {
   draft: EnvDraft | null
   editState: EnvEditState
@@ -29,6 +30,7 @@ export function EnvEditorPane({
   saving: boolean
   error: string | null
   focused: boolean
+  onPaneFocus?: () => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -72,6 +74,7 @@ export function EnvEditorPane({
             Variables
           </Badge>
         }
+        onPaneFocus={onPaneFocus}
       >
         <text fg={theme.textMuted}>Select an environment to edit</text>
       </Frame>
@@ -123,6 +126,7 @@ export function EnvEditorPane({
           Variables
         </Badge>
       }
+      onPaneFocus={onPaneFocus}
     >
       <scrollbox
         ref={scrollRef}

--- a/src/ui/env-editor/EnvHeaderPane.tsx
+++ b/src/ui/env-editor/EnvHeaderPane.tsx
@@ -55,11 +55,11 @@ export const EnvHeaderPane = forwardRef<
   }, [focused])
 
   useEffect(() => {
-    if (focused && !prevFocused.current) {
+    if (focused && !prevFocused.current && !colorFocused) {
       nameRef.current?.focus()
     }
     prevFocused.current = focused
-  }, [focused])
+  }, [focused, colorFocused])
 
   const colorItems: SelectItem[] = useMemo(() => {
     const t = theme as unknown as Record<string, string>
@@ -120,6 +120,7 @@ export const EnvHeaderPane = forwardRef<
         dropdownAlign="right"
         badge
         onOpenChange={setSelectOpen}
+        onActivate={() => setColorFocused(true)}
       />
     </Frame>
   )

--- a/src/ui/env-editor/EnvHeaderPane.tsx
+++ b/src/ui/env-editor/EnvHeaderPane.tsx
@@ -27,9 +27,10 @@ export const EnvHeaderPane = forwardRef<
     onNameChange: (name: string) => void
     onColorChange: (color: string | undefined) => void
     focused: boolean
+    onPaneFocus?: () => void
   }
 >(function EnvHeaderPane(
-  { name, color, onNameChange, onColorChange, focused },
+  { name, color, onNameChange, onColorChange, focused, onPaneFocus },
   ref,
 ) {
   const theme = useTheme()
@@ -96,6 +97,7 @@ export const EnvHeaderPane = forwardRef<
           Environment
         </Badge>
       }
+      onPaneFocus={onPaneFocus}
     >
       <input
         ref={nameRef}

--- a/src/ui/env-editor/EnvHeaderPane.tsx
+++ b/src/ui/env-editor/EnvHeaderPane.tsx
@@ -12,7 +12,6 @@ import type { InputRenderable } from "@opentui/core"
 import { Select, type SelectItem } from "../Select"
 import { VALID_COLORS } from "../../env/constants"
 import { Frame } from "../Frame"
-import { Badge } from "../Badge"
 
 export interface EnvHeaderPaneHandle {
   focusName: () => void
@@ -38,6 +37,7 @@ export const EnvHeaderPane = forwardRef<
   const prevFocused = useRef(false)
   const [colorFocused, setColorFocused] = useState(false)
   const [selectOpen, setSelectOpen] = useState(false)
+  const nameFocused = focused && !colorFocused
 
   useImperativeHandle(ref, () => ({
     focusName: () => {
@@ -89,14 +89,6 @@ export const EnvHeaderPane = forwardRef<
       border={[...FullBorder.border]}
       customBorderChars={FullBorder.customBorderChars}
       borderColor={focused ? theme.primary : theme.borderSubtle}
-      titleRight={
-        <Badge
-          bg={theme.backgroundPanel}
-          fg={focused ? theme.primary : theme.textMuted}
-        >
-          Environment
-        </Badge>
-      }
       onPaneFocus={onPaneFocus}
     >
       <input
@@ -104,11 +96,14 @@ export const EnvHeaderPane = forwardRef<
         value={name}
         placeholder="Environment name"
         onInput={onNameChange}
-        focused={focused}
-        backgroundColor={theme.backgroundElement}
+        focused={nameFocused}
+        backgroundColor={
+          nameFocused ? theme.backgroundElement : theme.backgroundPanel
+        }
         focusedBackgroundColor={theme.borderSubtle}
         textColor={theme.text}
         cursorColor={theme.primary}
+        paddingX={1}
         style={{ flexGrow: 1 }}
       />
       <Select

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from "../theme"
 import { FullBorder, LeftBar } from "../borders"
-import { ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, ScrollBoxRenderable } from "@opentui/core"
 import { useEffect, useRef } from "react"
 import { VALID_COLORS } from "../../env/constants"
 import { Frame } from "../Frame"
@@ -12,7 +12,7 @@ export function EnvSidebar({
   activeEnvName: _activeEnvName,
   envColors,
   dirty,
-  onSelectEnv: _onSelectEnv,
+  onSelectEnv,
   onCreate: _onCreate,
   onClone: _onClone,
   onDelete: _onDelete,
@@ -104,6 +104,12 @@ export function EnvSidebar({
                 border={[...LeftBar.border]}
                 customBorderChars={LeftBar.customBorderChars}
                 borderColor={isSelected ? theme.primary : theme.backgroundPanel}
+                onMouseDown={(event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  onSelectEnv(name)
+                  onPaneFocus?.()
+                  event.stopPropagation()
+                }}
               >
                 <box style={{ flexDirection: "row" }}>
                   {colorHex && <text fg={colorHex}>● </text>}

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -56,7 +56,7 @@ export function EnvSidebar({
       border={[...FullBorder.border]}
       customBorderChars={FullBorder.customBorderChars}
       borderColor={focused ? theme.primary : theme.borderSubtle}
-      titleLeft={
+      titleRight={
         <Badge
           bg={theme.backgroundPanel}
           fg={focused ? theme.primary : theme.textMuted}

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "../theme"
 import { FullBorder, LeftBar } from "../borders"
 import { MouseButton, ScrollBoxRenderable } from "@opentui/core"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { VALID_COLORS } from "../../env/constants"
 import { Frame } from "../Frame"
 import { Badge } from "../Badge"
@@ -33,6 +33,7 @@ export function EnvSidebar({
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const [hoveredEnvName, setHoveredEnvName] = useState<string | null>(null)
 
   const selectedIndex = selectedEnvName ? envNames.indexOf(selectedEnvName) : -1
 
@@ -83,6 +84,7 @@ export function EnvSidebar({
           {envNames.map((name, i) => {
             const isSelected = name === selectedEnvName
             const isDirty = isSelected && dirty
+            const isHovered = hoveredEnvName === name
             const colorKey = envColors?.[name]
             const colorHex =
               colorKey !== undefined
@@ -97,9 +99,10 @@ export function EnvSidebar({
                 style={{
                   flexDirection: "row",
                   justifyContent: "space-between",
-                  backgroundColor: isSelected
-                    ? theme.backgroundElement
-                    : undefined,
+                  backgroundColor:
+                    isSelected || isHovered
+                      ? theme.backgroundElement
+                      : undefined,
                 }}
                 border={[...LeftBar.border]}
                 customBorderChars={LeftBar.customBorderChars}
@@ -110,6 +113,8 @@ export function EnvSidebar({
                   onPaneFocus?.()
                   event.stopPropagation()
                 }}
+                onMouseOver={() => setHoveredEnvName(name)}
+                onMouseOut={() => setHoveredEnvName(null)}
               >
                 <box style={{ flexDirection: "row" }}>
                   {colorHex && <text fg={colorHex}>● </text>}

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -17,6 +17,7 @@ export function EnvSidebar({
   onClone: _onClone,
   onDelete: _onDelete,
   focused,
+  onPaneFocus,
 }: {
   envNames: string[]
   selectedEnvName: string | null
@@ -28,6 +29,7 @@ export function EnvSidebar({
   onClone: () => void
   onDelete: () => void
   focused: boolean
+  onPaneFocus?: () => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -61,6 +63,7 @@ export function EnvSidebar({
           Environments
         </Badge>
       }
+      onPaneFocus={onPaneFocus}
     >
       {envNames.length === 0 ? (
         <text fg={theme.textMuted}>(no environments)</text>

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -12,7 +12,7 @@ interface EnvironmentEditorViewProps {
   envColors: Record<string, string | undefined>
   focus: Focus
   envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
-  setFocus: (focus: Focus) => void
+  onPaneFocus?: (focus: Focus) => void
   setEnvDeletePending: (name: string | null) => void
 }
 
@@ -22,7 +22,7 @@ export function EnvironmentEditorView({
   envColors,
   focus,
   envHeaderRef,
-  setFocus,
+  onPaneFocus = () => {},
   setEnvDeletePending,
 }: EnvironmentEditorViewProps) {
   return (
@@ -36,7 +36,7 @@ export function EnvironmentEditorView({
         onSelectEnv={envEditor.selectEnv}
         onCreate={() => {
           envEditor.openEditor()
-          setFocus("env-vars")
+          onPaneFocus("env-vars")
         }}
         onClone={() => {
           if (envEditor.selectedEnvName) {
@@ -50,6 +50,7 @@ export function EnvironmentEditorView({
           }
         }}
         focused={focus === "env-sidebar"}
+        onPaneFocus={() => onPaneFocus("env-sidebar")}
       />
       <box
         style={{
@@ -66,6 +67,7 @@ export function EnvironmentEditorView({
           onNameChange={envEditor.setName}
           onColorChange={envEditor.setColor}
           focused={focus === "env-header"}
+          onPaneFocus={() => onPaneFocus("env-header")}
         />
         <EnvEditorPane
           draft={envEditor.draft}
@@ -77,6 +79,7 @@ export function EnvironmentEditorView({
           saving={envEditor.saving}
           error={envEditor.error}
           focused={focus === "env-vars"}
+          onPaneFocus={() => onPaneFocus("env-vars")}
         />
       </box>
     </box>

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -56,7 +56,7 @@ export function EnvironmentEditorView({
         style={{
           flexDirection: "column",
           flexGrow: 1,
-          gap: 1,
+          gap: 0,
           minHeight: 0,
         }}
       >
@@ -80,6 +80,14 @@ export function EnvironmentEditorView({
           error={envEditor.error}
           focused={focus === "env-vars"}
           onPaneFocus={() => onPaneFocus("env-vars")}
+          onActivateRow={(row, addingRow) => {
+            onPaneFocus("env-vars")
+            envEditor.activateVar(row, addingRow)
+          }}
+          onToggleRow={(row) => {
+            onPaneFocus("env-vars")
+            envEditor.toggleVar(row)
+          }}
         />
       </box>
     </box>

--- a/src/ui/intercepts/useDialogIntercepts.ts
+++ b/src/ui/intercepts/useDialogIntercepts.ts
@@ -3,11 +3,11 @@ import type { RefObject } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 import type { SaveState } from "../saveState"
 import type { UseEnvironmentEditorResult } from "../../hooks/useEnvironmentEditor"
+import type { ActiveOverlay } from "../useOverlayState"
 
 export function useDialogIntercepts(opts: {
-  saveState: SaveState
+  activeOverlay: ActiveOverlay
   setSaveState: (s: SaveState) => void
-  doSave: () => void
   envDeletePending: string | null
   setEnvDeletePending: (s: string | null) => void
   envEditorRef: RefObject<UseEnvironmentEditorResult>
@@ -35,9 +35,8 @@ export function useDialogIntercepts(opts: {
 }): { onConfirm: () => void; onCancel: () => void } {
   const keymap = useKeymap()
   const {
-    saveState,
+    activeOverlay,
     setSaveState,
-    doSave,
     envDeletePending,
     setEnvDeletePending,
     envEditorRef,
@@ -46,20 +45,15 @@ export function useDialogIntercepts(opts: {
     collectionSwitchPending,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm,
-    requestDeletePending,
     setRequestDeletePending,
     onRequestDeleteConfirm,
-    folderDeletePending,
     setFolderDeletePending,
     onFolderDeleteConfirm,
-    undoAllPending,
     setUndoAllPending,
     draftRef,
     folderDraftRef,
-    initPending,
     setInitPending,
     onInitConfirm,
-    updateConfirmVisible,
     onConfirmInstall,
     onCancelUpdate,
   } = opts
@@ -119,86 +113,48 @@ export function useDialogIntercepts(opts: {
   ])
 
   const onConfirm = useCallback(() => {
-    if (saveState.kind === "confirming") doSave()
-    else if (envDeletePending) confirmEnvDelete()
-    else if (undoAllPending) confirmUndoAll()
-    else if (initPending) confirmInit()
-    else if (collectionSwitchPending) confirmCollectionSwitch()
-    else if (folderDeletePending) onFolderDeleteConfirm()
-    else if (requestDeletePending) onRequestDeleteConfirm()
-    else if (updateConfirmVisible) onConfirmInstall()
+    if (activeOverlay === "env-delete") confirmEnvDelete()
+    else if (activeOverlay === "undo-all") confirmUndoAll()
+    else if (activeOverlay === "init-confirm") confirmInit()
+    else if (activeOverlay === "collection-switch-confirm")
+      confirmCollectionSwitch()
+    else if (activeOverlay === "delete-folder") onFolderDeleteConfirm()
+    else if (activeOverlay === "request-delete") onRequestDeleteConfirm()
+    else if (activeOverlay === "update-confirm") onConfirmInstall()
   }, [
-    saveState.kind,
-    doSave,
-    envDeletePending,
+    activeOverlay,
     confirmEnvDelete,
-    undoAllPending,
     confirmUndoAll,
-    initPending,
     confirmInit,
-    collectionSwitchPending,
     confirmCollectionSwitch,
-    folderDeletePending,
     onFolderDeleteConfirm,
-    requestDeletePending,
     onRequestDeleteConfirm,
-    updateConfirmVisible,
     onConfirmInstall,
   ])
 
   const onCancel = useCallback(() => {
-    if (saveState.kind === "confirming") setSaveState({ kind: "idle" })
-    else if (envDeletePending) setEnvDeletePending(null)
-    else if (undoAllPending) setUndoAllPending(false)
-    else if (initPending) setInitPending(false)
-    else if (collectionSwitchPending) setCollectionSwitchPending(null)
-    else if (folderDeletePending) setFolderDeletePending(null)
-    else if (requestDeletePending) setRequestDeletePending(null)
-    else if (updateConfirmVisible) onCancelUpdate()
+    if (activeOverlay === "env-delete") setEnvDeletePending(null)
+    else if (activeOverlay === "undo-all") setUndoAllPending(false)
+    else if (activeOverlay === "init-confirm") setInitPending(false)
+    else if (activeOverlay === "collection-switch-confirm")
+      setCollectionSwitchPending(null)
+    else if (activeOverlay === "delete-folder") setFolderDeletePending(null)
+    else if (activeOverlay === "request-delete") setRequestDeletePending(null)
+    else if (activeOverlay === "update-confirm") onCancelUpdate()
   }, [
-    saveState.kind,
-    setSaveState,
-    envDeletePending,
+    activeOverlay,
     setEnvDeletePending,
-    undoAllPending,
     setUndoAllPending,
-    initPending,
     setInitPending,
-    collectionSwitchPending,
     setCollectionSwitchPending,
-    folderDeletePending,
     setFolderDeletePending,
-    requestDeletePending,
     setRequestDeletePending,
-    updateConfirmVisible,
     onCancelUpdate,
   ])
 
-  // ── Overlay: Save Confirm ──────────────────────────────────────────
-  useEffect(() => {
-    if (saveState.kind !== "confirming") return
-    const dispose = keymap.intercept(
-      "key",
-      (ctx) => {
-        const name = ctx.event.name
-        if (name === "y" || name === "return") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          onConfirm()
-        } else if (name === "n" || name === "escape") {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          onCancel()
-        }
-      },
-      { priority: 100 },
-    )
-    return dispose
-  }, [saveState.kind, keymap, onConfirm, onCancel])
-
   // ── Overlay: Delete env confirmation ──────────────────────────────
   useEffect(() => {
-    if (!envDeletePending) return
+    if (activeOverlay !== "env-delete") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -216,11 +172,11 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [envDeletePending, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   // ── Overlay: Collection switch confirmation ──────────────────────
   useEffect(() => {
-    if (!collectionSwitchPending) return
+    if (activeOverlay !== "collection-switch-confirm") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -238,11 +194,11 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [collectionSwitchPending, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   // ── Overlay: Delete Request ────────────────────────────────────────
   useEffect(() => {
-    if (!requestDeletePending) return
+    if (activeOverlay !== "request-delete") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -263,11 +219,11 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [requestDeletePending, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   // ── Overlay: Delete Folder ────────────────────────────────────────
   useEffect(() => {
-    if (!folderDeletePending) return
+    if (activeOverlay !== "delete-folder") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -288,11 +244,11 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [folderDeletePending, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   // ── Overlay: Undo All ──────────────────────────────────────────────
   useEffect(() => {
-    if (!undoAllPending) return
+    if (activeOverlay !== "undo-all") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -310,11 +266,11 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [undoAllPending, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   // ── Overlay: Init Confirm ─────────────────────────────────────────
   useEffect(() => {
-    if (!initPending) return
+    if (activeOverlay !== "init-confirm") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -332,11 +288,11 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [initPending, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   // ── Overlay: Update confirm ──────────────────────────────────────
   useEffect(() => {
-    if (!updateConfirmVisible) return
+    if (activeOverlay !== "update-confirm") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {
@@ -355,7 +311,7 @@ export function useDialogIntercepts(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [updateConfirmVisible, keymap, onConfirm, onCancel])
+  }, [activeOverlay, keymap, onConfirm, onCancel])
 
   return { onConfirm, onCancel }
 }

--- a/src/ui/intercepts/useDialogIntercepts.ts
+++ b/src/ui/intercepts/useDialogIntercepts.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useCallback, useEffect } from "react"
 import type { RefObject } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 import type { SaveState } from "../saveState"
@@ -32,7 +32,7 @@ export function useDialogIntercepts(opts: {
   updateConfirmVisible: boolean
   onConfirmInstall: () => void
   onCancelUpdate: () => void
-}): void {
+}): { onConfirm: () => void; onCancel: () => void } {
   const keymap = useKeymap()
   const {
     saveState,
@@ -64,6 +64,116 @@ export function useDialogIntercepts(opts: {
     onCancelUpdate,
   } = opts
 
+  const confirmEnvDelete = useCallback(() => {
+    if (!envDeletePending) return
+    const envName = envDeletePending
+    setEnvDeletePending(null)
+    envEditorRef.current
+      .deleteEnv()
+      .then(() => {
+        clearSaveTimer()
+        setSaveState({ kind: "success", message: `Deleted ${envName}` })
+        saveTimerRef.current = setTimeout(
+          () => setSaveState({ kind: "idle" }),
+          2000,
+        )
+      })
+      .catch((e: unknown) => {
+        const msg = e instanceof Error ? e.message : String(e)
+        clearSaveTimer()
+        setSaveState({ kind: "error", message: msg })
+        saveTimerRef.current = setTimeout(
+          () => setSaveState({ kind: "idle" }),
+          2000,
+        )
+      })
+  }, [
+    envDeletePending,
+    setEnvDeletePending,
+    envEditorRef,
+    clearSaveTimer,
+    setSaveState,
+    saveTimerRef,
+  ])
+
+  const confirmUndoAll = useCallback(() => {
+    draftRef.current.revertAllRequests()
+    folderDraftRef.current.revertAllFolders()
+    envEditorRef.current?.revertDraft()
+    setUndoAllPending(false)
+  }, [draftRef, folderDraftRef, envEditorRef, setUndoAllPending])
+
+  const confirmInit = useCallback(() => {
+    onInitConfirm()
+    setInitPending(false)
+  }, [onInitConfirm, setInitPending])
+
+  const confirmCollectionSwitch = useCallback(() => {
+    if (!collectionSwitchPending) return
+    setCollectionSwitchPending(null)
+    onCollectionSwitchConfirm(collectionSwitchPending)
+  }, [
+    collectionSwitchPending,
+    setCollectionSwitchPending,
+    onCollectionSwitchConfirm,
+  ])
+
+  const onConfirm = useCallback(() => {
+    if (saveState.kind === "confirming") doSave()
+    else if (envDeletePending) confirmEnvDelete()
+    else if (undoAllPending) confirmUndoAll()
+    else if (initPending) confirmInit()
+    else if (collectionSwitchPending) confirmCollectionSwitch()
+    else if (folderDeletePending) onFolderDeleteConfirm()
+    else if (requestDeletePending) onRequestDeleteConfirm()
+    else if (updateConfirmVisible) onConfirmInstall()
+  }, [
+    saveState.kind,
+    doSave,
+    envDeletePending,
+    confirmEnvDelete,
+    undoAllPending,
+    confirmUndoAll,
+    initPending,
+    confirmInit,
+    collectionSwitchPending,
+    confirmCollectionSwitch,
+    folderDeletePending,
+    onFolderDeleteConfirm,
+    requestDeletePending,
+    onRequestDeleteConfirm,
+    updateConfirmVisible,
+    onConfirmInstall,
+  ])
+
+  const onCancel = useCallback(() => {
+    if (saveState.kind === "confirming") setSaveState({ kind: "idle" })
+    else if (envDeletePending) setEnvDeletePending(null)
+    else if (undoAllPending) setUndoAllPending(false)
+    else if (initPending) setInitPending(false)
+    else if (collectionSwitchPending) setCollectionSwitchPending(null)
+    else if (folderDeletePending) setFolderDeletePending(null)
+    else if (requestDeletePending) setRequestDeletePending(null)
+    else if (updateConfirmVisible) onCancelUpdate()
+  }, [
+    saveState.kind,
+    setSaveState,
+    envDeletePending,
+    setEnvDeletePending,
+    undoAllPending,
+    setUndoAllPending,
+    initPending,
+    setInitPending,
+    collectionSwitchPending,
+    setCollectionSwitchPending,
+    folderDeletePending,
+    setFolderDeletePending,
+    requestDeletePending,
+    setRequestDeletePending,
+    updateConfirmVisible,
+    onCancelUpdate,
+  ])
+
   // ── Overlay: Save Confirm ──────────────────────────────────────────
   useEffect(() => {
     if (saveState.kind !== "confirming") return
@@ -74,17 +184,17 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          doSave()
+          onConfirm()
         } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setSaveState({ kind: "idle" })
+          onCancel()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [saveState.kind, doSave, keymap, setSaveState])
+  }, [saveState.kind, keymap, onConfirm, onCancel])
 
   // ── Overlay: Delete env confirmation ──────────────────────────────
   useEffect(() => {
@@ -96,46 +206,17 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          const envName = envDeletePending
-          if (!envName) return
-          setEnvDeletePending(null)
-          envEditorRef.current
-            .deleteEnv()
-            .then(() => {
-              clearSaveTimer()
-              setSaveState({ kind: "success", message: `Deleted ${envName}` })
-              saveTimerRef.current = setTimeout(
-                () => setSaveState({ kind: "idle" }),
-                2000,
-              )
-            })
-            .catch((e: unknown) => {
-              const msg = e instanceof Error ? e.message : String(e)
-              clearSaveTimer()
-              setSaveState({ kind: "error", message: msg })
-              saveTimerRef.current = setTimeout(
-                () => setSaveState({ kind: "idle" }),
-                2000,
-              )
-            })
+          onConfirm()
         } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setEnvDeletePending(null)
+          onCancel()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    envDeletePending,
-    keymap,
-    setEnvDeletePending,
-    setSaveState,
-    clearSaveTimer,
-    saveTimerRef,
-    envEditorRef,
-  ])
+  }, [envDeletePending, keymap, onConfirm, onCancel])
 
   // ── Overlay: Collection switch confirmation ──────────────────────
   useEffect(() => {
@@ -147,24 +228,17 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          const nextDir = collectionSwitchPending
-          setCollectionSwitchPending(null)
-          onCollectionSwitchConfirm(nextDir)
+          onConfirm()
         } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setCollectionSwitchPending(null)
+          onCancel()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    collectionSwitchPending,
-    keymap,
-    onCollectionSwitchConfirm,
-    setCollectionSwitchPending,
-  ])
+  }, [collectionSwitchPending, keymap, onConfirm, onCancel])
 
   // ── Overlay: Delete Request ────────────────────────────────────────
   useEffect(() => {
@@ -176,25 +250,20 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          onRequestDeleteConfirm()
+          onConfirm()
           return
         }
         if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setRequestDeletePending(null)
+          onCancel()
           return
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    requestDeletePending,
-    onRequestDeleteConfirm,
-    setRequestDeletePending,
-    keymap,
-  ])
+  }, [requestDeletePending, keymap, onConfirm, onCancel])
 
   // ── Overlay: Delete Folder ────────────────────────────────────────
   useEffect(() => {
@@ -206,25 +275,20 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          onFolderDeleteConfirm()
+          onConfirm()
           return
         }
         if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setFolderDeletePending(null)
+          onCancel()
           return
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    folderDeletePending,
-    onFolderDeleteConfirm,
-    setFolderDeletePending,
-    keymap,
-  ])
+  }, [folderDeletePending, keymap, onConfirm, onCancel])
 
   // ── Overlay: Undo All ──────────────────────────────────────────────
   useEffect(() => {
@@ -236,27 +300,17 @@ export function useDialogIntercepts(opts: {
         if (name === "y") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          draftRef.current.revertAllRequests()
-          folderDraftRef.current.revertAllFolders()
-          envEditorRef.current?.revertDraft()
-          setUndoAllPending(false)
+          onConfirm()
         } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setUndoAllPending(false)
+          onCancel()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [
-    undoAllPending,
-    keymap,
-    setUndoAllPending,
-    draftRef,
-    folderDraftRef,
-    envEditorRef,
-  ])
+  }, [undoAllPending, keymap, onConfirm, onCancel])
 
   // ── Overlay: Init Confirm ─────────────────────────────────────────
   useEffect(() => {
@@ -268,18 +322,17 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          onInitConfirm()
-          setInitPending(false)
+          onConfirm()
         } else if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          setInitPending(false)
+          onCancel()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [initPending, keymap, onInitConfirm, setInitPending])
+  }, [initPending, keymap, onConfirm, onCancel])
 
   // ── Overlay: Update confirm ──────────────────────────────────────
   useEffect(() => {
@@ -291,16 +344,18 @@ export function useDialogIntercepts(opts: {
         if (name === "y" || name === "return") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          onConfirmInstall()
+          onConfirm()
         }
         if (name === "n" || name === "escape") {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          onCancelUpdate()
+          onCancel()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [updateConfirmVisible, keymap, onConfirmInstall, onCancelUpdate])
+  }, [updateConfirmVisible, keymap, onConfirm, onCancel])
+
+  return { onConfirm, onCancel }
 }

--- a/src/ui/intercepts/useFormOverlayIntercept.ts
+++ b/src/ui/intercepts/useFormOverlayIntercept.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useCallback, useEffect } from "react"
 import type { RefObject } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 
@@ -14,9 +14,13 @@ export function useFormOverlayIntercept(opts: {
   onConfirm: (result: any) => void
   onCancel: () => void
   passThroughFocuses?: string[]
-}): void {
+}): { confirm: () => void; cancel: () => void } {
   const { visible, handleRef, onConfirm, onCancel, passThroughFocuses } = opts
   const keymap = useKeymap()
+  const confirm = useCallback(() => {
+    const result = handleRef.current?.confirm()
+    if (result) onConfirm(result)
+  }, [handleRef, onConfirm])
 
   useEffect(() => {
     if (!visible) return
@@ -47,8 +51,7 @@ export function useFormOverlayIntercept(opts: {
           if (focus === "url") {
             e.preventDefault()
             e.stopPropagation()
-            const result = handle.confirm()
-            if (result) onConfirm(result)
+            confirm()
           } else if (focus) {
             e.preventDefault()
             e.stopPropagation()
@@ -59,8 +62,7 @@ export function useFormOverlayIntercept(opts: {
         if (e.name === "s" && e.ctrl) {
           e.preventDefault()
           e.stopPropagation()
-          const result = handle.confirm()
-          if (result) onConfirm(result)
+          confirm()
           return
         }
         if (e.name === "escape") {
@@ -73,7 +75,9 @@ export function useFormOverlayIntercept(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [visible, keymap, handleRef, onConfirm, onCancel, passThroughFocuses])
+  }, [visible, keymap, handleRef, confirm, onCancel, passThroughFocuses])
+
+  return { confirm, cancel: onCancel }
 }
 
 export function useSingleFieldFormOverlayIntercept(opts: {
@@ -81,9 +85,13 @@ export function useSingleFieldFormOverlayIntercept(opts: {
   handleRef: RefObject<{ confirm: () => string | null } | null>
   onConfirm: (result: string) => void
   onCancel: () => void
-}): void {
+}): { confirm: () => void; cancel: () => void } {
   const { visible, handleRef, onConfirm, onCancel } = opts
   const keymap = useKeymap()
+  const confirm = useCallback(() => {
+    const result = handleRef.current?.confirm()
+    if (result) onConfirm(result)
+  }, [handleRef, onConfirm])
 
   useEffect(() => {
     if (!visible) return
@@ -97,8 +105,7 @@ export function useSingleFieldFormOverlayIntercept(opts: {
         if (e.name === "s" && e.ctrl) {
           e.preventDefault()
           e.stopPropagation()
-          const result = handle.confirm()
-          if (result) onConfirm(result)
+          confirm()
           return
         }
         if (e.name === "escape") {
@@ -111,5 +118,7 @@ export function useSingleFieldFormOverlayIntercept(opts: {
       { priority: 100 },
     )
     return dispose
-  }, [visible, keymap, handleRef, onConfirm, onCancel])
+  }, [visible, keymap, handleRef, confirm, onCancel])
+
+  return { confirm, cancel: onCancel }
 }

--- a/src/ui/keybindingHints.ts
+++ b/src/ui/keybindingHints.ts
@@ -22,6 +22,7 @@ export interface KeybindingHintsContext {
 export interface HintSegment {
   key: string
   word: string
+  command?: string
 }
 
 export interface KeybindingHints {
@@ -50,14 +51,34 @@ function getHeaderHints(ctx: KeybindingHintsContext): HintSegment[] {
   }
   if (ctx.view === "env-editor") {
     return [
-      { key: displayKey(ctx.keybinds.command_palette), word: "commands" },
-      { key: displayKey(ctx.keybinds.help_toggle), word: "help" },
+      {
+        key: displayKey(ctx.keybinds.command_palette),
+        word: "commands",
+        command: "app.command-palette",
+      },
+      {
+        key: displayKey(ctx.keybinds.help_toggle),
+        word: "help",
+        command: "app.help",
+      },
     ]
   }
   return [
-    { key: displayKey(ctx.keybinds.jump_mode), word: "jump" },
-    { key: displayKey(ctx.keybinds.command_palette), word: "commands" },
-    { key: displayKey(ctx.keybinds.help_toggle), word: "help" },
+    {
+      key: displayKey(ctx.keybinds.jump_mode),
+      word: "jump",
+      command: "jump.enter",
+    },
+    {
+      key: displayKey(ctx.keybinds.command_palette),
+      word: "commands",
+      command: "app.command-palette",
+    },
+    {
+      key: displayKey(ctx.keybinds.help_toggle),
+      word: "help",
+      command: "app.help",
+    },
   ]
 }
 
@@ -71,26 +92,40 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
     if (!col) return []
     if (ctx.focus === "env-sidebar") {
       return [
-        { key: displayKey(kb.env_new), word: "new" },
-        { key: displayKey(kb.env_delete), word: "delete" },
-        { key: displayKey(kb.env_clone), word: "clone" },
+        { key: displayKey(kb.env_new), word: "new", command: "env.new" },
+        {
+          key: displayKey(kb.env_delete),
+          word: "delete",
+          command: "env.delete",
+        },
+        {
+          key: displayKey(kb.env_clone),
+          word: "clone",
+          command: "env.clone",
+        },
       ]
     }
     if (ctx.focus === "env-header") {
       return [
-        { key: displayKey(kb.env_new), word: "new" },
-        { key: displayKey(kb.env_save), word: "save" },
+        { key: displayKey(kb.env_new), word: "new", command: "env.new" },
+        { key: displayKey(kb.env_save), word: "save", command: "env.save" },
       ]
     }
     if (ctx.focus === "env-vars" && ctx.paneMode === "browse") {
       return [
-        { key: "Space", word: "toggle" },
-        { key: displayKey(kb.browse_delete), word: "revert" },
-        { key: displayKey(kb.env_save), word: "save" },
+        { key: "Space", word: "toggle", command: "env-browse.toggle" },
+        {
+          key: displayKey(kb.browse_delete),
+          word: "revert",
+          command: "env-browse.revert",
+        },
+        { key: displayKey(kb.env_save), word: "save", command: "env.save" },
       ]
     }
     if (ctx.focus === "env-vars" && ctx.paneMode === "edit") {
-      return [{ key: displayKey(kb.env_save), word: "save" }]
+      return [
+        { key: displayKey(kb.env_save), word: "save", command: "env.save" },
+      ]
     }
     return []
   }
@@ -98,17 +133,39 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
   if (ctx.focus === "sidebar") {
     if (!col) return []
     return [
-      { key: displayKey(kb.request_new), word: "new" },
-      { key: displayKey(kb.folder_new), word: "new folder" },
-      { key: displayKey(kb.request_delete), word: "delete" },
-      { key: displayKey(kb.request_clone), word: "clone" },
-      { key: displayKey(kb.request_save), word: "save" },
+      { key: displayKey(kb.request_new), word: "new", command: "request.new" },
+      {
+        key: displayKey(kb.folder_new),
+        word: "new folder",
+        command: "folder.new",
+      },
+      {
+        key: displayKey(kb.request_delete),
+        word: "delete",
+        command: "request.delete",
+      },
+      {
+        key: displayKey(kb.request_clone),
+        word: "clone",
+        command: "request.clone",
+      },
+      {
+        key: displayKey(kb.request_save),
+        word: "save",
+        command: "request.save",
+      },
     ]
   }
 
   if (ctx.focus === "urlbar") {
     if (!col) return []
-    return [{ key: displayKey(kb.request_save), word: "save" }]
+    return [
+      {
+        key: displayKey(kb.request_save),
+        word: "save",
+        command: "request.save",
+      },
+    ]
   }
 
   if (ctx.focus === "request") {
@@ -122,8 +179,16 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
       if (!col) return []
       return [
         ...foldSegments,
-        { key: displayKey(kb.pane_expand), word: "expand" },
-        { key: displayKey(kb.request_save), word: "save" },
+        {
+          key: displayKey(kb.pane_expand),
+          word: "expand",
+          command: "request.expand-toggle",
+        },
+        {
+          key: displayKey(kb.request_save),
+          word: "save",
+          command: "request.save",
+        },
       ]
     }
     if (ctx.paneMode === "browse") {
@@ -133,20 +198,40 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
         ctx.tab === "params" ||
         (ctx.tab === "body" &&
           (ctx.bodyType === "urlencoded" || ctx.bodyType === "multipart"))
-          ? [{ key: "Space", word: "toggle" }]
+          ? [{ key: "Space", word: "toggle", command: "browse.toggle" }]
           : []
       return [
         ...foldSegments,
         ...toggleSegments,
-        { key: displayKey(kb.browse_delete), word: "revert" },
-        { key: displayKey(kb.browse_revert_all), word: "revert all" },
-        { key: displayKey(kb.pane_expand), word: "expand" },
-        { key: displayKey(kb.request_save), word: "save" },
+        {
+          key: displayKey(kb.browse_delete),
+          word: "revert",
+          command: "browse.delete",
+        },
+        {
+          key: displayKey(kb.browse_revert_all),
+          word: "revert all",
+          command: "browse.revert-all",
+        },
+        {
+          key: displayKey(kb.pane_expand),
+          word: "expand",
+          command: "request.expand-toggle",
+        },
+        {
+          key: displayKey(kb.request_save),
+          word: "save",
+          command: "browse.save",
+        },
       ]
     }
     return [
       ...foldSegments,
-      { key: displayKey(kb.pane_expand), word: "expand" },
+      {
+        key: displayKey(kb.pane_expand),
+        word: "expand",
+        command: "request.expand-toggle",
+      },
     ]
   }
 
@@ -154,32 +239,72 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
     if (ctx.sendState.status === "done" && ctx.tab === "body") {
       if (ctx.queryVisible) return []
       return [
-        { key: displayKey(kb.response_copy_body), word: "copy" },
-        { key: displayKey(kb.response_query), word: "filter" },
-        { key: displayKey(kb.pane_expand), word: "expand" },
+        {
+          key: displayKey(kb.response_copy_body),
+          word: "copy",
+          command: "response.copy-body",
+        },
+        {
+          key: displayKey(kb.response_query),
+          word: "filter",
+          command: "response.query",
+        },
+        {
+          key: displayKey(kb.pane_expand),
+          word: "expand",
+          command: "request.expand-toggle",
+        },
       ]
     }
-    return [{ key: displayKey(kb.pane_expand), word: "expand" }]
+    return [
+      {
+        key: displayKey(kb.pane_expand),
+        word: "expand",
+        command: "request.expand-toggle",
+      },
+    ]
   }
 
   if (ctx.focus === "folder") {
     if (ctx.paneMode === "base") {
       if (!col) return []
       return [
-        { key: displayKey(kb.request_delete), word: "delete" },
-        { key: displayKey(kb.request_save), word: "save" },
+        {
+          key: displayKey(kb.request_delete),
+          word: "delete",
+          command: "folder.delete",
+        },
+        {
+          key: displayKey(kb.request_save),
+          word: "save",
+          command: "folder.save",
+        },
       ]
     }
     if (ctx.paneMode === "browse") {
       if (!col) return []
       const toggleSegments =
-        ctx.tab === "headers" ? [{ key: "Space", word: "toggle" }] : []
+        ctx.tab === "headers"
+          ? [{ key: "Space", word: "toggle", command: "folder-browse.toggle" }]
+          : []
       if (ctx.tab === "activity") return []
       return [
         ...toggleSegments,
-        { key: displayKey(kb.browse_delete), word: "revert" },
-        { key: displayKey(kb.browse_revert_all), word: "revert all" },
-        { key: displayKey(kb.request_save), word: "save" },
+        {
+          key: displayKey(kb.browse_delete),
+          word: "revert",
+          command: "folder-browse.revert-field",
+        },
+        {
+          key: displayKey(kb.browse_revert_all),
+          word: "revert all",
+          command: "folder-browse.revert-all",
+        },
+        {
+          key: displayKey(kb.request_save),
+          word: "save",
+          command: "folder.save",
+        },
       ]
     }
     return []

--- a/src/ui/keymap/folderLayers.ts
+++ b/src/ui/keymap/folderLayers.ts
@@ -1,5 +1,5 @@
 import type { UseBindingsLayer } from "@opentui/keymap/react"
-import { cloneRequest, deleteFolder } from "../commandActions"
+import { cloneRequest, deleteFolder, saveFolder } from "../commandActions"
 import type { AppKeymapContext } from "./types"
 
 export function createFolderLayers(
@@ -65,7 +65,7 @@ export function createFolderLayers(
       {
         name: "folder.save",
         enabled: canEdit,
-        run: () => folder.folderSaveRef.current(),
+        run: () => saveFolder(actions),
       },
       {
         name: "folder.delete",

--- a/src/ui/keymap/requestLayers.ts
+++ b/src/ui/keymap/requestLayers.ts
@@ -31,7 +31,7 @@ export function createRequestLayers(
         run: () => {
           openEnvironmentEditor(actions)
           global.setView("env-editor")
-          global.setFocus("env-header")
+          global.setFocus("env-sidebar")
         },
       },
       {

--- a/src/ui/overlays/AboutOverlay.tsx
+++ b/src/ui/overlays/AboutOverlay.tsx
@@ -2,8 +2,15 @@ import { TextAttributes } from "@opentui/core"
 import pkg from "../../../package.json" with { type: "json" }
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 
-export function AboutOverlay({ visible }: { visible: boolean }) {
+export function AboutOverlay({
+  visible,
+  onClose = () => {},
+}: {
+  visible: boolean
+  onClose?: () => void
+}) {
   const theme = useTheme()
 
   return (
@@ -19,7 +26,7 @@ export function AboutOverlay({ visible }: { visible: boolean }) {
         <text fg={theme.text} attributes={TextAttributes.BOLD}>
           About
         </text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={onClose} />
       </box>
       <box style={{ flexDirection: "column", gap: 1, paddingX: 4 }}>
         <text fg={theme.text}>Noodle v{pkg.version}</text>

--- a/src/ui/overlays/CloneRequestOverlay.tsx
+++ b/src/ui/overlays/CloneRequestOverlay.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from "react"
-import type { InputRenderable } from "@opentui/core"
+import { MouseButton, type InputRenderable } from "@opentui/core"
 import { Overlay } from "./Overlay"
 import { useTheme } from "../theme"
 
@@ -16,15 +16,23 @@ export interface CloneRequestOverlayHandle {
 interface CloneRequestOverlayProps {
   visible: boolean
   initialName: string
+  onConfirm?: () => void
+  onClose?: () => void
 }
 
 export const CloneRequestOverlay = forwardRef<
   CloneRequestOverlayHandle,
   CloneRequestOverlayProps
->(function CloneRequestOverlay({ visible, initialName }, ref) {
+>(function CloneRequestOverlay(
+  { visible, initialName, onConfirm, onClose },
+  ref,
+) {
   const theme = useTheme()
   const [name, setName] = useState(initialName)
   const [errorText, setErrorText] = useState<string | null>(null)
+  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
+    null,
+  )
   const nameRef = useRef<InputRenderable | null>(null)
 
   useEffect(() => {
@@ -90,11 +98,46 @@ export const CloneRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.text}>^S</text>
-        <text fg={theme.textMuted}>save</text>
-        <text fg={theme.textMuted}> · </text>
-        <text fg={theme.text}>esc</text>
-        <text fg={theme.textMuted}>close</text>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("save")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "save" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>^S</text>
+          <text fg={theme.textMuted}> save</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onClose?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("close")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "close" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>esc</text>
+          <text fg={theme.textMuted}> close</text>
+        </box>
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/CloneRequestOverlay.tsx
+++ b/src/ui/overlays/CloneRequestOverlay.tsx
@@ -7,6 +7,7 @@ import {
 } from "react"
 import { MouseButton, type InputRenderable } from "@opentui/core"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 import { useTheme } from "../theme"
 
 export interface CloneRequestOverlayHandle {
@@ -65,7 +66,7 @@ export const CloneRequestOverlay = forwardRef<
         }}
       >
         <text fg={theme.text}>Clone Request</text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={() => onClose?.()} />
       </box>
 
       <box style={{ paddingX: 2, flexDirection: "column", paddingBottom: 1 }}>

--- a/src/ui/overlays/CodeGeneratorOverlay.tsx
+++ b/src/ui/overlays/CodeGeneratorOverlay.tsx
@@ -170,6 +170,7 @@ export function CodeGeneratorOverlay({
             setClientId(lang.defaultClientId)
           }}
           focused={focus === "language"}
+          onActivate={() => setFocus("language")}
           triggerPriority={110}
           width={22}
         />
@@ -181,6 +182,7 @@ export function CodeGeneratorOverlay({
               setClientId(value)
             }}
             focused={focus === "library"}
+            onActivate={() => setFocus("library")}
             triggerPriority={110}
             width={24}
           />

--- a/src/ui/overlays/CodeGeneratorOverlay.tsx
+++ b/src/ui/overlays/CodeGeneratorOverlay.tsx
@@ -9,6 +9,7 @@ import { useRenderer } from "../RendererContext"
 import { showToast } from "../Toast"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 import { Select, type SelectItem } from "../Select"
 import { highlightGeneratedCode } from "./codeSyntax"
 
@@ -156,7 +157,7 @@ export function CodeGeneratorOverlay({
       >
         <text fg={theme.text}>Generate code</text>
         <box style={{ flexGrow: 1 }} />
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={onClose} />
       </box>
       <box
         paddingLeft={4}

--- a/src/ui/overlays/CodeGeneratorOverlay.tsx
+++ b/src/ui/overlays/CodeGeneratorOverlay.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useKeymap } from "@opentui/keymap/react"
-import type { ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
 import type { Collection, Environment, Request } from "../../schema"
 import { generateCode, getCodeTarget } from "../../codegen"
 import { CODE_LANGUAGES } from "../../codegen/targets"
@@ -51,6 +51,9 @@ export function CodeGeneratorOverlay({
   const [clientId, setClientId] = useState(DEFAULT_LANG.defaultClientId)
   const [focus, setFocus] = useState<"language" | "library">("language")
   const [interpolate, setInterpolate] = useState(false)
+  const [hoveredAction, setHoveredAction] = useState<
+    "interpolate" | "copy" | "close" | null
+  >(null)
 
   const clientItems = buildClientItems(languageKey)
   const hasClients = clientItems.length > 0
@@ -93,6 +96,17 @@ export function CodeGeneratorOverlay({
   )
   const lineNumberWidth = String(Math.max(1, highlightedCode.length)).length
 
+  const toggleInterpolate = useCallback(() => {
+    if (env) setInterpolate((prev) => !prev)
+  }, [env])
+
+  const copyCode = useCallback(() => {
+    if (!result.generated) return
+    if (copyToClipboard(result.generated.code, renderer))
+      showToast("Generated code copied", "success")
+    else showToast("Failed to copy generated code", "error")
+  }, [result.generated, renderer])
+
   useEffect(() => {
     if (!visible) return
     const dispose = keymap.intercept(
@@ -116,11 +130,9 @@ export function CodeGeneratorOverlay({
                   : "language",
           )
         } else if (key.name === "i" && !key.ctrl) {
-          if (env) setInterpolate((prev) => !prev)
+          toggleInterpolate()
         } else if (key.name === "c" && !key.ctrl && result.generated) {
-          if (copyToClipboard(result.generated.code, renderer))
-            showToast("Generated code copied", "success")
-          else showToast("Failed to copy generated code", "error")
+          copyCode()
         } else if (key.name === "up") scrollRef.current?.scrollBy(-1)
         else if (key.name === "down") scrollRef.current?.scrollBy(1)
         else if (key.name === "pageup")
@@ -131,16 +143,7 @@ export function CodeGeneratorOverlay({
       { priority: 100 },
     )
     return dispose
-  }, [
-    visible,
-    keymap,
-    onClose,
-    hasClients,
-    focus,
-    env,
-    result.generated,
-    renderer,
-  ])
+  }, [visible, keymap, onClose, hasClients, focus, toggleInterpolate, copyCode])
 
   if (!visible) return null
 
@@ -204,6 +207,14 @@ export function CodeGeneratorOverlay({
           paddingRight={4}
           maxHeight={20}
           scrollbarOptions={{ visible: false }}
+          onMouseScroll={(event) => {
+            const direction = event.scroll?.direction
+            if (!direction) return
+            const amount = event.scroll?.delta || 1
+            scrollRef.current?.scrollBy((direction === "up" ? -1 : 1) * amount)
+            event.preventDefault()
+            event.stopPropagation()
+          }}
         >
           <box style={{ flexDirection: "column", width: 82 }}>
             {highlightedCode.map((line, index) => (
@@ -240,27 +251,86 @@ export function CodeGeneratorOverlay({
             justifyContent: "flex-end",
             paddingX: 2,
             flexGrow: 1,
+            gap: 1,
           }}
         >
-          <text fg={theme.text}>i</text>
-          <text
-            fg={
-              !env
-                ? theme.border
-                : interpolate
-                  ? theme.primary
-                  : theme.textMuted
+          <box
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT || !env) return
+              toggleInterpolate()
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseOver={
+              env ? () => setHoveredAction("interpolate") : undefined
             }
+            onMouseOut={() => setHoveredAction(null)}
+            style={{
+              flexDirection: "row",
+              paddingLeft: 1,
+              paddingRight: 1,
+              backgroundColor:
+                hoveredAction === "interpolate"
+                  ? theme.backgroundElement
+                  : undefined,
+            }}
           >
-            {" "}
-            interpolate{!env ? " (no env)" : ""}{" "}
-          </text>
-          <text fg={theme.textMuted}>· </text>
-          <text fg={theme.text}>c</text>
-          <text fg={theme.textMuted}> copy </text>
-          <text fg={theme.textMuted}>· </text>
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
+            <text fg={theme.text}>i</text>
+            <text
+              fg={
+                !env
+                  ? theme.border
+                  : interpolate
+                    ? theme.primary
+                    : theme.textMuted
+              }
+            >
+              {" "}
+              interpolate{!env ? " (no env)" : ""}{" "}
+            </text>
+          </box>
+          <box
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT || !result.generated) return
+              copyCode()
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseOver={
+              result.generated ? () => setHoveredAction("copy") : undefined
+            }
+            onMouseOut={() => setHoveredAction(null)}
+            style={{
+              flexDirection: "row",
+              paddingLeft: 1,
+              paddingRight: 1,
+              backgroundColor:
+                hoveredAction === "copy" ? theme.backgroundElement : undefined,
+            }}
+          >
+            <text fg={theme.text}>c</text>
+            <text fg={theme.textMuted}> copy </text>
+          </box>
+          <box
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT) return
+              onClose()
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseOver={() => setHoveredAction("close")}
+            onMouseOut={() => setHoveredAction(null)}
+            style={{
+              flexDirection: "row",
+              paddingLeft: 1,
+              paddingRight: 1,
+              backgroundColor:
+                hoveredAction === "close" ? theme.backgroundElement : undefined,
+            }}
+          >
+            <text fg={theme.text}>esc</text>
+            <text fg={theme.textMuted}> close</text>
+          </box>
         </box>
       </box>
     </Overlay>

--- a/src/ui/overlays/ConfirmOverlay.tsx
+++ b/src/ui/overlays/ConfirmOverlay.tsx
@@ -2,6 +2,7 @@ import { MouseButton } from "@opentui/core"
 import { useState } from "react"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 
 export interface ConfirmOverlayProps {
   visible: boolean
@@ -32,7 +33,7 @@ export function ConfirmOverlay({
         }}
       >
         <text fg={theme.text}>Confirm</text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={() => onCancel?.()} />
       </box>
       <box style={{ paddingX: 2, paddingBottom: 1 }}>
         <text fg={theme.text}>{message}</text>

--- a/src/ui/overlays/ConfirmOverlay.tsx
+++ b/src/ui/overlays/ConfirmOverlay.tsx
@@ -1,13 +1,25 @@
+import { MouseButton } from "@opentui/core"
+import { useState } from "react"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
 
 export interface ConfirmOverlayProps {
   visible: boolean
   message: string
+  onConfirm?: () => void
+  onCancel?: () => void
 }
 
-export function ConfirmOverlay({ visible, message }: ConfirmOverlayProps) {
+export function ConfirmOverlay({
+  visible,
+  message,
+  onConfirm,
+  onCancel,
+}: ConfirmOverlayProps) {
   const theme = useTheme()
+  const [hoveredAction, setHoveredAction] = useState<
+    "confirm" | "cancel" | null
+  >(null)
 
   return (
     <Overlay visible={visible} width={50} gap={1} padding={1}>
@@ -33,11 +45,46 @@ export function ConfirmOverlay({ visible, message }: ConfirmOverlayProps) {
           paddingX: 2,
         }}
       >
-        <text fg={theme.text}>y</text>
-        <text fg={theme.textMuted}>confirm</text>
-        <text fg={theme.textMuted}> · </text>
-        <text fg={theme.text}>n</text>
-        <text fg={theme.textMuted}>cancel</text>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("confirm")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "confirm" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>y</text>
+          <text fg={theme.textMuted}> confirm</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onCancel?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("cancel")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "cancel" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>n</text>
+          <text fg={theme.textMuted}> cancel</text>
+        </box>
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/EscapeClose.tsx
+++ b/src/ui/overlays/EscapeClose.tsx
@@ -1,0 +1,28 @@
+import { MouseButton } from "@opentui/core"
+import { useState } from "react"
+import { useTheme } from "../theme"
+
+export function EscapeClose({ onClose }: { onClose: () => void }) {
+  const theme = useTheme()
+  const [hovered, setHovered] = useState(false)
+
+  return (
+    <box
+      onMouseDown={(event) => {
+        if (event.button !== MouseButton.LEFT) return
+        onClose()
+        event.preventDefault()
+        event.stopPropagation()
+      }}
+      onMouseOver={() => setHovered(true)}
+      onMouseOut={() => setHovered(false)}
+      style={{
+        paddingLeft: 1,
+        paddingRight: 1,
+        backgroundColor: hovered ? theme.backgroundElement : undefined,
+      }}
+    >
+      <text fg={hovered ? theme.text : theme.textMuted}>esc</text>
+    </box>
+  )
+}

--- a/src/ui/overlays/HelpOverlay.tsx
+++ b/src/ui/overlays/HelpOverlay.tsx
@@ -82,6 +82,17 @@ export function HelpOverlay({
         focused={visible}
         maxHeight={20}
         style={{ flexGrow: 1 }}
+        onMouseScroll={(event) => {
+          const direction = event.scroll?.direction
+          if (!direction) return
+          const amount = event.scroll?.delta || 1
+          scrollRef.current?.scrollBy(
+            (direction === "up" ? -1 : 1) * (amount / 5),
+            "viewport",
+          )
+          event.preventDefault()
+          event.stopPropagation()
+        }}
         verticalScrollbarOptions={{
           trackOptions: {
             backgroundColor: theme.background,

--- a/src/ui/overlays/HelpOverlay.tsx
+++ b/src/ui/overlays/HelpOverlay.tsx
@@ -6,15 +6,18 @@ import { TextAttributes } from "@opentui/core"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useEffect, useRef } from "react"
 import { useKeymap } from "@opentui/keymap/react"
+import { EscapeClose } from "./EscapeClose"
 
 const keyColumnWidth = 16
 
 export function HelpOverlay({
   visible,
   keybinds,
+  onClose = () => {},
 }: {
   visible: boolean
   keybinds: Keybinds
+  onClose?: () => void
 }) {
   const theme = useTheme()
   const keymap = useKeymap()
@@ -74,7 +77,7 @@ export function HelpOverlay({
         }}
       >
         <text fg={theme.text}>Keybindings</text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={onClose} />
       </box>
       <scrollbox
         ref={scrollRef}

--- a/src/ui/overlays/ImportCurlOverlay.tsx
+++ b/src/ui/overlays/ImportCurlOverlay.tsx
@@ -119,6 +119,7 @@ export const ImportCurlOverlay = forwardRef<
             onChange={setFolderPath}
             focused={focus === "folder"}
             onOpenChange={setFolderSelectOpen}
+            onActivate={() => setFocus("folder")}
             triggerPriority={110}
           />
         </box>

--- a/src/ui/overlays/ImportCurlOverlay.tsx
+++ b/src/ui/overlays/ImportCurlOverlay.tsx
@@ -14,6 +14,7 @@ import type { SelectItem } from "../Select"
 import { Select } from "../Select"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 
 export interface ImportCurlOverlayHandle {
   cycleFocus: (direction: 1 | -1) => void
@@ -107,7 +108,7 @@ export const ImportCurlOverlay = forwardRef<
         }}
       >
         <text fg={theme.text}>Import cURL Request</text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={() => onClose?.()} />
       </box>
 
       <box

--- a/src/ui/overlays/ImportCurlOverlay.tsx
+++ b/src/ui/overlays/ImportCurlOverlay.tsx
@@ -5,7 +5,11 @@ import {
   useRef,
   useState,
 } from "react"
-import type { InputRenderable, TextareaRenderable } from "@opentui/core"
+import {
+  MouseButton,
+  type InputRenderable,
+  type TextareaRenderable,
+} from "@opentui/core"
 import type { SelectItem } from "../Select"
 import { Select } from "../Select"
 import { useTheme } from "../theme"
@@ -22,6 +26,8 @@ interface ImportCurlOverlayProps {
   visible: boolean
   folderPaths: SelectItem[]
   initialFolderPath: string
+  onConfirm?: () => void
+  onClose?: () => void
 }
 
 const FOCUS_ORDER: Array<"folder" | "name" | "curl"> = [
@@ -33,7 +39,10 @@ const FOCUS_ORDER: Array<"folder" | "name" | "curl"> = [
 export const ImportCurlOverlay = forwardRef<
   ImportCurlOverlayHandle,
   ImportCurlOverlayProps
->(function ImportCurlOverlay({ visible, folderPaths, initialFolderPath }, ref) {
+>(function ImportCurlOverlay(
+  { visible, folderPaths, initialFolderPath, onConfirm, onClose },
+  ref,
+) {
   const theme = useTheme()
   const [command, setCommand] = useState("")
   const [name, setName] = useState("")
@@ -41,6 +50,9 @@ export const ImportCurlOverlay = forwardRef<
   const [focus, setFocus] = useState<"folder" | "name" | "curl">("folder")
   const [errorText, setErrorText] = useState<string | null>(null)
   const [folderSelectOpen, setFolderSelectOpen] = useState(false)
+  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
+    null,
+  )
   const curlRef = useRef<TextareaRenderable | null>(null)
   const nameRef = useRef<InputRenderable | null>(null)
 
@@ -131,6 +143,7 @@ export const ImportCurlOverlay = forwardRef<
             value={name}
             placeholder="e.g. Get Users"
             onInput={setName}
+            onMouseDown={() => setFocus("name")}
             focused={focus === "name"}
             backgroundColor={theme.backgroundElement}
             focusedBackgroundColor={theme.borderSubtle}
@@ -147,6 +160,7 @@ export const ImportCurlOverlay = forwardRef<
             initialValue={command}
             placeholder="curl https://api.example.com/users"
             onContentChange={() => setCommand(curlRef.current?.plainText ?? "")}
+            onMouseDown={() => setFocus("curl")}
             focused={focus === "curl"}
             backgroundColor={theme.backgroundElement}
             focusedBackgroundColor={theme.borderSubtle}
@@ -169,11 +183,46 @@ export const ImportCurlOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.text}>^S</text>
-        <text fg={theme.textMuted}>save</text>
-        <text fg={theme.textMuted}> · </text>
-        <text fg={theme.text}>esc</text>
-        <text fg={theme.textMuted}>close</text>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("save")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "save" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>^S</text>
+          <text fg={theme.textMuted}> save</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onClose?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("close")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "close" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>esc</text>
+          <text fg={theme.textMuted}> close</text>
+        </box>
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/NewFolderOverlay.tsx
+++ b/src/ui/overlays/NewFolderOverlay.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from "react"
-import type { InputRenderable } from "@opentui/core"
+import { MouseButton, type InputRenderable } from "@opentui/core"
 import { Overlay } from "./Overlay"
 import { useTheme } from "../theme"
 
@@ -15,15 +15,20 @@ export interface NewFolderOverlayHandle {
 
 interface NewFolderOverlayProps {
   visible: boolean
+  onConfirm?: () => void
+  onClose?: () => void
 }
 
 export const NewFolderOverlay = forwardRef<
   NewFolderOverlayHandle,
   NewFolderOverlayProps
->(function NewFolderOverlay({ visible }, ref) {
+>(function NewFolderOverlay({ visible, onConfirm, onClose }, ref) {
   const theme = useTheme()
   const [name, setName] = useState("")
   const [errorText, setErrorText] = useState<string | null>(null)
+  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
+    null,
+  )
   const nameRef = useRef<InputRenderable | null>(null)
 
   useEffect(() => {
@@ -89,11 +94,46 @@ export const NewFolderOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.text}>^S</text>
-        <text fg={theme.textMuted}>save</text>
-        <text fg={theme.textMuted}> · </text>
-        <text fg={theme.text}>esc</text>
-        <text fg={theme.textMuted}>close</text>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("save")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "save" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>^S</text>
+          <text fg={theme.textMuted}> save</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onClose?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("close")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "close" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>esc</text>
+          <text fg={theme.textMuted}> close</text>
+        </box>
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/NewFolderOverlay.tsx
+++ b/src/ui/overlays/NewFolderOverlay.tsx
@@ -7,6 +7,7 @@ import {
 } from "react"
 import { MouseButton, type InputRenderable } from "@opentui/core"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 import { useTheme } from "../theme"
 
 export interface NewFolderOverlayHandle {
@@ -61,7 +62,7 @@ export const NewFolderOverlay = forwardRef<
         }}
       >
         <text fg={theme.text}>New Folder</text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={() => onClose?.()} />
       </box>
 
       <box style={{ paddingX: 2, flexDirection: "column", paddingBottom: 1 }}>

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -202,7 +202,9 @@ export const NewRequestOverlay = forwardRef<
             value={name}
             placeholder="e.g. Get Users"
             onInput={setName}
-            onMouseDown={() => setFocus("name")}
+            onMouseDown={(event) => {
+              if (event.button === MouseButton.LEFT) setFocus("name")
+            }}
             focused={focus === "name"}
             backgroundColor={theme.backgroundElement}
             focusedBackgroundColor={theme.borderSubtle}
@@ -225,7 +227,9 @@ export const NewRequestOverlay = forwardRef<
               triggerPriority={110}
             />
             <box
-              onMouseDown={() => setFocus("url")}
+              onMouseDown={(event) => {
+                if (event.button === MouseButton.LEFT) setFocus("url")
+              }}
               style={{ flexGrow: 1, flexShrink: 1 }}
             >
               <VarInput

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -181,6 +181,7 @@ export const NewRequestOverlay = forwardRef<
               onChange={setFolderPath}
               focused={focus === "folder"}
               onOpenChange={setFolderSelectOpen}
+              onActivate={() => setFocus("folder")}
               triggerPriority={110}
             />
           </box>
@@ -211,6 +212,7 @@ export const NewRequestOverlay = forwardRef<
               onChange={(id) => setMethod(id as Method)}
               focused={focus === "method"}
               badge
+              onActivate={() => setFocus("method")}
               triggerPriority={110}
             />
             <VarInput

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from "react"
-import type { InputRenderable } from "@opentui/core"
+import { MouseButton, type InputRenderable } from "@opentui/core"
 import { VarInput, type VarInputHandle } from "../VarInput"
 import { Overlay } from "./Overlay"
 import { Select, type SelectItem } from "../Select"
@@ -36,6 +36,8 @@ interface NewRequestOverlayProps {
   folderPaths?: SelectItem[]
   initialFolderPath?: string
   activeEnv?: Environment | null
+  onConfirm?: () => void
+  onClose?: () => void
 }
 
 function slugify(name: string): string {
@@ -59,6 +61,8 @@ export const NewRequestOverlay = forwardRef<
     folderPaths,
     initialFolderPath,
     activeEnv,
+    onConfirm,
+    onClose,
   },
   ref,
 ) {
@@ -74,6 +78,9 @@ export const NewRequestOverlay = forwardRef<
   )
   const [errorText, setErrorText] = useState<string | null>(null)
   const [folderSelectOpen, setFolderSelectOpen] = useState(false)
+  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
+    null,
+  )
 
   const nameRef = useRef<InputRenderable | null>(null)
   const urlRef = useRef<VarInputHandle | null>(null)
@@ -194,6 +201,7 @@ export const NewRequestOverlay = forwardRef<
             value={name}
             placeholder="e.g. Get Users"
             onInput={setName}
+            onMouseDown={() => setFocus("name")}
             focused={focus === "name"}
             backgroundColor={theme.backgroundElement}
             focusedBackgroundColor={theme.borderSubtle}
@@ -215,19 +223,24 @@ export const NewRequestOverlay = forwardRef<
               onActivate={() => setFocus("method")}
               triggerPriority={110}
             />
-            <VarInput
-              ref={urlRef}
-              value={url || ""}
-              env={activeEnv ?? null}
-              isEditing
-              onChange={setUrl}
-              isFocused={focus === "url"}
-              placeholder="https://api.example.com/users"
-              backgroundColor={theme.backgroundElement}
-              focusedBackgroundColor={theme.borderSubtle}
-              paddingX={1}
+            <box
+              onMouseDown={() => setFocus("url")}
               style={{ flexGrow: 1, flexShrink: 1 }}
-            />
+            >
+              <VarInput
+                ref={urlRef}
+                value={url || ""}
+                env={activeEnv ?? null}
+                isEditing
+                onChange={setUrl}
+                isFocused={focus === "url"}
+                placeholder="https://api.example.com/users"
+                backgroundColor={theme.backgroundElement}
+                focusedBackgroundColor={theme.borderSubtle}
+                paddingX={1}
+                style={{ flexGrow: 1, flexShrink: 1 }}
+              />
+            </box>
           </box>
         </box>
 
@@ -243,11 +256,46 @@ export const NewRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <text fg={theme.text}>^S</text>
-        <text fg={theme.textMuted}>save</text>
-        <text fg={theme.textMuted}> · </text>
-        <text fg={theme.text}>esc</text>
-        <text fg={theme.textMuted}>close</text>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("save")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "save" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>^S</text>
+          <text fg={theme.textMuted}> save</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onClose?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("close")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "close" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>esc</text>
+          <text fg={theme.textMuted}> close</text>
+        </box>
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -8,6 +8,7 @@ import {
 import { MouseButton, type InputRenderable } from "@opentui/core"
 import { VarInput, type VarInputHandle } from "../VarInput"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 import { Select, type SelectItem } from "../Select"
 import { useTheme } from "../theme"
 import type { Method, Environment } from "../../schema"
@@ -163,7 +164,7 @@ export const NewRequestOverlay = forwardRef<
         }}
       >
         <text fg={theme.text}>{isEdit ? "Edit Request" : "New Request"}</text>
-        <text fg={theme.textMuted}>esc</text>
+        <EscapeClose onClose={() => onClose?.()} />
       </box>
 
       <box

--- a/src/ui/overlays/PickerOverlay.tsx
+++ b/src/ui/overlays/PickerOverlay.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import type { ReactNode } from "react"
-import type { ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
 import { useKeymap } from "@opentui/keymap/react"
 import { Overlay } from "./Overlay"
 import { useTheme } from "../theme"
@@ -192,10 +192,20 @@ export function PickerOverlay<T>({
           {filtered.map((item) => {
             const key = keyExtractor(item)
             const isHighlighted = currentHighlight === item
+            const navigable = isNavigable?.(item) ?? true
             return (
               <box
                 key={key}
                 id={`picker-item-${key}`}
+                onMouseDown={(event) => {
+                  if (event.button !== MouseButton.LEFT || !navigable) return
+                  onSelect(item)
+                  event.preventDefault()
+                  event.stopPropagation()
+                }}
+                onMouseOver={
+                  navigable ? () => onHighlightChange?.(item) : undefined
+                }
                 style={{
                   flexDirection: "row",
                   paddingLeft: 3,

--- a/src/ui/overlays/PickerOverlay.tsx
+++ b/src/ui/overlays/PickerOverlay.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react"
 import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
 import { useKeymap } from "@opentui/keymap/react"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 import { useTheme } from "../theme"
 
 export interface PickerOverlayProps<T> {
@@ -165,7 +166,7 @@ export function PickerOverlay<T>({
       <box paddingLeft={4} paddingRight={4}>
         <box flexDirection="row" justifyContent="space-between">
           <text fg={theme.text}>{title}</text>
-          <text fg={theme.textMuted}>esc</text>
+          <EscapeClose onClose={onClose} />
         </box>
         <box paddingTop={1}>
           <input

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useKeymap } from "@opentui/keymap/react"
-import { t, fg, type ScrollBoxRenderable } from "@opentui/core"
+import { MouseButton, t, fg, type ScrollBoxRenderable } from "@opentui/core"
 import type { TimelineBodyRef, TimelineEntry } from "../../schema"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
@@ -103,6 +103,15 @@ export function TimelineDetailOverlay({
   const [bodyError, setBodyError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [showLargeBody, setShowLargeBody] = useState(false)
+  const [hoveredAction, setHoveredAction] = useState<
+    | "view"
+    | "large-copy"
+    | "large-export"
+    | "headers"
+    | "body"
+    | "export"
+    | null
+  >(null)
   const [highlightPriority, setHighlightPriority] = useState<"start" | "end">(
     "start",
   )
@@ -115,6 +124,54 @@ export function TimelineDetailOverlay({
   const info =
     entry && activeTab !== "network" ? bodyInfo(entry, activeTab) : null
   const isLarge = (info?.size ?? 0) > AUTO_RENDER_LIMIT
+
+  const selectTab = useCallback((tab: DetailTab) => {
+    setActiveTab(tab)
+    setLoadedBody(null)
+    setBodyError(null)
+    setShowLargeBody(false)
+  }, [])
+
+  const copyHeaders = useCallback(() => {
+    if (!entry || activeTab === "network") return
+    const headers =
+      activeTab === "request"
+        ? buildDetailRequestHeaders(entry.request.auth, entry.request.headers)
+        : entry.response
+          ? Object.entries(entry.response.headers)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([key, value]) => ({ key, value }))
+          : []
+    onCopyHeaders(formatHeaderEntries(headers))
+  }, [entry, activeTab, onCopyHeaders])
+
+  const copyBody = useCallback(() => {
+    if (activeTab === "network") return
+    const body = loadedBody ?? info?.body
+    if (body !== undefined) onCopyBody(body)
+    else if (info?.ref) {
+      onLoadBody(info.ref)
+        .then(onCopyBody)
+        .catch(() => setBodyError("Unable to load the saved response body"))
+    }
+  }, [activeTab, loadedBody, info, onCopyBody, onLoadBody])
+
+  const exportBody = useCallback(() => {
+    if (!entry || activeTab === "network") return
+    const runExport = (body?: string) =>
+      onExportBody(entry, activeTab, body).catch(() =>
+        setBodyError("Failed to export timeline entry"),
+      )
+    const body = loadedBody ?? info?.body
+    if (body !== undefined) runExport(body)
+    else if (info?.ref) {
+      onLoadBody(info.ref)
+        .then(runExport)
+        .catch(() => setBodyError("Unable to load the saved response body"))
+    } else {
+      runExport()
+    }
+  }, [entry, activeTab, loadedBody, info, onExportBody, onLoadBody])
 
   useEffect(() => {
     if (!visible) return
@@ -168,58 +225,17 @@ export function TimelineDetailOverlay({
         key.stopPropagation()
         if (key.name === "escape") onClose()
         else if (key.name === "left" || key.name === "right") {
-          setActiveTab((prev) => {
-            const ids: DetailTab[] = hasNetwork
-              ? ["request", "response", "network"]
-              : ["request", "response"]
-            const index = ids.indexOf(prev)
-            const direction = key.name === "left" ? -1 : 1
-            return ids[(index + direction + ids.length) % ids.length]!
-          })
-          setLoadedBody(null)
-          setBodyError(null)
-          setShowLargeBody(false)
+          const ids: DetailTab[] = hasNetwork
+            ? ["request", "response", "network"]
+            : ["request", "response"]
+          const index = ids.indexOf(activeTab)
+          const direction = key.name === "left" ? -1 : 1
+          selectTab(ids[(index + direction + ids.length) % ids.length]!)
         } else if (key.name === "v" && isLarge) setShowLargeBody(true)
-        else if (key.name === "h" && activeTab !== "network") {
-          const currentHeaders =
-            activeTab === "request"
-              ? buildDetailRequestHeaders(
-                  entry.request.auth,
-                  entry.request.headers,
-                )
-              : entry.response
-                ? Object.entries(entry.response.headers)
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([key, value]) => ({ key, value }))
-                : []
-          onCopyHeaders(formatHeaderEntries(currentHeaders))
-        } else if (key.name === "b" && activeTab !== "network") {
-          const body = loadedBody ?? info?.body
-          if (body !== undefined) onCopyBody(body)
-          else if (info?.ref) {
-            onLoadBody(info.ref)
-              .then(onCopyBody)
-              .catch(() =>
-                setBodyError("Unable to load the saved response body"),
-              )
-          }
-        } else if (key.name === "e" && activeTab !== "network") {
-          const exportBody = (body?: string) =>
-            onExportBody(entry, activeTab, body).catch(() =>
-              setBodyError("Failed to export timeline entry"),
-            )
-          const body = loadedBody ?? info?.body
-          if (body !== undefined) exportBody(body)
-          else if (info?.ref) {
-            onLoadBody(info.ref)
-              .then(exportBody)
-              .catch(() =>
-                setBodyError("Unable to load the saved response body"),
-              )
-          } else {
-            exportBody(undefined)
-          }
-        } else if (key.name === "up") bodyScrollRef.current?.scrollBy(-1)
+        else if (key.name === "h") copyHeaders()
+        else if (key.name === "b") copyBody()
+        else if (key.name === "e") exportBody()
+        else if (key.name === "up") bodyScrollRef.current?.scrollBy(-1)
         else if (key.name === "down") bodyScrollRef.current?.scrollBy(1)
         else if (key.name === "pageup")
           bodyScrollRef.current?.scrollBy(-1, "viewport")
@@ -247,12 +263,12 @@ export function TimelineDetailOverlay({
     isLarge,
     loadedBody,
     info,
-    onCopyHeaders,
-    onCopyBody,
-    onExportBody,
-    onLoadBody,
     activeTab,
     hasNetwork,
+    selectTab,
+    copyHeaders,
+    copyBody,
+    exportBody,
   ])
 
   if (!visible || !entry) return null
@@ -285,6 +301,7 @@ export function TimelineDetailOverlay({
         <Tabs
           tabs={tabs}
           activeId={activeTab}
+          onChange={(tab) => selectTab(tab as DetailTab)}
           rightChildren={<text fg={theme.textMuted}>esc</text>}
         >
           {activeTab === "network" ? (
@@ -402,9 +419,74 @@ export function TimelineDetailOverlay({
                   <text
                     fg={theme.warning}
                   >{`Body is ${formatSize(info!.size)}. It was not rendered automatically.`}</text>
-                  <text fg={theme.textMuted}>
-                    v view raw · b copy · e export
-                  </text>
+                  <box style={{ flexDirection: "row", gap: 1 }}>
+                    <box
+                      onMouseDown={(event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        setShowLargeBody(true)
+                        event.preventDefault()
+                        event.stopPropagation()
+                      }}
+                      onMouseOver={() => setHoveredAction("view")}
+                      onMouseOut={() => setHoveredAction(null)}
+                      style={{
+                        flexDirection: "row",
+                        paddingLeft: 1,
+                        paddingRight: 1,
+                        backgroundColor:
+                          hoveredAction === "view"
+                            ? theme.backgroundElement
+                            : undefined,
+                      }}
+                    >
+                      <text fg={theme.text}>v</text>
+                      <text fg={theme.textMuted}> view raw </text>
+                    </box>
+                    <box
+                      onMouseDown={(event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        copyBody()
+                        event.preventDefault()
+                        event.stopPropagation()
+                      }}
+                      onMouseOver={() => setHoveredAction("large-copy")}
+                      onMouseOut={() => setHoveredAction(null)}
+                      style={{
+                        flexDirection: "row",
+                        paddingLeft: 1,
+                        paddingRight: 1,
+                        backgroundColor:
+                          hoveredAction === "large-copy"
+                            ? theme.backgroundElement
+                            : undefined,
+                      }}
+                    >
+                      <text fg={theme.text}>b</text>
+                      <text fg={theme.textMuted}> copy </text>
+                    </box>
+                    <box
+                      onMouseDown={(event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        exportBody()
+                        event.preventDefault()
+                        event.stopPropagation()
+                      }}
+                      onMouseOver={() => setHoveredAction("large-export")}
+                      onMouseOut={() => setHoveredAction(null)}
+                      style={{
+                        flexDirection: "row",
+                        paddingLeft: 1,
+                        paddingRight: 1,
+                        backgroundColor:
+                          hoveredAction === "large-export"
+                            ? theme.backgroundElement
+                            : undefined,
+                      }}
+                    >
+                      <text fg={theme.text}>e</text>
+                      <text fg={theme.textMuted}> export</text>
+                    </box>
+                  </box>
                 </box>
               ) : renderedBody ? (
                 (() => {
@@ -418,6 +500,16 @@ export function TimelineDetailOverlay({
                       ref={bodyScrollRef}
                       scrollY
                       height={computedBodyHeight}
+                      onMouseScroll={(event) => {
+                        const direction = event.scroll?.direction
+                        if (!direction) return
+                        const amount = event.scroll?.delta || 1
+                        bodyScrollRef.current?.scrollBy(
+                          (direction === "up" ? -1 : 1) * amount,
+                        )
+                        event.preventDefault()
+                        event.stopPropagation()
+                      }}
                       verticalScrollbarOptions={{
                         trackOptions: {
                           backgroundColor: theme.background,
@@ -448,16 +540,75 @@ export function TimelineDetailOverlay({
               flexDirection: "row",
               justifyContent: "flex-end",
               marginTop: 1,
+              gap: 1,
             }}
           >
-            <text fg={theme.text}>h</text>
-            <text fg={theme.textMuted}> copy headers </text>
-            <text fg={theme.textMuted}>· </text>
-            <text fg={theme.text}>b</text>
-            <text fg={theme.textMuted}> copy body </text>
-            <text fg={theme.textMuted}>· </text>
-            <text fg={theme.text}>e</text>
-            <text fg={theme.textMuted}> export</text>
+            <box
+              onMouseDown={(event) => {
+                if (event.button !== MouseButton.LEFT) return
+                copyHeaders()
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onMouseOver={() => setHoveredAction("headers")}
+              onMouseOut={() => setHoveredAction(null)}
+              style={{
+                flexDirection: "row",
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor:
+                  hoveredAction === "headers"
+                    ? theme.backgroundElement
+                    : undefined,
+              }}
+            >
+              <text fg={theme.text}>h</text>
+              <text fg={theme.textMuted}> copy headers </text>
+            </box>
+            <box
+              onMouseDown={(event) => {
+                if (event.button !== MouseButton.LEFT) return
+                copyBody()
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onMouseOver={() => setHoveredAction("body")}
+              onMouseOut={() => setHoveredAction(null)}
+              style={{
+                flexDirection: "row",
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor:
+                  hoveredAction === "body"
+                    ? theme.backgroundElement
+                    : undefined,
+              }}
+            >
+              <text fg={theme.text}>b</text>
+              <text fg={theme.textMuted}> copy body </text>
+            </box>
+            <box
+              onMouseDown={(event) => {
+                if (event.button !== MouseButton.LEFT) return
+                exportBody()
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onMouseOver={() => setHoveredAction("export")}
+              onMouseOut={() => setHoveredAction(null)}
+              style={{
+                flexDirection: "row",
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor:
+                  hoveredAction === "export"
+                    ? theme.backgroundElement
+                    : undefined,
+              }}
+            >
+              <text fg={theme.text}>e</text>
+              <text fg={theme.textMuted}> export</text>
+            </box>
           </box>
         )}
       </box>

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -4,6 +4,7 @@ import { MouseButton, t, fg, type ScrollBoxRenderable } from "@opentui/core"
 import type { TimelineBodyRef, TimelineEntry } from "../../schema"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
+import { EscapeClose } from "./EscapeClose"
 import { Tabs, type TabDef } from "../Tabs"
 import { Badge } from "../Badge"
 import { formatSize, statusColor } from "../format"
@@ -302,7 +303,7 @@ export function TimelineDetailOverlay({
           tabs={tabs}
           activeId={activeTab}
           onChange={(tab) => selectTab(tab as DetailTab)}
-          rightChildren={<text fg={theme.textMuted}>esc</text>}
+          rightChildren={<EscapeClose onClose={onClose} />}
         >
           {activeTab === "network" ? (
             <NetworkTab

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -103,6 +103,7 @@ export function BodySection({
   activeEnv,
   onBodyChange,
   onEditorActivate,
+  onEditorRef,
   onFormRowActivate,
   onFormRowToggle,
 }: {
@@ -118,6 +119,7 @@ export function BodySection({
   activeEnv?: Environment | null
   onBodyChange: (body: string) => void
   onEditorActivate?: () => void
+  onEditorRef?: (editor: CodeEditorRenderable | null) => void
   onFormRowActivate?: (row: number, addingRow: boolean) => void
   onFormRowToggle?: (row: number) => void
 }) {
@@ -132,6 +134,7 @@ export function BodySection({
     useState<CodeEditorRenderable | null>(null)
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
+  const hoveredFoldLineRef = useRef<number | null>(null)
 
   const extraHighlights = useCallback(
     (content: string): Highlight[] => {
@@ -160,14 +163,46 @@ export function BodySection({
     onBodyChange(ed.plainText)
   }, [onBodyChange, setEditValue])
 
-  const handleFoldsChange = useCallback(() => {
-    const ed = editorRef.current
-    const ln = lineNumberRef.current
-    if (ed && ln) {
-      ln.setLineSigns(reserveFoldSigns(ed.getFoldSigns()))
+  const syncFoldSigns = useCallback(
+    (hoveredFoldLine?: number) => {
+      const ed = editorRef.current
+      const ln = lineNumberRef.current
+      if (!ed || !ln) return
+      const signs = ed.getFoldSigns()
+      const sign =
+        hoveredFoldLine === undefined ? undefined : signs.get(hoveredFoldLine)
+      if (sign && hoveredFoldLine !== undefined) {
+        signs.set(hoveredFoldLine, { ...sign, beforeColor: theme.primary })
+      }
+      ln.setLineSigns(reserveFoldSigns(signs))
       ln.setHideLineNumbers(ed.getHiddenLineNumbers())
-    }
-  }, [])
+    },
+    [theme.primary],
+  )
+
+  const handleFoldsChange = useCallback(() => {
+    hoveredFoldLineRef.current = null
+    syncFoldSigns()
+  }, [syncFoldSigns])
+
+  const updateFoldHover = useCallback(
+    (event: { x: number; y: number }) => {
+      const editor = editorRef.current
+      const lineNumbers = lineNumberRef.current
+      const displayLine =
+        editor && lineNumbers && event.x === lineNumbers.x
+          ? editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
+          : undefined
+      const hoveredFoldLine =
+        displayLine !== undefined && editor?.getFoldSigns().has(displayLine)
+          ? displayLine
+          : null
+      if (hoveredFoldLine === hoveredFoldLineRef.current) return
+      hoveredFoldLineRef.current = hoveredFoldLine
+      syncFoldSigns(hoveredFoldLine ?? undefined)
+    },
+    [syncFoldSigns],
+  )
 
   const editingBody = inEdit && editState.cursor.field === "body"
 
@@ -275,6 +310,40 @@ export function BodySection({
             fg={theme.textMuted}
             bg={theme.backgroundPanel}
             lineSigns={RESERVED_FOLD_SIGN}
+            onMouseMove={updateFoldHover}
+            onMouseOut={() => {
+              if (hoveredFoldLineRef.current === null) return
+              hoveredFoldLineRef.current = null
+              syncFoldSigns()
+            }}
+            onMouseScroll={(event) => {
+              const editor = editorRef.current
+              if (!editor || !event.scroll) return
+              if (event.scroll.direction === "up") {
+                editor.scrollBy(-event.scroll.delta)
+              } else if (event.scroll.direction === "down") {
+                editor.scrollBy(event.scroll.delta)
+              } else {
+                return
+              }
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseDown={(event) => {
+              const editor = editorRef.current
+              if (event.button !== MouseButton.LEFT || !editor) return
+              if (event.x >= editor.x) return
+              const displayLine =
+                editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
+              if (
+                displayLine === undefined ||
+                !editor.getFoldSigns().has(displayLine)
+              )
+                return
+              editor.toggleFold(displayLine)
+              event.preventDefault()
+              event.stopPropagation()
+            }}
             style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0, minHeight: 0 }}
             width="100%"
           >
@@ -282,6 +351,7 @@ export function BodySection({
               ref={(editor) => {
                 editorRef.current = editor
                 setEditorInstance(editor)
+                onEditorRef?.(editor)
               }}
               filetype="json"
               theme={theme}

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -32,6 +32,7 @@ export function BodyTypeSelector({
   onBodyTypeChange,
   onSelectOpenChange,
   onActivate,
+  interactive = true,
 }: {
   request: Request
   editState: EditState
@@ -39,6 +40,7 @@ export function BodyTypeSelector({
   onBodyTypeChange: (t: BodyType) => void
   onSelectOpenChange?: (open: boolean) => void
   onActivate?: () => void
+  interactive?: boolean
 }) {
   const bodyType = request.bodyType ?? "json"
 
@@ -82,6 +84,7 @@ export function BodyTypeSelector({
         badge={false}
         onOpenChange={handleBodyTypeSelectOpen}
         onActivate={onActivate}
+        interactive={interactive}
       />
     </box>
   )

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -100,6 +100,8 @@ export function BodySection({
   activeEnv,
   onBodyChange,
   onEditorActivate,
+  onFormRowActivate,
+  onFormRowToggle,
 }: {
   request: Request
   editState: EditState
@@ -113,6 +115,8 @@ export function BodySection({
   activeEnv?: Environment | null
   onBodyChange: (body: string) => void
   onEditorActivate?: () => void
+  onFormRowActivate?: (row: number, addingRow: boolean) => void
+  onFormRowToggle?: (row: number) => void
 }) {
   const bodyType = request.bodyType ?? "json"
 
@@ -211,6 +215,8 @@ export function BodySection({
           browseActive={browseActive}
           theme={theme}
           activeEnv={activeEnv}
+          onActivateRow={onFormRowActivate}
+          onToggleRow={onFormRowToggle}
         />
       ) : isBinaryMode ? (
         editingBody ? (
@@ -225,11 +231,23 @@ export function BodySection({
             focusedBackgroundColor={theme.borderSubtle}
           />
         ) : (
-          <VarInput
-            value={request.filePath || "(no file selected)"}
-            env={activeEnv ?? null}
-            isEditing={false}
-          />
+          <box
+            onMouseDown={
+              onEditorActivate
+                ? (event) => {
+                    if (event.button !== MouseButton.LEFT) return
+                    onEditorActivate()
+                    event.stopPropagation()
+                  }
+                : undefined
+            }
+          >
+            <VarInput
+              value={request.filePath || "(no file selected)"}
+              env={activeEnv ?? null}
+              isEditing={false}
+            />
+          </box>
         )
       ) : (
         <box

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import type { LineNumberRenderable, LineSign } from "@opentui/core"
-import type { Highlight } from "@opentui/core"
+import {
+  MouseButton,
+  type Highlight,
+  type LineNumberRenderable,
+  type LineSign,
+} from "@opentui/core"
 import type { Request, Environment } from "../../schema"
 import { formatBody } from "../formatRequest"
 import type { EditState } from "../editMode"
@@ -27,12 +31,14 @@ export function BodyTypeSelector({
   browseActive,
   onBodyTypeChange,
   onSelectOpenChange,
+  onActivate,
 }: {
   request: Request
   editState: EditState
   browseActive: boolean
   onBodyTypeChange: (t: BodyType) => void
   onSelectOpenChange?: (open: boolean) => void
+  onActivate?: () => void
 }) {
   const bodyType = request.bodyType ?? "json"
 
@@ -75,6 +81,7 @@ export function BodyTypeSelector({
         }
         badge={false}
         onOpenChange={handleBodyTypeSelectOpen}
+        onActivate={onActivate}
       />
     </box>
   )
@@ -92,6 +99,7 @@ export function BodySection({
   theme,
   activeEnv,
   onBodyChange,
+  onEditorActivate,
 }: {
   request: Request
   editState: EditState
@@ -104,6 +112,7 @@ export function BodySection({
   theme: Theme
   activeEnv?: Environment | null
   onBodyChange: (body: string) => void
+  onEditorActivate?: () => void
 }) {
   const bodyType = request.bodyType ?? "json"
 
@@ -225,6 +234,9 @@ export function BodySection({
       ) : (
         <box
           id="body-field"
+          onMouseDown={(event) => {
+            if (event.button === MouseButton.LEFT) onEditorActivate?.()
+          }}
           style={{
             flexDirection: "column",
             gap: 1,

--- a/src/ui/request-pane/RequestSettingsTab.tsx
+++ b/src/ui/request-pane/RequestSettingsTab.tsx
@@ -1,4 +1,5 @@
 import type { Request, Environment } from "../../schema"
+import { MouseButton } from "@opentui/core"
 import type { EditState } from "../editMode"
 import type { Theme } from "../theme"
 import { VarInput } from "../VarInput"
@@ -13,6 +14,8 @@ export function SettingsSection({
   browseActive,
   theme,
   activeEnv,
+  onActivateRow,
+  onToggleRow,
 }: {
   request: Request
   editState: EditState
@@ -21,6 +24,8 @@ export function SettingsSection({
   browseActive: boolean
   theme: Theme
   activeEnv?: Environment | null
+  onActivateRow?: (row: number) => void
+  onToggleRow?: (row: number) => void
 }) {
   const rows = [
     {
@@ -69,6 +74,15 @@ export function SettingsSection({
                 gap: editingRow ? 1 : undefined,
                 backgroundColor: isActive ? theme.backgroundElement : undefined,
               }}
+              onMouseDown={
+                !editingRow && idx !== 1 && onActivateRow
+                  ? (event) => {
+                      if (event.button !== MouseButton.LEFT) return
+                      onActivateRow(idx)
+                      event.stopPropagation()
+                    }
+                  : undefined
+              }
             >
               {editingRow ? (
                 <>
@@ -84,10 +98,22 @@ export function SettingsSection({
               ) : idx === 1 ? (
                 <box style={{ flexDirection: "row", gap: 1 }}>
                   <text fg={theme.text}>{row.label}: </text>
-                  <Checkbox
-                    checked={request.followRedirects ?? true}
-                    theme={theme}
-                  />
+                  <box
+                    onMouseDown={
+                      onToggleRow
+                        ? (event) => {
+                            if (event.button !== MouseButton.LEFT) return
+                            onToggleRow(idx)
+                            event.stopPropagation()
+                          }
+                        : undefined
+                    }
+                  >
+                    <Checkbox
+                      checked={request.followRedirects ?? true}
+                      theme={theme}
+                    />
+                  </box>
                 </box>
               ) : (
                 <VarInput

--- a/src/ui/request-pane/RequestSettingsTab.tsx
+++ b/src/ui/request-pane/RequestSettingsTab.tsx
@@ -1,5 +1,6 @@
 import type { Request, Environment } from "../../schema"
 import { MouseButton } from "@opentui/core"
+import { useState } from "react"
 import type { EditState } from "../editMode"
 import type { Theme } from "../theme"
 import { VarInput } from "../VarInput"
@@ -27,6 +28,7 @@ export function SettingsSection({
   onActivateRow?: (row: number) => void
   onToggleRow?: (row: number) => void
 }) {
+  const [hoveredRow, setHoveredRow] = useState<number | null>(null)
   const rows = [
     {
       label: "Timeout (ms)",
@@ -59,6 +61,9 @@ export function SettingsSection({
           browseActive &&
           editState.cursor.field === "settings" &&
           editState.cursor.row === idx
+        const canHoverRow =
+          !editingRow &&
+          (idx === 1 ? onToggleRow !== undefined : onActivateRow !== undefined)
 
         return (
           <box key={row.label} style={{ flexDirection: "column" }}>
@@ -72,7 +77,10 @@ export function SettingsSection({
               style={{
                 flexDirection: editingRow ? "row" : undefined,
                 gap: editingRow ? 1 : undefined,
-                backgroundColor: isActive ? theme.backgroundElement : undefined,
+                backgroundColor:
+                  isActive || (canHoverRow && hoveredRow === idx)
+                    ? theme.backgroundElement
+                    : undefined,
               }}
               onMouseDown={
                 !editingRow && idx !== 1 && onActivateRow
@@ -83,6 +91,8 @@ export function SettingsSection({
                     }
                   : undefined
               }
+              onMouseOver={canHoverRow ? () => setHoveredRow(idx) : undefined}
+              onMouseOut={canHoverRow ? () => setHoveredRow(null) : undefined}
             >
               {editingRow ? (
                 <>

--- a/src/ui/saveState.ts
+++ b/src/ui/saveState.ts
@@ -1,5 +1,4 @@
 export type SaveState =
   | { kind: "idle" }
-  | { kind: "confirming"; requestId: string }
   | { kind: "success"; message: string }
   | { kind: "error"; message: string }

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -1,5 +1,6 @@
 import type { TimelineEntry as TimelineEntryType } from "../../schema"
 import { MouseButton } from "@opentui/core"
+import { useState } from "react"
 import { useTheme } from "../theme"
 import { statusColor } from "../format"
 import {
@@ -27,10 +28,12 @@ export function TimelineEntry({
   onActivate?: () => void
 }) {
   const theme = useTheme()
+  const [hovered, setHovered] = useState(false)
   const status = entryStatus(entry)
   const hasError = entry.error !== undefined
 
-  const rowBg = isSelected ? theme.backgroundElement : undefined
+  const rowBg =
+    isSelected || (hovered && onActivate) ? theme.backgroundElement : undefined
   const rowFg = isSelected ? theme.text : theme.textMuted
 
   const method = entryMethod(entry)
@@ -64,6 +67,8 @@ export function TimelineEntry({
             }
           : undefined
       }
+      onMouseOver={onActivate ? () => setHovered(true) : undefined}
+      onMouseOut={onActivate ? () => setHovered(false) : undefined}
     >
       <box
         style={{

--- a/src/ui/timeline/TimelineEntry.tsx
+++ b/src/ui/timeline/TimelineEntry.tsx
@@ -1,4 +1,5 @@
 import type { TimelineEntry as TimelineEntryType } from "../../schema"
+import { MouseButton } from "@opentui/core"
 import { useTheme } from "../theme"
 import { statusColor } from "../format"
 import {
@@ -17,11 +18,13 @@ export function TimelineEntry({
   entry,
   isSelected,
   containerWidth,
+  onActivate,
 }: {
   id?: string
   entry: TimelineEntryType
   isSelected: boolean
   containerWidth: number
+  onActivate?: () => void
 }) {
   const theme = useTheme()
   const status = entryStatus(entry)
@@ -52,6 +55,15 @@ export function TimelineEntry({
         backgroundColor: rowBg,
         overflow: "hidden",
       }}
+      onMouseDown={
+        onActivate
+          ? (event) => {
+              if (event.button !== MouseButton.LEFT) return
+              onActivate()
+              event.stopPropagation()
+            }
+          : undefined
+      }
     >
       <box
         style={{

--- a/src/ui/timeline/TimelineTab.tsx
+++ b/src/ui/timeline/TimelineTab.tsx
@@ -9,12 +9,14 @@ export function TimelineTab({
   entries,
   focused,
   onOpenEntry,
+  onPaneFocus,
   layout,
   expanded,
 }: {
   entries: TimelineEntryType[]
   focused: boolean
   onOpenEntry?: (entry: TimelineEntryType) => void
+  onPaneFocus?: () => void
   layout?: "stacked" | "side-by-side"
   expanded?: "request" | "response" | null
 }) {
@@ -106,6 +108,11 @@ export function TimelineTab({
           entry={entry}
           isSelected={idx === selectedIdx}
           containerWidth={containerWidth}
+          onActivate={() => {
+            onPaneFocus?.()
+            setSelectedIdx(idx)
+            onOpenEntry?.(entry)
+          }}
         />
       ))}
     </scrollbox>

--- a/src/ui/tree.ts
+++ b/src/ui/tree.ts
@@ -22,6 +22,27 @@ export function updateFolderByPath(
   })
 }
 
+export function updateRequestById(
+  items: CollectionItem[],
+  id: string,
+  request: Request,
+): CollectionItem[] {
+  return items.map((item) => {
+    if (item.type === "request") {
+      return item.data.id === id
+        ? { type: "request", data: { ...request } }
+        : item
+    }
+    return {
+      type: "folder",
+      data: {
+        ...item.data,
+        children: updateRequestById(item.data.children, id, request),
+      },
+    }
+  })
+}
+
 export function findFolderByPath(
   items: CollectionItem[],
   path: string,

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -35,6 +35,7 @@ function createActionsConfig(
     activeIndexRef: global.activeIndexRef,
     savingRef: request.savingRef,
     doSaveRef: request.doSaveRef,
+    folderSaveRef: folder.folderSaveRef,
     focusedFolderPathRef: folder.focusedFolderPathRef,
     focusedFolderNameRef: folder.focusedFolderNameRef,
     folderDeletePathRef: folder.folderDeletePathRef,

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -121,6 +121,7 @@ export function useCollectionFileActions({
       savingRef.current = false
     }
   }, [
+    collection,
     collectionDir,
     folderDraftRef,
     savingRef,

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -23,7 +23,7 @@ import type { SaveState } from "./saveState"
 interface UseCollectionFileActionsOptions {
   collectionDir: string
   collection: Collection | null
-  updateCollection: (collection: Collection) => void
+  updateCollection: Dispatch<SetStateAction<Collection | null>>
   selectedRequest: NoodleRequest | null
   requestDraftRef: MutableRefObject<UseRequestDraftResult>
   folderDraftRef: MutableRefObject<UseFolderDraftResult>
@@ -96,14 +96,18 @@ export function useCollectionFileActions({
     try {
       await saveFolder(collectionDir, draftFolder)
       folderDraftRef.current?.markSaved(draftFolder)
-      updateCollection({
-        ...collection,
-        items: updateFolderByPath(
-          collection.items,
-          draftFolder.path,
-          draftFolder,
-        ),
-      })
+      updateCollection((current) =>
+        current
+          ? {
+              ...current,
+              items: updateFolderByPath(
+                current.items,
+                draftFolder.path,
+                draftFolder,
+              ),
+            }
+          : current,
+      )
       showSaveResult({
         kind: "success",
         message: `Successfully saved folder ${draftFolder.name}`,
@@ -112,7 +116,6 @@ export function useCollectionFileActions({
       showError(e)
     }
   }, [
-    collection,
     collectionDir,
     folderDraftRef,
     showError,

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -32,6 +32,7 @@ interface UseCollectionFileActionsOptions {
   setCollectionReloadToken: Dispatch<SetStateAction<number>>
   setFocus: Dispatch<SetStateAction<Focus>>
   setSaveState: Dispatch<SetStateAction<SaveState>>
+  savingRef: MutableRefObject<boolean>
   clearSaveTimer: () => void
   saveTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>
   setSelectedId: (id: string) => void
@@ -58,6 +59,7 @@ export function useCollectionFileActions({
   setCollectionReloadToken,
   setFocus,
   setSaveState,
+  savingRef,
   clearSaveTimer,
   saveTimerRef,
   setSelectedId,
@@ -92,7 +94,8 @@ export function useCollectionFileActions({
 
   const handleFolderSave = useCallback(async () => {
     const draftFolder = folderDraftRef.current?.folderDraft
-    if (!draftFolder || !collection) return
+    if (!draftFolder || !collection || savingRef.current) return
+    savingRef.current = true
     try {
       await saveFolder(collectionDir, draftFolder)
       folderDraftRef.current?.markSaved(draftFolder)
@@ -114,10 +117,13 @@ export function useCollectionFileActions({
       })
     } catch (e: unknown) {
       showError(e)
+    } finally {
+      savingRef.current = false
     }
   }, [
     collectionDir,
     folderDraftRef,
+    savingRef,
     showError,
     showSaveResult,
     updateCollection,

--- a/src/ui/useModalKeyboardShield.ts
+++ b/src/ui/useModalKeyboardShield.ts
@@ -17,7 +17,6 @@ export const EDITABLE_OVERLAYS = new Set([
 export const HARD_BLOCKING_OVERLAYS = new Set([
   "help",
   "about",
-  "confirm",
   "env-delete",
   "undo-all",
   "init-confirm",
@@ -25,6 +24,7 @@ export const HARD_BLOCKING_OVERLAYS = new Set([
   "code-generator",
   "delete-folder",
   "request-delete",
+  "update-confirm",
   "timeline-detail",
 ])
 

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -102,12 +102,12 @@ export function useOverlayIntercepts(opts: {
   updateConfirmVisible: boolean
   onConfirmInstall: () => void
   onCancelUpdate: () => void
-}): void {
+}) {
   useGlobalIntercepts(opts)
 
-  useDialogIntercepts(opts)
+  const dialogActions = useDialogIntercepts(opts)
 
-  useFormOverlayIntercept({
+  const newRequestActions = useFormOverlayIntercept({
     visible: opts.newRequestVisible,
     handleRef: opts.newRequestRef,
     onConfirm: opts.onNewRequestConfirm,
@@ -115,14 +115,14 @@ export function useOverlayIntercepts(opts: {
     passThroughFocuses: ["method"],
   })
 
-  useFormOverlayIntercept({
+  const importCurlActions = useFormOverlayIntercept({
     visible: opts.importCurlVisible,
     handleRef: opts.importCurlRef,
     onConfirm: opts.onImportCurlConfirm,
     onCancel: () => opts.setImportCurlVisible(false),
   })
 
-  useFormOverlayIntercept({
+  const editRequestActions = useFormOverlayIntercept({
     visible: opts.editRequestVisible,
     handleRef: opts.editRequestRef,
     onConfirm: opts.onEditRequestConfirm,
@@ -130,14 +130,14 @@ export function useOverlayIntercepts(opts: {
     passThroughFocuses: ["method", "folder"],
   })
 
-  useSingleFieldFormOverlayIntercept({
+  const cloneRequestActions = useSingleFieldFormOverlayIntercept({
     visible: opts.cloneRequestVisible,
     handleRef: opts.cloneRequestRef,
     onConfirm: opts.onCloneRequestConfirm,
     onCancel: () => opts.setCloneRequestVisible(false),
   })
 
-  useSingleFieldFormOverlayIntercept({
+  const newFolderActions = useSingleFieldFormOverlayIntercept({
     visible: opts.newFolderVisible,
     handleRef: opts.newFolderRef,
     onConfirm: opts.onNewFolderConfirm,
@@ -145,4 +145,13 @@ export function useOverlayIntercepts(opts: {
   })
 
   useEnvEditorIntercept(opts)
+
+  return {
+    ...dialogActions,
+    newRequest: newRequestActions,
+    importCurl: importCurlActions,
+    editRequest: editRequestActions,
+    cloneRequest: cloneRequestActions,
+    newFolder: newFolderActions,
+  }
 }

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -9,6 +9,7 @@ import type { NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
 import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
+import type { ActiveOverlay } from "./useOverlayState"
 import { useGlobalIntercepts } from "./intercepts/useGlobalIntercepts"
 import { useDialogIntercepts } from "./intercepts/useDialogIntercepts"
 import {
@@ -29,11 +30,9 @@ export function shouldCancelSend(
 }
 
 export function useOverlayIntercepts(opts: {
-  activeOverlay: string
+  activeOverlay: ActiveOverlay
   cancelSendRef: RefObject<() => void>
-  saveState: SaveState
   setSaveState: (s: SaveState) => void
-  doSave: () => void
   envDeletePending: string | null
   envDeletePendingRef: RefObject<string | null>
   setEnvDeletePending: (s: string | null) => void

--- a/src/ui/useOverlayState.ts
+++ b/src/ui/useOverlayState.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { TimelineEntry } from "../schema"
-import type { SaveState } from "./saveState"
 import type { UpdateFlowState, YamlEditorState } from "./appState"
 import { initialYamlEditorState } from "./appState"
 import type { NewRequestOverlayHandle } from "./overlays/NewRequestOverlay"
@@ -15,7 +14,6 @@ export type ActiveOverlay =
   | "help"
   | "about"
   | "theme"
-  | "confirm"
   | "env-delete"
   | "undo-all"
   | "init-confirm"
@@ -35,7 +33,6 @@ export type ActiveOverlay =
 
 interface UseOverlayStateProps {
   previewIndex: number | null
-  saveState: SaveState
   collectionSwitcherVisible: boolean
   collectionSwitchPending: string | null
   updatePhase: UpdateFlowState["phase"]
@@ -43,7 +40,6 @@ interface UseOverlayStateProps {
 
 export function useOverlayState({
   previewIndex,
-  saveState,
   collectionSwitcherVisible,
   collectionSwitchPending,
   updatePhase,
@@ -90,7 +86,6 @@ export function useOverlayState({
     if (helpVisible) return "help"
     if (aboutVisible) return "about"
     if (previewIndex !== null) return "theme"
-    if (saveState.kind === "confirming") return "confirm"
     if (envDeletePending !== null) return "env-delete"
     if (undoAllPending) return "undo-all"
     if (initPending) return "init-confirm"
@@ -114,7 +109,6 @@ export function useOverlayState({
     helpVisible,
     aboutVisible,
     previewIndex,
-    saveState.kind,
     envDeletePending,
     undoAllPending,
     initPending,

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test"
+import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { extend } from "@opentui/react"
 import { KeymapProvider } from "@opentui/keymap/react"
@@ -40,6 +42,38 @@ const editStateBrowse = {
 }
 
 describe("BodySection — edit mode", () => {
+  it("activates the JSON editor without activating the body type selector", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let editorActivations = 0
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={20}>
+            <RequestPane
+              request={testRequest}
+              editState={editStateBrowse}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={true}
+              activeTab="body"
+              onJsonEditorFocus={() => editorActivations++}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(5, 5, MouseButtons.LEFT)
+    })
+    expect(editorActivations).toBe(1)
+    cleanup()
+  })
+
   it("renders body content in edit mode", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -4,9 +4,11 @@ import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { extend } from "@opentui/react"
 import { KeymapProvider } from "@opentui/keymap/react"
+import { readFile } from "node:fs/promises"
 import { RequestPane } from "../src/ui/RequestPane"
 import { ThemeProvider } from "../src/ui/theme"
 import { CodeEditorRenderable } from "../src/ui/editor/CodeEditor"
+import { lang } from "../src/lang"
 import type { Request } from "../src/schema"
 import { setupKeymap } from "./unit/_helpers"
 
@@ -233,6 +235,170 @@ describe("BodySection — edit mode", () => {
     const bottomLine = captureCharFrame().trimEnd().split("\n").at(-1) ?? ""
     expect(bottomLine).toContain("└")
     expect(bottomLine).toContain("┘")
+    cleanup()
+  })
+
+  it("toggles a JSON fold from its gutter icon", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const body = '{\n  "name": "hello",\n  "count": 42\n}'
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={20}>
+            <RequestPane
+              request={{ ...testRequest, body }}
+              editState={editStateEditing}
+              editKey=""
+              editValue={body}
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={true}
+              activeTab="body"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    await renderOnce()
+
+    const rows = captureCharFrame().split("\n")
+    const row = rows.find((line) => line.includes("▼") && line.includes("{"))
+    if (!row) throw new Error("Expected JSON fold icon")
+    const y = rows.indexOf(row)
+    const x = row.indexOf("▼")
+
+    await act(async () => {
+      await mockMouse.click(x, y, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("{... } (3 lines)")
+    cleanup()
+  })
+
+  it("pages through an unfocused JSON body", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const tallRequest: Request = {
+      ...testRequest,
+      body: JSON.stringify(
+        Object.fromEntries(
+          Array.from({ length: 30 }, (_, i) => [`key${i}`, i]),
+        ),
+      ),
+    }
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={8}>
+            <RequestPane
+              request={tallRequest}
+              editState={editStateBrowse}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={true}
+              activeTab="body"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+
+    for (let i = 0; i < 20; i++) {
+      act(() => {
+        mockInput.pressKey("\x1b[6~")
+      })
+      await renderOnce()
+    }
+
+    expect(captureCharFrame()).toContain('"key29"')
+    cleanup()
+  })
+
+  it("scrolls an unfocused JSON body from its gutter", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const tallRequest: Request = {
+      ...testRequest,
+      body: JSON.stringify(
+        Object.fromEntries(
+          Array.from({ length: 30 }, (_, i) => [`key${i}`, i]),
+        ),
+      ),
+    }
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={8}>
+            <RequestPane
+              request={tallRequest}
+              editState={editStateBrowse}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={false}
+              activeTab="body"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const row = rows.find((line) => line.includes("{") && line.includes("1"))
+    if (!row) throw new Error("Expected JSON gutter row")
+
+    for (let i = 0; i < 30; i++) {
+      await mockMouse.scroll(row.indexOf("1"), rows.indexOf(row), "down")
+      await renderOnce()
+    }
+
+    expect(captureCharFrame()).toContain('"key29"')
+    cleanup()
+  })
+
+  it("scrolls Create Post to the end while unfocused", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const request = lang.parseRequest(
+      "posts/create-post",
+      await readFile("collections/posts/create-post.yml", "utf8"),
+    )
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={12}>
+            <RequestPane
+              request={request}
+              editState={editStateBrowse}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={false}
+              activeTab="body"
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const row = rows.find((line) => line.includes("{") && line.includes("1"))
+    if (!row) throw new Error("Expected JSON gutter row")
+
+    for (let i = 0; i < 100; i++) {
+      await mockMouse.scroll(row.indexOf("1"), rows.indexOf(row), "down")
+      await renderOnce()
+    }
+
+    expect(captureCharFrame()).toContain('"likes": 0')
     cleanup()
   })
 

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -41,6 +41,12 @@ const editStateBrowse = {
   editingRow: -1,
 }
 
+const editStateEditingTimeout = {
+  mode: "editing" as const,
+  cursor: { field: "settings" as const, row: 0, addingRow: false },
+  editingRow: 0,
+}
+
 describe("BodySection — edit mode", () => {
   it("activates the JSON editor without activating the body type selector", async () => {
     const { keymap, cleanup } = setupKeymap()
@@ -58,7 +64,7 @@ describe("BodySection — edit mode", () => {
               setEditValue={() => {}}
               focused={true}
               activeTab="body"
-              onJsonEditorFocus={() => editorActivations++}
+              onBodyEditorFocus={() => editorActivations++}
             />
           </box>
         </ThemeProvider>
@@ -262,6 +268,45 @@ describe("BodySection — edit mode", () => {
     cleanup()
   })
 
+  it("activates a binary body editor on click", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const binaryRequest: Request = {
+      ...testRequest,
+      bodyType: "binary",
+      filePath: "/tmp/payload.bin",
+    }
+    let activated = ""
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={20}>
+            <RequestPane
+              request={binaryRequest}
+              editState={editStateBrowse}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={true}
+              activeTab="body"
+              onBodyEditorFocus={(bodyType) => {
+                activated = bodyType
+              }}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(5, 5, MouseButtons.LEFT)
+    })
+    expect(activated).toBe("binary")
+    cleanup()
+  })
+
   it("shows inline validation errors for malformed JSON while editing", async () => {
     const { keymap, cleanup } = setupKeymap()
     const invalidRequest: Request = {
@@ -290,6 +335,42 @@ describe("BodySection — edit mode", () => {
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain("Invalid JSON")
+    cleanup()
+  })
+})
+
+describe("RequestPane mouse transitions", () => {
+  it("commits before switching tabs from an active edit", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const events: string[] = []
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={20}>
+            <RequestPane
+              request={testRequest}
+              editState={editStateEditingTimeout}
+              editKey=""
+              editValue="10"
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused={true}
+              activeTab="settings"
+              onInteraction={() => events.push("commit")}
+              onTabChange={(tab) => events.push(tab)}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(12, 1, MouseButtons.LEFT)
+    })
+
+    expect(events).toEqual(["commit", "params"])
     cleanup()
   })
 })

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -278,7 +278,7 @@ describe("BodySection — edit mode", () => {
     cleanup()
   })
 
-  it("pages through an unfocused JSON body", async () => {
+  it("pages through a focused JSON body", async () => {
     const { keymap, cleanup } = setupKeymap()
     const tallRequest: Request = {
       ...testRequest,

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -3,6 +3,7 @@ import {
   findRequestById,
   findFolderByPath,
   updateFolderByPath,
+  updateRequestById,
   flattenRequests,
   visibleNodes,
   getFolderPaths,
@@ -143,6 +144,33 @@ describe("updateFolderByPath", () => {
       children: [],
     })
     expect(updated).toEqual(nestedItems)
+  })
+})
+
+describe("updateRequestById", () => {
+  it("replaces a nested request with its saved state", () => {
+    const saved = {
+      id: "auth/login",
+      name: "Login",
+      method: "POST" as const,
+      url: "https://example.com/users/:photoId",
+      headers: { Authorization: { value: "Bearer token", enabled: true } },
+      params: [{ name: "include", value: "metadata", enabled: true }],
+      pathParams: [{ name: "photoId", value: "42", enabled: true }],
+      body: '{"enabled":true}',
+      bodyType: "json" as const,
+      timeout: 5000,
+      followRedirects: false,
+      maxRedirects: 2,
+      auth: { type: "bearer" as const, token: "token" },
+    }
+
+    const updated = updateRequestById(nestedItems, saved.id, saved)
+
+    expect(findRequestById(updated, saved.id)).toEqual(saved)
+    expect(findRequestById(updated, "users/list")?.url).toBe(
+      "https://example.com",
+    )
   })
 })
 

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { act } from "react"
+import { AuthEditor } from "../../src/ui/AuthEditor"
+import { initialEditState } from "../../src/ui/editMode"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
+import { setupKeymap } from "./_helpers"
+
+describe("AuthEditor", () => {
+  it("activates the API key placement row before opening its select", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let focusedRow = -1
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <AuthEditor
+            auth={{
+              type: "api_key",
+              key: "X-API-Key",
+              value: "secret",
+              placement: "header",
+            }}
+            editState={initialEditState()}
+            inEdit={false}
+            browseActive={false}
+            setEditValue={() => {}}
+            theme={THEMES[0]!}
+            onAuthTypeChange={() => {}}
+            onApiKeyPlacementChange={() => {}}
+            onFocusRow={(row) => {
+              focusedRow = row
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 10 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(10, 6, MouseButtons.LEFT)
+    })
+    expect(focusedRow).toBe(3)
+    cleanup()
+  })
+})

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -261,6 +261,38 @@ describe("CodeEditorRenderable", () => {
     expect(editor!.scrollY).toBeGreaterThan(0)
   })
 
+  it("does not move the cursor for a zero scroll delta", async () => {
+    let editor: CodeEditorRenderable | null = null
+    const { renderOnce } = await testRender(
+      <box width={40} height={3}>
+        <code-editor
+          ref={(r) => {
+            editor = r
+          }}
+          filetype="json"
+          theme={opencodeTheme}
+          initialValue={'"line0"\n"line1"'}
+          debounceMs={0}
+          backgroundColor={opencodeTheme.backgroundPanel}
+          focusedBackgroundColor={opencodeTheme.backgroundPanel}
+          textColor={opencodeTheme.text}
+          cursorColor={opencodeTheme.primary}
+        />
+      </box>,
+      { width: 40, height: 3 },
+    )
+    await renderOnce()
+
+    let moves = 0
+    editor!.moveCursorDown = () => {
+      moves++
+      return true
+    }
+    editor!.scrollBy(0)
+
+    expect(moves).toBe(0)
+  })
+
   it("folds nested JSON ranges by their own start line", async () => {
     let editor: CodeEditorRenderable | null = null
     const content = `{

--- a/tests/unit/CodeGeneratorOverlay.test.tsx
+++ b/tests/unit/CodeGeneratorOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, spyOn } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { CliRenderer } from "@opentui/core"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -202,6 +203,46 @@ describe("CodeGeneratorOverlay", () => {
     expect(backgroundKeys).toEqual([])
     expect(copySpy).toHaveBeenCalled()
     disposeBackground()
+    copySpy.mockRestore()
+    cleanup()
+  })
+
+  it("copies generated code and closes from footer clicks", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const copySpy = spyOn(clipboard, "copyToClipboard").mockReturnValue(true)
+    let closed = 0
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <RendererProvider renderer={{} as unknown as CliRenderer}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <CodeGeneratorOverlay
+              visible
+              request={baseRequest}
+              onClose={() => closed++}
+            />
+          </ThemeProvider>
+        </RendererProvider>
+      </KeymapProvider>,
+      { width: 100, height: 32 },
+    )
+    await render.renderOnce()
+    const rows = render.captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("copy"))
+    expect(rows[y]).not.toContain("·")
+    await act(async () => {
+      await render.mockMouse.click(
+        rows[y]!.indexOf("copy"),
+        y,
+        MouseButtons.LEFT,
+      )
+      await render.mockMouse.click(
+        rows[y]!.indexOf("close"),
+        y,
+        MouseButtons.LEFT,
+      )
+    })
+    expect(copySpy).toHaveBeenCalled()
+    expect(closed).toBe(1)
     copySpy.mockRestore()
     cleanup()
   })

--- a/tests/unit/DeleteConfirmation.test.tsx
+++ b/tests/unit/DeleteConfirmation.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test"
+import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -97,6 +99,36 @@ describe("Delete confirmation", () => {
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain("esc")
+    cleanup()
+  })
+
+  it("runs confirm and cancel callbacks when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let confirmed = 0
+    let cancelled = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ConfirmOverlay
+            visible
+            message="Delete?"
+            onConfirm={() => confirmed++}
+            onCancel={() => cancelled++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 10 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("confirm"))
+    expect(rows[y]).not.toContain("·")
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("confirm"), y, MouseButtons.LEFT)
+      await mockMouse.click(rows[y]!.indexOf("cancel"), y, MouseButtons.LEFT)
+    })
+    expect(confirmed).toBe(1)
+    expect(cancelled).toBe(1)
     cleanup()
   })
 })

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { EnvEditorPane } from "../../src/ui/env-editor/EnvEditorPane"
+
+const inactive = {
+  mode: "inactive" as const,
+  row: -1,
+  addingRow: false,
+  editingRow: -1,
+}
+
+describe("EnvEditorPane", () => {
+  it("activates rows, toggles checkboxes, and activates the add row", async () => {
+    const activations: Array<[number, boolean]> = []
+    const toggles: number[] = []
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={8}>
+          <EnvEditorPane
+            draft={{
+              name: "development",
+              color: undefined,
+              varRows: [
+                {
+                  id: 1,
+                  key: "BASE_URL",
+                  value: "https://api.test",
+                  enabled: true,
+                },
+              ],
+            }}
+            editState={inactive}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused
+            onActivateRow={(row, addingRow) =>
+              activations.push([row, addingRow])
+            }
+            onToggleRow={(row) => toggles.push(row)}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(10, 2, MouseButtons.LEFT)
+    await mockMouse.click(2, 2, MouseButtons.LEFT)
+    await mockMouse.click(10, 3, MouseButtons.LEFT)
+
+    expect(activations).toEqual([
+      [0, false],
+      [-1, true],
+    ])
+    expect(toggles).toEqual([0])
+  })
+})

--- a/tests/unit/EnvHeaderPane.test.tsx
+++ b/tests/unit/EnvHeaderPane.test.tsx
@@ -28,7 +28,7 @@ describe("EnvHeaderPane", () => {
     const frame = captureCharFrame()
     expect(frame).toContain("dev")
     expect(frame).toContain("(none)")
-    expect(frame).toContain("Environment")
+    expect(frame).not.toContain("Environment")
     cleanup()
   })
 
@@ -78,7 +78,7 @@ describe("EnvHeaderPane", () => {
     cleanup()
   })
 
-  it("shows focused border when focused", async () => {
+  it("renders when focused without a pane title", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
@@ -96,7 +96,8 @@ describe("EnvHeaderPane", () => {
     )
     await renderOnce()
     const frame = captureCharFrame()
-    expect(frame).toContain("Environment")
+    expect(frame).toContain("dev")
+    expect(frame).not.toContain("Environment")
     cleanup()
   })
 

--- a/tests/unit/EnvHeaderPane.test.tsx
+++ b/tests/unit/EnvHeaderPane.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test"
+import { act, useState } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -122,6 +124,40 @@ describe("EnvHeaderPane", () => {
       .join("")
     expect(allText).toContain("primary")
     expect(allText).toContain("dev")
+    cleanup()
+  })
+
+  it("opens the color menu when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    function Harness() {
+      const [focused, setFocused] = useState(false)
+      return (
+        <EnvHeaderPane
+          name="dev"
+          color={undefined}
+          onNameChange={() => {}}
+          onColorChange={() => {}}
+          focused={focused}
+          onPaneFocus={() => setFocused(true)}
+        />
+      )
+    }
+
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 16 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(50, 1, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("primary")
     cleanup()
   })
 })

--- a/tests/unit/EnvSidebar.test.tsx
+++ b/tests/unit/EnvSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { RGBA } from "@opentui/core"
+import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { EnvSidebar } from "../../src/ui/env-editor/EnvSidebar"
 
@@ -27,6 +28,39 @@ describe("EnvSidebar", () => {
     expect(frame).toContain("dev")
     expect(frame).toContain("staging")
     expect(frame).toContain("prod")
+  })
+
+  it("selects an environment on left click only", async () => {
+    let selected = ""
+    let focused = 0
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <EnvSidebar
+          envNames={["dev", "staging"]}
+          selectedEnvName={null}
+          activeEnvName={undefined}
+          dirty={false}
+          onSelectEnv={(name) => {
+            selected = name
+          }}
+          onCreate={() => {}}
+          onClone={() => {}}
+          onDelete={() => {}}
+          focused={false}
+          onPaneFocus={() => focused++}
+        />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(2, 3, MouseButtons.RIGHT)
+    expect(selected).toBe("")
+    expect(focused).toBe(0)
+
+    await mockMouse.click(2, 3, MouseButtons.LEFT)
+    expect(selected).toBe("staging")
+    expect(focused).toBe(1)
   })
 
   it("shows (no environments) when list is empty", async () => {

--- a/tests/unit/EscapeClose.test.tsx
+++ b/tests/unit/EscapeClose.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { EscapeClose } from "../../src/ui/overlays/EscapeClose"
+
+describe("EscapeClose", () => {
+  it("closes when clicked", async () => {
+    let closed = false
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <EscapeClose onClose={() => (closed = true)} />
+      </ThemeProvider>,
+      { width: 10, height: 2 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(0, 0, MouseButtons.LEFT)
+    })
+    expect(closed).toBe(true)
+  })
+})

--- a/tests/unit/Frame.test.tsx
+++ b/tests/unit/Frame.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { MouseButtons } from "@opentui/core/testing"
+import { Frame } from "../../src/ui/Frame"
+
+describe("Frame", () => {
+  it("focuses its pane only on a left click", async () => {
+    let focusCount = 0
+    const { renderOnce, mockMouse } = await testRender(
+      <Frame onPaneFocus={() => focusCount++}>
+        <text>content</text>
+      </Frame>,
+      { width: 20, height: 4 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(1, 0, MouseButtons.RIGHT)
+    expect(focusCount).toBe(0)
+
+    await mockMouse.click(1, 0, MouseButtons.LEFT)
+    expect(focusCount).toBe(1)
+  })
+})

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -18,6 +18,7 @@ describe("Header", () => {
         <Header
           headerHints={[
             { key: "^p", word: "commands", command: "app.command-palette" },
+            { key: "F1", word: "help", command: "app.help" },
           ]}
           onHintActivate={(command) => activated.push(command)}
         />
@@ -26,7 +27,10 @@ describe("Header", () => {
     )
     await renderOnce()
 
-    const [x, y] = textPosition(captureCharFrame(), "commands")
+    const frame = captureCharFrame()
+    expect(frame).not.toContain("·")
+    expect(frame.indexOf("F1") - frame.indexOf("commands") - 8).toBe(3)
+    const [x, y] = textPosition(frame, "commands")
     await mockMouse.click(x, y, MouseButtons.RIGHT)
     expect(activated).toEqual([])
 

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { Header } from "../../src/ui/Header"
+import { ThemeProvider } from "../../src/ui/theme"
+
+function textPosition(frame: string, text: string): [number, number] {
+  const lines = frame.split("\n")
+  const y = lines.findIndex((line) => line.includes(text))
+  return [lines[y].indexOf(text), y]
+}
+
+describe("Header", () => {
+  it("activates command hints on left click only", async () => {
+    const activated: string[] = []
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Header
+          headerHints={[
+            { key: "^p", word: "commands", command: "app.command-palette" },
+          ]}
+          onHintActivate={(command) => activated.push(command)}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 1 },
+    )
+    await renderOnce()
+
+    const [x, y] = textPosition(captureCharFrame(), "commands")
+    await mockMouse.click(x, y, MouseButtons.RIGHT)
+    expect(activated).toEqual([])
+
+    await mockMouse.click(x, y, MouseButtons.LEFT)
+    expect(activated).toEqual(["app.command-palette"])
+  })
+
+  it("opens About on left click of the brand only", async () => {
+    let opened = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Header headerHints={[]} onAboutActivate={() => opened++} />
+      </ThemeProvider>,
+      { width: 80, height: 1 },
+    )
+    await renderOnce()
+
+    const [x, y] = textPosition(captureCharFrame(), "Noodle")
+    await mockMouse.click(x, y, MouseButtons.RIGHT)
+    expect(opened).toBe(0)
+
+    await mockMouse.click(x, y, MouseButtons.LEFT)
+    expect(opened).toBe(1)
+  })
+})

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { Header } from "../../src/ui/Header"
-import { ThemeProvider } from "../../src/ui/theme"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
 
 function textPosition(frame: string, text: string): [number, number] {
   const lines = frame.split("\n")
@@ -54,5 +56,43 @@ describe("Header", () => {
 
     await mockMouse.click(x, y, MouseButtons.LEFT)
     expect(opened).toBe(1)
+  })
+
+  it("clears a hint hover when it is activated", async () => {
+    const { renderOnce, captureCharFrame, captureSpans, mockMouse } =
+      await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Header
+            headerHints={[
+              { key: "^p", word: "commands", command: "app.command-palette" },
+            ]}
+            onHintActivate={() => {}}
+          />
+        </ThemeProvider>,
+        { width: 80, height: 1 },
+      )
+    await renderOnce()
+
+    const [x, y] = textPosition(captureCharFrame(), "commands")
+    await act(async () => {
+      await mockMouse.moveTo(x, y)
+    })
+    await renderOnce()
+
+    const hoverColor = RGBA.fromHex(THEMES[0]!.backgroundElement)
+    const hoveredSpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("commands"))
+    expect(hoveredSpan!.bg.equals(hoverColor)).toBe(true)
+
+    await act(async () => {
+      await mockMouse.click(x, y, MouseButtons.LEFT)
+    })
+    await renderOnce()
+
+    const clickedSpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("commands"))
+    expect(clickedSpan!.bg.equals(hoverColor)).toBe(false)
   })
 })

--- a/tests/unit/HelpOverlay.test.tsx
+++ b/tests/unit/HelpOverlay.test.tsx
@@ -78,4 +78,24 @@ describe("HelpOverlay", () => {
 
     cleanup()
   })
+
+  it("scrolls with the mouse wheel", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <HelpOverlay visible keybinds={bindingDefaults()} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 15 },
+    )
+    await renderOnce()
+    const initial = captureCharFrame()
+    await act(async () => {
+      await mockMouse.scroll(40, 7, "down")
+    })
+    await renderOnce()
+    expect(captureCharFrame()).not.toBe(initial)
+    cleanup()
+  })
 })

--- a/tests/unit/ImportCurlOverlay.test.tsx
+++ b/tests/unit/ImportCurlOverlay.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act, createRef } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -101,6 +102,37 @@ describe("ImportCurlOverlay", () => {
     expect(ref.current?.getFocus()).toBe("name")
     await act(async () => ref.current?.cycleFocus(1))
     expect(ref.current?.getFocus()).toBe("curl")
+    cleanup()
+  })
+
+  it("runs footer actions when clicked without dot separators", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let saved = 0
+    let closed = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ImportCurlOverlay
+            visible
+            folderPaths={[{ id: "", label: "(root)" }]}
+            initialFolderPath=""
+            onConfirm={() => saved++}
+            onClose={() => closed++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("save"))
+    expect(rows[y]).not.toContain("·")
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("save"), y, MouseButtons.LEFT)
+      await mockMouse.click(rows[y]!.indexOf("close"), y, MouseButtons.LEFT)
+    })
+    expect(saved).toBe(1)
+    expect(closed).toBe(1)
     cleanup()
   })
 })

--- a/tests/unit/PickerOverlay.test.tsx
+++ b/tests/unit/PickerOverlay.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test"
+import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -192,6 +194,37 @@ describe("PickerOverlay", () => {
     const frame = captureCharFrame()
     expect(frame).not.toContain("Test")
     expect(frame).not.toContain("Alpha")
+    cleanup()
+  })
+
+  it("selects a navigable item when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const selected: string[] = []
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <PickerOverlay
+            visible
+            title="Test"
+            items={testItems}
+            keyExtractor={(item) => item.id}
+            filter={() => true}
+            renderItem={(item) => <text>{item.label}</text>}
+            onSelect={(item) => selected.push(item.id)}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 20 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("Beta"))
+    const x = rows[y]!.indexOf("Beta")
+    await act(async () => {
+      await mockMouse.click(x, y, MouseButtons.LEFT)
+    })
+    expect(selected).toEqual(["b"])
     cleanup()
   })
 

--- a/tests/unit/RequestPane-clickCommit.test.tsx
+++ b/tests/unit/RequestPane-clickCommit.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { MouseButtons } from "@opentui/core/testing"
+import { ThemeProvider } from "../../src/ui/theme"
+import { RequestPane } from "../../src/ui/RequestPane"
+import type { FieldKind } from "../../src/ui/editMode"
+import type { Request } from "../../src/schema"
+import { setupKeymap } from "./_helpers"
+
+const request: Request = {
+  id: "photo",
+  name: "Photo",
+  method: "GET",
+  url: "https://example.com/photos/:photoId",
+  headers: {},
+  params: [{ name: "include", value: "metadata", enabled: true }],
+  pathParams: [{ name: "photoId", value: "42", enabled: true }],
+  timeout: 0,
+  followRedirects: true,
+  maxRedirects: 5,
+  auth: { type: "none" },
+}
+
+function EditingPane({
+  activeTab,
+  onInteraction,
+}: {
+  activeTab: FieldKind
+  onInteraction: () => void
+}) {
+  const isPath = activeTab === "pathParams"
+  return (
+    <RequestPane
+      request={request}
+      editState={{
+        mode: "editing",
+        cursor: {
+          field: activeTab,
+          row: 0,
+          addingRow: false,
+          subfield: "value",
+        },
+        editingRow: 0,
+      }}
+      editKey={isPath ? "photoId" : "include"}
+      editValue={isPath ? "42" : "metadata"}
+      setEditKey={() => {}}
+      setEditValue={() => {}}
+      activeTab={activeTab}
+      onInteraction={onInteraction}
+    />
+  )
+}
+
+describe("RequestPane blank click commit", () => {
+  it("commits a Path edit when clicking blank tab space", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let interactions = 0
+    try {
+      const { renderOnce, mockMouse } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <EditingPane
+              activeTab="pathParams"
+              onInteraction={() => interactions++}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
+
+      await renderOnce()
+      await act(async () => {
+        await mockMouse.click(40, 10, MouseButtons.LEFT)
+      })
+
+      expect(interactions).toBe(1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("commits a Params edit when clicking blank tab space", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let interactions = 0
+    try {
+      const { renderOnce, mockMouse } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <EditingPane
+              activeTab="params"
+              onInteraction={() => interactions++}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
+
+      await renderOnce()
+      await act(async () => {
+        await mockMouse.click(40, 10, MouseButtons.LEFT)
+      })
+
+      expect(interactions).toBe(1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("does not commit when clicking the active value input", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let interactions = 0
+    try {
+      const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <EditingPane
+              activeTab="pathParams"
+              onInteraction={() => interactions++}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
+
+      await renderOnce()
+      const lines = captureCharFrame().split("\n")
+      const valueRow = lines.findIndex((line) => line.includes("photoId"))
+      if (valueRow < 0) throw new Error("path parameter row was not rendered")
+      const valueColumn = lines[valueRow]!.lastIndexOf("42")
+      if (valueColumn < 0)
+        throw new Error("path parameter value was not rendered")
+      await act(async () => {
+        await mockMouse.click(valueColumn, valueRow, MouseButtons.LEFT)
+      })
+
+      expect(interactions).toBe(0)
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -78,6 +78,7 @@ describe("Select", () => {
   it("opens and selects with left clicks", async () => {
     const { keymap, cleanup } = setupKeymap()
     let selected = ""
+    let activated = 0
     const { renderOnce, captureCharFrame, mockMouse } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
@@ -87,6 +88,7 @@ describe("Select", () => {
             onChange={(id) => {
               selected = id
             }}
+            onActivate={() => activated++}
           />
         </ThemeProvider>
       </KeymapProvider>,
@@ -97,6 +99,7 @@ describe("Select", () => {
     await act(async () => {
       await mockMouse.click(1, 0, MouseButtons.LEFT)
     })
+    expect(activated).toBe(1)
     await renderOnce()
     expect(captureCharFrame()).toContain("POST")
 

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -110,6 +110,42 @@ describe("Select", () => {
     cleanup()
   })
 
+  it("does not open or select when non-interactive", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let selected = ""
+    let activated = 0
+    let open = false
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Select
+            items={testItems}
+            onChange={(id) => {
+              selected = id
+            }}
+            onActivate={() => activated++}
+            onOpenChange={(value) => {
+              open = value
+            }}
+            interactive={false}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 40, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(1, 0, MouseButtons.LEFT)
+    })
+    await renderOnce()
+
+    expect(activated).toBe(0)
+    expect(open).toBe(false)
+    expect(selected).toBe("")
+    cleanup()
+  })
+
   it("closes when its trigger is clicked again", async () => {
     const { keymap, cleanup } = setupKeymap()
     let open = false

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
 import { testRender } from "@opentui/react/test-utils"
+import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { Select, type SelectItem } from "../../src/ui/Select"
@@ -71,6 +72,38 @@ describe("Select", () => {
     })
     await renderOnce()
     expect(open).toBe(true)
+    cleanup()
+  })
+
+  it("opens and selects with left clicks", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let selected = ""
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Select
+            items={testItems}
+            focused
+            onChange={(id) => {
+              selected = id
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 40, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(1, 0, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("POST")
+
+    await act(async () => {
+      await mockMouse.click(2, 3, MouseButtons.LEFT)
+    })
+    expect(selected).toBe("post")
     cleanup()
   })
 

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -110,6 +110,72 @@ describe("Select", () => {
     cleanup()
   })
 
+  it("closes when its trigger is clicked again", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let open = false
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Select
+            items={testItems}
+            focused
+            onOpenChange={(value) => {
+              open = value
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 40, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(1, 0, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(open).toBe(true)
+
+    await act(async () => {
+      await mockMouse.click(1, 0, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(open).toBe(false)
+    cleanup()
+  })
+
+  it("closes when clicking outside the dropdown", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let open = false
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Select
+            items={testItems}
+            focused
+            onOpenChange={(value) => {
+              open = value
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 40, height: 20 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(1, 0, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(open).toBe(true)
+
+    await act(async () => {
+      await mockMouse.click(30, 15, MouseButtons.LEFT)
+    })
+    await renderOnce()
+    expect(open).toBe(false)
+    cleanup()
+  })
+
   it("closes dropdown on Escape", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     let open = false

--- a/tests/unit/Sidebar.test.tsx
+++ b/tests/unit/Sidebar.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { Sidebar } from "../../src/ui/Sidebar"
+import { ThemeProvider } from "../../src/ui/theme"
+
+describe("Sidebar", () => {
+  it("selects a request on left click only", async () => {
+    let selected = ""
+    let focused = 0
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Sidebar
+          items={[]}
+          loading={false}
+          error={null}
+          visibleItems={[
+            {
+              type: "request",
+              id: "example",
+              name: "Example",
+              depth: 0,
+              expanded: false,
+              hasChildren: false,
+              method: "GET",
+            },
+          ]}
+          cursorIndex={0}
+          selectedId="example"
+          expanded={new Set()}
+          onPaneFocus={() => focused++}
+          onRequestSelect={(id) => {
+            selected = id
+          }}
+        />
+      </ThemeProvider>,
+      { width: 40, height: 8 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(2, 1, MouseButtons.RIGHT)
+    expect(selected).toBe("")
+    expect(focused).toBe(0)
+
+    await mockMouse.click(3, 1, MouseButtons.LEFT)
+    expect(selected).toBe("example")
+    expect(focused).toBe(1)
+  })
+
+  it("toggles a folder only when its chevron is clicked", async () => {
+    let selected = ""
+    let toggled = ""
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Sidebar
+          items={[]}
+          loading={false}
+          error={null}
+          visibleItems={[
+            {
+              type: "folder",
+              id: "api",
+              name: "API",
+              depth: 0,
+              expanded: false,
+              hasChildren: true,
+            },
+          ]}
+          cursorIndex={0}
+          selectedId={null}
+          expanded={new Set()}
+          onFolderSelect={(id) => {
+            selected = id
+          }}
+          onFolderToggle={(id) => {
+            toggled = id
+          }}
+        />
+      </ThemeProvider>,
+      { width: 40, height: 8 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(3, 1, MouseButtons.LEFT)
+    expect(toggled).toBe("api")
+    expect(selected).toBe("")
+
+    await mockMouse.click(6, 1, MouseButtons.LEFT)
+    expect(selected).toBe("api")
+  })
+})

--- a/tests/unit/Sidebar.test.tsx
+++ b/tests/unit/Sidebar.test.tsx
@@ -5,9 +5,10 @@ import { Sidebar } from "../../src/ui/Sidebar"
 import { ThemeProvider } from "../../src/ui/theme"
 
 describe("Sidebar", () => {
-  it("selects a request on left click only", async () => {
+  it("selects on left click and opens the request context menu on right click", async () => {
     let selected = ""
     let focused = 0
+    let contextId = ""
     const { renderOnce, mockMouse } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
         <Sidebar
@@ -32,6 +33,9 @@ describe("Sidebar", () => {
           onRequestSelect={(id) => {
             selected = id
           }}
+          onRequestContextMenu={(id) => {
+            contextId = id
+          }}
         />
       </ThemeProvider>,
       { width: 40, height: 8 },
@@ -41,6 +45,7 @@ describe("Sidebar", () => {
     await mockMouse.click(2, 1, MouseButtons.RIGHT)
     expect(selected).toBe("")
     expect(focused).toBe(0)
+    expect(contextId).toBe("example")
 
     await mockMouse.click(3, 1, MouseButtons.LEFT)
     expect(selected).toBe("example")
@@ -87,5 +92,39 @@ describe("Sidebar", () => {
 
     await mockMouse.click(6, 1, MouseButtons.LEFT)
     expect(selected).toBe("api")
+  })
+
+  it("opens the folder context menu on right click", async () => {
+    let contextId = ""
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Sidebar
+          items={[]}
+          loading={false}
+          error={null}
+          visibleItems={[
+            {
+              type: "folder",
+              id: "api",
+              name: "API",
+              depth: 0,
+              expanded: false,
+              hasChildren: true,
+            },
+          ]}
+          cursorIndex={0}
+          selectedId={null}
+          expanded={new Set()}
+          onFolderContextMenu={(id) => {
+            contextId = id
+          }}
+        />
+      </ThemeProvider>,
+      { width: 40, height: 8 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(6, 1, MouseButtons.RIGHT)
+    expect(contextId).toBe("api")
   })
 })

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
-import { ThemeProvider } from "../../src/ui/theme"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { StatusBar } from "../../src/ui/StatusBar"
 import { bindingDefaults } from "../../src/ui/keybind"
 import { getKeybindingHints } from "../../src/ui/keybindingHints"
@@ -213,5 +215,48 @@ describe("StatusBar component", () => {
 
     await mockMouse.click(x, y, MouseButtons.LEFT)
     expect(opened).toBe(1)
+  })
+
+  it("clears a hint hover when it is activated", async () => {
+    const { renderOnce, captureCharFrame, captureSpans, mockMouse } =
+      await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <StatusBar
+            method="GET"
+            url="/users"
+            isDirty={false}
+            sendState={{ status: "idle" }}
+            envLabel="dev"
+            saveState={{ kind: "idle" }}
+            kb={kb}
+            footerHints={[{ key: "^s", word: "save", command: "request.save" }]}
+            onHintActivate={() => {}}
+          />
+        </ThemeProvider>,
+        { width: 80, height: 1 },
+      )
+    await renderOnce()
+
+    const [x, y] = textPosition(captureCharFrame(), "save")
+    await act(async () => {
+      await mockMouse.moveTo(x, y)
+    })
+    await renderOnce()
+
+    const hoverColor = RGBA.fromHex(THEMES[0]!.backgroundElement)
+    const hoveredSpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("save"))
+    expect(hoveredSpan!.bg.equals(hoverColor)).toBe(true)
+
+    await act(async () => {
+      await mockMouse.click(x, y, MouseButtons.LEFT)
+    })
+    await renderOnce()
+
+    const clickedSpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("save"))
+    expect(clickedSpan!.bg.equals(hoverColor)).toBe(false)
   })
 })

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -101,6 +101,7 @@ describe("StatusBar component", () => {
     expect(frame).toContain("new")
     expect(frame).toContain("new folder")
     expect(frame).toContain("delete")
+    expect(frame).not.toContain("·")
   })
 
   it("returns empty contextual shortcuts when overlay is active", async () => {
@@ -159,6 +160,31 @@ describe("StatusBar component", () => {
     await mockMouse.click(saveX, saveY, MouseButtons.LEFT)
     await mockMouse.click(sendX, sendY, MouseButtons.LEFT)
     expect(activated).toEqual(["request.save", "request.send"])
+  })
+
+  it("leaves a gap between footer hints", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <StatusBar
+          method="GET"
+          url="/users"
+          isDirty={false}
+          sendState={{ status: "idle" }}
+          envLabel="dev"
+          saveState={{ kind: "idle" }}
+          kb={kb}
+          footerHints={[
+            { key: "^s", word: "save", command: "request.save" },
+            { key: "^n", word: "new", command: "request.new" },
+          ]}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 1 },
+    )
+    await renderOnce()
+
+    const frame = captureCharFrame()
+    expect(frame.indexOf("^n") - frame.indexOf("save") - 4).toBe(3)
   })
 
   it("opens the environment editor on left click of the environment", async () => {

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { ThemeProvider } from "../../src/ui/theme"
 import { StatusBar } from "../../src/ui/StatusBar"
@@ -8,6 +9,12 @@ import type { HintSegment } from "../../src/ui/keybindingHints"
 
 const kb = bindingDefaults()
 const emptyHints: HintSegment[] = []
+
+function textPosition(frame: string, text: string): [number, number] {
+  const lines = frame.split("\n")
+  const y = lines.findIndex((line) => line.includes(text))
+  return [lines[y].indexOf(text), y]
+}
 
 function sidebarHints(): HintSegment[] {
   return getKeybindingHints({
@@ -119,5 +126,66 @@ describe("StatusBar component", () => {
     const frame = captureCharFrame()
 
     expect(frame).toContain("dev")
+  })
+
+  it("activates footer and send hints on left click only", async () => {
+    const activated: string[] = []
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <StatusBar
+          method="GET"
+          url="/users"
+          isDirty={false}
+          sendState={{ status: "idle" }}
+          envLabel="dev"
+          saveState={{ kind: "idle" }}
+          kb={kb}
+          footerHints={[{ key: "^s", word: "save", command: "request.save" }]}
+          sendCommand="request.send"
+          onHintActivate={(command) => activated.push(command)}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 1 },
+    )
+    await renderOnce()
+
+    const frame = captureCharFrame()
+    const [saveX, saveY] = textPosition(frame, "save")
+    const [sendX, sendY] = textPosition(frame, "send")
+    await mockMouse.click(saveX, saveY, MouseButtons.RIGHT)
+    await mockMouse.click(sendX, sendY, MouseButtons.RIGHT)
+    expect(activated).toEqual([])
+
+    await mockMouse.click(saveX, saveY, MouseButtons.LEFT)
+    await mockMouse.click(sendX, sendY, MouseButtons.LEFT)
+    expect(activated).toEqual(["request.save", "request.send"])
+  })
+
+  it("opens the environment editor on left click of the environment", async () => {
+    let opened = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <StatusBar
+          method="GET"
+          url="/users"
+          isDirty={false}
+          sendState={{ status: "idle" }}
+          envLabel="dev"
+          saveState={{ kind: "idle" }}
+          kb={kb}
+          footerHints={emptyHints}
+          onEnvironmentActivate={() => opened++}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 1 },
+    )
+    await renderOnce()
+
+    const [x, y] = textPosition(captureCharFrame(), "dev")
+    await mockMouse.click(x, y, MouseButtons.RIGHT)
+    expect(opened).toBe(0)
+
+    await mockMouse.click(x, y, MouseButtons.LEFT)
+    expect(opened).toBe(1)
   })
 })

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { act, useState, type ComponentProps } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { KeymapProvider } from "@opentui/keymap/react"
+import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider } from "../../src/ui/theme"
 import {
   TimelineDetailOverlay,
@@ -353,6 +354,53 @@ describe("TimelineDetailOverlay", () => {
     await act(async () => host.press("right"))
     await renderOnce()
     expect(captureCharFrame()).toContain("response body content")
+    cleanup()
+  })
+
+  it("switches tabs and copies the active body when clicked", async () => {
+    const copied: string[] = []
+    const { renderOnce, captureCharFrame, mockMouse, cleanup } =
+      await renderOverlay(
+        makeEntry({
+          request: {
+            ...makeEntry().request,
+            body: "request body",
+          },
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: "response body",
+            timeMs: 1,
+            size: 13,
+          },
+        }),
+        () => {},
+        true,
+        { onCopyBody: (body) => copied.push(body) },
+      )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const tabY = rows.findIndex((row) => row.includes("Response"))
+    await act(async () => {
+      await mockMouse.click(
+        rows[tabY]!.indexOf("Response"),
+        tabY,
+        MouseButtons.LEFT,
+      )
+    })
+    await renderOnce()
+    const updatedRows = captureCharFrame().split("\n")
+    const footerY = updatedRows.findIndex((row) => row.includes("copy body"))
+    expect(updatedRows[footerY]).not.toContain("·")
+    await act(async () => {
+      await mockMouse.click(
+        updatedRows[footerY]!.indexOf("copy body"),
+        footerY,
+        MouseButtons.LEFT,
+      )
+    })
+    expect(copied).toEqual(["response body"])
     cleanup()
   })
 

--- a/tests/unit/TimelineTab.test.tsx
+++ b/tests/unit/TimelineTab.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -72,6 +73,24 @@ describe("TimelineTab", () => {
     await act(async () => mockInput.pressKey("RETURN"))
     await renderOnce()
     expect(opened?.request.id).toBe("2")
+    cleanup()
+  })
+
+  it("opens an entry on left click", async () => {
+    const entries = [makeEntry("1"), makeEntry("2")]
+    let opened: TimelineEntry | undefined
+    const { renderOnce, mockMouse, cleanup } = await renderTimeline(
+      entries,
+      true,
+      (entry) => {
+        opened = entry
+      },
+    )
+    await renderOnce()
+    await act(async () => {
+      await mockMouse.click(2, 0, MouseButtons.LEFT)
+    })
+    expect(opened?.request.id).toBe("1")
     cleanup()
   })
 

--- a/tests/unit/Toast.test.tsx
+++ b/tests/unit/Toast.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { showToast, Toast } from "../../src/ui/Toast"
+
+describe("Toast", () => {
+  it("renders above overlays", async () => {
+    const { renderOnce, captureCharFrame, renderer } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Toast />
+      </ThemeProvider>,
+      { width: 40, height: 10 },
+    )
+    await renderOnce()
+
+    act(() => {
+      showToast("Saved")
+    })
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("Saved")
+    expect(
+      renderer.root.getChildren().some((child) => child.zIndex === 10003),
+    ).toBe(true)
+
+    act(() => {
+      renderer.destroy()
+    })
+  })
+})

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { act, useState } from "react"
 import { testRender } from "@opentui/react/test-utils"
+import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { UrlBar } from "../../src/ui/UrlBar"
@@ -14,6 +15,7 @@ function UrlBarHarness({
   onMethodChange,
   onDefocus,
   jumpMode = false,
+  onPaneFocus,
 }: {
   subFocus?: "select" | "text"
   focused?: boolean
@@ -21,6 +23,7 @@ function UrlBarHarness({
   onMethodChange?: (method: string) => void
   onDefocus?: (rawUrl: string) => void
   jumpMode?: boolean
+  onPaneFocus?: () => void
 }) {
   const [url, setUrl] = useState("https://example.com")
   const [method, setMethod] = useState<Method>(initialMethod)
@@ -38,6 +41,7 @@ function UrlBarHarness({
       focused={focused}
       subFocus={subFocus}
       jumpMode={jumpMode}
+      onPaneFocus={onPaneFocus}
       activeEnv={{
         name: "test",
         vars: { base_url: "https://api.example.com" },
@@ -47,6 +51,27 @@ function UrlBarHarness({
 }
 
 describe("UrlBar", () => {
+  it("focuses its pane only on a left click", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let focusCount = 0
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <UrlBarHarness onPaneFocus={() => focusCount++} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(0, 0, MouseButtons.RIGHT)
+    expect(focusCount).toBe(0)
+
+    await mockMouse.click(0, 0, MouseButtons.LEFT)
+    expect(focusCount).toBe(1)
+    cleanup()
+  })
+
   it("renders jump badges above real method and URL controls", async () => {
     const { keymap, cleanup } = setupKeymap()
     try {

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -16,6 +16,7 @@ function UrlBarHarness({
   onDefocus,
   jumpMode = false,
   onPaneFocus,
+  onSubFocus,
 }: {
   subFocus?: "select" | "text"
   focused?: boolean
@@ -24,6 +25,7 @@ function UrlBarHarness({
   onDefocus?: (rawUrl: string) => void
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onSubFocus?: (subFocus: "select" | "text") => void
 }) {
   const [url, setUrl] = useState("https://example.com")
   const [method, setMethod] = useState<Method>(initialMethod)
@@ -42,6 +44,7 @@ function UrlBarHarness({
       subFocus={subFocus}
       jumpMode={jumpMode}
       onPaneFocus={onPaneFocus}
+      onSubFocus={onSubFocus}
       activeEnv={{
         name: "test",
         vars: { base_url: "https://api.example.com" },
@@ -69,6 +72,29 @@ describe("UrlBar", () => {
 
     await mockMouse.click(0, 0, MouseButtons.LEFT)
     expect(focusCount).toBe(1)
+    cleanup()
+  })
+
+  it("focuses the URL text input on left click", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let subFocus = ""
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <UrlBarHarness
+            subFocus="select"
+            onSubFocus={(next) => {
+              subFocus = next
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(12, 1, MouseButtons.LEFT)
+    expect(subFocus).toBe("text")
     cleanup()
   })
 

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -149,6 +149,48 @@ describe("YamlEditorOverlay", () => {
     cleanup()
   })
 
+  it("toggles a YAML fold from its gutter icon", async () => {
+    await writeFile(
+      filePath,
+      "headers:\n  accept: application/json\n  x-id: 1\n",
+    )
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <YamlEditorOverlay
+            visible
+            filePath={filePath}
+            requestName="get-users"
+            onSaved={() => {}}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 30 },
+    )
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    await renderOnce()
+
+    const rows = captureCharFrame().split("\n")
+    const row = rows.find(
+      (line) => line.includes("▼") && line.includes("headers:"),
+    )
+    if (!row) throw new Error("Expected YAML fold icon")
+
+    await act(async () => {
+      await mockMouse.click(
+        row.indexOf("▼"),
+        rows.indexOf(row),
+        MouseButtons.LEFT,
+      )
+    })
+    await renderOnce()
+    expect(captureCharFrame()).not.toContain("accept: application/json")
+    cleanup()
+  })
+
   it("shows loading text when content not yet loaded (visible=false)", async () => {
     // Clear the module mock to test without content
     const { keymap, cleanup } = setupKeymap()

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { extend } from "@opentui/react"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -100,6 +102,50 @@ describe("YamlEditorOverlay", () => {
     expect(frame).toContain("save")
     expect(frame).toContain("esc")
     expect(frame).toContain("close")
+    cleanup()
+  })
+
+  it("runs footer save and close actions on click", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let saved = 0
+    let closed = 0
+    let resolveSaved: (() => void) | undefined
+    const savedPromise = new Promise<void>((resolve) => {
+      resolveSaved = resolve
+    })
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <YamlEditorOverlay
+            visible
+            filePath={filePath}
+            requestName="get-users"
+            onSaved={() => {
+              saved++
+              resolveSaved?.()
+            }}
+            onClose={() => closed++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 30 },
+    )
+    await renderOnce()
+    await new Promise((r) => setTimeout(r, 20))
+    await renderOnce()
+
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("save"))
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("save"), y, MouseButtons.LEFT)
+    })
+    await savedPromise
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("close"), y, MouseButtons.LEFT)
+    })
+
+    expect(saved).toBe(1)
+    expect(closed).toBe(1)
     cleanup()
   })
 

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -101,6 +101,7 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     actions: {
       trySendRef: request.trySendRef,
       envEditorRef: environment.envEditorRef,
+      focusedFolderPathRef: { current: null },
     },
   } as unknown as AppKeymapContext
   return { context, calls }

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -145,6 +145,25 @@ describe("app keymap layers", () => {
     cleanup()
   })
 
+  it("dispatches only active commands programmatically", () => {
+    const { keymap, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    const disposers = register(context)
+
+    expect(keymap.dispatchCommand("request.send")).toMatchObject({ ok: true })
+    expect(calls.send).toBe(1)
+
+    keymap.setData("app.mode", "browse")
+    expect(keymap.dispatchCommand("request.send")).toMatchObject({
+      ok: false,
+      reason: "disabled",
+    })
+    expect(calls.send).toBe(1)
+
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
   it("blocks request send outside collection mode", () => {
     const { keymap, host, cleanup } = setup()
     const { context, calls } = createContext(keymap)

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -7,6 +7,7 @@ import type { Collection } from "../../src/schema"
 import {
   cloneRequest,
   getEditRequestYamlFile,
+  saveFolder,
   saveRequest,
   sendRequest,
 } from "../../src/ui/commandActions"
@@ -327,6 +328,29 @@ describe("buildCommandPaletteCommands", () => {
     const save = commands.find((c) => c.id === "request.save")!
     save.run()
     expect(saved).toBe(false)
+  })
+
+  it("folder.save only runs for a dirty folder when no save is pending", () => {
+    const ctx = minimalContext()
+    let saved = 0
+    ctx.focusedFolderPathRef = { current: "api" } as never
+    ctx.folderDraftRef = {
+      current: { folderDraft: { path: "api" }, isDirty: false },
+    } as never
+    ctx.folderSaveRef = { current: () => saved++ } as never
+
+    expect(saveFolder(ctx)).toBe(false)
+    expect(saved).toBe(0)
+
+    ctx.folderDraftRef = {
+      current: { folderDraft: { path: "api" }, isDirty: true },
+    } as never
+    ctx.savingRef = { current: true } as never
+    expect(saveFolder(ctx)).toBe(false)
+
+    ctx.savingRef = { current: false } as never
+    expect(saveFolder(ctx)).toBe(true)
+    expect(saved).toBe(1)
   })
 
   it("does not run request actions while a folder is focused", () => {

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -4,7 +4,12 @@ import { buildCommandPaletteCommands } from "../../src/ui/commands"
 import type { CommandBuilderContext } from "../../src/ui/commands"
 import { bindingDefaults } from "../../src/ui/keybind"
 import type { Collection } from "../../src/schema"
-import { getEditRequestYamlFile } from "../../src/ui/commandActions"
+import {
+  cloneRequest,
+  getEditRequestYamlFile,
+  saveRequest,
+  sendRequest,
+} from "../../src/ui/commandActions"
 
 function minimalContext(): CommandBuilderContext {
   const keybinds = bindingDefaults()
@@ -27,6 +32,7 @@ function minimalContext(): CommandBuilderContext {
     activeIndexRef: { current: 0 } as never,
     savingRef: { current: false } as never,
     doSaveRef: { current: () => {} } as never,
+    folderSaveRef: { current: () => {} } as never,
     focusedFolderPathRef: { current: null } as never,
     focusedFolderNameRef: { current: null } as never,
     folderDeletePathRef: { current: null } as never,
@@ -57,6 +63,7 @@ function minimalContext(): CommandBuilderContext {
     setEnvDeletePending: () => {},
     onReloadCollection: () => {},
     triggerUpdateCheck: () => {},
+    paletteTarget: null,
   }
 }
 
@@ -82,6 +89,38 @@ describe("buildCommandPaletteCommands", () => {
       "Workspace",
       "System",
     ])
+  })
+
+  it("shows only request commands for a request context menu", () => {
+    const ctx = minimalContext()
+    ctx.paletteTarget = "request"
+
+    const ids = buildCommandPaletteCommands(ctx).map((command) => command.id)
+
+    expect(ids).toEqual([
+      "request.generate-client-code",
+      "request.send",
+      "request.save",
+      "request.edit-overlay",
+      "request.clone",
+      "request.delete",
+      "workspace.edit-yaml",
+    ])
+  })
+
+  it("shows only folder commands for a folder context menu", () => {
+    const ctx = minimalContext()
+    ctx.paletteTarget = "folder"
+
+    const commands = buildCommandPaletteCommands(ctx)
+    expect(commands.map((command) => command.id)).toEqual([
+      "folder.save",
+      "request.new",
+      "folder.new",
+      "folder.delete",
+      "workspace.edit-yaml",
+    ])
+    expect(commands.every((command) => command.section === "Folder")).toBe(true)
   })
 
   it("includes the JSONPath response query command", () => {
@@ -288,6 +327,22 @@ describe("buildCommandPaletteCommands", () => {
     const save = commands.find((c) => c.id === "request.save")!
     save.run()
     expect(saved).toBe(false)
+  })
+
+  it("does not run request actions while a folder is focused", () => {
+    const ctx = minimalContext()
+    let sent = false
+    ctx.focusedFolderPathRef = { current: "api" } as never
+    ctx.trySendRef = {
+      current: () => {
+        sent = true
+      },
+    } as never
+
+    expect(sendRequest(ctx)).toBe(false)
+    expect(saveRequest(ctx)).toBe(false)
+    expect(cloneRequest(ctx)).toBe(false)
+    expect(sent).toBe(false)
   })
 
   it("pane.expand toggles expanded when focus is request", () => {

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -179,6 +179,33 @@ describe("buildCommandPaletteCommands", () => {
     expect(opened).toBe(true)
   })
 
+  it("opens the environment editor with the sidebar focused", () => {
+    const ctx = minimalContext()
+    let opened = ""
+    let view = ""
+    let focus = ""
+    ctx.envStateRef = {
+      current: { activeEnv: { name: "development" } },
+    } as never
+    ctx.envEditorRef = {
+      current: { openEditor: (name: string) => (opened = name) },
+    } as never
+    ctx.setView = (value) => {
+      if (typeof value === "string") view = value
+    }
+    ctx.setFocus = (value) => {
+      if (typeof value === "string") focus = value
+    }
+
+    const command = buildCommandPaletteCommands(ctx).find(
+      (item) => item.id === "env.editor-open",
+    )!
+    expect(command.run()).toBe(true)
+    expect(opened).toBe("development")
+    expect(view).toBe("env-editor")
+    expect(focus).toBe("env-sidebar")
+  })
+
   it("opens client code generation for the current request draft", () => {
     const ctx = minimalContext()
     let visible = false

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -219,6 +219,42 @@ describe("buildCommandPaletteCommands", () => {
     expect(opened).toBe(true)
   })
 
+  it("opens the edit request overlay for the selected request", () => {
+    const ctx = minimalContext()
+    let opened = false
+    ctx.selectedIdRef = { current: "users" } as never
+    ctx.collectionRef = {
+      current: {
+        id: "collection",
+        name: "collection",
+        items: [
+          {
+            type: "request",
+            data: {
+              id: "users",
+              name: "Users",
+              method: "GET",
+              url: "https://example.com/users",
+              timeout: 0,
+              headers: {},
+              params: [],
+            },
+          },
+        ],
+      },
+    } as never
+    ctx.setEditRequestVisible = (value) => {
+      opened = value === true
+    }
+
+    const command = buildCommandPaletteCommands(ctx).find(
+      (item) => item.id === "request.edit-overlay",
+    )
+
+    expect(command?.run()).toBe(true)
+    expect(opened).toBe(true)
+  })
+
   it("opens the environment editor with the sidebar focused", () => {
     const ctx = minimalContext()
     let opened = ""

--- a/tests/unit/formOverlayActions.test.tsx
+++ b/tests/unit/formOverlayActions.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider } from "../../src/ui/theme"
+import { CloneRequestOverlay } from "../../src/ui/overlays/CloneRequestOverlay"
+import { NewFolderOverlay } from "../../src/ui/overlays/NewFolderOverlay"
+
+describe("form overlay footer actions", () => {
+  it("runs Clone Request actions without a separator", async () => {
+    let saved = 0
+    let closed = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <CloneRequestOverlay
+          visible
+          initialName="Users - Copy"
+          onConfirm={() => saved++}
+          onClose={() => closed++}
+        />
+      </ThemeProvider>,
+      { width: 70, height: 20 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("save"))
+    expect(rows[y]).not.toContain("·")
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("save"), y, MouseButtons.LEFT)
+      await mockMouse.click(rows[y]!.indexOf("close"), y, MouseButtons.LEFT)
+    })
+    expect(saved).toBe(1)
+    expect(closed).toBe(1)
+  })
+
+  it("runs New Folder actions without a separator", async () => {
+    let saved = 0
+    let closed = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <NewFolderOverlay
+          visible
+          onConfirm={() => saved++}
+          onClose={() => closed++}
+        />
+      </ThemeProvider>,
+      { width: 70, height: 20 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("save"))
+    expect(rows[y]).not.toContain("·")
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("save"), y, MouseButtons.LEFT)
+      await mockMouse.click(rows[y]!.indexOf("close"), y, MouseButtons.LEFT)
+    })
+    expect(saved).toBe(1)
+    expect(closed).toBe(1)
+  })
+})

--- a/tests/unit/getContextualSegments.test.ts
+++ b/tests/unit/getContextualSegments.test.ts
@@ -38,14 +38,14 @@ function base(overrides: Partial<KeybindingHintsContext> = {}) {
 describe("getContextualSegments", () => {
   it("returns empty when overlay is active", () => {
     const r = base({ focus: "sidebar", overlayActive: true })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   // ── sidebar ──────────────────────────────────────
 
   it("sidebar in collection mode", () => {
     const r = base({ focus: "sidebar" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^n", "new"),
       seg("^alt+n", "new folder"),
       seg("^w", "delete"),
@@ -56,26 +56,26 @@ describe("getContextualSegments", () => {
 
   it("sidebar in read-only mode returns empty", () => {
     const r = base({ focus: "sidebar", collectionMode: "browse" })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   // ── urlbar ──────────────────────────────────────
 
   it("urlbar in collection mode", () => {
     const r = base({ focus: "urlbar" })
-    expect(r.footer).toEqual([seg("^s", "save")])
+    expect(r.footer).toMatchObject([seg("^s", "save")])
   })
 
   it("urlbar in read-only mode returns empty", () => {
     const r = base({ focus: "urlbar", collectionMode: "browse" })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   // ── request ─────────────────────────────────────
 
   it("request base in collection mode", () => {
     const r = base({ focus: "request" })
-    expect(r.footer).toEqual([seg("f2", "expand"), seg("^s", "save")])
+    expect(r.footer).toMatchObject([seg("f2", "expand"), seg("^s", "save")])
   })
 
   it("request JSON body shows fold", () => {
@@ -85,17 +85,17 @@ describe("getContextualSegments", () => {
       tab: "body",
       bodyType: "json",
     })
-    expect(r.footer).toEqual([seg("^g", "fold"), seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("^g", "fold"), seg("f2", "expand")])
   })
 
   it("request base in read-only mode returns empty", () => {
     const r = base({ focus: "request", collectionMode: "browse" })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   it("request browse in collection mode with no tab", () => {
     const r = base({ focus: "request", paneMode: "browse" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -105,7 +105,7 @@ describe("getContextualSegments", () => {
 
   it("request browse with headers tab shows Space toggle", () => {
     const r = base({ focus: "request", paneMode: "browse", tab: "headers" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("^d", "revert"),
       seg("^r", "revert all"),
@@ -116,7 +116,7 @@ describe("getContextualSegments", () => {
 
   it("request browse with params tab shows Space toggle", () => {
     const r = base({ focus: "request", paneMode: "browse", tab: "params" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("^d", "revert"),
       seg("^r", "revert all"),
@@ -127,7 +127,7 @@ describe("getContextualSegments", () => {
 
   it("request browse with body tab and no bodyType hides Space toggle", () => {
     const r = base({ focus: "request", paneMode: "browse", tab: "body" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -142,7 +142,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       bodyType: "urlencoded",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("^d", "revert"),
       seg("^r", "revert all"),
@@ -158,7 +158,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       bodyType: "multipart",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("^d", "revert"),
       seg("^r", "revert all"),
@@ -174,7 +174,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       bodyType: "json",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -189,7 +189,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       bodyType: "none",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -204,7 +204,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       bodyType: "binary",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -214,7 +214,7 @@ describe("getContextualSegments", () => {
 
   it("request browse with auth tab hides Space toggle", () => {
     const r = base({ focus: "request", paneMode: "browse", tab: "auth" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -224,7 +224,7 @@ describe("getContextualSegments", () => {
 
   it("request browse with settings tab hides Space toggle", () => {
     const r = base({ focus: "request", paneMode: "browse", tab: "settings" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("f2", "expand"),
@@ -238,19 +238,19 @@ describe("getContextualSegments", () => {
       paneMode: "browse",
       collectionMode: "browse",
     })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   it("request edit returns expand", () => {
     const r = base({ focus: "request", paneMode: "edit" })
-    expect(r.footer).toEqual([seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("f2", "expand")])
   })
 
   // ── response ────────────────────────────────────
 
   it("response when done shows copy and filter on body tab", () => {
     const r = base({ focus: "response", sendState: done, tab: "body" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^b", "copy"),
       seg("/", "filter"),
       seg("f2", "expand"),
@@ -259,22 +259,22 @@ describe("getContextualSegments", () => {
 
   it("response when done on headers tab shows expand", () => {
     const r = base({ focus: "response", sendState: done, tab: "headers" })
-    expect(r.footer).toEqual([seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("f2", "expand")])
   })
 
   it("response when done on timeline tab shows expand", () => {
     const r = base({ focus: "response", sendState: done, tab: "timeline" })
-    expect(r.footer).toEqual([seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("f2", "expand")])
   })
 
   it("response when done on network tab shows expand", () => {
     const r = base({ focus: "response", sendState: done, tab: "network" })
-    expect(r.footer).toEqual([seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("f2", "expand")])
   })
 
   it("response when done without tab shows expand", () => {
     const r = base({ focus: "response", sendState: done })
-    expect(r.footer).toEqual([seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("f2", "expand")])
   })
 
   it("response when done with open query hides hints", () => {
@@ -284,7 +284,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       queryVisible: true,
     })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   it("response when done with closed query shows filter", () => {
@@ -294,7 +294,7 @@ describe("getContextualSegments", () => {
       tab: "body",
       queryVisible: false,
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^b", "copy"),
       seg("/", "filter"),
       seg("f2", "expand"),
@@ -307,7 +307,7 @@ describe("getContextualSegments", () => {
       sendState: done,
       tab: "body",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^b", "copy"),
       seg("/", "filter"),
       seg("f2", "expand"),
@@ -316,24 +316,24 @@ describe("getContextualSegments", () => {
 
   it("response when idle shows expand", () => {
     const r = base({ focus: "response" })
-    expect(r.footer).toEqual([seg("f2", "expand")])
+    expect(r.footer).toMatchObject([seg("f2", "expand")])
   })
 
   // ── folder ──────────────────────────────────────
 
   it("folder base in collection mode", () => {
     const r = base({ focus: "folder" })
-    expect(r.footer).toEqual([seg("^w", "delete"), seg("^s", "save")])
+    expect(r.footer).toMatchObject([seg("^w", "delete"), seg("^s", "save")])
   })
 
   it("folder base in read-only returns empty", () => {
     const r = base({ focus: "folder", collectionMode: "browse" })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   it("folder browse with headers tab shows Space toggle", () => {
     const r = base({ focus: "folder", paneMode: "browse", tab: "headers" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("^d", "revert"),
       seg("^r", "revert all"),
@@ -343,7 +343,7 @@ describe("getContextualSegments", () => {
 
   it("folder browse with meta tab hides Space toggle", () => {
     const r = base({ focus: "folder", paneMode: "browse", tab: "meta" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("^s", "save"),
@@ -352,7 +352,7 @@ describe("getContextualSegments", () => {
 
   it("folder browse with auth tab hides Space toggle", () => {
     const r = base({ focus: "folder", paneMode: "browse", tab: "auth" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^d", "revert"),
       seg("^r", "revert all"),
       seg("^s", "save"),
@@ -361,7 +361,7 @@ describe("getContextualSegments", () => {
 
   it("folder browse with activity tab returns empty", () => {
     const r = base({ focus: "folder", paneMode: "browse", tab: "activity" })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   it("folder browse in read-only returns empty", () => {
@@ -370,19 +370,19 @@ describe("getContextualSegments", () => {
       paneMode: "browse",
       collectionMode: "browse",
     })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   it("folder edit returns empty", () => {
     const r = base({ focus: "folder", paneMode: "edit" })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 
   // ── env editor ──────────────────────────────────
 
   it("env-sidebar", () => {
     const r = base({ focus: "env-sidebar", view: "env-editor" })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("^n", "new"),
       seg("^w", "delete"),
       seg("^k", "clone"),
@@ -391,7 +391,7 @@ describe("getContextualSegments", () => {
 
   it("env-header", () => {
     const r = base({ focus: "env-header", view: "env-editor" })
-    expect(r.footer).toEqual([seg("^n", "new"), seg("^s", "save")])
+    expect(r.footer).toMatchObject([seg("^n", "new"), seg("^s", "save")])
   })
 
   it("env-vars browse", () => {
@@ -400,7 +400,7 @@ describe("getContextualSegments", () => {
       paneMode: "browse",
       view: "env-editor",
     })
-    expect(r.footer).toEqual([
+    expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("^d", "revert"),
       seg("^s", "save"),
@@ -413,7 +413,7 @@ describe("getContextualSegments", () => {
       paneMode: "edit",
       view: "env-editor",
     })
-    expect(r.footer).toEqual([seg("^s", "save")])
+    expect(r.footer).toMatchObject([seg("^s", "save")])
   })
 
   it("env-editor read-only returns empty", () => {
@@ -422,6 +422,6 @@ describe("getContextualSegments", () => {
       view: "env-editor",
       collectionMode: "browse",
     })
-    expect(r.footer).toEqual([])
+    expect(r.footer).toMatchObject([])
   })
 })

--- a/tests/unit/keybindingHints.test.ts
+++ b/tests/unit/keybindingHints.test.ts
@@ -7,8 +7,8 @@ import type { SendState } from "../../src/ui/sendState"
 const kb = bindingDefaults()
 const idle: SendState = { status: "idle" }
 
-function seg(key: string, word: string) {
-  return { key, word }
+function seg(key: string, word: string, command?: string) {
+  return command ? { key, word, command } : { key, word }
 }
 
 function ctx(
@@ -44,22 +44,69 @@ describe("getKeybindingHints header", () => {
   it("shows env-editor hints", () => {
     const r = ctx({ view: "env-editor" })
     expect(getKeybindingHints(r).header).toEqual([
-      seg("^p", "commands"),
-      seg("f1", "help"),
+      seg("^p", "commands", "app.command-palette"),
+      seg("f1", "help", "app.help"),
     ])
   })
 
   it("shows main view hints", () => {
     const r = ctx()
     expect(getKeybindingHints(r).header).toEqual([
-      seg("g", "jump"),
-      seg("^p", "commands"),
-      seg("f1", "help"),
+      seg("g", "jump", "jump.enter"),
+      seg("^p", "commands", "app.command-palette"),
+      seg("f1", "help", "app.help"),
     ])
   })
 
   it("overlay active takes priority over jump mode", () => {
     const r = ctx({ overlayActive: true, jumpMode: true })
     expect(getKeybindingHints(r).header).toEqual([seg("Esc", "close")])
+  })
+})
+
+describe("getKeybindingHints footer", () => {
+  it("uses the active request browse commands", () => {
+    expect(
+      getKeybindingHints(
+        ctx({
+          focus: "request",
+          paneMode: "browse",
+          tab: "headers",
+        }),
+      ).footer,
+    ).toEqual([
+      seg("Space", "toggle", "browse.toggle"),
+      seg("^d", "revert", "browse.delete"),
+      seg("^r", "revert all", "browse.revert-all"),
+      seg("f2", "expand", "request.expand-toggle"),
+      seg("^s", "save", "browse.save"),
+    ])
+  })
+
+  it("uses folder and environment command variants", () => {
+    expect(
+      getKeybindingHints(
+        ctx({ focus: "folder", paneMode: "browse", tab: "headers" }),
+      ).footer,
+    ).toEqual([
+      seg("Space", "toggle", "folder-browse.toggle"),
+      seg("^d", "revert", "folder-browse.revert-field"),
+      seg("^r", "revert all", "folder-browse.revert-all"),
+      seg("^s", "save", "folder.save"),
+    ])
+
+    expect(
+      getKeybindingHints(
+        ctx({
+          view: "env-editor",
+          focus: "env-vars",
+          paneMode: "browse",
+        }),
+      ).footer,
+    ).toEqual([
+      seg("Space", "toggle", "env-browse.toggle"),
+      seg("^d", "revert", "env-browse.revert"),
+      seg("^s", "save", "env.save"),
+    ])
   })
 })

--- a/tests/unit/newRequestOverlay.test.tsx
+++ b/tests/unit/newRequestOverlay.test.tsx
@@ -117,6 +117,60 @@ describe("NewRequestOverlay mode prop", () => {
     cleanup()
   })
 
+  it("focuses the URL field when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<NewRequestOverlayHandle>()
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <NewRequestOverlay visible ref={ref} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("https://api.example.com"))
+    await act(async () => {
+      await mockMouse.click(
+        rows[y]!.indexOf("https://api.example.com"),
+        y,
+        MouseButtons.LEFT,
+      )
+    })
+    expect(ref.current?.getFocus()).toBe("url")
+    cleanup()
+  })
+
+  it("runs footer actions when clicked without dot separators", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let saved = 0
+    let closed = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <NewRequestOverlay
+            visible
+            onConfirm={() => saved++}
+            onClose={() => closed++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("save"))
+    expect(rows[y]).not.toContain("·")
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("save"), y, MouseButtons.LEFT)
+      await mockMouse.click(rows[y]!.indexOf("close"), y, MouseButtons.LEFT)
+    })
+    expect(saved).toBe(1)
+    expect(closed).toBe(1)
+    cleanup()
+  })
+
   it("shows 'New Request' title when mode is not set", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(

--- a/tests/unit/newRequestOverlay.test.tsx
+++ b/tests/unit/newRequestOverlay.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test"
+import { act, createRef } from "react"
+import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -12,6 +14,7 @@ import {
   slugify,
   METHOD_ITEMS,
   NewRequestOverlay,
+  type NewRequestOverlayHandle,
 } from "../../src/ui/overlays/NewRequestOverlay"
 
 function setupKeymap() {
@@ -93,6 +96,27 @@ describe("METHOD_ITEMS", () => {
 })
 
 describe("NewRequestOverlay mode prop", () => {
+  it("focuses the method selector when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<NewRequestOverlayHandle>()
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <NewRequestOverlay visible ref={ref} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    expect(ref.current?.getFocus()).toBe("name")
+
+    await act(async () => {
+      await mockMouse.click(15, 14, MouseButtons.LEFT)
+    })
+    expect(ref.current?.getFocus()).toBe("method")
+    cleanup()
+  })
+
   it("shows 'New Request' title when mode is not set", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(

--- a/tests/unit/newRequestOverlay.test.tsx
+++ b/tests/unit/newRequestOverlay.test.tsx
@@ -142,6 +142,33 @@ describe("NewRequestOverlay mode prop", () => {
     cleanup()
   })
 
+  it("ignores right clicks on text fields", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<NewRequestOverlayHandle>()
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <NewRequestOverlay visible ref={ref} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("https://api.example.com"))
+
+    await act(async () => {
+      await mockMouse.click(
+        rows[y]!.indexOf("https://api.example.com"),
+        y,
+        MouseButtons.RIGHT,
+      )
+    })
+
+    expect(ref.current?.getFocus()).toBe("name")
+    cleanup()
+  })
+
   it("runs footer actions when clicked without dot separators", async () => {
     const { keymap, cleanup } = setupKeymap()
     let saved = 0

--- a/tests/unit/rowMouseControls.test.tsx
+++ b/tests/unit/rowMouseControls.test.tsx
@@ -123,4 +123,41 @@ describe("request row mouse controls", () => {
       .find((candidate) => candidate.text.includes("Accept"))
     expect(span!.bg.equals(elementColor)).toBe(false)
   })
+
+  it("does not reactivate an add row while it is being edited", async () => {
+    const activations: Array<[number, boolean]> = []
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={4}>
+          <KeyValueSection
+            kind="headers"
+            entries={[]}
+            editState={{
+              mode: "editing",
+              cursor: {
+                field: "headers",
+                row: -1,
+                addingRow: true,
+                subfield: "key",
+              },
+              editingRow: -1,
+            }}
+            editKey="Accept"
+            editValue="application/json"
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            theme={THEMES[0]!}
+            onActivateRow={(row, addingRow) =>
+              activations.push([row, addingRow])
+            }
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 4 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(8, 0, MouseButtons.LEFT)
+    expect(activations).toEqual([])
+  })
 })

--- a/tests/unit/rowMouseControls.test.tsx
+++ b/tests/unit/rowMouseControls.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
+import { initialEditState } from "../../src/ui/editMode"
+import { KeyValueSection } from "../../src/ui/KeyValueSection"
+import { FormEditor } from "../../src/ui/FormEditor"
+
+describe("request row mouse controls", () => {
+  it("activates and toggles key/value rows independently", async () => {
+    const activations: Array<[number, boolean]> = []
+    const toggles: number[] = []
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={4}>
+          <KeyValueSection
+            kind="headers"
+            entries={[
+              {
+                key: "Accept",
+                value: { value: "application/json", enabled: true },
+              },
+            ]}
+            editState={initialEditState()}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            theme={THEMES[0]!}
+            onActivateRow={(row, addingRow) =>
+              activations.push([row, addingRow])
+            }
+            onToggleRow={(row) => toggles.push(row)}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 4 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(8, 0, MouseButtons.LEFT)
+    await mockMouse.click(1, 0, MouseButtons.LEFT)
+
+    expect(activations).toEqual([[0, false]])
+    expect(toggles).toEqual([0])
+  })
+
+  it("activates and toggles form rows independently", async () => {
+    const activations: Array<[number, boolean]> = []
+    const toggles: number[] = []
+    const { renderOnce, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={4}>
+          <FormEditor
+            request={{
+              bodyType: "multipart",
+              formData: [
+                {
+                  name: "avatar",
+                  value: "/tmp/avatar.png",
+                  enabled: true,
+                  type: "file",
+                },
+              ],
+            }}
+            editState={initialEditState()}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            browseActive={false}
+            theme={THEMES[0]!}
+            onActivateRow={(row, addingRow) =>
+              activations.push([row, addingRow])
+            }
+            onToggleRow={(row) => toggles.push(row)}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 4 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(8, 0, MouseButtons.LEFT)
+    await mockMouse.click(1, 0, MouseButtons.LEFT)
+
+    expect(activations).toEqual([[0, false]])
+    expect(toggles).toEqual([0])
+  })
+})

--- a/tests/unit/rowMouseControls.test.tsx
+++ b/tests/unit/rowMouseControls.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
@@ -86,5 +87,40 @@ describe("request row mouse controls", () => {
 
     expect(activations).toEqual([[0, false]])
     expect(toggles).toEqual([0])
+  })
+
+  it("only highlights rows with an available mouse action", async () => {
+    const { renderOnce, captureSpans, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={4}>
+          <KeyValueSection
+            kind="headers"
+            entries={[
+              {
+                key: "Accept",
+                value: { value: "application/json", enabled: true },
+              },
+            ]}
+            editState={initialEditState()}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            theme={THEMES[0]!}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 4 },
+    )
+    await renderOnce()
+
+    await mockMouse.moveTo(8, 0)
+    await renderOnce()
+
+    const elementColor = RGBA.fromHex(THEMES[0]!.backgroundElement)
+    const span = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((candidate) => candidate.text.includes("Accept"))
+    expect(span!.bg.equals(elementColor)).toBe(false)
   })
 })

--- a/tests/unit/tabs.test.tsx
+++ b/tests/unit/tabs.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "bun:test"
+import { act } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { Tabs } from "../../src/ui/Tabs"
-import { ThemeProvider } from "../../src/ui/theme"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
 
 describe("Tabs", () => {
   it("renders all tab labels", async () => {
@@ -71,6 +72,46 @@ describe("Tabs", () => {
 
     await mockMouse.click(9, 0, MouseButtons.LEFT)
     expect(selected).toBe("b")
+  })
+
+  it("highlights clickable tabs while the mouse is over them", async () => {
+    const { renderOnce, captureSpans, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Tabs
+          tabs={[
+            { id: "a", label: "Tab A" },
+            { id: "b", label: "Tab B" },
+          ]}
+          activeId="a"
+          onChange={() => {}}
+        >
+          <text>content</text>
+        </Tabs>
+      </ThemeProvider>,
+      { width: 30, height: 5 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.moveTo(9, 0)
+    })
+    await renderOnce()
+
+    const hoverColor = RGBA.fromHex(THEMES[0]!.text)
+    const hoveredSpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("Tab B"))
+    expect(hoveredSpan!.fg.equals(hoverColor)).toBe(true)
+
+    await act(async () => {
+      await mockMouse.moveTo(29, 4)
+    })
+    await renderOnce()
+
+    const unhoveredSpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("Tab B"))
+    expect(unhoveredSpan!.fg.equals(hoverColor)).toBe(false)
   })
 
   it("does not show ▸ prefix on any tab", async () => {

--- a/tests/unit/tabs.test.tsx
+++ b/tests/unit/tabs.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { RGBA } from "@opentui/core"
+import { MouseButtons } from "@opentui/core/testing"
 import { Tabs } from "../../src/ui/Tabs"
 import { ThemeProvider } from "../../src/ui/theme"
 
@@ -44,6 +45,32 @@ describe("Tabs", () => {
 
     const frame = captureCharFrame()
     expect(frame).toContain("content for b")
+  })
+
+  it("selects a tab on left click only", async () => {
+    let selected = ""
+    const { renderOnce, mockMouse } = await testRender(
+      <Tabs
+        tabs={[
+          { id: "a", label: "Tab A" },
+          { id: "b", label: "Tab B" },
+        ]}
+        activeId="a"
+        onChange={(id) => {
+          selected = id
+        }}
+      >
+        <text>content</text>
+      </Tabs>,
+      { width: 30, height: 5 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(9, 0, MouseButtons.RIGHT)
+    expect(selected).toBe("")
+
+    await mockMouse.click(9, 0, MouseButtons.LEFT)
+    expect(selected).toBe("b")
   })
 
   it("does not show ▸ prefix on any tab", async () => {

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { act, useEffect, useRef, useState } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import type { Collection, Folder } from "../../src/schema"
+import type { UseFolderDraftResult } from "../../src/hooks/useFolderDraft"
+import { useCollectionFileActions } from "../../src/ui/useCollectionFileActions"
+
+const initialFolder: Folder = {
+  id: "api",
+  name: "API",
+  path: "api",
+  children: [],
+}
+
+const savedFolder: Folder = { ...initialFolder, name: "Saved API" }
+
+function ActionsHarness({
+  collectionDir,
+  onSaveReady,
+  onMarkSaved,
+}: {
+  collectionDir: string
+  onSaveReady: (save: () => void) => void
+  onMarkSaved: () => void
+}) {
+  const [collection, updateCollection] = useState<Collection | null>(null)
+  const folderDraftRef = useRef<UseFolderDraftResult>({
+    folderDraft: savedFolder,
+    markSaved: onMarkSaved,
+  } as never)
+  const savingRef = useRef(false)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const actions = useCollectionFileActions({
+    collectionDir,
+    collection,
+    updateCollection,
+    selectedRequest: null,
+    requestDraftRef: useRef({} as never),
+    folderDraftRef,
+    newRequestFolderRef: useRef(null),
+    folderDeletePathRef: useRef(null),
+    setCollectionReloadToken: () => {},
+    setFocus: () => {},
+    setSaveState: () => {},
+    savingRef,
+    clearSaveTimer: () => {},
+    saveTimerRef,
+    setSelectedId: () => {},
+    expandFolder: () => {},
+    setNewRequestVisible: () => {},
+    setImportCurlVisible: () => {},
+    setCloneRequestVisible: () => {},
+    setNewFolderVisible: () => {},
+    setEditRequestVisible: () => {},
+    setRequestDeletePending: () => {},
+    setFolderDeletePending: () => {},
+    onCollectionBootstrapped: () => {},
+  })
+
+  useEffect(() => {
+    updateCollection({ id: "collection", name: "Collection", items: [] })
+  }, [updateCollection])
+
+  useEffect(() => {
+    onSaveReady(actions.handleFolderSave)
+  }, [actions.handleFolderSave, onSaveReady])
+
+  return null
+}
+
+describe("useCollectionFileActions", () => {
+  const dirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true })))
+  })
+
+  it("saves a folder after the collection loads", async () => {
+    const collectionDir = await mkdtemp(join(tmpdir(), "noodle-actions-"))
+    dirs.push(collectionDir)
+    let save: (() => void) | undefined
+    let markedSaved = 0
+    const render = await testRender(
+      <ActionsHarness
+        collectionDir={collectionDir}
+        onSaveReady={(handleSave) => (save = handleSave)}
+        onMarkSaved={() => markedSaved++}
+      />,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await render.renderOnce()
+    await act(async () => {
+      await save?.()
+    })
+
+    expect(markedSaved).toBe(1)
+    expect(
+      await readFile(join(collectionDir, "api", "folder.yml"), "utf8"),
+    ).toContain("name: Saved API")
+  })
+})

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
-import { useEffect, useRef } from "react"
+import { act, useEffect, useRef } from "react"
 import { mkdtemp, rm, readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -89,6 +89,47 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
 
     await ref.current!.deleteEnv()
     expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it("activates existing and new variable rows for editing", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    act(() => {
+      ref.current!.activateVar(0)
+    })
+    await renderOnce()
+    expect(ref.current!.editKey).toBe("key")
+    expect(ref.current!.editValue).toBe("val")
+    expect(ref.current!.editState).toMatchObject({
+      mode: "editing",
+      row: 0,
+      addingRow: false,
+      subfield: "key",
+    })
+
+    act(() => {
+      ref.current!.activateVar(-1, true)
+    })
+    await renderOnce()
+    expect(ref.current!.editKey).toBe("")
+    expect(ref.current!.editValue).toBe("")
+    expect(ref.current!.editState).toMatchObject({
+      mode: "editing",
+      row: -1,
+      addingRow: true,
+      subfield: "key",
+    })
   })
 
   it("delete env removes file from disk", async () => {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -167,6 +167,40 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     })
   })
 
+  it("keeps the selected variable after committing a deletion above it", async () => {
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: { first: "one", second: "two" },
+    })
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    act(() => {
+      ref.current!.activateVar(0)
+      ref.current!.setEditKey("")
+    })
+    await renderOnce()
+
+    act(() => {
+      ref.current!.activateVar(1)
+    })
+    await renderOnce()
+
+    expect(ref.current!.draft?.varRows).toHaveLength(1)
+    expect(ref.current!.editKey).toBe("second")
+    expect(ref.current!.editValue).toBe("two")
+    expect(ref.current!.editState).toMatchObject({ row: 0, editingRow: 0 })
+  })
+
   it("delete env removes file from disk", async () => {
     const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
       current: null,

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -132,6 +132,41 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     })
   })
 
+  it("commits the active variable before activating another row", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    act(() => {
+      ref.current!.activateVar(0)
+      ref.current!.setEditKey("updated")
+      ref.current!.setEditValue("value")
+    })
+    await renderOnce()
+
+    act(() => {
+      ref.current!.activateVar(-1, true)
+    })
+    await renderOnce()
+
+    expect(ref.current!.draft?.varRows[0]).toMatchObject({
+      key: "updated",
+      value: "value",
+    })
+    expect(ref.current!.editState).toMatchObject({
+      mode: "editing",
+      addingRow: true,
+    })
+  })
+
   it("delete env removes file from disk", async () => {
     const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
       current: null,


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Full mouse support across the TUI. Clicks now focus panes, selects, and tabs; hover states and click affordances appear across the header, footer, status bar, sidebar, request/response panes, and overlays. Click-to-edit enters browse-mode fields, right-click opens sidebar context menus, and code editors gained click-to-fold on the gutter, fold hover highlighting, mouse-wheel scrolling, and clickable footer save/close actions. Also fixes Select interactivity, header/status bar selection, and request state propagation after save.

### How did you verify your code works?

`bun test` (1988 pass), `bun run lint`, `bun run typecheck`, and `bunx prettier --check` all pass. Added unit tests covering the new click, hover, fold, scroll, and mouse-row behaviors across panes, overlays, and editors.

### Screenshots / recordings

N/A — terminal TUI.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse-based activation, selection, editing, toggling, scrolling, and hover feedback across requests, folders, environments, tabs, timelines, and overlays.
  * Added context-aware command palette actions, including folder saving and safeguards while browsing folders.
  * Added clickable Save, Close, Confirm, Cancel, Copy, and Export controls.
* **Bug Fixes**
  * Improved focus transitions, edit committing, configurable request parameters, and nested request updates.
  * Updated sample requests to use reusable path and query parameters.
* **Tests**
  * Expanded coverage for mouse interactions, command behavior, scrolling, editing, and nested request updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->