### PR TITLE
fix(ui): commit in-progress edits when clicking outside active input

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -477,6 +477,7 @@ export function AppInner({
       if (next !== focus) {
         eb.commitEdit()
         folderEb.commitEdit()
+        envEditor.commitEdit()
       }
       if (next === "urlbar") setUrlbarSubFocus("select")
       if (mode === "collection" && next === "request") eb.enterBrowse()
@@ -487,6 +488,7 @@ export function AppInner({
     [
       eb.commitEdit,
       eb.enterBrowse,
+      envEditor.commitEdit,
       envEditor.enterBrowse,
       focus,
       folderEb.commitEdit,

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -133,6 +133,7 @@ export function FolderPane({
         )
       }
       onPaneFocus={onPaneFocus}
+      onInteraction={onInteraction}
     >
       {folder ? (
         <>

--- a/src/ui/Frame.tsx
+++ b/src/ui/Frame.tsx
@@ -1,5 +1,7 @@
-import type { ReactNode } from "react"
+import { createContext, type ReactNode } from "react"
 import { MouseButton, type BorderCharacters } from "@opentui/core"
+
+export const FrameInteractionContext = createContext(false)
 
 export interface FrameProps {
   children?: ReactNode
@@ -17,6 +19,7 @@ export interface FrameProps {
   bottomTitle?: string
   bottomTitleAlignment?: "left" | "center" | "right"
   onPaneFocus?: () => void
+  onInteraction?: () => void
 }
 
 export function Frame({
@@ -35,6 +38,7 @@ export function Frame({
   bottomTitle,
   bottomTitleAlignment,
   onPaneFocus,
+  onInteraction,
 }: FrameProps) {
   return (
     <box
@@ -50,12 +54,20 @@ export function Frame({
       onMouseDown={
         onPaneFocus
           ? (event) => {
-              if (event.button === MouseButton.LEFT) onPaneFocus()
+              if (event.button !== MouseButton.LEFT) return
+              onInteraction?.()
+              onPaneFocus()
             }
-          : undefined
+          : onInteraction
+            ? (event) => {
+                if (event.button === MouseButton.LEFT) onInteraction()
+              }
+            : undefined
       }
     >
-      {children}
+      <FrameInteractionContext.Provider value={onInteraction !== undefined}>
+        {children}
+      </FrameInteractionContext.Provider>
       {titleLeft ? (
         <box style={{ position: "absolute", top: -1, left: 2 }}>
           {titleLeft}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -1,4 +1,4 @@
-import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
+import { type ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useKeymap } from "@opentui/keymap/react"
 import { useCallback, useEffect, useMemo, useRef } from "react"
@@ -177,6 +177,7 @@ export function RequestPane({
         )
       }
       onPaneFocus={onPaneFocus}
+      onInteraction={onInteraction}
     >
       {request ? (
         <>
@@ -258,14 +259,6 @@ export function RequestPane({
                 <scrollbox
                   ref={scrollRef}
                   scrollY
-                  onMouseDown={
-                    activeTab === "params" || activeTab === "pathParams"
-                      ? (event) => {
-                          if (event.button === MouseButton.LEFT)
-                            onInteraction?.()
-                        }
-                      : undefined
-                  }
                   style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
                 >
                   {activeTab === "body" && (

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -1,6 +1,7 @@
 import {
   forwardRef,
   useCallback,
+  useContext,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -14,6 +15,7 @@ import {
   useTerminalDimensions,
 } from "@opentui/react"
 import { useTheme } from "./theme"
+import { FrameInteractionContext } from "./Frame"
 import { VarText } from "./VarText"
 import type { Environment, ParamEntry } from "../schema"
 import { highlightVariables } from "./variable-completion/variableHighlight"
@@ -73,6 +75,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     ref,
   ) {
     const theme = useTheme()
+    const frameCapturesInteractions = useContext(FrameInteractionContext)
     const defaultColor = baseColor ?? theme.text
     const inputRef = useRef<InputRenderable | null>(null)
     const textareaRef = useRef<TextareaRenderable | null>(null)
@@ -209,7 +212,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         return (
           <box
             onMouseDown={
-              stopMousePropagation
+              stopMousePropagation || (isEditing && frameCapturesInteractions)
                 ? (event) => event.stopPropagation()
                 : undefined
             }
@@ -247,7 +250,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       return (
         <box
           onMouseDown={
-            stopMousePropagation
+            stopMousePropagation || (isEditing && frameCapturesInteractions)
               ? (event) => event.stopPropagation()
               : undefined
           }

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -22,6 +22,7 @@ export function EnvEditorPane({
   focused: _focused,
   jumpMode = false,
   onPaneFocus,
+  onInteraction,
   onActivateRow,
   onToggleRow,
 }: {
@@ -36,6 +37,7 @@ export function EnvEditorPane({
   focused: boolean
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onInteraction?: () => void
   onActivateRow?: (
     row: number,
     addingRow: boolean,
@@ -144,6 +146,7 @@ export function EnvEditorPane({
         )
       }
       onPaneFocus={onPaneFocus}
+      onInteraction={onInteraction}
     >
       {jumpMode && <JumpBadge letter="v" style={JUMP_BADGE_TOP_INDENT} />}
       <scrollbox

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -88,12 +88,14 @@ export function EnvironmentEditorView({
           focused={focus === "env-vars"}
           jumpMode={jumpMode}
           onPaneFocus={() => onPaneFocus("env-vars")}
+          onInteraction={envEditor.commitEdit}
           onActivateRow={(row, addingRow, subfield) => {
             onPaneFocus("env-vars")
             envEditor.activateVar(row, addingRow, subfield)
           }}
           onToggleRow={(row) => {
             onPaneFocus("env-vars")
+            envEditor.commitEdit()
             envEditor.toggleVar(row)
           }}
         />

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -12,6 +12,59 @@ const inactive = {
 }
 
 describe("EnvEditorPane", () => {
+  it("commits when clicking pane background but not the active input", async () => {
+    let interactions = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={8}>
+          <EnvEditorPane
+            draft={{
+              name: "development",
+              color: undefined,
+              varRows: [
+                {
+                  id: 1,
+                  key: "BASE_URL",
+                  value: "https://api.test",
+                  enabled: true,
+                },
+              ],
+            }}
+            editState={{
+              mode: "editing",
+              row: 0,
+              addingRow: false,
+              subfield: "value",
+              editingRow: 0,
+            }}
+            editKey="BASE_URL"
+            editValue="https://api.test"
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused
+            onInteraction={() => interactions++}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+
+    const lines = captureCharFrame().split("\n")
+    const valueRow = lines.findIndex((line) =>
+      line.includes("https://api.test"),
+    )
+    if (valueRow < 0) throw new Error("environment value row was not rendered")
+    const valueColumn = lines[valueRow]!.indexOf("https://api.test")
+    await mockMouse.click(valueColumn, valueRow, MouseButtons.LEFT)
+    expect(interactions).toBe(0)
+
+    await mockMouse.click(70, 6, MouseButtons.LEFT)
+    expect(interactions).toBe(1)
+  })
+
   it("shows a variables jump badge in jump mode", async () => {
     const { renderOnce, captureSpans } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>

--- a/tests/unit/FolderPane-clickCommit.test.tsx
+++ b/tests/unit/FolderPane-clickCommit.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test"
+import { act } from "react"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { MouseButtons } from "@opentui/core/testing"
+import { ThemeProvider } from "../../src/ui/theme"
+import { THEMES } from "../../src/ui/theme-data"
+import { FolderPane } from "../../src/ui/FolderPane"
+import { setupKeymap } from "./_helpers"
+
+describe("FolderPane blank click commit", () => {
+  it("commits a metadata edit when clicking blank pane space", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let interactions = 0
+    try {
+      const { renderOnce, mockMouse } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <FolderPane
+              collectionDir="/tmp/collection"
+              folder={{
+                id: "api",
+                path: "api",
+                name: "API",
+                overrides: {},
+                children: [],
+              }}
+              focused
+              editState={{
+                mode: "editing",
+                cursor: {
+                  field: "meta",
+                  row: 0,
+                  addingRow: false,
+                  subfield: undefined,
+                },
+                editingRow: 0,
+              }}
+              editKey=""
+              editValue="API"
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              activeTab="meta"
+              onAuthTypeChange={() => {}}
+              onApiKeyPlacementChange={() => {}}
+              activeEnv={null}
+              theme={THEMES[0]!}
+              onInteraction={() => interactions++}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
+      await renderOnce()
+      await act(async () => {
+        await mockMouse.click(60, 10, MouseButtons.LEFT)
+      })
+      expect(interactions).toBe(1)
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/tests/unit/RequestPane-clickCommit.test.tsx
+++ b/tests/unit/RequestPane-clickCommit.test.tsx
@@ -55,6 +55,33 @@ function EditingPane({
 }
 
 describe("RequestPane blank click commit", () => {
+  it("commits a Settings edit when clicking blank tab space", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let interactions = 0
+    try {
+      const { renderOnce, mockMouse } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <EditingPane
+              activeTab="settings"
+              onInteraction={() => interactions++}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
+
+      await renderOnce()
+      await act(async () => {
+        await mockMouse.click(40, 10, MouseButtons.LEFT)
+      })
+
+      expect(interactions).toBe(1)
+    } finally {
+      cleanup()
+    }
+  })
+
   it("commits a Path edit when clicking blank tab space", async () => {
     const { keymap, cleanup } = setupKeymap()
     let interactions = 0


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clicking outside an active input now commits in-progress edits instead of discarding them. Applies to the environment editor (env vars pane), folder metadata, and request settings/path/params tabs. Previously, clicking pane background space while editing lost the unsaved text.

Centralizes mouse-interaction handling in `Frame` via a new `onInteraction` prop + `FrameInteractionContext`; `VarInput` stops propagation of the mouse-down while editing so clicking inside the field keeps the edit alive, while a click anywhere else in the pane commits. Also adds `envEditor.commitEdit()` to the focus-change path in `AppInner` so tabbing away also commits env edits.

### How did you verify your code works?

Added unit tests using `testRender` + `mockMouse`:
- `tests/unit/EnvEditorPane.test.tsx` — click on pane background commits, click on the active input does not
- `tests/unit/FolderPane-clickCommit.test.tsx` — blank click in folder meta commits
- `tests/unit/RequestPane-clickCommit.test.tsx` — blank click in settings tab commits

`bun test`, `bun run lint`, and `bun run typecheck` pass.

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edits in environment variables, folders, and settings are now saved when clicking elsewhere or switching panes.
  * Clicking inside an active input no longer triggers unintended pane interactions.
  * Pane focus and click behavior is now more consistent across the application.

* **Tests**
  * Added coverage for committing edits through pane clicks and preserving input interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->