### PR TITLE
feat(ui): improve request creation and sending

### DIFF
--- a/collections/delayed-response.yml
+++ b/collections/delayed-response.yml
@@ -1,7 +1,7 @@
 name: Delayed Response
 method: GET
 url: https://httpbin.org/delay/:delayTime
-timeout: 5000
+timeout: 0
 followRedirects: true
 maxRedirects: 5
 path_params:

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -20,6 +20,7 @@ import {
 } from "../filestore"
 import { lang } from "../lang"
 import { executor, substitute } from "../requests"
+import { withDefaultHttpsScheme } from "../requests/url"
 import type {
   Collection,
   CollectionItem,
@@ -536,7 +537,7 @@ export async function requestCreate(
 ): Promise<{ id: string; path: string }> {
   validateId(id)
   if (!url) throw new Error("url is required")
-  new URL(url)
+  new URL(withDefaultHttpsScheme(url))
   const dir = await requireCollectionRoot(collectionDir)
   const path = join(dir, `${id}.yml`)
   if (existsSync(path)) throw new Error(`request already exists: ${id}`)

--- a/src/filestore/save.ts
+++ b/src/filestore/save.ts
@@ -25,7 +25,11 @@ function validatePathId(id: string | undefined): void {
   }
 }
 
-export async function saveRequest(dir: string, req: Request): Promise<void> {
+export async function saveRequest(
+  dir: string,
+  req: Request,
+  options?: { overwrite?: boolean },
+): Promise<void> {
   const id = (req as { id?: string }).id
   validatePathId(id)
 
@@ -42,7 +46,10 @@ export async function saveRequest(dir: string, req: Request): Promise<void> {
   const yamlStr = lang.serializeRequest(req)
 
   try {
-    await writeFile(filePath, yamlStr, "utf8")
+    await writeFile(filePath, yamlStr, {
+      encoding: "utf8",
+      flag: options?.overwrite === false ? "wx" : "w",
+    })
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
     throw new Error(`filestore.saveRequest: ${msg}`, { cause: e })

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -217,7 +217,12 @@ export interface UseEditBrowseResult {
   toggleFormRowType: () => void
   cycleInactiveTab: (delta: 1 | -1) => void
   enterBrowseAt: (field: FieldKind, row?: number) => void
-  activateAt: (field: FieldKind, row: number, addingRow?: boolean) => void
+  activateAt: (
+    field: FieldKind,
+    row: number,
+    addingRow?: boolean,
+    subfield?: "key" | "value",
+  ) => void
   toggleAt: (field: FieldKind, row: number) => void
   canEnterJsonBodyEditor: boolean
   isEditingJsonBody: boolean
@@ -307,7 +312,12 @@ export function useEditBrowse(
   }, [])
 
   const activateAt = useCallback(
-    (field: FieldKind, row: number, addingRow = false) => {
+    (
+      field: FieldKind,
+      row: number,
+      addingRow = false,
+      subfield?: "key" | "value",
+    ) => {
       setInactiveTab(field)
       const currentDraft = draftRef.current
 
@@ -336,12 +346,15 @@ export function useEditBrowse(
           prev.mode === "inactive"
             ? enterEditBrowse(prev, rowCount(currentDraft), field)
             : cancelEditing(prev)
-        return beginEditing({
+        const next = beginEditing({
           ...browsed,
           mode: "browsing",
           editingRow: -1,
           cursor: { field, row, addingRow },
         })
+        return subfield
+          ? { ...next, cursor: { ...next.cursor, subfield } }
+          : next
       })
     },
     [],

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -70,7 +70,11 @@ export interface UseEnvironmentEditorResult {
   browseFirst: () => void
   browseLast: () => void
   enterEdit: () => void
-  activateVar: (row: number, addingRow?: boolean) => void
+  activateVar: (
+    row: number,
+    addingRow?: boolean,
+    subfield?: "key" | "value",
+  ) => void
   commitEdit: () => void
   cancelEdit: () => void
   browseTab: () => void
@@ -410,7 +414,7 @@ export function useEnvironmentEditor({
   }, [])
 
   const activateVar = useCallback(
-    (row: number, addingRow = false) => {
+    (row: number, addingRow = false, subfield: "key" | "value" = "key") => {
       const targetId = addingRow
         ? undefined
         : draftRef.current?.varRows[row]?.id
@@ -430,7 +434,7 @@ export function useEnvironmentEditor({
         mode: "editing",
         row: resolvedRow,
         addingRow,
-        subfield: "key",
+        subfield,
         editingRow: addingRow ? -1 : resolvedRow,
       })
     },

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -45,7 +45,12 @@ export interface UseFolderEditBrowseResult {
   revertAll: () => void
   toggleRow: () => void
   cycleInactiveTab: (delta: 1 | -1) => void
-  activateAt: (field: FolderFieldKind, row: number, addingRow?: boolean) => void
+  activateAt: (
+    field: FolderFieldKind,
+    row: number,
+    addingRow?: boolean,
+    subfield?: "key" | "value",
+  ) => void
   toggleAt: (field: FolderFieldKind, row: number) => void
 }
 
@@ -227,7 +232,12 @@ export function useFolderEditBrowse(
   }, [])
 
   const activateAt = useCallback(
-    (field: FolderFieldKind, row: number, addingRow = false) => {
+    (
+      field: FolderFieldKind,
+      row: number,
+      addingRow = false,
+      subfield?: "key" | "value",
+    ) => {
       if (field === "auth" && row === 0) return
       setInactiveTab(field)
       const currentFolder = draftRef.current
@@ -239,12 +249,15 @@ export function useFolderEditBrowse(
           prev.mode === "inactive"
             ? enterFolderEditBrowse(prev, folderRowCount(currentFolder), field)
             : cancelEditing(prev)
-        return beginEditing({
+        const next = beginEditing({
           ...browsed,
           mode: "browsing",
           editingRow: -1,
           cursor: { field, row, addingRow },
         })
+        return subfield
+          ? { ...next, cursor: { ...next.cursor, subfield } }
+          : next
       })
     },
     [],

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -14,6 +14,7 @@ import { substitute } from "./substitute"
 import type { SubstitutedRequest } from "./substitute"
 import { mergeFolderOverrides } from "./mergeFolderOverrides"
 import { PATH_TOKEN_RE } from "./pathParams"
+import { withDefaultHttpsScheme } from "./url"
 
 export function interpolatePathParams(
   url: string,
@@ -87,7 +88,10 @@ export async function send(
       ? (merged.pathParams ?? [])
       : ((substituted as SubstitutedRequest).pathParams ?? [])
 
-  const urlWithPath = interpolatePathParams(substituted.url, pathParams)
+  const urlWithPath = interpolatePathParams(
+    withDefaultHttpsScheme(substituted.url),
+    pathParams,
+  )
 
   let finalUrl: string
   try {

--- a/src/requests/url.ts
+++ b/src/requests/url.ts
@@ -1,5 +1,30 @@
-const HTTP_SCHEME_RE = /^https?:\/\//i
+import { isIP } from "node:net"
+
+const EXPLICIT_SCHEME_RE = /^([a-z][a-z\d+.-]*):\/\//i
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase()
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "::1" ||
+    (isIP(host) === 4 && host.startsWith("127."))
+  )
+}
 
 export function withDefaultHttpsScheme(url: string): string {
-  return HTTP_SCHEME_RE.test(url) ? url : `https://${url}`
+  const scheme = url.match(EXPLICIT_SCHEME_RE)?.[1]?.toLowerCase()
+  if (scheme) {
+    if (scheme === "http" || scheme === "https") return url
+    throw new Error(`requests.url: unsupported URL scheme "${scheme}:"`)
+  }
+
+  try {
+    if (isLoopbackHost(new URL(`http://${url}`).hostname)) {
+      return `http://${url}`
+    }
+  } catch {
+    // Let the creation or send boundary report the invalid URL.
+  }
+  return `https://${url}`
 }

--- a/src/requests/url.ts
+++ b/src/requests/url.ts
@@ -1,0 +1,5 @@
+const HTTP_SCHEME_RE = /^https?:\/\//i
+
+export function withDefaultHttpsScheme(url: string): string {
+  return HTTP_SCHEME_RE.test(url) ? url : `https://${url}`
+}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1026,6 +1026,13 @@ export function AppInner({
             jumpMode={jumpMode}
             onPaneFocus={focusPane}
             onUrlbarFocus={focusUrlbar}
+            onSend={
+              sendCommand
+                ? () => {
+                    keymap.dispatchCommand(sendCommand)
+                  }
+                : undefined
+            }
             onRequestSelect={(id) => {
               revealRequest(id)
             }}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -831,7 +831,7 @@ export function AppInner({
     newRequestRef,
     setNewRequestVisible,
     onNewRequestConfirm: (v) =>
-      handleNewRequestConfirm(v.name, v.method as Method, v.url),
+      handleNewRequestConfirm(v.name, v.method as Method, v.url, v.folderPath),
     importCurlVisible,
     importCurlRef,
     setImportCurlVisible,
@@ -1108,6 +1108,7 @@ export function AppInner({
           newRequestVisible={newRequestVisible}
           newRequestRef={newRequestRef}
           newRequestActions={overlayActions.newRequest}
+          newRequestInitialFolder={requestParentFolder ?? ""}
           importCurlVisible={importCurlVisible}
           importCurlRef={importCurlRef}
           importCurlActions={overlayActions.importCurl}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -41,6 +41,7 @@ import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
 import { initialYamlEditorState, type YamlEditorState } from "./appState"
 import type { ActiveOverlay } from "./useOverlayState"
+import { buildDisplayUrl } from "./urlParams"
 
 interface FolderPathOption {
   id: string
@@ -354,7 +355,12 @@ export function AppOverlays({
           mode="edit"
           initialName={selectedRequest?.name}
           initialMethod={selectedRequest?.method}
-          initialUrl={selectedRequest?.url}
+          initialUrl={
+            selectedRequest
+              ? buildDisplayUrl(selectedRequest.url, selectedRequest.params)
+              : undefined
+          }
+          initialPathParams={selectedRequest?.pathParams}
           folderPaths={folderPaths}
           initialFolderPath={editRequestInitialFolder}
           ref={editRequestRef}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -95,6 +95,7 @@ interface AppOverlaysProps {
   newRequestVisible: boolean
   newRequestRef: RefObject<NewRequestOverlayHandle | null>
   newRequestActions: { confirm: () => void; cancel: () => void }
+  newRequestInitialFolder: string
   importCurlVisible: boolean
   importCurlRef: RefObject<ImportCurlOverlayHandle | null>
   importCurlActions: { confirm: () => void; cancel: () => void }
@@ -181,6 +182,7 @@ export function AppOverlays({
   newRequestVisible,
   newRequestRef,
   newRequestActions,
+  newRequestInitialFolder,
   importCurlVisible,
   importCurlRef,
   importCurlActions,
@@ -335,6 +337,8 @@ export function AppOverlays({
           visible
           ref={newRequestRef}
           activeEnv={activeEnv}
+          folderPaths={folderPaths}
+          initialFolderPath={newRequestInitialFolder}
           onConfirm={newRequestActions.confirm}
           onClose={newRequestActions.cancel}
         />

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -36,6 +36,7 @@ interface FolderPaneProps {
     field: FolderFieldKind,
     row: number,
     addingRow?: boolean,
+    subfield?: "key" | "value",
   ) => void
   onFieldToggle?: (field: FolderFieldKind, row: number) => void
   onInteraction?: () => void
@@ -194,10 +195,10 @@ export function FolderPane({
                     activeEnv={activeEnv}
                     onActivateRow={
                       onFieldActivate
-                        ? (row, addingRow) => {
+                        ? (row, addingRow, subfield) => {
                             onPaneFocus?.()
                             onInteraction?.()
-                            onFieldActivate("headers", row, addingRow)
+                            onFieldActivate("headers", row, addingRow, subfield)
                           }
                         : undefined
                     }

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -16,7 +16,11 @@ export interface KeyValueSectionProps {
   setEditValue: (v: string) => void
   theme: Theme
   activeEnv?: Environment | null
-  onActivateRow?: (row: number, addingRow: boolean) => void
+  onActivateRow?: (
+    row: number,
+    addingRow: boolean,
+    subfield?: "key" | "value",
+  ) => void
   onToggleRow?: (row: number) => void
 }
 
@@ -173,38 +177,68 @@ export function KeyValueSection({
                     <Checkbox checked={kv.enabled} theme={theme} />
                   </box>
                 ) : null}
-                <VarInput
-                  value={isEditingThisRow ? editKey : entry.key}
-                  placeholder="Key..."
-                  env={activeEnv ?? null}
-                  isEditing={kind !== "pathParams" && isEditingThisRow}
-                  onChange={setEditKey}
-                  isFocused={editState.cursor.subfield === "key"}
-                  baseColor={keyBaseColor}
-                  backgroundColor={
-                    isEditingThisRow ? theme.backgroundElement : undefined
+                <box
+                  onMouseDown={
+                    !isEditingThisRow && onActivateRow
+                      ? (event) => {
+                          if (event.button !== MouseButton.LEFT) return
+                          onActivateRow(
+                            i,
+                            false,
+                            kind === "pathParams" ? "value" : "key",
+                          )
+                          event.stopPropagation()
+                        }
+                      : undefined
                   }
-                  focusedBackgroundColor={theme.borderSubtle}
-                  paddingX={1}
-                  stopMousePropagation={isEditingThisRow}
                   style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-                />
-                <VarInput
-                  value={isEditingThisRow ? editValue : kv.value}
-                  placeholder="Value..."
-                  env={activeEnv ?? null}
-                  isEditing={isEditingThisRow}
-                  onChange={setEditValue}
-                  isFocused={editState.cursor.subfield === "value"}
-                  baseColor={valueBaseColor}
-                  backgroundColor={
-                    isEditingThisRow ? theme.backgroundElement : undefined
+                >
+                  <VarInput
+                    value={isEditingThisRow ? editKey : entry.key}
+                    placeholder="Key..."
+                    env={activeEnv ?? null}
+                    isEditing={kind !== "pathParams" && isEditingThisRow}
+                    onChange={setEditKey}
+                    isFocused={editState.cursor.subfield === "key"}
+                    baseColor={keyBaseColor}
+                    backgroundColor={
+                      isEditingThisRow ? theme.backgroundElement : undefined
+                    }
+                    focusedBackgroundColor={theme.borderSubtle}
+                    paddingX={1}
+                    stopMousePropagation={isEditingThisRow}
+                    style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                  />
+                </box>
+                <box
+                  onMouseDown={
+                    !isEditingThisRow && onActivateRow
+                      ? (event) => {
+                          if (event.button !== MouseButton.LEFT) return
+                          onActivateRow(i, false, "value")
+                          event.stopPropagation()
+                        }
+                      : undefined
                   }
-                  focusedBackgroundColor={theme.borderSubtle}
-                  paddingX={1}
-                  stopMousePropagation={isEditingThisRow}
                   style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-                />
+                >
+                  <VarInput
+                    value={isEditingThisRow ? editValue : kv.value}
+                    placeholder="Value..."
+                    env={activeEnv ?? null}
+                    isEditing={isEditingThisRow}
+                    onChange={setEditValue}
+                    isFocused={editState.cursor.subfield === "value"}
+                    baseColor={valueBaseColor}
+                    backgroundColor={
+                      isEditingThisRow ? theme.backgroundElement : undefined
+                    }
+                    focusedBackgroundColor={theme.borderSubtle}
+                    paddingX={1}
+                    stopMousePropagation={isEditingThisRow}
+                    style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                  />
+                </box>
               </box>
             )
           })}
@@ -248,46 +282,74 @@ export function KeyValueSection({
                     }
                   >
                     <Checkbox checked={false} theme={theme} />
-                    <VarInput
-                      value={editingAdd ? editKey : ""}
-                      placeholder="Key..."
-                      env={activeEnv ?? null}
-                      isEditing={editingAdd}
-                      onChange={setEditKey}
-                      isFocused={editState.cursor.subfield === "key"}
-                      baseColor={
-                        editingAdd || (cursorHere && editState.cursor.addingRow)
-                          ? theme.primary
-                          : theme.textMuted
+                    <box
+                      onMouseDown={
+                        onActivateRow && !editingAdd
+                          ? (event) => {
+                              if (event.button !== MouseButton.LEFT) return
+                              onActivateRow(-1, true, "key")
+                              event.stopPropagation()
+                            }
+                          : undefined
                       }
-                      backgroundColor={
-                        editingAdd ? theme.backgroundElement : undefined
-                      }
-                      focusedBackgroundColor={theme.borderSubtle}
-                      paddingX={1}
-                      stopMousePropagation={editingAdd}
                       style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-                    />
-                    <VarInput
-                      value={editingAdd ? editValue : ""}
-                      placeholder="Value..."
-                      env={activeEnv ?? null}
-                      isEditing={editingAdd}
-                      onChange={setEditValue}
-                      isFocused={editState.cursor.subfield === "value"}
-                      baseColor={
-                        editingAdd || (cursorHere && editState.cursor.addingRow)
-                          ? theme.text
-                          : theme.textMuted
+                    >
+                      <VarInput
+                        value={editingAdd ? editKey : ""}
+                        placeholder="Key..."
+                        env={activeEnv ?? null}
+                        isEditing={editingAdd}
+                        onChange={setEditKey}
+                        isFocused={editState.cursor.subfield === "key"}
+                        baseColor={
+                          editingAdd ||
+                          (cursorHere && editState.cursor.addingRow)
+                            ? theme.primary
+                            : theme.textMuted
+                        }
+                        backgroundColor={
+                          editingAdd ? theme.backgroundElement : undefined
+                        }
+                        focusedBackgroundColor={theme.borderSubtle}
+                        paddingX={1}
+                        stopMousePropagation={editingAdd}
+                        style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                      />
+                    </box>
+                    <box
+                      onMouseDown={
+                        onActivateRow && !editingAdd
+                          ? (event) => {
+                              if (event.button !== MouseButton.LEFT) return
+                              onActivateRow(-1, true, "value")
+                              event.stopPropagation()
+                            }
+                          : undefined
                       }
-                      backgroundColor={
-                        editingAdd ? theme.backgroundElement : undefined
-                      }
-                      focusedBackgroundColor={theme.borderSubtle}
-                      paddingX={1}
-                      stopMousePropagation={editingAdd}
                       style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-                    />
+                    >
+                      <VarInput
+                        value={editingAdd ? editValue : ""}
+                        placeholder="Value..."
+                        env={activeEnv ?? null}
+                        isEditing={editingAdd}
+                        onChange={setEditValue}
+                        isFocused={editState.cursor.subfield === "value"}
+                        baseColor={
+                          editingAdd ||
+                          (cursorHere && editState.cursor.addingRow)
+                            ? theme.text
+                            : theme.textMuted
+                        }
+                        backgroundColor={
+                          editingAdd ? theme.backgroundElement : undefined
+                        }
+                        focusedBackgroundColor={theme.borderSubtle}
+                        paddingX={1}
+                        stopMousePropagation={editingAdd}
+                        style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                      />
+                    </box>
                   </box>
                 )
               })()

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -172,9 +172,7 @@ export function KeyValueSection({
                   >
                     <Checkbox checked={kv.enabled} theme={theme} />
                   </box>
-                ) : (
-                  <box style={{ width: 3 }} />
-                )}
+                ) : null}
                 <VarInput
                   value={isEditingThisRow ? editKey : entry.key}
                   placeholder="Key..."

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -48,6 +48,7 @@ interface MainViewProps {
   onQueryVisibleChange?: (v: boolean) => void
   onPaneFocus?: (focus: Focus) => void
   onUrlbarFocus?: (subFocus: UrlBarSubFocus) => void
+  onSend?: () => void
   onRequestSelect?: (id: string) => void
   onFolderSelect?: (path: string) => void
   onFolderToggle?: (path: string) => void
@@ -89,6 +90,7 @@ export function MainView({
   onQueryVisibleChange,
   onPaneFocus = () => {},
   onUrlbarFocus,
+  onSend,
   onRequestSelect,
   onFolderSelect,
   onFolderToggle,
@@ -195,6 +197,7 @@ export function MainView({
             onQueryVisibleChange={onQueryVisibleChange}
             onPaneFocus={onPaneFocus}
             onUrlbarFocus={onUrlbarFocus}
+            onSend={onSend}
             onRequestTabChange={eb.enterBrowseAt}
             onRequestBodyTypeFocus={() => eb.enterBrowseAt("body")}
             onRequestAuthFocusRow={(row) => eb.enterBrowseAt("auth", row)}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -42,7 +42,12 @@ interface Props {
   onBodyTypeFocus?: () => void
   onAuthFocusRow?: (row: number) => void
   onBodyEditorFocus?: (bodyType: BodyType) => void
-  onFieldActivate?: (field: FieldKind, row: number, addingRow?: boolean) => void
+  onFieldActivate?: (
+    field: FieldKind,
+    row: number,
+    addingRow?: boolean,
+    subfield?: "key" | "value",
+  ) => void
   onFieldToggle?: (field: FieldKind, row: number) => void
   onInteraction?: () => void
   interactive?: boolean
@@ -320,10 +325,15 @@ export function RequestPane({
                       activeEnv={activeEnv}
                       onActivateRow={
                         onFieldActivate
-                          ? (row, addingRow) => {
+                          ? (row, addingRow, subfield) => {
                               onInteraction?.()
                               onPaneFocus?.()
-                              onFieldActivate("headers", row, addingRow)
+                              onFieldActivate(
+                                "headers",
+                                row,
+                                addingRow,
+                                subfield,
+                              )
                             }
                           : undefined
                       }
@@ -354,10 +364,15 @@ export function RequestPane({
                       activeEnv={activeEnv}
                       onActivateRow={
                         onFieldActivate
-                          ? (row, addingRow) => {
+                          ? (row, addingRow, subfield) => {
                               onInteraction?.()
                               onPaneFocus?.()
-                              onFieldActivate("params", row, addingRow)
+                              onFieldActivate(
+                                "params",
+                                row,
+                                addingRow,
+                                subfield,
+                              )
                             }
                           : undefined
                       }
@@ -391,10 +406,15 @@ export function RequestPane({
                       activeEnv={activeEnv}
                       onActivateRow={
                         onFieldActivate
-                          ? (row, addingRow) => {
+                          ? (row, addingRow, subfield) => {
                               onInteraction?.()
                               onPaneFocus?.()
-                              onFieldActivate("pathParams", row, addingRow)
+                              onFieldActivate(
+                                "pathParams",
+                                row,
+                                addingRow,
+                                subfield,
+                              )
                             }
                           : undefined
                       }

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -35,6 +35,7 @@ interface RequestResponseViewProps {
   onQueryVisibleChange?: (v: boolean) => void
   onPaneFocus?: (focus: Focus) => void
   onUrlbarFocus?: (subFocus: UrlBarSubFocus) => void
+  onSend?: () => void
   onRequestTabChange?: (tab: FieldKind) => void
   onRequestBodyTypeFocus?: () => void
   onRequestAuthFocusRow?: (row: number) => void
@@ -72,6 +73,7 @@ export function RequestResponseView({
   onQueryVisibleChange,
   onPaneFocus = () => {},
   onUrlbarFocus,
+  onSend,
   onRequestTabChange,
   onRequestBodyTypeFocus,
   onRequestAuthFocusRow,
@@ -150,6 +152,8 @@ export function RequestResponseView({
         jumpMode={jumpMode && draft.draft !== null && expanded !== "response"}
         onPaneFocus={() => onPaneFocus("urlbar")}
         onSubFocus={onUrlbarFocus}
+        onSend={onSend}
+        sending={responseState.status === "sending"}
       />
       <box
         key={layout}

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -43,6 +43,7 @@ interface RequestResponseViewProps {
     field: FieldKind,
     row: number,
     addingRow?: boolean,
+    subfield?: "key" | "value",
   ) => void
   onRequestFieldToggle?: (field: FieldKind, row: number) => void
   onRequestInteraction?: () => void

--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -11,6 +11,8 @@ import type { UrlBarSubFocus } from "./focus"
 import { JumpBadge, JUMP_BADGE_TOP_LEFT } from "./JumpBadge"
 import { splitUrlPathVars } from "./variable-completion/envHighlight"
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
 export function UrlBar({
   method,
   url,
@@ -26,6 +28,8 @@ export function UrlBar({
   jumpMode = false,
   onPaneFocus,
   onSubFocus,
+  onSend,
+  sending = false,
 }: {
   method: Method
   url: string
@@ -41,11 +45,15 @@ export function UrlBar({
   jumpMode?: boolean
   onPaneFocus?: () => void
   onSubFocus?: (subFocus: UrlBarSubFocus) => void
+  onSend?: () => void
+  sending?: boolean
 }) {
   const theme = useTheme()
   const pathParams = pathParamsProp ?? []
   const [inputValue, setInputValue] = useState(url)
   const [methodSelectOpen, setMethodSelectOpen] = useState(false)
+  const [sendHovered, setSendHovered] = useState(false)
+  const [spinnerIdx, setSpinnerIdx] = useState(0)
   const prevFocused = useRef(focused)
   const initDisplayRef = useRef("")
   const inputValueRef = useRef(inputValue)
@@ -77,6 +85,14 @@ export function UrlBar({
       initDisplayRef.current = displayUrl
     }
   }, [url, params, focused])
+
+  useEffect(() => {
+    if (!sending) return
+    const id = setInterval(() => {
+      setSpinnerIdx((i) => (i + 1) % SPINNER_FRAMES.length)
+    }, 80)
+    return () => clearInterval(id)
+  }, [sending])
 
   const displayUrl = buildDisplayUrl(url, params)
 
@@ -164,6 +180,40 @@ export function UrlBar({
               />
             )}
           </box>
+          {onSend && (
+            <box
+              onMouseDown={
+                interactive && !sending
+                  ? (event) => {
+                      if (event.button !== MouseButton.LEFT) return
+                      setSendHovered(false)
+                      onSend()
+                      event.stopPropagation()
+                    }
+                  : undefined
+              }
+              onMouseOver={
+                interactive && !sending ? () => setSendHovered(true) : undefined
+              }
+              onMouseOut={
+                interactive && !sending
+                  ? () => setSendHovered(false)
+                  : undefined
+              }
+              style={{
+                flexShrink: 0,
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor: sendHovered
+                  ? theme.backgroundElement
+                  : undefined,
+              }}
+            >
+              <text fg={theme.primary} selectable={false}>
+                {sending ? `${SPINNER_FRAMES[spinnerIdx]} Send` : "Send"}
+              </text>
+            </box>
+          )}
         </box>
       )}
     </box>

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -33,7 +33,11 @@ export function EnvEditorPane({
   error: string | null
   focused: boolean
   onPaneFocus?: () => void
-  onActivateRow?: (row: number, addingRow: boolean) => void
+  onActivateRow?: (
+    row: number,
+    addingRow: boolean,
+    subfield?: "key" | "value",
+  ) => void
   onToggleRow?: (row: number) => void
 }) {
   const theme = useTheme()
@@ -200,38 +204,64 @@ export function EnvEditorPane({
               >
                 <Checkbox checked={row.enabled} theme={theme} />
               </box>
-              <VarInput
-                value={isEditingThisRow ? editKey : row.key}
-                placeholder="Key..."
-                env={draftEnv}
-                isEditing={isEditingThisRow}
-                onChange={setEditKey}
-                isFocused={isEditingThisRow && editState.subfield === "key"}
-                baseColor={keyBaseColor}
-                backgroundColor={
-                  isEditingThisRow ? theme.backgroundElement : undefined
+              <box
+                onMouseDown={
+                  canActivateRow
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(i, false, "key")
+                        event.stopPropagation()
+                      }
+                    : undefined
                 }
-                focusedBackgroundColor={theme.borderSubtle}
-                paddingX={1}
                 style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-                variableNames={variableNames}
-              />
-              <VarInput
-                value={isEditingThisRow ? editValue : row.value}
-                placeholder="Value..."
-                env={draftEnv}
-                isEditing={isEditingThisRow}
-                onChange={setEditValue}
-                isFocused={isEditingThisRow && editState.subfield === "value"}
-                baseColor={valueBaseColor}
-                backgroundColor={
-                  isEditingThisRow ? theme.backgroundElement : undefined
+              >
+                <VarInput
+                  value={isEditingThisRow ? editKey : row.key}
+                  placeholder="Key..."
+                  env={draftEnv}
+                  isEditing={isEditingThisRow}
+                  onChange={setEditKey}
+                  isFocused={isEditingThisRow && editState.subfield === "key"}
+                  baseColor={keyBaseColor}
+                  backgroundColor={
+                    isEditingThisRow ? theme.backgroundElement : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                  variableNames={variableNames}
+                />
+              </box>
+              <box
+                onMouseDown={
+                  canActivateRow
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(i, false, "value")
+                        event.stopPropagation()
+                      }
+                    : undefined
                 }
-                focusedBackgroundColor={theme.borderSubtle}
-                paddingX={1}
                 style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-                variableNames={variableNames}
-              />
+              >
+                <VarInput
+                  value={isEditingThisRow ? editValue : row.value}
+                  placeholder="Value..."
+                  env={draftEnv}
+                  isEditing={isEditingThisRow}
+                  onChange={setEditValue}
+                  isFocused={isEditingThisRow && editState.subfield === "value"}
+                  baseColor={valueBaseColor}
+                  backgroundColor={
+                    isEditingThisRow ? theme.backgroundElement : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                  variableNames={variableNames}
+                />
+              </box>
             </box>
           )
         })}
@@ -275,46 +305,72 @@ export function EnvEditorPane({
               }
             >
               <Checkbox checked={false} theme={theme} />
-              <VarInput
-                value={editingAdd ? editKey : ""}
-                placeholder="Key..."
-                env={draftEnv}
-                isEditing={editingAdd}
-                onChange={setEditKey}
-                isFocused={editingAdd && editState.subfield === "key"}
-                baseColor={
-                  editingAdd || (inBrowse && editState.addingRow)
-                    ? theme.primary
-                    : theme.textMuted
+              <box
+                onMouseDown={
+                  onActivateRow && !editingAdd
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(-1, true, "key")
+                        event.stopPropagation()
+                      }
+                    : undefined
                 }
-                backgroundColor={
-                  editingAdd ? theme.backgroundElement : undefined
-                }
-                focusedBackgroundColor={theme.borderSubtle}
-                paddingX={1}
                 style={{ flexGrow: 4, flexShrink: 1, flexBasis: 0 }}
-                variableNames={variableNames}
-              />
-              <VarInput
-                value={editingAdd ? editValue : ""}
-                placeholder="Value..."
-                env={draftEnv}
-                isEditing={editingAdd}
-                onChange={setEditValue}
-                isFocused={editingAdd && editState.subfield === "value"}
-                baseColor={
-                  editingAdd || (inBrowse && editState.addingRow)
-                    ? theme.text
-                    : theme.textMuted
+              >
+                <VarInput
+                  value={editingAdd ? editKey : ""}
+                  placeholder="Key..."
+                  env={draftEnv}
+                  isEditing={editingAdd}
+                  onChange={setEditKey}
+                  isFocused={editingAdd && editState.subfield === "key"}
+                  baseColor={
+                    editingAdd || (inBrowse && editState.addingRow)
+                      ? theme.primary
+                      : theme.textMuted
+                  }
+                  backgroundColor={
+                    editingAdd ? theme.backgroundElement : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                  variableNames={variableNames}
+                />
+              </box>
+              <box
+                onMouseDown={
+                  onActivateRow && !editingAdd
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onActivateRow(-1, true, "value")
+                        event.stopPropagation()
+                      }
+                    : undefined
                 }
-                backgroundColor={
-                  editingAdd ? theme.backgroundElement : undefined
-                }
-                focusedBackgroundColor={theme.borderSubtle}
-                paddingX={1}
                 style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
-                variableNames={variableNames}
-              />
+              >
+                <VarInput
+                  value={editingAdd ? editValue : ""}
+                  placeholder="Value..."
+                  env={draftEnv}
+                  isEditing={editingAdd}
+                  onChange={setEditValue}
+                  isFocused={editingAdd && editState.subfield === "value"}
+                  baseColor={
+                    editingAdd || (inBrowse && editState.addingRow)
+                      ? theme.text
+                      : theme.textMuted
+                  }
+                  backgroundColor={
+                    editingAdd ? theme.backgroundElement : undefined
+                  }
+                  focusedBackgroundColor={theme.borderSubtle}
+                  paddingX={1}
+                  style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+                  variableNames={variableNames}
+                />
+              </box>
             </box>
           )
         })()}

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -80,9 +80,9 @@ export function EnvironmentEditorView({
           error={envEditor.error}
           focused={focus === "env-vars"}
           onPaneFocus={() => onPaneFocus("env-vars")}
-          onActivateRow={(row, addingRow) => {
+          onActivateRow={(row, addingRow, subfield) => {
             onPaneFocus("env-vars")
-            envEditor.activateVar(row, addingRow)
+            envEditor.activateVar(row, addingRow, subfield)
           }}
           onToggleRow={(row) => {
             onPaneFocus("env-vars")

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -11,7 +11,7 @@ import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
 import { Select, type SelectItem } from "../Select"
 import { useTheme } from "../theme"
-import type { Method, Environment } from "../../schema"
+import type { Method, Environment, ParamEntry } from "../../schema"
 import { METHOD_ITEMS } from "../methodItems"
 
 export { METHOD_ITEMS }
@@ -34,6 +34,7 @@ interface NewRequestOverlayProps {
   initialName?: string
   initialMethod?: Method
   initialUrl?: string
+  initialPathParams?: ParamEntry[]
   folderPaths?: SelectItem[]
   initialFolderPath?: string
   activeEnv?: Environment | null
@@ -59,6 +60,7 @@ export const NewRequestOverlay = forwardRef<
     initialName,
     initialMethod,
     initialUrl,
+    initialPathParams,
     folderPaths,
     initialFolderPath,
     activeEnv,
@@ -236,6 +238,7 @@ export const NewRequestOverlay = forwardRef<
                 ref={urlRef}
                 value={url || ""}
                 env={activeEnv ?? null}
+                pathParams={initialPathParams}
                 isEditing
                 onChange={setUrl}
                 isFocused={focus === "url"}

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -71,7 +71,7 @@ export const NewRequestOverlay = forwardRef<
 ) {
   const theme = useTheme()
   const isEdit = mode === "edit"
-  const showFolder = isEdit && folderPaths && folderPaths.length > 0
+  const showFolder = (folderPaths?.length ?? 0) > 0
   const [name, setName] = useState("")
   const [method, setMethod] = useState<Method>("GET")
   const [url, setUrl] = useState("")
@@ -133,7 +133,7 @@ export const NewRequestOverlay = forwardRef<
         setName("")
         setMethod("GET")
         setUrl("")
-        setFolderPath("")
+        setFolderPath(initialFolderPath ?? "")
       }
       setFocus(showFolder ? "folder" : "name")
       setErrorText(null)

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -289,7 +289,7 @@ export function TimelineDetailOverlay({
   const headerHeight = 5
 
   return (
-    <Overlay visible width={70} gap={1} padding={1}>
+    <Overlay visible width={70} height="80%" gap={1} padding={1}>
       <box
         style={{
           paddingLeft: 4,
@@ -310,7 +310,6 @@ export function TimelineDetailOverlay({
               key="network"
               events={entry.network}
               scrollRef={bodyScrollRef}
-              height={Math.min(Math.max(entry.network?.length ?? 1, 1), 10)}
             />
           ) : (
             <box
@@ -490,43 +489,33 @@ export function TimelineDetailOverlay({
                   </box>
                 </box>
               ) : renderedBody ? (
-                (() => {
-                  const bodyLines = renderedBody.split("\n").length
-                  const computedBodyHeight = Math.min(
-                    Math.max(bodyLines, 1),
-                    10,
-                  )
-                  return (
-                    <scrollbox
-                      ref={bodyScrollRef}
-                      scrollY
-                      height={computedBodyHeight}
-                      onMouseScroll={(event) => {
-                        const direction = event.scroll?.direction
-                        if (!direction) return
-                        const amount = event.scroll?.delta || 1
-                        bodyScrollRef.current?.scrollBy(
-                          (direction === "up" ? -1 : 1) * amount,
-                        )
-                        event.preventDefault()
-                        event.stopPropagation()
-                      }}
-                      verticalScrollbarOptions={{
-                        trackOptions: {
-                          backgroundColor: theme.background,
-                          foregroundColor: theme.borderActive,
-                        },
-                      }}
-                      style={{ flexShrink: 0 }}
-                    >
-                      <JsonBodyViewer
-                        body={renderedBody}
-                        theme={theme}
-                        highlightPriority={highlightPriority}
-                      />
-                    </scrollbox>
-                  )
-                })()
+                <scrollbox
+                  ref={bodyScrollRef}
+                  scrollY
+                  onMouseScroll={(event) => {
+                    const direction = event.scroll?.direction
+                    if (!direction) return
+                    const amount = event.scroll?.delta || 1
+                    bodyScrollRef.current?.scrollBy(
+                      (direction === "up" ? -1 : 1) * amount,
+                    )
+                    event.preventDefault()
+                    event.stopPropagation()
+                  }}
+                  verticalScrollbarOptions={{
+                    trackOptions: {
+                      backgroundColor: theme.background,
+                      foregroundColor: theme.borderActive,
+                    },
+                  }}
+                  style={{ flexGrow: 1, flexBasis: 0, minHeight: 0 }}
+                >
+                  <JsonBodyViewer
+                    body={renderedBody}
+                    theme={theme}
+                    highlightPriority={highlightPriority}
+                  />
+                </scrollbox>
               ) : (
                 <text fg={theme.textMuted}>
                   {entry.response ? "(empty body)" : "No response"}

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -153,7 +153,7 @@ export function useCollectionFileActions({
         body: "",
       }
 
-      saveRequest(collectionDir, req)
+      saveRequest(collectionDir, req, { overwrite: false })
         .then(() => {
           if (folder) expandFolder(folder)
           setCollectionReloadToken((n) => n + 1)
@@ -196,7 +196,7 @@ export function useCollectionFileActions({
         name: newName,
       }
 
-      saveRequest(collectionDir, cloned)
+      saveRequest(collectionDir, cloned, { overwrite: false })
         .then(() => {
           setCollectionReloadToken((n) => n + 1)
           setCloneRequestVisible(false)
@@ -235,7 +235,7 @@ export function useCollectionFileActions({
       const id = folderPath ? `${folderPath}/${baseId}` : baseId
       const request: NoodleRequest = { ...imported, id, name }
 
-      saveRequest(collectionDir, request)
+      saveRequest(collectionDir, request, { overwrite: false })
         .then(() => {
           if (folderPath) expandFolder(folderPath)
           setCollectionReloadToken((n) => n + 1)

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -371,7 +371,9 @@ export function useCollectionFileActions({
           : {}),
       }
 
-      const savePromise = saveRequest(collectionDir, updated).then(() => {
+      const savePromise = saveRequest(collectionDir, updated, {
+        overwrite: !nameChanged,
+      }).then(() => {
         if (nameChanged || folderChanged) {
           deleteRequest(collectionDir, req.id).catch(() => {
             /* stale file not cleaned up - new file is safe */

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -132,10 +132,10 @@ export function useCollectionFileActions({
   ])
 
   const handleNewRequestConfirm = useCallback(
-    (name: string, method: Method, url: string) => {
+    (name: string, method: Method, url: string, folderPath?: string) => {
       const baseId = slugify(name)
       if (!baseId) return
-      const folder = newRequestFolderRef.current
+      const folder = folderPath ?? newRequestFolderRef.current
       const id = folder ? `${folder}/${baseId}` : baseId
 
       const req: NoodleRequest = {

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -137,17 +137,20 @@ export function useCollectionFileActions({
       if (!baseId) return
       const folder = folderPath ?? newRequestFolderRef.current
       const id = folder ? `${folder}/${baseId}` : baseId
+      const synced = syncParamsWithUrl([], url)
+      const pathParams = syncPathParamsWithUrl([], url)
 
       const req: NoodleRequest = {
         id,
         name,
         method,
-        url,
+        url: synced.baseUrl,
         timeout: 0,
         followRedirects: true,
         maxRedirects: 5,
         headers: {},
-        params: [],
+        params: synced.params,
+        pathParams,
         auth: { type: "none" },
         bodyType: "none",
         body: "",

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -17,6 +17,7 @@ import {
 } from "../filestore"
 import { slugify } from "./overlays/NewRequestOverlay"
 import { updateFolderByPath } from "./tree"
+import { syncParamsWithUrl, syncPathParamsWithUrl } from "./urlParams"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
 
@@ -338,9 +339,16 @@ export function useCollectionFileActions({
         ? req.id.slice(0, req.id.lastIndexOf("/"))
         : ""
 
+      const synced = syncParamsWithUrl(req.params, url)
+      const pathParams = syncPathParamsWithUrl(req.pathParams ?? [], url)
       const nameChanged = newId !== req.id
       const folderChanged = newFolder !== oldFolder
-      const changed = nameChanged || method !== req.method || url !== req.url
+      const changed =
+        nameChanged ||
+        method !== req.method ||
+        synced.baseUrl !== req.url ||
+        JSON.stringify(synced.params) !== JSON.stringify(req.params) ||
+        JSON.stringify(pathParams) !== JSON.stringify(req.pathParams ?? [])
 
       if (!changed) {
         setEditRequestVisible(false)
@@ -353,7 +361,11 @@ export function useCollectionFileActions({
         id: newId,
         name,
         method,
-        url,
+        url: synced.baseUrl,
+        params: synced.params,
+        ...(req.pathParams !== undefined || pathParams.length > 0
+          ? { pathParams }
+          : {}),
       }
 
       const savePromise = saveRequest(collectionDir, updated).then(() => {

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -56,6 +56,7 @@ export function useOverlayIntercepts(opts: {
     name: string
     method: string
     url: string
+    folderPath?: string
   }) => void
   importCurlVisible: boolean
   importCurlRef: RefObject<ImportCurlOverlayHandle | null>
@@ -111,7 +112,7 @@ export function useOverlayIntercepts(opts: {
     handleRef: opts.newRequestRef,
     onConfirm: opts.onNewRequestConfirm,
     onCancel: () => opts.setNewRequestVisible(false),
-    passThroughFocuses: ["method"],
+    passThroughFocuses: ["method", "folder"],
   })
 
   const importCurlActions = useFormOverlayIntercept({

--- a/tests/automation.test.ts
+++ b/tests/automation.test.ts
@@ -102,6 +102,20 @@ describe("automation services", () => {
     ])
   })
 
+  it("accepts scheme-less request URLs without rewriting them", async () => {
+    await writeFile(join(dir, "settings.yml"), "{}\n", "utf8")
+    await requestCreate("bare-url", "www.example.com", "GET", dir)
+
+    const result = await collectionInspect(dir)
+    expect(result.tree).toContainEqual({
+      type: "request",
+      id: "bare-url",
+      name: "bare-url",
+      method: "GET",
+      url: "www.example.com",
+    })
+  })
+
   it("sets existing environment values and re-enables disabled variables", async () => {
     const envDir = join(dir, ".environments")
     await env.saveEnvironment(envDir, {

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -16,6 +16,7 @@ import {
   saveSettings,
   saveFolder,
   deleteFolder,
+  saveRequest,
 } from "../src/filestore"
 import type { Folder, Request, Collection } from "../src/schema"
 
@@ -228,6 +229,19 @@ describe("filestore.saveRequest — writes", () => {
     const content = await readFile(join(dir, "x.yml"), "utf8")
     expect(content).toContain("name: New")
     expect(content).not.toContain("name: Old")
+  })
+
+  it("does not overwrite an existing file when overwrite is disabled", async () => {
+    await saveRequest(dir, makeReq({ id: "x", name: "Old" }))
+
+    await expect(
+      saveRequest(dir, makeReq({ id: "x", name: "New" }), {
+        overwrite: false,
+      }),
+    ).rejects.toThrow("EEXIST")
+
+    const content = await readFile(join(dir, "x.yml"), "utf8")
+    expect(content).toContain("name: Old")
   })
 
   it("written file round-trips through lang.parseRequest", async () => {

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -13,10 +13,10 @@ import {
   requestRun,
   validateId,
   workspaceAudit,
-} from "../src/app/services"
-import { collection as collectionCommand } from "../src/app/commands/automation"
-import { env } from "../src/env"
-import { executor } from "../src/requests"
+} from "../../src/app/services"
+import { collection as collectionCommand } from "../../src/app/commands/automation"
+import { env } from "../../src/env"
+import { executor } from "../../src/requests"
 
 let dir: string
 beforeEach(async () => {
@@ -114,6 +114,64 @@ describe("automation services", () => {
       method: "GET",
       url: "www.example.com",
     })
+  })
+
+  it("accepts scheme-less host-and-port URLs without rewriting them", async () => {
+    await writeFile(join(dir, "settings.yml"), "{}\n", "utf8")
+    await requestCreate("bare-port", "localhost:3000/health", "GET", dir)
+    await requestCreate("loopback", "127.0.0.1:8080/health", "GET", dir)
+    await requestCreate(
+      "remote-port",
+      "api.example.com:8443/health",
+      "GET",
+      dir,
+    )
+    await requestCreate("service-port", "api:3000/health", "GET", dir)
+    await requestCreate("ftp-port", "ftp:21", "GET", dir)
+
+    const result = await collectionInspect(dir)
+    expect(result.tree).toContainEqual({
+      type: "request",
+      id: "bare-port",
+      name: "bare-port",
+      method: "GET",
+      url: "localhost:3000/health",
+    })
+    expect(result.tree).toContainEqual({
+      type: "request",
+      id: "loopback",
+      name: "loopback",
+      method: "GET",
+      url: "127.0.0.1:8080/health",
+    })
+    expect(result.tree).toContainEqual({
+      type: "request",
+      id: "remote-port",
+      name: "remote-port",
+      method: "GET",
+      url: "api.example.com:8443/health",
+    })
+    expect(result.tree).toContainEqual({
+      type: "request",
+      id: "service-port",
+      name: "service-port",
+      method: "GET",
+      url: "api:3000/health",
+    })
+    expect(result.tree).toContainEqual({
+      type: "request",
+      id: "ftp-port",
+      name: "ftp-port",
+      method: "GET",
+      url: "ftp:21",
+    })
+  })
+
+  it("rejects non-HTTP request URL schemes", async () => {
+    await writeFile(join(dir, "settings.yml"), "{}\n", "utf8")
+    await expect(
+      requestCreate("ftp-url", "ftp://example.com/file", "GET", dir),
+    ).rejects.toThrow('unsupported URL scheme "ftp:"')
   })
 
   it("sets existing environment values and re-enables disabled variables", async () => {

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -13,7 +13,8 @@ const inactive = {
 
 describe("EnvEditorPane", () => {
   it("activates rows, toggles checkboxes, and activates the add row", async () => {
-    const activations: Array<[number, boolean]> = []
+    const activations: Array<[number, boolean, "key" | "value" | undefined]> =
+      []
     const toggles: number[] = []
     const { renderOnce, mockMouse } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
@@ -39,8 +40,8 @@ describe("EnvEditorPane", () => {
             saving={false}
             error={null}
             focused
-            onActivateRow={(row, addingRow) =>
-              activations.push([row, addingRow])
+            onActivateRow={(row, addingRow, subfield) =>
+              activations.push([row, addingRow, subfield])
             }
             onToggleRow={(row) => toggles.push(row)}
           />
@@ -51,12 +52,14 @@ describe("EnvEditorPane", () => {
     await renderOnce()
 
     await mockMouse.click(10, 2, MouseButtons.LEFT)
+    await mockMouse.click(60, 2, MouseButtons.LEFT)
     await mockMouse.click(2, 2, MouseButtons.LEFT)
     await mockMouse.click(10, 3, MouseButtons.LEFT)
 
     expect(activations).toEqual([
-      [0, false],
-      [-1, true],
+      [0, false, "key"],
+      [0, false, "value"],
+      [-1, true, "key"],
     ])
     expect(toggles).toEqual([0])
   })

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -312,27 +312,36 @@ describe("TimelineDetailOverlay", () => {
     cleanup()
   })
 
-  it("dynamically adjusts body container height to fit short bodies", async () => {
+  it("keeps footer position stable when switching body tabs", async () => {
     const { renderOnce, captureCharFrame, host, cleanup } = await renderOverlay(
       makeEntry({
+        request: {
+          ...makeEntry().request,
+          body: "request body",
+        },
         response: {
           status: 200,
           statusText: "OK",
           headers: {},
-          body: "{}",
+          body: Array.from({ length: 20 }, (_, i) => `response line ${i}`).join(
+            "\n",
+          ),
           timeMs: 12,
-          size: 2,
+          size: 100,
         },
       }),
       () => {},
     )
     await renderOnce()
+    const requestFooterRow = captureCharFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("copy headers"))
     await act(async () => host.press("right"))
     await renderOnce()
-    const lines = captureCharFrame().split("\n")
-    const bodyTitleIndex = lines.findIndex((l) => l.trim() === "Body")
-    expect(bodyTitleIndex).toBeGreaterThanOrEqual(0)
-    expect(lines[bodyTitleIndex + 2]).toContain("{}")
+    const responseFooterRow = captureCharFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("copy headers"))
+    expect(responseFooterRow).toBe(requestFooterRow)
     cleanup()
   })
 

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -341,6 +341,8 @@ describe("TimelineDetailOverlay", () => {
     const responseFooterRow = captureCharFrame()
       .split("\n")
       .findIndex((line) => line.includes("copy headers"))
+    expect(requestFooterRow).toBeGreaterThanOrEqual(0)
+    expect(responseFooterRow).toBeGreaterThanOrEqual(0)
     expect(responseFooterRow).toBe(requestFooterRow)
     cleanup()
   })

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -17,6 +17,8 @@ function UrlBarHarness({
   jumpMode = false,
   onPaneFocus,
   onSubFocus,
+  onSend,
+  sending = false,
 }: {
   subFocus?: "select" | "text"
   focused?: boolean
@@ -26,6 +28,8 @@ function UrlBarHarness({
   jumpMode?: boolean
   onPaneFocus?: () => void
   onSubFocus?: (subFocus: "select" | "text") => void
+  onSend?: () => void
+  sending?: boolean
 }) {
   const [url, setUrl] = useState("https://example.com")
   const [method, setMethod] = useState<Method>(initialMethod)
@@ -45,6 +49,8 @@ function UrlBarHarness({
       jumpMode={jumpMode}
       onPaneFocus={onPaneFocus}
       onSubFocus={onSubFocus}
+      onSend={onSend}
+      sending={sending}
       activeEnv={{
         name: "test",
         vars: { base_url: "https://api.example.com" },
@@ -54,6 +60,82 @@ function UrlBarHarness({
 }
 
 describe("UrlBar", () => {
+  it("sends on left click only without focusing the URL bar", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let sends = 0
+    let focusCount = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <UrlBarHarness
+            onSend={() => sends++}
+            onPaneFocus={() => focusCount++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+    await renderOnce()
+
+    const frame = captureCharFrame()
+    const lines = frame.split("\n")
+    const sendY = lines.findIndex((line) => line.includes("Send"))
+    const sendX = lines[sendY].indexOf("Send")
+    await mockMouse.click(sendX, sendY, MouseButtons.RIGHT)
+    expect(sends).toBe(0)
+
+    await mockMouse.click(sendX, sendY, MouseButtons.LEFT)
+    expect(sends).toBe(1)
+    expect(focusCount).toBe(0)
+    cleanup()
+  })
+
+  it("hides the Send control when sending is unavailable", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <UrlBarHarness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+    await renderOnce()
+
+    expect(captureCharFrame()).not.toContain("Send")
+    cleanup()
+  })
+
+  it("shows a spinner beside Send and prevents repeat sends", async () => {
+    const originalSetInterval = globalThis.setInterval
+    globalThis.setInterval = (() => 0) as unknown as typeof setInterval
+    const { keymap, cleanup } = setupKeymap()
+    try {
+      let sends = 0
+      const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <UrlBarHarness onSend={() => sends++} sending />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 12 },
+      )
+      await renderOnce()
+
+      const frame = captureCharFrame()
+      const lines = frame.split("\n")
+      const sendY = lines.findIndex((line) => line.includes("⠋ Send"))
+      const sendX = lines[sendY].indexOf("Send")
+      expect(sendY).toBeGreaterThanOrEqual(0)
+
+      await mockMouse.click(sendX, sendY, MouseButtons.LEFT)
+      expect(sends).toBe(0)
+    } finally {
+      cleanup()
+      globalThis.setInterval = originalSetInterval
+    }
+  })
+
   it("focuses its pane only on a left click", async () => {
     const { keymap, cleanup } = setupKeymap()
     let focusCount = 0

--- a/tests/unit/newRequestOverlay.test.tsx
+++ b/tests/unit/newRequestOverlay.test.tsx
@@ -319,14 +319,20 @@ describe("NewRequestOverlay mode prop", () => {
     cleanup()
   })
 
-  it("does not show folder selector in create mode even with folderPaths", async () => {
+  it("shows the contextual folder in create mode", async () => {
     const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<NewRequestOverlayHandle>()
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <NewRequestOverlay
             visible
-            folderPaths={[{ id: "auth", label: "auth" }]}
+            ref={ref}
+            folderPaths={[
+              { id: "", label: "(root)" },
+              { id: "auth", label: "auth" },
+            ]}
+            initialFolderPath="auth"
           />
         </ThemeProvider>
       </KeymapProvider>,
@@ -334,7 +340,31 @@ describe("NewRequestOverlay mode prop", () => {
     )
     await renderOnce()
     const frame = captureCharFrame()
-    expect(frame).not.toContain("Folder")
+    expect(frame).toContain("Folder")
+    expect(frame).toContain("auth")
+    expect(ref.current?.getFocus()).toBe("folder")
+    cleanup()
+  })
+
+  it("shows root as the default create folder", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <NewRequestOverlay
+            visible
+            folderPaths={[
+              { id: "", label: "(root)" },
+              { id: "auth", label: "auth" },
+            ]}
+            initialFolderPath=""
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("(root)")
     cleanup()
   })
 })

--- a/tests/unit/newRequestOverlay.test.tsx
+++ b/tests/unit/newRequestOverlay.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { act, createRef } from "react"
+import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -9,7 +10,7 @@ import {
 } from "@opentui/keymap/addons"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
-import { ThemeProvider } from "../../src/ui/theme"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import {
   slugify,
   METHOD_ITEMS,
@@ -32,6 +33,14 @@ function setupKeymap() {
       hostCleanup()
     },
   }
+}
+
+function hexToRgba(hex: string): RGBA {
+  return RGBA.fromInts(
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+  )
 }
 
 describe("slugify", () => {
@@ -253,6 +262,30 @@ describe("NewRequestOverlay mode prop", () => {
     expect(frame).toContain("Get Users")
     expect(frame).toContain("POST")
     expect(frame).toContain("https://api.example.com/v2/users")
+    cleanup()
+  })
+
+  it("highlights resolved path params in the edit URL", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureSpans } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <NewRequestOverlay
+            visible
+            mode="edit"
+            initialUrl="https://api.example.com/users/:userId"
+            initialPathParams={[{ name: "userId", value: "42", enabled: true }]}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    const pathParam = spans.find((span) => span.text.includes(":userId"))
+    expect(pathParam).toBeDefined()
+    expect(pathParam!.fg.equals(hexToRgba(THEMES[0]!.primary))).toBe(true)
     cleanup()
   })
 

--- a/tests/unit/rowMouseControls.test.tsx
+++ b/tests/unit/rowMouseControls.test.tsx
@@ -9,7 +9,8 @@ import { FormEditor } from "../../src/ui/FormEditor"
 
 describe("request row mouse controls", () => {
   it("activates and toggles key/value rows independently", async () => {
-    const activations: Array<[number, boolean]> = []
+    const activations: Array<[number, boolean, "key" | "value" | undefined]> =
+      []
     const toggles: number[] = []
     const { renderOnce, mockMouse } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
@@ -28,8 +29,8 @@ describe("request row mouse controls", () => {
             setEditKey={() => {}}
             setEditValue={() => {}}
             theme={THEMES[0]!}
-            onActivateRow={(row, addingRow) =>
-              activations.push([row, addingRow])
+            onActivateRow={(row, addingRow, subfield) =>
+              activations.push([row, addingRow, subfield])
             }
             onToggleRow={(row) => toggles.push(row)}
           />
@@ -40,9 +41,13 @@ describe("request row mouse controls", () => {
     await renderOnce()
 
     await mockMouse.click(8, 0, MouseButtons.LEFT)
+    await mockMouse.click(60, 0, MouseButtons.LEFT)
     await mockMouse.click(1, 0, MouseButtons.LEFT)
 
-    expect(activations).toEqual([[0, false]])
+    expect(activations).toEqual([
+      [0, false, "key"],
+      [0, false, "value"],
+    ])
     expect(toggles).toEqual([0])
   })
 

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -431,7 +431,7 @@ describe("interpolatePathParams", () => {
 })
 
 describe("send — URL scheme", () => {
-  it("defaults scheme-less URLs to HTTPS and preserves explicit HTTP", async () => {
+  it("defaults remote URLs to HTTPS and local URLs to HTTP", async () => {
     const captured: string[] = []
     const orig = globalThis.fetch
     globalThis.fetch = mock(async (url: RequestInfo | URL) => {
@@ -447,13 +447,40 @@ describe("send — URL scheme", () => {
         }),
       )
       await send(makeReq({ url: "http://localhost:3000/health" }))
+      await send(makeReq({ url: "localhost:3000/health" }))
+      await send(makeReq({ url: "api.localhost:8080/health" }))
+      await send(makeReq({ url: "api.example.com:8443/health" }))
+      await send(makeReq({ url: "192.168.1.10:8080/health" }))
+      await send(makeReq({ url: "127.0.0.1:8080/health" }))
+      await send(makeReq({ url: "[::1]:8080/health" }))
+      await send(makeReq({ url: "api:3000/health" }))
+      await send(makeReq({ url: "ftp:21" }))
 
       expect(captured).toEqual([
         "https://www.example.com/users/42",
         "http://localhost:3000/health",
+        "http://localhost:3000/health",
+        "http://api.localhost:8080/health",
+        "https://api.example.com:8443/health",
+        "https://192.168.1.10:8080/health",
+        "http://127.0.0.1:8080/health",
+        "http://[::1]:8080/health",
+        "https://api:3000/health",
+        "https://ftp:21/",
       ])
     } finally {
       globalThis.fetch = orig
+    }
+  })
+
+  it("rejects unsupported URL schemes", async () => {
+    for (const [url, scheme] of [
+      ["ftp://example.com/file", "ftp"],
+      ["ws://example.com/socket", "ws"],
+    ]) {
+      await expect(send(makeReq({ url }))).rejects.toThrow(
+        `unsupported URL scheme "${scheme}:"`,
+      )
     }
   })
 })

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -430,6 +430,34 @@ describe("interpolatePathParams", () => {
   })
 })
 
+describe("send — URL scheme", () => {
+  it("defaults scheme-less URLs to HTTPS and preserves explicit HTTP", async () => {
+    const captured: string[] = []
+    const orig = globalThis.fetch
+    globalThis.fetch = mock(async (url: RequestInfo | URL) => {
+      captured.push(url.toString())
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await send(
+        makeReq({
+          url: "www.example.com/users/:id",
+          pathParams: [{ name: "id", value: "42", enabled: true }],
+        }),
+      )
+      await send(makeReq({ url: "http://localhost:3000/health" }))
+
+      expect(captured).toEqual([
+        "https://www.example.com/users/42",
+        "http://localhost:3000/health",
+      ])
+    } finally {
+      globalThis.fetch = orig
+    }
+  })
+})
+
 describe("send — required path parameters", () => {
   it("does not fetch for an empty value, with or without an environment", async () => {
     let calls = 0

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -194,7 +194,7 @@ describe("useCollectionFileActions", () => {
     ])
   })
 
-  it("creates a request in the selected folder", async () => {
+  it("creates a request with synchronized URL parameters in the selected folder", async () => {
     const collectionDir = await mkdtemp(join(tmpdir(), "noodle-actions-"))
     dirs.push(collectionDir)
     let create:
@@ -222,7 +222,12 @@ describe("useCollectionFileActions", () => {
 
     await render.renderOnce()
     await act(async () => {
-      create?.("Get Users", "GET", "https://api.example.com/users", "api")
+      create?.(
+        "Get Users",
+        "GET",
+        "https://api.example.com/users/:id?limit=10",
+        "api",
+      )
     })
     await saved
 
@@ -231,6 +236,13 @@ describe("useCollectionFileActions", () => {
       await readFile(join(collectionDir, "api", "get-users.yml"), "utf8"),
     )
     expect(request.id).toBe("api/get-users")
+    expect(request.url).toBe("https://api.example.com/users/:id")
+    expect(request.params).toEqual([
+      { name: "limit", value: "10", enabled: true },
+    ])
+    expect(request.pathParams).toEqual([
+      { name: "id", value: "", enabled: true },
+    ])
   })
 
   it("does not overwrite a request with the same slug in the selected folder", async () => {

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { act, useEffect, useRef, useState } from "react"
@@ -41,6 +41,7 @@ function ActionsHarness({
   onEditReady,
   onEditSaved,
   onNewReady,
+  onCreateFailed,
 }: {
   collectionDir: string
   onSaveReady: (save: () => void) => void
@@ -63,6 +64,7 @@ function ActionsHarness({
       folderPath?: string,
     ) => void,
   ) => void
+  onCreateFailed?: () => void
 }) {
   const [collection, updateCollection] = useState<Collection | null>(null)
   const folderDraftRef = useRef<UseFolderDraftResult>({
@@ -82,7 +84,11 @@ function ActionsHarness({
     folderDeletePathRef: useRef(null),
     setCollectionReloadToken: () => onEditSaved?.(),
     setFocus: () => {},
-    setSaveState: () => {},
+    setSaveState: (state) => {
+      if (typeof state !== "function" && state.kind === "error") {
+        onCreateFailed?.()
+      }
+    },
     savingRef,
     clearSaveTimer: () => {},
     saveTimerRef,
@@ -225,5 +231,54 @@ describe("useCollectionFileActions", () => {
       await readFile(join(collectionDir, "api", "get-users.yml"), "utf8"),
     )
     expect(request.id).toBe("api/get-users")
+  })
+
+  it("does not overwrite a request with the same slug in the selected folder", async () => {
+    const collectionDir = await mkdtemp(join(tmpdir(), "noodle-actions-"))
+    dirs.push(collectionDir)
+    await mkdir(join(collectionDir, "api"))
+    await writeFile(
+      join(collectionDir, "api", "get-users.yml"),
+      lang.serializeRequest({
+        ...initialRequest,
+        id: "api/get-users",
+        name: "Existing request",
+      }),
+    )
+    let create:
+      | ((
+          name: string,
+          method: NoodleRequest["method"],
+          url: string,
+          folderPath?: string,
+        ) => void)
+      | undefined
+    let resolveFailed: (() => void) | undefined
+    const failed = new Promise<void>((resolve) => {
+      resolveFailed = resolve
+    })
+    const render = await testRender(
+      <ActionsHarness
+        collectionDir={collectionDir}
+        onSaveReady={() => {}}
+        onMarkSaved={() => {}}
+        onNewReady={(handleCreate) => (create = handleCreate)}
+        onCreateFailed={() => resolveFailed?.()}
+      />,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await act(async () => {
+      create?.("Get Users", "POST", "https://api.example.com/new", "api")
+    })
+    await failed
+
+    const request = lang.parseRequest(
+      "api/get-users",
+      await readFile(join(collectionDir, "api", "get-users.yml"), "utf8"),
+    )
+    expect(request.name).toBe("Existing request")
+    expect(request.method).toBe("GET")
   })
 })

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -40,6 +40,7 @@ function ActionsHarness({
   selectedRequest = null,
   onEditReady,
   onEditSaved,
+  onNewReady,
 }: {
   collectionDir: string
   onSaveReady: (save: () => void) => void
@@ -54,6 +55,14 @@ function ActionsHarness({
     ) => void,
   ) => void
   onEditSaved?: () => void
+  onNewReady?: (
+    create: (
+      name: string,
+      method: NoodleRequest["method"],
+      url: string,
+      folderPath?: string,
+    ) => void,
+  ) => void
 }) {
   const [collection, updateCollection] = useState<Collection | null>(null)
   const folderDraftRef = useRef<UseFolderDraftResult>({
@@ -100,6 +109,10 @@ function ActionsHarness({
   useEffect(() => {
     onEditReady?.(actions.handleEditRequestConfirm)
   }, [actions.handleEditRequestConfirm, onEditReady])
+
+  useEffect(() => {
+    onNewReady?.(actions.handleNewRequestConfirm)
+  }, [actions.handleNewRequestConfirm, onNewReady])
 
   return null
 }
@@ -173,5 +186,44 @@ describe("useCollectionFileActions", () => {
     expect(request.pathParams).toEqual([
       { name: "userId", value: "42", enabled: true },
     ])
+  })
+
+  it("creates a request in the selected folder", async () => {
+    const collectionDir = await mkdtemp(join(tmpdir(), "noodle-actions-"))
+    dirs.push(collectionDir)
+    let create:
+      | ((
+          name: string,
+          method: NoodleRequest["method"],
+          url: string,
+          folderPath?: string,
+        ) => void)
+      | undefined
+    let resolveSaved: (() => void) | undefined
+    const saved = new Promise<void>((resolve) => {
+      resolveSaved = resolve
+    })
+    const render = await testRender(
+      <ActionsHarness
+        collectionDir={collectionDir}
+        onSaveReady={() => {}}
+        onMarkSaved={() => {}}
+        onNewReady={(handleCreate) => (create = handleCreate)}
+        onEditSaved={() => resolveSaved?.()}
+      />,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await act(async () => {
+      create?.("Get Users", "GET", "https://api.example.com/users", "api")
+    })
+    await saved
+
+    const request = lang.parseRequest(
+      "api/get-users",
+      await readFile(join(collectionDir, "api", "get-users.yml"), "utf8"),
+    )
+    expect(request.id).toBe("api/get-users")
   })
 })

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -4,9 +4,14 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { act, useEffect, useRef, useState } from "react"
 import { testRender } from "@opentui/react/test-utils"
-import type { Collection, Folder } from "../../src/schema"
+import type {
+  Collection,
+  Folder,
+  Request as NoodleRequest,
+} from "../../src/schema"
 import type { UseFolderDraftResult } from "../../src/hooks/useFolderDraft"
 import { useCollectionFileActions } from "../../src/ui/useCollectionFileActions"
+import { lang } from "../../src/lang"
 
 const initialFolder: Folder = {
   id: "api",
@@ -17,14 +22,38 @@ const initialFolder: Folder = {
 
 const savedFolder: Folder = { ...initialFolder, name: "Saved API" }
 
+const initialRequest: NoodleRequest = {
+  id: "get-user",
+  name: "Get User",
+  method: "GET",
+  url: "https://api.example.com/users/:id",
+  timeout: 0,
+  headers: {},
+  params: [],
+  pathParams: [{ name: "id", value: "42", enabled: true }],
+}
+
 function ActionsHarness({
   collectionDir,
   onSaveReady,
   onMarkSaved,
+  selectedRequest = null,
+  onEditReady,
+  onEditSaved,
 }: {
   collectionDir: string
   onSaveReady: (save: () => void) => void
   onMarkSaved: () => void
+  selectedRequest?: NoodleRequest | null
+  onEditReady?: (
+    edit: (
+      name: string,
+      method: NoodleRequest["method"],
+      url: string,
+      folderPath?: string,
+    ) => void,
+  ) => void
+  onEditSaved?: () => void
 }) {
   const [collection, updateCollection] = useState<Collection | null>(null)
   const folderDraftRef = useRef<UseFolderDraftResult>({
@@ -37,12 +66,12 @@ function ActionsHarness({
     collectionDir,
     collection,
     updateCollection,
-    selectedRequest: null,
-    requestDraftRef: useRef({} as never),
+    selectedRequest,
+    requestDraftRef: useRef({ moveRequestDraft: () => {} } as never),
     folderDraftRef,
     newRequestFolderRef: useRef(null),
     folderDeletePathRef: useRef(null),
-    setCollectionReloadToken: () => {},
+    setCollectionReloadToken: () => onEditSaved?.(),
     setFocus: () => {},
     setSaveState: () => {},
     savingRef,
@@ -67,6 +96,10 @@ function ActionsHarness({
   useEffect(() => {
     onSaveReady(actions.handleFolderSave)
   }, [actions.handleFolderSave, onSaveReady])
+
+  useEffect(() => {
+    onEditReady?.(actions.handleEditRequestConfirm)
+  }, [actions.handleEditRequestConfirm, onEditReady])
 
   return null
 }
@@ -102,5 +135,43 @@ describe("useCollectionFileActions", () => {
     expect(
       await readFile(join(collectionDir, "api", "folder.yml"), "utf8"),
     ).toContain("name: Saved API")
+  })
+
+  it("synchronizes renamed path params when saving an edited URL", async () => {
+    const collectionDir = await mkdtemp(join(tmpdir(), "noodle-actions-"))
+    dirs.push(collectionDir)
+    let edit:
+      | ((name: string, method: NoodleRequest["method"], url: string) => void)
+      | undefined
+    let resolveSaved: (() => void) | undefined
+    const saved = new Promise<void>((resolve) => {
+      resolveSaved = resolve
+    })
+    const render = await testRender(
+      <ActionsHarness
+        collectionDir={collectionDir}
+        onSaveReady={() => {}}
+        onMarkSaved={() => {}}
+        selectedRequest={initialRequest}
+        onEditReady={(handleEdit) => (edit = handleEdit)}
+        onEditSaved={() => resolveSaved?.()}
+      />,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await act(async () => {
+      edit?.("Get User", "GET", "https://api.example.com/users/:userId")
+    })
+    await saved
+
+    const request = lang.parseRequest(
+      "get-user",
+      await readFile(join(collectionDir, "get-user.yml"), "utf8"),
+    )
+    expect(request.url).toBe("https://api.example.com/users/:userId")
+    expect(request.pathParams).toEqual([
+      { name: "userId", value: "42", enabled: true },
+    ])
   })
 })

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -119,6 +119,17 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     })
 
     act(() => {
+      ref.current!.activateVar(0, false, "value")
+    })
+    await renderOnce()
+    expect(ref.current!.editState).toMatchObject({
+      mode: "editing",
+      row: 0,
+      addingRow: false,
+      subfield: "value",
+    })
+
+    act(() => {
       ref.current!.activateVar(-1, true)
     })
     await renderOnce()


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Keeps URL query and path parameters in sync, supports clicking directly into key or value fields, and lets new requests target a folder.
- Defaults scheme-less request URLs to HTTPS and adds a mouse Send control with in-progress feedback.
- Stabilizes the timeline detail response layout.

### How did you verify your code works?

- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bunx prettier --check ./src ./tests`

### Screenshots / recordings

Not captured.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Send control with loading feedback and duplicate-send prevention.
  - Key and value fields can now be activated and edited independently.
  - New requests can inherit their folder and preserve query and path parameters.
  - Request URLs now display and retain path parameters more reliably.

- **Bug Fixes**
  - URLs without a scheme are normalized appropriately; unsupported schemes are rejected.
  - Prevented cloned or imported requests from overwriting existing requests.
  - Improved timeline detail layout and scrolling across request and response views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->