### PR TITLE
feat(env-editor): jump mode targets for environment editor

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -286,8 +286,9 @@ export function AppInner({
         draft.draft !== null,
         expanded,
         focusedFolder !== null,
+        view === "env-editor",
       ),
-    [draft.draft, expanded, focusedFolder],
+    [draft.draft, expanded, focusedFolder, view],
   )
   useEffect(() => {
     jumpTargetsRef.current = availableJumpTargets
@@ -748,6 +749,7 @@ export function AppInner({
     },
     global: {
       focusRef,
+      headerFieldRef,
       urlbarSubFocusRef,
       viewRef,
       activeIndexRef,
@@ -809,6 +811,8 @@ export function AppInner({
     setUrlbarSubFocus,
     ebRef,
     folderEbRef,
+    envHeaderRef,
+    headerFieldRef,
     setTab,
     selectedIdRef,
     targetsRef: jumpTargetsRef,
@@ -1076,6 +1080,10 @@ export function AppInner({
             envColors={envColors}
             focus={focus}
             envHeaderRef={envHeaderRef}
+            jumpMode={jumpMode}
+            onHeaderFieldFocus={(field) => {
+              headerFieldRef.current = field
+            }}
             onPaneFocus={focusPane}
             setEnvDeletePending={setEnvDeletePending}
           />

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -151,6 +151,7 @@ export function AppInner({
   const [jumpMode, setJumpMode] = useState(false)
   const jumpTargetsRef = useRef<Map<string, JumpTarget>>(new Map())
   const headerFieldRef = useRef<"name" | "color">("name")
+  const pendingHeaderFieldRef = useRef<"name" | "color" | null>(null)
 
   // ── Collection ──────────────────────────────────────────────────────
   const isCollection = mode === "collection"
@@ -597,6 +598,7 @@ export function AppInner({
     jumpMode,
     setJumpMode,
     headerFieldRef,
+    pendingHeaderFieldRef,
     overlayActiveRef,
   })
 
@@ -813,6 +815,7 @@ export function AppInner({
     folderEbRef,
     envHeaderRef,
     headerFieldRef,
+    pendingHeaderFieldRef,
     setTab,
     selectedIdRef,
     targetsRef: jumpTargetsRef,

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -8,6 +8,7 @@ import { MouseButton, ScrollBoxRenderable } from "@opentui/core"
 import { useEffect, useRef, useState } from "react"
 import { Frame } from "../Frame"
 import { Badge } from "../Badge"
+import { JumpBadge, JUMP_BADGE_TOP_INDENT } from "../JumpBadge"
 
 export function EnvEditorPane({
   draft,
@@ -19,6 +20,7 @@ export function EnvEditorPane({
   saving,
   error,
   focused: _focused,
+  jumpMode = false,
   onPaneFocus,
   onActivateRow,
   onToggleRow,
@@ -32,6 +34,7 @@ export function EnvEditorPane({
   saving: boolean
   error: string | null
   focused: boolean
+  jumpMode?: boolean
   onPaneFocus?: () => void
   onActivateRow?: (
     row: number,
@@ -79,12 +82,15 @@ export function EnvEditorPane({
         customBorderChars={FullBorder.customBorderChars}
         borderColor={theme.borderSubtle}
         titleRight={
-          <Badge bg={theme.backgroundPanel} fg={theme.textMuted}>
-            Variables
-          </Badge>
+          jumpMode ? undefined : (
+            <Badge bg={theme.backgroundPanel} fg={theme.textMuted}>
+              Variables
+            </Badge>
+          )
         }
         onPaneFocus={onPaneFocus}
       >
+        {jumpMode && <JumpBadge letter="v" style={JUMP_BADGE_TOP_INDENT} />}
         <text fg={theme.textMuted}>Select an environment to edit</text>
       </Frame>
     )
@@ -128,15 +134,18 @@ export function EnvEditorPane({
       customBorderChars={FullBorder.customBorderChars}
       borderColor={_focused ? theme.primary : theme.borderSubtle}
       titleRight={
-        <Badge
-          bg={theme.backgroundPanel}
-          fg={_focused ? theme.primary : theme.textMuted}
-        >
-          Variables
-        </Badge>
+        jumpMode ? undefined : (
+          <Badge
+            bg={theme.backgroundPanel}
+            fg={_focused ? theme.primary : theme.textMuted}
+          >
+            Variables
+          </Badge>
+        )
       }
       onPaneFocus={onPaneFocus}
     >
+      {jumpMode && <JumpBadge letter="v" style={JUMP_BADGE_TOP_INDENT} />}
       <scrollbox
         ref={scrollRef}
         scrollY

--- a/src/ui/env-editor/EnvHeaderPane.tsx
+++ b/src/ui/env-editor/EnvHeaderPane.tsx
@@ -12,6 +12,7 @@ import type { InputRenderable } from "@opentui/core"
 import { Select, type SelectItem } from "../Select"
 import { VALID_COLORS } from "../../env/constants"
 import { Frame } from "../Frame"
+import { JumpBadge, JUMP_BADGE_TOP_LEFT } from "../JumpBadge"
 
 export interface EnvHeaderPaneHandle {
   focusName: () => void
@@ -26,10 +27,21 @@ export const EnvHeaderPane = forwardRef<
     onNameChange: (name: string) => void
     onColorChange: (color: string | undefined) => void
     focused: boolean
+    jumpMode?: boolean
+    onColorFocus?: () => void
     onPaneFocus?: () => void
   }
 >(function EnvHeaderPane(
-  { name, color, onNameChange, onColorChange, focused, onPaneFocus },
+  {
+    name,
+    color,
+    onNameChange,
+    onColorChange,
+    focused,
+    jumpMode = false,
+    onColorFocus,
+    onPaneFocus,
+  },
   ref,
 ) {
   const theme = useTheme()
@@ -91,32 +103,41 @@ export const EnvHeaderPane = forwardRef<
       borderColor={focused ? theme.primary : theme.borderSubtle}
       onPaneFocus={onPaneFocus}
     >
-      <input
-        ref={nameRef}
-        value={name}
-        placeholder="Environment name"
-        onInput={onNameChange}
-        focused={nameFocused}
-        backgroundColor={
-          nameFocused ? theme.backgroundElement : theme.backgroundPanel
-        }
-        focusedBackgroundColor={theme.borderSubtle}
-        textColor={theme.text}
-        cursorColor={theme.primary}
-        paddingX={1}
-        style={{ flexGrow: 1 }}
-      />
-      <Select
-        items={colorItems}
-        value={color ?? "none"}
-        onChange={(id) => onColorChange(id === "none" ? undefined : id)}
-        focused={colorFocused}
-        maxDropdownHeight={10}
-        dropdownAlign="right"
-        badge
-        onOpenChange={setSelectOpen}
-        onActivate={() => setColorFocused(true)}
-      />
+      <box style={{ flexGrow: 1, position: "relative" }}>
+        {jumpMode && <JumpBadge letter="m" style={JUMP_BADGE_TOP_LEFT} />}
+        <input
+          ref={nameRef}
+          value={name}
+          placeholder="Environment name"
+          onInput={onNameChange}
+          focused={nameFocused}
+          backgroundColor={
+            nameFocused ? theme.backgroundElement : theme.backgroundPanel
+          }
+          focusedBackgroundColor={theme.borderSubtle}
+          textColor={theme.text}
+          cursorColor={theme.primary}
+          paddingX={1}
+          style={{ flexGrow: 1 }}
+        />
+      </box>
+      <box style={{ flexShrink: 0, position: "relative" }}>
+        {jumpMode && <JumpBadge letter="c" style={JUMP_BADGE_TOP_LEFT} />}
+        <Select
+          items={colorItems}
+          value={color ?? "none"}
+          onChange={(id) => onColorChange(id === "none" ? undefined : id)}
+          focused={colorFocused}
+          maxDropdownHeight={10}
+          dropdownAlign="right"
+          badge
+          onOpenChange={setSelectOpen}
+          onActivate={() => {
+            setColorFocused(true)
+            onColorFocus?.()
+          }}
+        />
+      </box>
     </Frame>
   )
 })

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react"
 import { VALID_COLORS } from "../../env/constants"
 import { Frame } from "../Frame"
 import { Badge } from "../Badge"
+import { JumpBadge, JUMP_BADGE_TOP_INDENT } from "../JumpBadge"
 
 export function EnvSidebar({
   envNames,
@@ -17,6 +18,7 @@ export function EnvSidebar({
   onClone: _onClone,
   onDelete: _onDelete,
   focused,
+  jumpMode = false,
   onPaneFocus,
 }: {
   envNames: string[]
@@ -29,6 +31,7 @@ export function EnvSidebar({
   onClone: () => void
   onDelete: () => void
   focused: boolean
+  jumpMode?: boolean
   onPaneFocus?: () => void
 }) {
   const theme = useTheme()
@@ -57,15 +60,18 @@ export function EnvSidebar({
       customBorderChars={FullBorder.customBorderChars}
       borderColor={focused ? theme.primary : theme.borderSubtle}
       titleRight={
-        <Badge
-          bg={theme.backgroundPanel}
-          fg={focused ? theme.primary : theme.textMuted}
-        >
-          Environments
-        </Badge>
+        jumpMode ? undefined : (
+          <Badge
+            bg={theme.backgroundPanel}
+            fg={focused ? theme.primary : theme.textMuted}
+          >
+            Environments
+          </Badge>
+        )
       }
       onPaneFocus={onPaneFocus}
     >
+      {jumpMode && <JumpBadge letter="s" style={JUMP_BADGE_TOP_INDENT} />}
       {envNames.length === 0 ? (
         <text fg={theme.textMuted}>(no environments)</text>
       ) : (

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -12,6 +12,8 @@ interface EnvironmentEditorViewProps {
   envColors: Record<string, string | undefined>
   focus: Focus
   envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
+  jumpMode?: boolean
+  onHeaderFieldFocus?: (field: "name" | "color") => void
   onPaneFocus?: (focus: Focus) => void
   setEnvDeletePending: (name: string | null) => void
 }
@@ -22,6 +24,8 @@ export function EnvironmentEditorView({
   envColors,
   focus,
   envHeaderRef,
+  jumpMode = false,
+  onHeaderFieldFocus,
   onPaneFocus = () => {},
   setEnvDeletePending,
 }: EnvironmentEditorViewProps) {
@@ -50,6 +54,7 @@ export function EnvironmentEditorView({
           }
         }}
         focused={focus === "env-sidebar"}
+        jumpMode={jumpMode}
         onPaneFocus={() => onPaneFocus("env-sidebar")}
       />
       <box
@@ -67,6 +72,8 @@ export function EnvironmentEditorView({
           onNameChange={envEditor.setName}
           onColorChange={envEditor.setColor}
           focused={focus === "env-header"}
+          jumpMode={jumpMode}
+          onColorFocus={() => onHeaderFieldFocus?.("color")}
           onPaneFocus={() => onPaneFocus("env-header")}
         />
         <EnvEditorPane
@@ -79,6 +86,7 @@ export function EnvironmentEditorView({
           saving={envEditor.saving}
           error={envEditor.error}
           focused={focus === "env-vars"}
+          jumpMode={jumpMode}
           onPaneFocus={() => onPaneFocus("env-vars")}
           onActivateRow={(row, addingRow, subfield) => {
             onPaneFocus("env-vars")

--- a/src/ui/keymap/globalLayers.ts
+++ b/src/ui/keymap/globalLayers.ts
@@ -210,12 +210,14 @@ export function createGlobalLayers(
           const focus = keymap.getData("app.focus")
           const editingUrlText =
             focus === "urlbar" && global.urlbarSubFocusRef.current === "text"
+          const editingEnvName =
+            focus === "env-header" && global.headerFieldRef.current === "name"
           return (
             keymap.getData("app.overlay") === "none" &&
-            keymap.getData("app.view") !== "env-editor" &&
             keymap.getData("app.mode") !== "edit" &&
             keymap.getData("app.jump") !== "active" &&
-            !editingUrlText
+            !editingUrlText &&
+            !editingEnvName
           )
         },
         run: () => global.setJumpMode(true),

--- a/src/ui/keymap/types.ts
+++ b/src/ui/keymap/types.ts
@@ -25,6 +25,7 @@ export interface AppKeymapRuntime {
 
 export interface AppKeymapGlobal {
   focusRef: RefObject<Focus>
+  headerFieldRef: RefObject<"name" | "color">
   urlbarSubFocusRef: RefObject<UrlBarSubFocus>
   viewRef: RefObject<AppView>
   activeIndexRef: RefObject<number>

--- a/src/ui/useJumpMode.ts
+++ b/src/ui/useJumpMode.ts
@@ -34,6 +34,7 @@ interface UseJumpModeOpts {
   folderEbRef: RefObject<UseFolderEditBrowseResult>
   envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
   headerFieldRef: RefObject<"name" | "color">
+  pendingHeaderFieldRef: RefObject<"name" | "color" | null>
   setTab: UseUIStateResult["setTab"]
   selectedIdRef: RefObject<string | null>
   targetsRef: RefObject<Map<string, JumpTarget>>
@@ -51,6 +52,7 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
     folderEbRef,
     envHeaderRef,
     headerFieldRef,
+    pendingHeaderFieldRef,
     setTab,
     selectedIdRef,
     targetsRef,
@@ -107,11 +109,13 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
             break
           case "env-name":
             headerFieldRef.current = "name"
+            pendingHeaderFieldRef.current = "name"
             setFocus("env-header")
             envHeaderRef.current?.focusName()
             break
           case "env-color":
             headerFieldRef.current = "color"
+            pendingHeaderFieldRef.current = "color"
             setFocus("env-header")
             envHeaderRef.current?.focusColor()
             break
@@ -133,6 +137,7 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
     folderEbRef,
     envHeaderRef,
     headerFieldRef,
+    pendingHeaderFieldRef,
     setTab,
     selectedIdRef,
   ])

--- a/src/ui/useJumpMode.ts
+++ b/src/ui/useJumpMode.ts
@@ -11,6 +11,7 @@ import type { Focus, UrlBarSubFocus } from "./focus"
 import type { FieldKind } from "./editMode"
 import type { ResponseTabKind } from "./tabs/uiState"
 import type { Request } from "../schema"
+import type { EnvHeaderPaneHandle } from "./env-editor/EnvHeaderPane"
 
 export type JumpTarget =
   | { kind: "sidebar" }
@@ -19,6 +20,10 @@ export type JumpTarget =
   | { kind: "request-tab"; field: FieldKind }
   | { kind: "folder-tab"; field: FolderFieldKind }
   | { kind: "response-tab"; tab: ResponseTabKind }
+  | { kind: "env-sidebar" }
+  | { kind: "env-name" }
+  | { kind: "env-color" }
+  | { kind: "env-vars" }
 
 interface UseJumpModeOpts {
   jumpMode: boolean
@@ -27,6 +32,8 @@ interface UseJumpModeOpts {
   setUrlbarSubFocus: (f: UrlBarSubFocus) => void
   ebRef: RefObject<UseEditBrowseResult>
   folderEbRef: RefObject<UseFolderEditBrowseResult>
+  envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
+  headerFieldRef: RefObject<"name" | "color">
   setTab: UseUIStateResult["setTab"]
   selectedIdRef: RefObject<string | null>
   targetsRef: RefObject<Map<string, JumpTarget>>
@@ -42,6 +49,8 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
     setUrlbarSubFocus,
     ebRef,
     folderEbRef,
+    envHeaderRef,
+    headerFieldRef,
     setTab,
     selectedIdRef,
     targetsRef,
@@ -93,6 +102,22 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
             setFocus("response")
             break
           }
+          case "env-sidebar":
+            setFocus("env-sidebar")
+            break
+          case "env-name":
+            headerFieldRef.current = "name"
+            setFocus("env-header")
+            envHeaderRef.current?.focusName()
+            break
+          case "env-color":
+            headerFieldRef.current = "color"
+            setFocus("env-header")
+            envHeaderRef.current?.focusColor()
+            break
+          case "env-vars":
+            setFocus("env-vars")
+            break
         }
         setJumpMode(false)
       },
@@ -106,6 +131,8 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
     setUrlbarSubFocus,
     ebRef,
     folderEbRef,
+    envHeaderRef,
+    headerFieldRef,
     setTab,
     selectedIdRef,
   ])
@@ -115,8 +142,16 @@ export function getAvailableTargets(
   hasRequest: boolean,
   expanded: "request" | "response" | null,
   folderView: boolean,
+  environmentView = false,
 ): Map<string, JumpTarget> {
   const targets = new Map<string, JumpTarget>()
+  if (environmentView) {
+    targets.set("s", { kind: "env-sidebar" })
+    targets.set("m", { kind: "env-name" })
+    targets.set("c", { kind: "env-color" })
+    targets.set("v", { kind: "env-vars" })
+    return targets
+  }
   if (folderView) {
     targets.set("s", { kind: "sidebar" })
     targets.set("m", { kind: "folder-tab", field: "meta" })

--- a/src/ui/useKeymapSync.ts
+++ b/src/ui/useKeymapSync.ts
@@ -13,6 +13,7 @@ interface UseKeymapSyncProps {
   jumpMode: boolean
   setJumpMode: Dispatch<SetStateAction<boolean>>
   headerFieldRef: RefObject<"name" | "color">
+  pendingHeaderFieldRef: RefObject<"name" | "color" | null>
   overlayActiveRef: RefObject<boolean>
 }
 
@@ -23,6 +24,7 @@ export function useKeymapSync({
   jumpMode,
   setJumpMode,
   headerFieldRef,
+  pendingHeaderFieldRef,
   overlayActiveRef,
 }: UseKeymapSyncProps): boolean {
   const keymap = useKeymap()
@@ -30,8 +32,13 @@ export function useKeymapSync({
 
   useEffect(() => {
     keymap.setData("app.focus", focus)
-    if (focus === "env-header") headerFieldRef.current = "name"
-  }, [focus, headerFieldRef, keymap])
+    if (focus !== "env-header") {
+      pendingHeaderFieldRef.current = null
+      return
+    }
+    headerFieldRef.current = pendingHeaderFieldRef.current ?? "name"
+    pendingHeaderFieldRef.current = null
+  }, [focus, headerFieldRef, keymap, pendingHeaderFieldRef])
 
   useEffect(() => {
     keymap.setData("app.overlay", activeOverlay)

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -12,6 +12,32 @@ const inactive = {
 }
 
 describe("EnvEditorPane", () => {
+  it("shows a variables jump badge in jump mode", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={8}>
+          <EnvEditorPane
+            draft={null}
+            editState={inactive}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused={false}
+            jumpMode
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    expect(spans.map((span) => span.text)).toContain("v")
+    expect(spans.map((span) => span.text).join("")).not.toContain("Variables")
+  })
+
   it("activates rows, toggles checkboxes, and activates the add row", async () => {
     const activations: Array<[number, boolean, "key" | "value" | undefined]> =
       []

--- a/tests/unit/EnvHeaderPane.test.tsx
+++ b/tests/unit/EnvHeaderPane.test.tsx
@@ -128,6 +128,30 @@ describe("EnvHeaderPane", () => {
     cleanup()
   })
 
+  it("shows name and color jump badges in jump mode", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureSpans } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <EnvHeaderPane
+            name="dev"
+            color={undefined}
+            onNameChange={() => {}}
+            onColorChange={() => {}}
+            focused={false}
+            jumpMode
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 6 },
+    )
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    expect(spans.map((span) => span.text)).toContain("m")
+    expect(spans.map((span) => span.text)).toContain("c")
+    cleanup()
+  })
+
   it("opens the color menu when clicked", async () => {
     const { keymap, cleanup } = setupKeymap()
     function Harness() {
@@ -159,6 +183,36 @@ describe("EnvHeaderPane", () => {
     })
     await renderOnce()
     expect(captureCharFrame()).toContain("primary")
+    cleanup()
+  })
+
+  it("reports color focus when the color select is activated", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let colorFocused = false
+    const { renderOnce, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <EnvHeaderPane
+            name="dev"
+            color={undefined}
+            onNameChange={() => {}}
+            onColorChange={() => {}}
+            focused={false}
+            onColorFocus={() => {
+              colorFocused = true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 16 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      await mockMouse.click(50, 1, MouseButtons.LEFT)
+    })
+
+    expect(colorFocused).toBe(true)
     cleanup()
   })
 })

--- a/tests/unit/EnvSidebar.test.tsx
+++ b/tests/unit/EnvSidebar.test.tsx
@@ -151,6 +151,30 @@ describe("EnvSidebar", () => {
     expect(frame).toContain("Environments")
   })
 
+  it("shows a jump badge instead of the title in jump mode", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <EnvSidebar
+          envNames={["dev"]}
+          selectedEnvName={null}
+          activeEnvName={undefined}
+          dirty={false}
+          onSelectEnv={() => {}}
+          onCreate={() => {}}
+          onClone={() => {}}
+          onDelete={() => {}}
+          focused={false}
+          jumpMode
+        />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    const text = captureSpans().lines.flatMap((line) => line.spans)
+    expect(text.map((span) => span.text)).toContain("s")
+    expect(text.map((span) => span.text).join("")).not.toContain("Environments")
+  })
+
   it("uses theme.text foreground for all env names", async () => {
     const { renderOnce, captureSpans } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -492,6 +492,15 @@ describe("getAvailableTargets", () => {
     expect(targets.get("y")).toEqual({ kind: "folder-tab", field: "activity" })
   })
 
+  it("returns environment editor targets", () => {
+    const targets = getAvailableTargets(false, null, false, true)
+    expect(targets.size).toBe(4)
+    expect(targets.get("s")).toEqual({ kind: "env-sidebar" })
+    expect(targets.get("m")).toEqual({ kind: "env-name" })
+    expect(targets.get("c")).toEqual({ kind: "env-color" })
+    expect(targets.get("v")).toEqual({ kind: "env-vars" })
+  })
+
   it("returns sidebar + urlbar + all request/response tabs when not expanded", () => {
     const targets = getAvailableTargets(true, null, false)
     expect(targets.has("s")).toBe(true)

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -42,6 +42,7 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     jsonLeave: 0,
     jsonReturnToSelect: 0,
     focus: "",
+    jumpMode: false,
   }
   const request = {
     ebRef: {
@@ -87,11 +88,15 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     global: {
       modeRef: { current: "collection" },
       focusRef: { current: "sidebar" },
+      headerFieldRef: { current: "name" },
       urlbarSubFocusRef: { current: "select" },
       viewRef: { current: "main" },
       expandedRef: { current: null },
       setFocus: (focus: string) => {
         calls.focus = focus
+      },
+      setJumpMode: (jumpMode: boolean) => {
+        calls.jumpMode = jumpMode
       },
       setUrlbarSubFocus: () => {},
     },
@@ -436,6 +441,49 @@ describe("app keymap layers", () => {
     host.press("up")
 
     expect(calls.envUp).toBe(1)
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("enters jump mode from the environment editor outside editable header fields", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    keymap.setData("app.view", "env-editor")
+    keymap.setData("app.focus", "env-sidebar")
+    const disposers = register(context)
+
+    host.press("g")
+
+    expect(calls.jumpMode).toBe(true)
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("does not enter jump mode while editing the environment name", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    keymap.setData("app.view", "env-editor")
+    keymap.setData("app.focus", "env-header")
+    const disposers = register(context)
+
+    host.press("g")
+
+    expect(calls.jumpMode).toBe(false)
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("enters jump mode while the environment color select is focused", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    context.global.headerFieldRef.current = "color"
+    keymap.setData("app.view", "env-editor")
+    keymap.setData("app.focus", "env-header")
+    const disposers = register(context)
+
+    host.press("g")
+
+    expect(calls.jumpMode).toBe(true)
     disposers.forEach((dispose) => dispose())
     cleanup()
   })

--- a/tests/unit/useFolderEditBrowse.test.tsx
+++ b/tests/unit/useFolderEditBrowse.test.tsx
@@ -63,6 +63,7 @@ function JumpHarness({
   const selectedIdRef = useRef<string | null>(null)
   const envHeaderRef = useRef<EnvHeaderPaneHandle | null>(null)
   const headerFieldRef = useRef<"name" | "color">("name")
+  const pendingHeaderFieldRef = useRef<"name" | "color" | null>(null)
   const targetsRef = useRef<Map<string, JumpTarget>>(
     new Map([["h", { kind: "folder-tab", field: "headers" }]]),
   )
@@ -84,6 +85,7 @@ function JumpHarness({
     folderEbRef,
     envHeaderRef,
     headerFieldRef,
+    pendingHeaderFieldRef,
     setTab: () => {},
     selectedIdRef,
     targetsRef,
@@ -131,6 +133,7 @@ function EnvironmentJumpHarness({
     focusColor: () => headerCalls.current.push("color"),
   })
   const headerFieldRef = useRef<"name" | "color">("name")
+  const pendingHeaderFieldRef = useRef<"name" | "color" | null>(null)
   const targetsRef = useRef<Map<string, JumpTarget>>(
     new Map([
       ["s", { kind: "env-sidebar" }],
@@ -151,11 +154,19 @@ function EnvironmentJumpHarness({
     folderEbRef,
     envHeaderRef,
     headerFieldRef,
+    pendingHeaderFieldRef,
     setTab: () => {},
     selectedIdRef,
     targetsRef,
     triggerKey: "g",
   })
+
+  useEffect(() => {
+    if (focus === "env-header") {
+      headerFieldRef.current = pendingHeaderFieldRef.current ?? "name"
+      pendingHeaderFieldRef.current = null
+    }
+  }, [focus])
 
   useEffect(() => {
     onSnapshot({

--- a/tests/unit/useFolderEditBrowse.test.tsx
+++ b/tests/unit/useFolderEditBrowse.test.tsx
@@ -2,12 +2,16 @@ import { describe, expect, it } from "bun:test"
 import { act, useEffect, useRef, useState } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { KeymapProvider } from "@opentui/keymap/react"
-import { useFolderEditBrowse } from "../../src/hooks/useFolderEditBrowse"
+import {
+  useFolderEditBrowse,
+  type UseFolderEditBrowseResult,
+} from "../../src/hooks/useFolderEditBrowse"
 import type { UseFolderDraftResult } from "../../src/hooks/useFolderDraft"
 import type { UseEditBrowseResult } from "../../src/hooks/useEditBrowse"
 import type { Folder } from "../../src/schema"
 import { useJumpMode, type JumpTarget } from "../../src/ui/useJumpMode"
 import type { Focus } from "../../src/ui/focus"
+import type { EnvHeaderPaneHandle } from "../../src/ui/env-editor/EnvHeaderPane"
 import { setupKeymap } from "./_helpers"
 
 const folder: Folder = {
@@ -57,6 +61,8 @@ function JumpHarness({
   folderEbRef.current = folderEb
   const ebRef = useRef({} as UseEditBrowseResult)
   const selectedIdRef = useRef<string | null>(null)
+  const envHeaderRef = useRef<EnvHeaderPaneHandle | null>(null)
+  const headerFieldRef = useRef<"name" | "color">("name")
   const targetsRef = useRef<Map<string, JumpTarget>>(
     new Map([["h", { kind: "folder-tab", field: "headers" }]]),
   )
@@ -76,6 +82,8 @@ function JumpHarness({
     setUrlbarSubFocus: () => {},
     ebRef,
     folderEbRef,
+    envHeaderRef,
+    headerFieldRef,
     setTab: () => {},
     selectedIdRef,
     targetsRef,
@@ -109,6 +117,65 @@ interface Snapshot {
   calls: string[]
 }
 
+function EnvironmentJumpHarness({
+  onSnapshot,
+}: {
+  onSnapshot: (value: EnvironmentSnapshot) => void
+}) {
+  const headerCalls = useRef<string[]>([])
+  const ebRef = useRef({} as UseEditBrowseResult)
+  const folderEbRef = useRef({} as UseFolderEditBrowseResult)
+  const selectedIdRef = useRef<string | null>(null)
+  const envHeaderRef = useRef<EnvHeaderPaneHandle | null>({
+    focusName: () => headerCalls.current.push("name"),
+    focusColor: () => headerCalls.current.push("color"),
+  })
+  const headerFieldRef = useRef<"name" | "color">("name")
+  const targetsRef = useRef<Map<string, JumpTarget>>(
+    new Map([
+      ["s", { kind: "env-sidebar" }],
+      ["m", { kind: "env-name" }],
+      ["c", { kind: "env-color" }],
+      ["v", { kind: "env-vars" }],
+    ]),
+  )
+  const [jumpMode, setJumpMode] = useState(true)
+  const [focus, setFocus] = useState<Focus>("env-sidebar")
+
+  useJumpMode({
+    jumpMode,
+    setJumpMode,
+    setFocus,
+    setUrlbarSubFocus: () => {},
+    ebRef,
+    folderEbRef,
+    envHeaderRef,
+    headerFieldRef,
+    setTab: () => {},
+    selectedIdRef,
+    targetsRef,
+    triggerKey: "g",
+  })
+
+  useEffect(() => {
+    onSnapshot({
+      focus,
+      jumpMode,
+      headerField: headerFieldRef.current,
+      headerCalls: headerCalls.current,
+    })
+  }, [focus, jumpMode, onSnapshot])
+
+  return null
+}
+
+interface EnvironmentSnapshot {
+  focus: Focus
+  jumpMode: boolean
+  headerField: "name" | "color"
+  headerCalls: string[]
+}
+
 describe("useFolderEditBrowse jump mode", () => {
   it("cancels an active edit before jumping to another folder tab", async () => {
     const { keymap, host, cleanup } = setupKeymap()
@@ -139,5 +206,40 @@ describe("useFolderEditBrowse jump mode", () => {
       calls: [],
     })
     cleanup()
+  })
+})
+
+describe("useJumpMode environment editor", () => {
+  it("jumps to each environment editor target", async () => {
+    const cases: Array<[string, Focus, "name" | "color", string[]]> = [
+      ["s", "env-sidebar", "name", []],
+      ["m", "env-header", "name", ["name"]],
+      ["c", "env-header", "color", ["color"]],
+      ["v", "env-vars", "name", []],
+    ]
+
+    for (const [key, focus, headerField, headerCalls] of cases) {
+      const { keymap, host, cleanup } = setupKeymap()
+      let snapshot: EnvironmentSnapshot | undefined
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <EnvironmentJumpHarness onSnapshot={(value) => (snapshot = value)} />
+        </KeymapProvider>,
+        { width: 1, height: 1 },
+      )
+
+      await render.renderOnce()
+      await act(async () => host.press(key))
+      await render.renderOnce()
+      await render.renderOnce()
+
+      expect(snapshot).toMatchObject({
+        focus,
+        jumpMode: false,
+        headerField,
+        headerCalls,
+      })
+      cleanup()
+    }
   })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds jump mode (`g`) targets to the environment editor: `s` sidebar, `m` env name, `c` env color, `v` variables. Previously jump mode was blocked in the env editor; now each pane/field is focusable with a letter hint, matching the jump-mode behavior in the main and folder views.

### How did you verify your code works?

- Added/updated unit tests for EnvEditorPane, EnvHeaderPane, EnvSidebar, app keymap layers, jump mode, and folder edit browse
- `bun test` passes (2026 tests)
- `bun run lint` passes
- `bun run typecheck` passes
- `bunx prettier --check ./src ./tests` passes

### Screenshots / recordings

N/A (terminal TUI)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR