### PR TITLE
fix(ui): prevent unsaved changes from carrying across request switches

### DIFF
--- a/.agents/skills/noodle-dev/SKILL.md
+++ b/.agents/skills/noodle-dev/SKILL.md
@@ -16,8 +16,38 @@ Terminal REST client. OpenTUI (React binding) on Bun. YAML files on disk.
 | Understand module boundaries, data flow, state, CLI, collection layout          | [architecture.md](architecture.md)                                 |
 | Add a keybinding, pane, overlay, auth type, body type, hook, importer, CLI flag | [recipes.md](recipes.md)                                           |
 | Write tests for new feature                                                     | [testing.md](testing.md)                                           |
+| Fix a bug or investigate a regression                                           | [testing.md](testing.md) → [Bug-fix workflow](#bug-fix-workflow)   |
 | Add/modify persistent state (new files, config, timeline)                       | [architecture.md](architecture.md) → "Collection directory layout" |
 | Build terminal UI components                                                    | **REQUIRED SUB-SKILL:** Use `opentui` skill                        |
+
+## Bug-fix workflow
+
+For bug reports, keep investigation, regression-test creation, implementation,
+and review as separate stages. Never declare a bug fixed based only on code
+inspection.
+
+1. Reproduce the reported behavior before changing production code.
+2. When practical, add the smallest focused failing regression test that proves
+   the defect.
+3. If the user requests investigation or approval first, stop after reporting
+   the reproduction, likely root cause, and proposed minimal fix; do not
+   implement until approved. Otherwise, continue with the authorized fix.
+4. Make the smallest localized change that passes the regression test. Do not
+   refactor unrelated code or change behavior outside the reported bug.
+5. Never delete, skip, weaken, or broadly rewrite tests merely to make them
+   pass.
+6. Run the focused test first, then the full test suite after the patch.
+7. Review the final diff for regressions and unintended behavior changes. Report
+   the root cause, changed files, tests changed or added, commands run,
+   user-visible behavior changes, and remaining risks.
+
+If an automated regression test is not practical, explain why and provide a
+reproducible manual acceptance procedure. If the issue cannot be reproduced,
+do not make speculative production changes; report what was attempted instead.
+
+Ask for explicit approval before a compatibility-sensitive change that has not
+already been authorized: public CLI or API behavior, collection or YAML formats,
+configuration, keybindings, persistence, or backwards compatibility.
 
 ## Key conventions
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  pre_merge_checks:
+    docstrings:
+      mode: "off"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ noodle environment set <key> <value> --env <name> [--collection <dir>] [--json]
 - **UI:** [OpenTUI](https://github.com/anomius/opentui) React binding (`@opentui/react`, `@opentui/core`). `jsxImportSource: "@opentui/react"` — this is NOT standard React DOM. JSX renders to a terminal TUI. Use `useKeyboard`, `createCliRenderer`, `createRoot` from OpenTUI.
 - **Language:** TypeScript 6, strict mode, `"type": "module"`.
 - **Lint:** ESLint 10 with `@eslint/js` + `typescript-eslint` recommended rules. `no-unused-vars` ignores `_`-prefixed args.
-- **Format:** Prettier 3 — `semi: false`, `singleQuote: false`. No trailing commas.
+- **Format:** Prettier 3 — `semi: false`, `singleQuote: false`; use Prettier's default trailing commas.
 - **Tests:** `bun:test` (not vitest/jest). `describe`, `it`, `expect`.
 - **Package manager:** Bun. `bun.lock` (not `yarn.lock`/`package-lock.json`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Noodle uses [OpenTUI](https://github.com/anomius/opentui) (`@opentui/react`) for
 
 Key conventions:
 - TypeScript 6, strict mode, `"type": "module"`
-- ESLint 10 + Prettier 3 (`semi: false`, `singleQuote: false`, no trailing commas)
+- ESLint 10 + Prettier 3 (`semi: false`, `singleQuote: false`, with Prettier's default trailing commas)
 - Tests use `bun:test` (not vitest/jest)
 - Error re-throws must pass `{ cause: e }` as second arg
 - Requests are `.yml` files, one per request

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -215,7 +215,6 @@ export function useRequestDraft(
   const revertAllRequests = useCallback(() => {
     clearRequestDraftCaches()
     setMap(new Map())
-    setOriginalMap(new Map())
   }, [])
 
   const markSaved = useCallback((request: Request) => {

--- a/src/hooks/useRequestDraft.ts
+++ b/src/hooks/useRequestDraft.ts
@@ -76,8 +76,14 @@ export function useRequestDraft(
 
   const apply = useCallback(
     (op: DraftOp) => {
+      if (!selectedRequest) return
+      setOriginalMap((prev) => {
+        if (prev.has(selectedRequest.id)) return prev
+        const next = new Map(prev)
+        next.set(selectedRequest.id, selectedRequest)
+        return next
+      })
       setMap((prev) => {
-        if (!selectedRequest) return prev
         return applyDraft(prev, selectedRequest.id, selectedRequest, op)
       })
     },
@@ -215,6 +221,7 @@ export function useRequestDraft(
   const revertAllRequests = useCallback(() => {
     clearRequestDraftCaches()
     setMap(new Map())
+    setOriginalMap(new Map())
   }, [])
 
   const markSaved = useCallback((request: Request) => {

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -514,8 +514,8 @@ export function AppInner({
     confirmCollectionSwitch,
   } = useCollectionSwitcher({
     collectionDir,
-    requestDirty: draft.isDirty,
-    folderDirty: folderDraft.isDirty,
+    requestDirty: draft.dirtyRequestIds.size > 0,
+    folderDirty: folderDraft.dirtyPaths.size > 0,
     environmentDirty: envEditor.dirty,
     onCollectionChange,
   })

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -65,6 +65,7 @@ import { useUpdateFlow } from "./useUpdateFlow"
 import { useTimelineActions } from "./useTimelineActions"
 import { useOverlayState } from "./useOverlayState"
 import { useCollectionSwitcher } from "./useCollectionSwitcher"
+import { useReloadGuard } from "./useReloadGuard"
 import { useKeymapSync } from "./useKeymapSync"
 import { useEditModeSync } from "./useEditModeSync"
 
@@ -505,6 +506,13 @@ export function AppInner({
     [eb.commitEdit, focus, folderEb.commitEdit],
   )
 
+  const hasUnsavedChanges =
+    draft.dirtyRequestIds.size > 0 ||
+    folderDraft.dirtyPaths.size > 0 ||
+    envEditor.dirty ||
+    eb.editState.mode === "editing" ||
+    folderEb.editState.mode === "editing" ||
+    envEditor.editState.mode === "editing"
   const {
     collectionSwitcherVisible,
     setCollectionSwitcherVisible,
@@ -514,11 +522,11 @@ export function AppInner({
     confirmCollectionSwitch,
   } = useCollectionSwitcher({
     collectionDir,
-    requestDirty: draft.dirtyRequestIds.size > 0,
-    folderDirty: folderDraft.dirtyPaths.size > 0,
-    environmentDirty: envEditor.dirty,
+    hasUnsavedChanges,
     onCollectionChange,
   })
+  const { reloadPending, requestReload, confirmReload, cancelReload } =
+    useReloadGuard(hasUnsavedChanges, onReloadCollection)
 
   const overlayActiveRef = useRef(false)
   const {
@@ -575,6 +583,7 @@ export function AppInner({
     previewIndex,
     collectionSwitcherVisible,
     collectionSwitchPending,
+    reloadPending,
     updatePhase: updateFlow.phase,
   })
   useEffect(() => {
@@ -866,6 +875,9 @@ export function AppInner({
     collectionSwitchPending,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm: confirmCollectionSwitch,
+    reloadPending,
+    setReloadPending: cancelReload,
+    onReloadConfirm: confirmReload,
     undoAllPending,
     setUndoAllPending,
     initPending,
@@ -944,7 +956,7 @@ export function AppInner({
         setExpanded,
         setPreviewIndexProp,
         setEnvDeletePending,
-        onReloadCollection,
+        onReloadCollection: requestReload,
         triggerUpdateCheck,
         paletteTarget,
       }),
@@ -954,7 +966,7 @@ export function AppInner({
       confirmUndoAll,
       onLayoutChange,
       setCollectionSwitcherVisible,
-      onReloadCollection,
+      requestReload,
       view,
       mode,
       paletteTarget,
@@ -1077,6 +1089,7 @@ export function AppInner({
           setAboutVisible={setAboutVisible}
           envDeletePending={envDeletePending}
           undoAllPending={undoAllPending}
+          reloadPending={reloadPending}
           initPending={initPending}
           collectionSwitchPending={collectionSwitchPending}
           onConfirmDialog={overlayActions.onConfirm}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -57,6 +57,7 @@ interface AppOverlaysProps {
   activeOverlay: ActiveOverlay
   envDeletePending: string | null
   undoAllPending: boolean
+  reloadPending: boolean
   initPending: boolean
   collectionSwitchPending: string | null
   onConfirmDialog: () => void
@@ -144,6 +145,7 @@ export function AppOverlays({
   activeOverlay,
   envDeletePending,
   undoAllPending,
+  reloadPending,
   initPending,
   collectionSwitchPending,
   onConfirmDialog,
@@ -235,6 +237,14 @@ export function AppOverlays({
         <ConfirmOverlay
           visible
           message="Discard all unsaved changes? (y/n)"
+          onConfirm={onConfirmDialog}
+          onCancel={onCancelDialog}
+        />
+      )}
+      {activeOverlay === "reload-confirm" && reloadPending && (
+        <ConfirmOverlay
+          visible
+          message="Reload collection and discard unsaved changes? (y/n)"
           onConfirm={onConfirmDialog}
           onCancel={onCancelDialog}
         />

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -138,6 +138,7 @@ export function RequestResponseView({
   return (
     <>
       <UrlBar
+        key={draft.draft?.id}
         method={draft.draft?.method ?? "GET"}
         url={draft.draft?.url ?? ""}
         params={draft.draft?.params ?? []}

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -264,7 +264,7 @@ export function Sidebar({
                       {truncName(node.name, 20)}
                     </text>
                   </box>
-                  {isFolderDirty && <text fg={theme.warning}>{`\u25CF`}</text>}
+                  {isFolderDirty && <text fg={theme.accent}>{`\u25CF`}</text>}
                 </box>
               )
             }
@@ -311,7 +311,7 @@ export function Sidebar({
                     {truncName(node.name, 20)}
                   </text>
                 </box>
-                {isDirty && <text fg={theme.warning}>{`\u25CF`}</text>}
+                {isDirty && <text fg={theme.accent}>{`\u25CF`}</text>}
               </box>
             )
           })}

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -261,10 +261,10 @@ export function Sidebar({
                       </text>
                     </box>
                     <text fg={theme.textMuted} wrapMode="none">
-                      {truncName(node.name, 20)}
+                      {truncName(node.name, 18)}
                     </text>
                   </box>
-                  {isFolderDirty && <text fg={theme.accent}>{`\u25CF`}</text>}
+                  {isFolderDirty && <text fg={theme.accent}>{`\u25CF `}</text>}
                 </box>
               )
             }
@@ -308,10 +308,10 @@ export function Sidebar({
                     {shortMethod(node.method ?? "GET").padEnd(7)}
                   </text>
                   <text fg={theme.text} wrapMode="none">
-                    {truncName(node.name, 20)}
+                    {truncName(node.name, 18)}
                   </text>
                 </box>
-                {isDirty && <text fg={theme.accent}>{`\u25CF`}</text>}
+                {isDirty && <text fg={theme.accent}>{`\u25CF `}</text>}
               </box>
             )
           })}

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -255,7 +255,8 @@ export function undoAll(c: CommandActionsConfig): boolean {
   const d = c.draftRef.current
   const fd = c.folderDraftRef.current
   const ee = c.envEditorRef.current
-  const hasDirty = d.isDirty || fd.isDirty || (ee?.dirty ?? false)
+  const hasDirty =
+    d.dirtyRequestIds.size > 0 || fd.dirtyPaths.size > 0 || (ee?.dirty ?? false)
   if (!hasDirty) return false
   if (c.confirmUndoAll) {
     return true

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -120,7 +120,7 @@ export function EnvSidebar({
                   {colorHex && <text fg={colorHex}>● </text>}
                   <text fg={theme.text}>{name}</text>
                 </box>
-                {isDirty && <text fg={theme.warning}>●</text>}
+                {isDirty && <text fg={theme.accent}>●</text>}
               </box>
             )
           })}

--- a/src/ui/intercepts/useDialogIntercepts.ts
+++ b/src/ui/intercepts/useDialogIntercepts.ts
@@ -16,6 +16,9 @@ export function useDialogIntercepts(opts: {
   collectionSwitchPending: string | null
   setCollectionSwitchPending: (s: string | null) => void
   onCollectionSwitchConfirm: (collectionDir: string) => void
+  reloadPending: boolean
+  setReloadPending: (v: boolean) => void
+  onReloadConfirm: () => void
   requestDeletePending: string | null
   setRequestDeletePending: (s: string | null) => void
   onRequestDeleteConfirm: () => void
@@ -45,6 +48,8 @@ export function useDialogIntercepts(opts: {
     collectionSwitchPending,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm,
+    setReloadPending,
+    onReloadConfirm,
     setRequestDeletePending,
     onRequestDeleteConfirm,
     setFolderDeletePending,
@@ -118,6 +123,7 @@ export function useDialogIntercepts(opts: {
     else if (activeOverlay === "init-confirm") confirmInit()
     else if (activeOverlay === "collection-switch-confirm")
       confirmCollectionSwitch()
+    else if (activeOverlay === "reload-confirm") onReloadConfirm()
     else if (activeOverlay === "delete-folder") onFolderDeleteConfirm()
     else if (activeOverlay === "request-delete") onRequestDeleteConfirm()
     else if (activeOverlay === "update-confirm") onConfirmInstall()
@@ -127,6 +133,7 @@ export function useDialogIntercepts(opts: {
     confirmUndoAll,
     confirmInit,
     confirmCollectionSwitch,
+    onReloadConfirm,
     onFolderDeleteConfirm,
     onRequestDeleteConfirm,
     onConfirmInstall,
@@ -138,6 +145,7 @@ export function useDialogIntercepts(opts: {
     else if (activeOverlay === "init-confirm") setInitPending(false)
     else if (activeOverlay === "collection-switch-confirm")
       setCollectionSwitchPending(null)
+    else if (activeOverlay === "reload-confirm") setReloadPending(false)
     else if (activeOverlay === "delete-folder") setFolderDeletePending(null)
     else if (activeOverlay === "request-delete") setRequestDeletePending(null)
     else if (activeOverlay === "update-confirm") onCancelUpdate()
@@ -147,6 +155,7 @@ export function useDialogIntercepts(opts: {
     setUndoAllPending,
     setInitPending,
     setCollectionSwitchPending,
+    setReloadPending,
     setFolderDeletePending,
     setRequestDeletePending,
     onCancelUpdate,
@@ -177,6 +186,28 @@ export function useDialogIntercepts(opts: {
   // ── Overlay: Collection switch confirmation ──────────────────────
   useEffect(() => {
     if (activeOverlay !== "collection-switch-confirm") return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        const name = ctx.event.name
+        if (name === "y" || name === "return") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          onConfirm()
+        } else if (name === "n" || name === "escape") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          onCancel()
+        }
+      },
+      { priority: 100 },
+    )
+    return dispose
+  }, [activeOverlay, keymap, onConfirm, onCancel])
+
+  // ── Overlay: Reload confirmation ─────────────────────────────────
+  useEffect(() => {
+    if (activeOverlay !== "reload-confirm") return
     const dispose = keymap.intercept(
       "key",
       (ctx) => {

--- a/src/ui/theme-data.ts
+++ b/src/ui/theme-data.ts
@@ -151,11 +151,11 @@ export const ayuTheme: Theme = {
   textMuted: "#565b66",
   background: "#0b0e14",
   backgroundPanel: "#0f131a",
-  borderDimmest: "#0e1118",
+  borderDimmest: "#161b26",
   backgroundElement: "#1d2335",
   border: "#6c7380",
   borderActive: "#6c7380",
-  borderSubtle: "#11151c",
+  borderSubtle: "#222a38",
 }
 
 export const monokaiTheme: Theme = {
@@ -175,7 +175,7 @@ export const monokaiTheme: Theme = {
   backgroundElement: "#3e3d32",
   border: "#3e3d32",
   borderActive: "#66d9ef",
-  borderSubtle: "#1e1f1c",
+  borderSubtle: "#49483e",
 }
 
 export const solarizedTheme: Theme = {
@@ -193,9 +193,9 @@ export const solarizedTheme: Theme = {
   backgroundPanel: "#073642",
   borderDimmest: "#073642",
   backgroundElement: "#114e5c",
-  border: "#073642",
+  border: "#586e75",
   borderActive: "#586e75",
-  borderSubtle: "#073642",
+  borderSubtle: "#586e75",
 }
 
 export const onedarkTheme: Theme = {
@@ -315,7 +315,7 @@ export const materialTheme: Theme = {
   backgroundElement: "#37474f",
   border: "#37474f",
   borderActive: "#82aaff",
-  borderSubtle: "#1e272c",
+  borderSubtle: "#37474f",
 }
 
 export const carbonfoxTheme: Theme = {
@@ -615,7 +615,7 @@ export const vercelTheme: Theme = {
   backgroundElement: "#292929",
   border: "#1f1f1f",
   borderActive: "#454545",
-  borderSubtle: "#0a0a0a",
+  borderSubtle: "#1f1f1f",
 }
 
 export const vesperTheme: Theme = {
@@ -655,7 +655,7 @@ export const zenburnTheme: Theme = {
   backgroundElement: "#777777",
   border: "#5f5f5f",
   borderActive: "#8cd0d3",
-  borderSubtle: "#4f4f4f",
+  borderSubtle: "#5f5f5f",
 }
 
 export const THEMES: Theme[] = [

--- a/src/ui/useCollectionSwitcher.ts
+++ b/src/ui/useCollectionSwitcher.ts
@@ -4,17 +4,13 @@ import type { Dispatch, SetStateAction } from "react"
 
 interface UseCollectionSwitcherProps {
   collectionDir: string
-  requestDirty: boolean
-  folderDirty: boolean
-  environmentDirty: boolean
+  hasUnsavedChanges: boolean
   onCollectionChange: (collectionDir: string) => void
 }
 
 export function useCollectionSwitcher({
   collectionDir,
-  requestDirty,
-  folderDirty,
-  environmentDirty,
+  hasUnsavedChanges,
   onCollectionChange,
 }: UseCollectionSwitcherProps): {
   collectionSwitcherVisible: boolean
@@ -40,14 +36,14 @@ export function useCollectionSwitcher({
         setCollectionSwitchPending(null)
         return
       }
-      if (requestDirty || folderDirty || environmentDirty) {
+      if (hasUnsavedChanges) {
         setCollectionSwitchPending(normalized)
         return
       }
       setCollectionSwitchPending(null)
       onCollectionChange(normalized)
     },
-    [requestDirty, folderDirty, environmentDirty, onCollectionChange],
+    [hasUnsavedChanges, onCollectionChange],
   )
 
   const confirmCollectionSwitch = useCallback(

--- a/src/ui/useModalKeyboardShield.ts
+++ b/src/ui/useModalKeyboardShield.ts
@@ -19,6 +19,7 @@ export const HARD_BLOCKING_OVERLAYS = new Set([
   "about",
   "env-delete",
   "undo-all",
+  "reload-confirm",
   "init-confirm",
   "collection-switch-confirm",
   "code-generator",

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -92,6 +92,9 @@ export function useOverlayIntercepts(opts: {
   collectionSwitchPending: string | null
   setCollectionSwitchPending: (s: string | null) => void
   onCollectionSwitchConfirm: (collectionDir: string) => void
+  reloadPending: boolean
+  setReloadPending: (v: boolean) => void
+  onReloadConfirm: () => void
   undoAllPending: boolean
   setUndoAllPending: (v: boolean) => void
   initPending: boolean

--- a/src/ui/useOverlayState.ts
+++ b/src/ui/useOverlayState.ts
@@ -16,6 +16,7 @@ export type ActiveOverlay =
   | "theme"
   | "env-delete"
   | "undo-all"
+  | "reload-confirm"
   | "init-confirm"
   | "collection-switch-confirm"
   | "collection-switcher"
@@ -35,6 +36,7 @@ interface UseOverlayStateProps {
   previewIndex: number | null
   collectionSwitcherVisible: boolean
   collectionSwitchPending: string | null
+  reloadPending: boolean
   updatePhase: UpdateFlowState["phase"]
 }
 
@@ -42,6 +44,7 @@ export function useOverlayState({
   previewIndex,
   collectionSwitcherVisible,
   collectionSwitchPending,
+  reloadPending,
   updatePhase,
 }: UseOverlayStateProps) {
   const [helpVisible, setHelpVisible] = useState(false)
@@ -88,6 +91,7 @@ export function useOverlayState({
     if (previewIndex !== null) return "theme"
     if (envDeletePending !== null) return "env-delete"
     if (undoAllPending) return "undo-all"
+    if (reloadPending) return "reload-confirm"
     if (initPending) return "init-confirm"
     if (collectionSwitchPending !== null) return "collection-switch-confirm"
     if (collectionSwitcherVisible) return "collection-switcher"
@@ -111,6 +115,7 @@ export function useOverlayState({
     previewIndex,
     envDeletePending,
     undoAllPending,
+    reloadPending,
     initPending,
     collectionSwitchPending,
     collectionSwitcherVisible,

--- a/src/ui/useReloadGuard.ts
+++ b/src/ui/useReloadGuard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useState } from "react"
 
 export function useReloadGuard(
   hasUnsavedChanges: boolean,
@@ -10,23 +10,19 @@ export function useReloadGuard(
   cancelReload: () => void
 } {
   const [reloadPending, setReloadPending] = useState(false)
-  const hasUnsavedChangesRef = useRef(hasUnsavedChanges)
-  hasUnsavedChangesRef.current = hasUnsavedChanges
-  const onReloadRef = useRef(onReload)
-  onReloadRef.current = onReload
 
   const requestReload = useCallback(() => {
-    if (hasUnsavedChangesRef.current) {
+    if (hasUnsavedChanges) {
       setReloadPending(true)
     } else {
-      onReloadRef.current()
+      onReload()
     }
-  }, [])
+  }, [hasUnsavedChanges, onReload])
 
   const confirmReload = useCallback(() => {
     setReloadPending(false)
-    onReloadRef.current()
-  }, [])
+    onReload()
+  }, [onReload])
 
   const cancelReload = useCallback(() => setReloadPending(false), [])
 

--- a/src/ui/useReloadGuard.ts
+++ b/src/ui/useReloadGuard.ts
@@ -1,0 +1,34 @@
+import { useCallback, useRef, useState } from "react"
+
+export function useReloadGuard(
+  hasUnsavedChanges: boolean,
+  onReload: () => void,
+): {
+  reloadPending: boolean
+  requestReload: () => void
+  confirmReload: () => void
+  cancelReload: () => void
+} {
+  const [reloadPending, setReloadPending] = useState(false)
+  const hasUnsavedChangesRef = useRef(hasUnsavedChanges)
+  hasUnsavedChangesRef.current = hasUnsavedChanges
+  const onReloadRef = useRef(onReload)
+  onReloadRef.current = onReload
+
+  const requestReload = useCallback(() => {
+    if (hasUnsavedChangesRef.current) {
+      setReloadPending(true)
+    } else {
+      onReloadRef.current()
+    }
+  }, [])
+
+  const confirmReload = useCallback(() => {
+    setReloadPending(false)
+    onReloadRef.current()
+  }, [])
+
+  const cancelReload = useCallback(() => setReloadPending(false), [])
+
+  return { reloadPending, requestReload, confirmReload, cancelReload }
+}

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -608,9 +608,9 @@ describe("Sidebar scrollbox", () => {
     expect(lines.length).toBeLessThan(50)
 
     // Text truncated to fit sidebar width; check truncated form present
-    expect(frame).toContain("Very long request n\u2026")
+    expect(frame).toContain("Very long request\u2026")
     // Should render many entries without crashing
-    const count = (frame.match(/Very long request n\u2026/g) || []).length
+    const count = (frame.match(/Very long request\u2026/g) || []).length
     expect(count).toBeGreaterThan(10)
   })
 

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -4,6 +4,7 @@ import { testRender } from "@opentui/react/test-utils"
 import { TextAttributes } from "@opentui/core"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { createTestKeymap } from "@opentui/keymap/testing"
+import { act, useState } from "react"
 import { RequestResponseView } from "../../src/ui/RequestResponseView"
 import { ThemeProvider } from "../../src/ui/theme"
 import { CodeEditorRenderable } from "../../src/ui/editor/CodeEditor"
@@ -386,6 +387,97 @@ describe("ResponsePane status text truncation and layout tests", () => {
         ),
       ).toBe(false)
     }
+  })
+
+  it("does not sync the previous URL when switching requests", async () => {
+    const { keymap } = createTestProps()
+    const syncedUrls: string[] = []
+    let switchRequest = () => {}
+
+    function RequestSwitchHarness() {
+      const [selectedId, setSelectedId] = useState("first")
+      const [focus, setFocus] = useState<"urlbar" | "sidebar">("urlbar")
+      const draft = {
+        draft: {
+          id: selectedId,
+          method: "GET" as const,
+          url: `https://${selectedId}.example.com`,
+          headers: {},
+          params: [],
+          auth: { type: "none" as const },
+          bodyType: "json" as const,
+        },
+        setUrl: () => {},
+        setMethod: () => {},
+        syncUrlParams: (url: string) => syncedUrls.push(url),
+        setAuthType: () => {},
+        setApiKeyPlacement: () => {},
+        setBodyType: () => {},
+        dirtyRequestIds: new Set<string>(),
+      }
+      const eb = {
+        editState: {
+          mode: "inactive" as const,
+          cursor: { field: "body" as const, row: 0, addingRow: false },
+          editingRow: -1,
+        },
+        editKey: "",
+        editValue: "",
+        setEditKey: () => {},
+        setEditValue: () => {},
+        activeTab: "body" as const,
+      }
+
+      switchRequest = () => {
+        setSelectedId("second")
+        setFocus("sidebar")
+      }
+
+      return (
+        <RequestResponseView
+          draft={
+            draft as unknown as Parameters<
+              typeof RequestResponseView
+            >[0]["draft"]
+          }
+          eb={eb as unknown as Parameters<typeof RequestResponseView>[0]["eb"]}
+          error={null}
+          focus={focus}
+          layout="stacked"
+          expanded={null}
+          activeEnv={null}
+          responseState={{ status: "idle" }}
+          timelineEntries={[]}
+          onResponseTabChange={() => {}}
+          setSelectOpen={() => {}}
+          urlbarSubFocus="text"
+          urlbarInteractive={true}
+        />
+      )
+    }
+
+    const { renderOnce } = await testRender(
+      <KeymapProvider
+        keymap={
+          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+        }
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ width: 100, height: 20, flexDirection: "column" }}>
+            <RequestSwitchHarness />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 20 },
+    )
+
+    await renderOnce()
+    act(() => {
+      switchRequest()
+    })
+    await renderOnce()
+
+    expect(syncedUrls).toEqual([])
   })
 })
 

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -10,6 +10,7 @@ import {
   saveFolder,
   saveRequest,
   sendRequest,
+  undoAll,
 } from "../../src/ui/commandActions"
 
 function minimalContext(): CommandBuilderContext {
@@ -364,6 +365,33 @@ describe("buildCommandPaletteCommands", () => {
     const save = commands.find((c) => c.id === "request.save")!
     save.run()
     expect(saved).toBe(false)
+  })
+
+  it("undoes a dirty request that is not selected", () => {
+    const ctx = minimalContext()
+    let requestsReverted = false
+    ctx.draftRef = {
+      current: {
+        isDirty: false,
+        dirtyRequestIds: new Set(["other-request"]),
+        revertAllRequests: () => {
+          requestsReverted = true
+        },
+      },
+    } as never
+    ctx.folderDraftRef = {
+      current: {
+        isDirty: false,
+        dirtyPaths: new Set(),
+        revertAllFolders: () => {},
+      },
+    } as never
+    ctx.envEditorRef = {
+      current: { dirty: false, revertDraft: () => {} },
+    } as never
+
+    expect(undoAll(ctx)).toBe(true)
+    expect(requestsReverted).toBe(true)
   })
 
   it("folder.save only runs for a dirty folder when no save is pending", () => {

--- a/tests/unit/unsavedChangesRegression.test.tsx
+++ b/tests/unit/unsavedChangesRegression.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useRequestDraft } from "../../src/hooks/useRequestDraft"
 import { useEditBrowse } from "../../src/hooks/useEditBrowse"
 import { useCollectionSwitcher } from "../../src/ui/useCollectionSwitcher"
@@ -43,6 +43,35 @@ function ReloadGuardHarness({
       onResult({ reloads, pending: reload.reloadPending })
     }
   }, [draft, onResult, reload, reloads, step])
+
+  return null
+}
+
+function ReloadGuardCommittedCallbackHarness({
+  onResult,
+}: {
+  onResult: (result: { reloads: number; pending: boolean }) => void
+}) {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+  const [reloads, setReloads] = useState(0)
+  const [step, setStep] = useState(0)
+  const firstRequestReload = useRef<(() => void) | null>(null)
+  const reload = useReloadGuard(hasUnsavedChanges, () =>
+    setReloads((count) => count + 1),
+  )
+
+  useEffect(() => {
+    if (step === 0) {
+      firstRequestReload.current = reload.requestReload
+      setHasUnsavedChanges(true)
+      setStep(1)
+    } else if (step === 1 && hasUnsavedChanges) {
+      firstRequestReload.current?.()
+      setStep(2)
+    } else if (step === 2) {
+      onResult({ reloads, pending: reload.reloadPending })
+    }
+  }, [hasUnsavedChanges, onResult, reload, reloads, step])
 
   return null
 }
@@ -107,5 +136,19 @@ describe("unsaved changes regressions", () => {
     for (let i = 0; i < 5; i++) await renderOnce()
 
     expect(result).toEqual({ changes: 0, pending: "/next" })
+  })
+
+  it("keeps a committed reload callback bound to its render values", async () => {
+    let result = { reloads: 0, pending: true }
+    const { renderOnce } = await testRender(
+      <ReloadGuardCommittedCallbackHarness
+        onResult={(next) => (result = next)}
+      />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 5; i++) await renderOnce()
+
+    expect(result).toEqual({ reloads: 1, pending: false })
   })
 })

--- a/tests/unit/unsavedChangesRegression.test.tsx
+++ b/tests/unit/unsavedChangesRegression.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { useEffect, useState } from "react"
+import { useRequestDraft } from "../../src/hooks/useRequestDraft"
+import { useEditBrowse } from "../../src/hooks/useEditBrowse"
+import { useCollectionSwitcher } from "../../src/ui/useCollectionSwitcher"
+import { useReloadGuard } from "../../src/ui/useReloadGuard"
+import type { Request } from "../../src/schema"
+
+const request: Request = {
+  id: "request",
+  name: "Request",
+  method: "GET",
+  url: "https://example.com",
+  headers: { "X-Test": { value: "original", enabled: true } },
+  params: [],
+  timeout: 0,
+  followRedirects: true,
+  maxRedirects: 5,
+  auth: { type: "none" },
+}
+
+function ReloadGuardHarness({
+  onResult,
+}: {
+  onResult: (result: { reloads: number; pending: boolean }) => void
+}) {
+  const draft = useRequestDraft(request)
+  const [step, setStep] = useState(0)
+  const [reloads, setReloads] = useState(0)
+  const reload = useReloadGuard(draft.dirtyRequestIds.size > 0, () =>
+    setReloads((count) => count + 1),
+  )
+
+  useEffect(() => {
+    if (step === 0) {
+      draft.setUrl("https://changed.example.com")
+      setStep(1)
+    } else if (step === 1 && draft.isDirty) {
+      reload.requestReload()
+      setStep(2)
+    } else if (step === 2) {
+      onResult({ reloads, pending: reload.reloadPending })
+    }
+  }, [draft, onResult, reload, reloads, step])
+
+  return null
+}
+
+function InlineEditSwitchHarness({
+  onResult,
+}: {
+  onResult: (result: { changes: number; pending: string | null }) => void
+}) {
+  const draft = useRequestDraft(request)
+  const editor = useEditBrowse(draft.draft, draft)
+  const [step, setStep] = useState(0)
+  const [changes, setChanges] = useState(0)
+  const switcher = useCollectionSwitcher({
+    collectionDir: "/current",
+    hasUnsavedChanges:
+      draft.dirtyRequestIds.size > 0 || editor.editState.mode === "editing",
+    onCollectionChange: () => setChanges((count) => count + 1),
+  })
+
+  useEffect(() => {
+    if (step === 0) {
+      editor.activateAt("headers", 0)
+      setStep(1)
+    } else if (step === 1 && editor.editState.mode === "editing") {
+      editor.setEditValue("changed")
+      setStep(2)
+    } else if (step === 2 && editor.editValue === "changed") {
+      switcher.requestCollectionSwitch("/next")
+      setStep(3)
+    } else if (step === 3) {
+      onResult({
+        changes,
+        pending: switcher.collectionSwitchPending,
+      })
+    }
+  }, [changes, editor, onResult, step, switcher])
+
+  return null
+}
+
+describe("unsaved changes regressions", () => {
+  it("warns before reloading a collection with unsaved drafts", async () => {
+    let result = { reloads: 0, pending: false }
+    const { renderOnce } = await testRender(
+      <ReloadGuardHarness onResult={(next) => (result = next)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 5; i++) await renderOnce()
+
+    expect(result).toEqual({ reloads: 0, pending: true })
+  })
+
+  it("warns before switching collections with an uncommitted field edit", async () => {
+    let result = { changes: 0, pending: null as string | null }
+    const { renderOnce } = await testRender(
+      <InlineEditSwitchHarness onResult={(next) => (result = next)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 5; i++) await renderOnce()
+
+    expect(result).toEqual({ changes: 0, pending: "/next" })
+  })
+})

--- a/tests/unit/useRequestDraftHook.test.tsx
+++ b/tests/unit/useRequestDraftHook.test.tsx
@@ -44,6 +44,12 @@ const savedFolder: Folder = {
   overrides: { auth: { type: "bearer", token: "saved-token" } },
 }
 
+const otherRequest: Request = {
+  ...request,
+  id: "r2",
+  name: "Other request",
+}
+
 function Harness({ onMethod }: { onMethod: (method: string) => void }) {
   const draft = useRequestDraft(request)
 
@@ -114,6 +120,65 @@ function MoveDraftHarness({
       onDraft(draft.draft)
     }
   }, [draft, movedRequest, onDraft, step])
+
+  return null
+}
+
+function BackgroundDirtyHarness({
+  onState,
+}: {
+  onState: (state: { isDirty: boolean; dirtyRequestIds: string[] }) => void
+}) {
+  const [selectedRequest, setSelectedRequest] = useState(request)
+  const draft = useRequestDraft(selectedRequest)
+
+  useEffect(() => {
+    if (selectedRequest.id === request.id) draft.setMethod("POST")
+  }, [draft.setMethod, selectedRequest.id])
+
+  useEffect(() => {
+    if (selectedRequest.id === request.id && draft.isDirty) {
+      setSelectedRequest(otherRequest)
+    }
+  }, [draft.isDirty, selectedRequest.id])
+
+  useEffect(() => {
+    if (selectedRequest.id === otherRequest.id) {
+      onState({
+        isDirty: draft.isDirty,
+        dirtyRequestIds: [...draft.dirtyRequestIds],
+      })
+    }
+  }, [draft.dirtyRequestIds, draft.isDirty, onState, selectedRequest.id])
+
+  return null
+}
+
+function UndoThenEditHarness({
+  onState,
+}: {
+  onState: (state: { isDirty: boolean; dirtyRequestIds: string[] }) => void
+}) {
+  const draft = useRequestDraft(request)
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    if (step === 0) {
+      draft.setUrl("https://first.example.com")
+      setStep(1)
+    } else if (step === 1 && draft.isDirty) {
+      draft.revertAllRequests()
+      setStep(2)
+    } else if (step === 2 && !draft.isDirty) {
+      draft.setUrl("https://second.example.com")
+      setStep(3)
+    } else if (step === 3) {
+      onState({
+        isDirty: draft.isDirty,
+        dirtyRequestIds: [...draft.dirtyRequestIds],
+      })
+    }
+  }, [draft, onState, step])
 
   return null
 }
@@ -230,6 +295,36 @@ describe("useRequestDraft setMethod", () => {
     await renderOnce()
 
     expect(isDirty).toBe(true)
+  })
+
+  it("keeps a dirty request ID after selecting another request", async () => {
+    let state = { isDirty: true, dirtyRequestIds: [] as string[] }
+    const { renderOnce } = await testRender(
+      <BackgroundDirtyHarness onState={(next) => (state = next)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 5; i++) await renderOnce()
+
+    expect(state).toEqual({
+      isDirty: false,
+      dirtyRequestIds: [request.id],
+    })
+  })
+
+  it("tracks edits made after undoing all requests", async () => {
+    let state = { isDirty: false, dirtyRequestIds: [] as string[] }
+    const { renderOnce } = await testRender(
+      <UndoThenEditHarness onState={(next) => (state = next)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 6; i++) await renderOnce()
+
+    expect(state).toEqual({
+      isDirty: true,
+      dirtyRequestIds: [request.id],
+    })
   })
 
   it("preserves unsaved method and URL when a request is renamed", async () => {

--- a/tests/unit/useRequestDraftHook.test.tsx
+++ b/tests/unit/useRequestDraftHook.test.tsx
@@ -183,6 +183,44 @@ function UndoThenEditHarness({
   return null
 }
 
+function UndoThenReloadHarness({
+  onState,
+}: {
+  onState: (state: {
+    url: string
+    isDirty: boolean
+    dirtyRequestIds: string[]
+  }) => void
+}) {
+  const reloadedRequest = { ...request, url: "https://reloaded.example.com" }
+  const [selectedRequest, setSelectedRequest] = useState(request)
+  const draft = useRequestDraft(selectedRequest)
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    if (step === 0) {
+      draft.setUrl("https://changed.example.com")
+      setStep(1)
+    } else if (step === 1 && draft.isDirty) {
+      draft.revertAllRequests()
+      setStep(2)
+    } else if (step === 2 && !draft.isDirty) {
+      setSelectedRequest(reloadedRequest)
+      setStep(3)
+    } else if (step === 3) {
+      setStep(4)
+    } else if (step === 4) {
+      onState({
+        url: draft.draft?.url ?? "",
+        isDirty: draft.isDirty,
+        dirtyRequestIds: [...draft.dirtyRequestIds],
+      })
+    }
+  }, [draft, onState, reloadedRequest, step])
+
+  return null
+}
+
 function RequestAuthSaveRaceHarness({
   onAuth,
 }: {
@@ -324,6 +362,22 @@ describe("useRequestDraft setMethod", () => {
     expect(state).toEqual({
       isDirty: true,
       dirtyRequestIds: [request.id],
+    })
+  })
+
+  it("uses reloaded data as the baseline after undoing all requests", async () => {
+    let state = { url: "", isDirty: true, dirtyRequestIds: [] as string[] }
+    const { renderOnce } = await testRender(
+      <UndoThenReloadHarness onState={(next) => (state = next)} />,
+      { width: 20, height: 5 },
+    )
+
+    for (let i = 0; i < 7; i++) await renderOnce()
+
+    expect(state).toEqual({
+      url: "https://reloaded.example.com",
+      isDirty: false,
+      dirtyRequestIds: [],
     })
   })
 


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes several dirty-state bugs where unsaved changes leaked across requests or were silently dropped:

- `useRequestDraft.revertAllRequests` no longer clears `originalMap`, so dirty state is retained correctly after "undo all" and re-edits are still tracked.
- URL bar is keyed by request id, so it no longer syncs the previous request's URL when switching requests.
- `undoAll` now checks the full dirty map (`dirtyRequestIds` / `dirtyPaths`) instead of only the selected request's dirty flag.
- Reload now goes through a new `useReloadGuard`, which prompts a confirm overlay (`reload-confirm`) when unsaved changes exist instead of discarding them silently.
- Collection switching uses a unified `hasUnsavedChanges` (draft + folder + env + inline edits) to guard against losing uncommitted field edits.
- Adds the bug-fix workflow section to the noodle-dev skill.

### How did you verify your code works?

- Added regression tests: `tests/unit/useRequestDraftHook.test.tsx` (background dirty retention, undo-then-edit), `tests/unit/unsavedChangesRegression.test.tsx` (reload guard + inline-edit switch guard), `tests/unit/commands.test.ts` (undo of unselected dirty request), and `tests/unit/ResponsePaneStatus.test.tsx` (no URL sync on switch).
- `bun test` passes.

### Screenshots / recordings

N/A (terminal TUI, no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [ ] `bun run lint` passes
- [ ] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before reloading or switching collections when unsaved changes exist.
  * Added keyboard shortcuts for confirming or canceling reloads.
* **Bug Fixes**
  * Improved draft restoration, undo behavior, and request switching.
  * Prevented previous request URLs from being incorrectly synchronized.
* **Style**
  * Updated dirty-state indicators, text truncation, and theme border colors.
* **Tests**
  * Added regression coverage for unsaved changes, draft handling, undo behavior, and request switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->