### PR TITLE
feat(ui): add environment context menu and cURL import to folder palette

### DIFF
--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -60,7 +60,7 @@ export interface UseEnvironmentEditorResult {
 
   openEditor: (name?: string) => Promise<void>
   closeEditor: () => void
-  selectEnv: (name: string) => Promise<void>
+  selectEnv: (name: string) => Promise<boolean>
   setName: (name: string) => void
   setColor: (color: string | undefined) => void
   enterBrowse: () => void
@@ -172,6 +172,8 @@ export function useEnvironmentEditor({
   originalRef.current = original
   const selectedEnvNameRef = useRef(selectedEnvName)
   selectedEnvNameRef.current = selectedEnvName
+  const loadedEnvNameRef = useRef<string | null>(null)
+  const loadGenerationRef = useRef(0)
   const onEnvsChangedRef = useRef(onEnvsChanged)
   onEnvsChangedRef.current = onEnvsChanged
   const onEnvDataChangedRef = useRef(onEnvDataChanged)
@@ -189,8 +191,10 @@ export function useEnvironmentEditor({
 
   const loadEnv = useCallback(
     async (name: string) => {
+      const generation = ++loadGenerationRef.current
       try {
         const loaded = await env.loadEnvironment(environmentsDir, name)
+        if (generation !== loadGenerationRef.current) return false
         const rows = envToVarRows(loaded.vars, loaded.disabledVars ?? {})
         const nextDraft = {
           name: loaded.name,
@@ -207,14 +211,19 @@ export function useEnvironmentEditor({
         setDraft(nextDraft)
         originalRef.current = nextOriginal
         setOriginal(nextOriginal)
+        selectedEnvNameRef.current = name
         setSelectedEnvName(name)
+        loadedEnvNameRef.current = name
         setEditState(initialEditState())
         setEditKey("")
         setEditValue("")
         setError(null)
+        return true
       } catch (e: unknown) {
+        if (generation !== loadGenerationRef.current) return false
         const msg = e instanceof Error ? e.message : String(e)
         setError(msg)
+        return false
       }
     },
     [environmentsDir],
@@ -262,9 +271,13 @@ export function useEnvironmentEditor({
 
   const selectEnv = useCallback(
     async (name: string) => {
-      if (selectedEnvNameRef.current === name) return
-      setSelectedEnvName(name)
-      await loadEnv(name)
+      if (
+        selectedEnvNameRef.current === name &&
+        loadedEnvNameRef.current === name
+      ) {
+        return true
+      }
+      return loadEnv(name)
     },
     [loadEnv],
   )

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -262,6 +262,7 @@ export function useEnvironmentEditor({
 
   const selectEnv = useCallback(
     async (name: string) => {
+      if (selectedEnvNameRef.current === name) return
       setSelectedEnvName(name)
       await loadEnv(name)
     },

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -560,6 +560,7 @@ export function useEnvironmentEditor({
       originalRef.current = nextOriginal
       setOriginal(nextOriginal)
       setSelectedEnvName(curDraft.name)
+      loadedEnvNameRef.current = curDraft.name
       if (oldName) {
         setLocalNames((prev) =>
           prev.map((n) => (n === oldName ? curDraft.name : n)),

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -275,6 +275,7 @@ export function useEnvironmentEditor({
         selectedEnvNameRef.current === name &&
         loadedEnvNameRef.current === name
       ) {
+        loadGenerationRef.current++
         return true
       }
       return loadEnv(name)

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1090,6 +1090,12 @@ export function AppInner({
               headerFieldRef.current = field
             }}
             onPaneFocus={focusPane}
+            onEnvironmentContextMenu={async (name) => {
+              focusPane("env-sidebar")
+              await envEditor.selectEnv(name)
+              setPaletteTarget("environment")
+              setCommandPaletteVisible(true)
+            }}
             setEnvDeletePending={setEnvDeletePending}
           />
         ) : null}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1092,7 +1092,7 @@ export function AppInner({
             onPaneFocus={focusPane}
             onEnvironmentContextMenu={async (name) => {
               focusPane("env-sidebar")
-              await envEditor.selectEnv(name)
+              if (!(await envEditor.selectEnv(name))) return
               setPaletteTarget("environment")
               setCommandPaletteVisible(true)
             }}

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -28,7 +28,7 @@ const TIPS = [
   "environment variables let you switch between dev, staging, prod",
   "clone a request with {^K}",
   "delete a request with {^W}",
-  "right-click a request or folder in the sidebar for its context menu",
+  "right-click a request, folder, or environment for its context menu",
   "copy the response body with {^B}",
   "create a new folder with {^Alt+N}",
   "press {F2} to expand a pane fullscreen",

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -581,7 +581,9 @@ export function buildCommandPaletteCommands(
     return [
       folderSaveCommand,
       ...requestCommands
-        .filter((command) => command.id === "request.new")
+        .filter((command) =>
+          ["request.new", "request.import-curl"].includes(command.id),
+        )
         .map((command) => ({ ...command, section: "Folder" })),
       ...workspaceCommands
         .filter((command) =>

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -40,7 +40,7 @@ import {
   type CommandActionsConfig,
 } from "./commandActions"
 
-export type CommandPaletteTarget = "request" | "folder"
+export type CommandPaletteTarget = "request" | "folder" | "environment"
 
 export interface CommandBuilderContext {
   keybinds: Keybinds
@@ -600,6 +600,13 @@ export function buildCommandPaletteCommands(
           section: "Folder",
         })),
     ]
+  }
+
+  if (paletteTarget === "environment") {
+    if (mode !== "collection") return []
+    return editorEnvCommands.filter((command) =>
+      ["env.save", "env.new", "env.clone", "env.delete"].includes(command.id),
+    )
   }
 
   if (view === "env-editor") {

--- a/src/ui/env-editor/EnvSidebar.tsx
+++ b/src/ui/env-editor/EnvSidebar.tsx
@@ -20,6 +20,7 @@ export function EnvSidebar({
   focused,
   jumpMode = false,
   onPaneFocus,
+  onEnvironmentContextMenu,
 }: {
   envNames: string[]
   selectedEnvName: string | null
@@ -33,6 +34,7 @@ export function EnvSidebar({
   focused: boolean
   jumpMode?: boolean
   onPaneFocus?: () => void
+  onEnvironmentContextMenu?: (name: string) => void
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -114,9 +116,14 @@ export function EnvSidebar({
                 customBorderChars={LeftBar.customBorderChars}
                 borderColor={isSelected ? theme.primary : theme.backgroundPanel}
                 onMouseDown={(event) => {
-                  if (event.button !== MouseButton.LEFT) return
-                  onSelectEnv(name)
-                  onPaneFocus?.()
+                  if (event.button === MouseButton.RIGHT) {
+                    onEnvironmentContextMenu?.(name)
+                  } else if (event.button === MouseButton.LEFT) {
+                    onSelectEnv(name)
+                    onPaneFocus?.()
+                  } else {
+                    return
+                  }
                   event.stopPropagation()
                 }}
                 onMouseOver={() => setHoveredEnvName(name)}

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -15,6 +15,7 @@ interface EnvironmentEditorViewProps {
   jumpMode?: boolean
   onHeaderFieldFocus?: (field: "name" | "color") => void
   onPaneFocus?: (focus: Focus) => void
+  onEnvironmentContextMenu?: (name: string) => void
   setEnvDeletePending: (name: string | null) => void
 }
 
@@ -27,6 +28,7 @@ export function EnvironmentEditorView({
   jumpMode = false,
   onHeaderFieldFocus,
   onPaneFocus = () => {},
+  onEnvironmentContextMenu,
   setEnvDeletePending,
 }: EnvironmentEditorViewProps) {
   return (
@@ -56,6 +58,7 @@ export function EnvironmentEditorView({
         focused={focus === "env-sidebar"}
         jumpMode={jumpMode}
         onPaneFocus={() => onPaneFocus("env-sidebar")}
+        onEnvironmentContextMenu={onEnvironmentContextMenu}
       />
       <box
         style={{

--- a/tests/unit/EnvSidebar.test.tsx
+++ b/tests/unit/EnvSidebar.test.tsx
@@ -30,9 +30,10 @@ describe("EnvSidebar", () => {
     expect(frame).toContain("prod")
   })
 
-  it("selects an environment on left click only", async () => {
+  it("selects on left click and opens the environment context menu on right click", async () => {
     let selected = ""
     let focused = 0
+    let contextName = ""
     const { renderOnce, mockMouse } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
         <EnvSidebar
@@ -48,6 +49,9 @@ describe("EnvSidebar", () => {
           onDelete={() => {}}
           focused={false}
           onPaneFocus={() => focused++}
+          onEnvironmentContextMenu={(name) => {
+            contextName = name
+          }}
         />
       </ThemeProvider>,
       { width: 40, height: 12 },
@@ -57,6 +61,7 @@ describe("EnvSidebar", () => {
     await mockMouse.click(2, 3, MouseButtons.RIGHT)
     expect(selected).toBe("")
     expect(focused).toBe(0)
+    expect(contextName).toBe("staging")
 
     await mockMouse.click(2, 3, MouseButtons.LEFT)
     expect(selected).toBe("staging")

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -126,6 +126,23 @@ describe("buildCommandPaletteCommands", () => {
     expect(commands.every((command) => command.section === "Folder")).toBe(true)
   })
 
+  it("shows only environment commands for an environment context menu", () => {
+    const ctx = minimalContext()
+    ctx.paletteTarget = "environment"
+
+    const commands = buildCommandPaletteCommands(ctx)
+
+    expect(commands.map((command) => command.id)).toEqual([
+      "env.save",
+      "env.new",
+      "env.clone",
+      "env.delete",
+    ])
+    expect(commands.every((command) => command.section === "Environment")).toBe(
+      true,
+    )
+  })
+
   it("opens the cURL import overlay from a folder context menu", () => {
     const ctx = minimalContext()
     ctx.paletteTarget = "folder"

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -118,11 +118,28 @@ describe("buildCommandPaletteCommands", () => {
     expect(commands.map((command) => command.id)).toEqual([
       "folder.save",
       "request.new",
+      "request.import-curl",
       "folder.new",
       "folder.delete",
       "workspace.edit-yaml",
     ])
     expect(commands.every((command) => command.section === "Folder")).toBe(true)
+  })
+
+  it("opens the cURL import overlay from a folder context menu", () => {
+    const ctx = minimalContext()
+    ctx.paletteTarget = "folder"
+    let opened = false
+    ctx.setImportCurlVisible = (value) => {
+      opened = value === true
+    }
+
+    const command = buildCommandPaletteCommands(ctx).find(
+      (item) => item.id === "request.import-curl",
+    )
+
+    expect(command?.run()).toBe(true)
+    expect(opened).toBe(true)
   })
 
   it("includes the JSONPath response query command", () => {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -281,7 +281,21 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     // Change name to trigger rename path
     ref.current!.setName("alpha-renamed")
     await ref.current!.save()
+    await renderOnce()
+
+    act(() => {
+      ref.current!.setColor("warning")
+    })
+    await renderOnce()
+
+    await act(async () => {
+      await ref.current!.selectEnv("alpha-renamed")
+    })
+    await renderOnce()
+
     expect(spy).toHaveBeenCalledTimes(1)
+    expect(ref.current!.draft?.color).toBe("warning")
+    expect(ref.current!.dirty).toBe(true)
   })
 
   it("calls onEnvDataChanged after save with same name (color edit)", async () => {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  mock,
+  spyOn,
+} from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
 import { act, useEffect, useRef } from "react"
 import { mkdtemp, rm, readFile } from "node:fs/promises"
@@ -9,6 +17,20 @@ import { useEnvironmentEditor } from "../src/hooks/useEnvironmentEditor"
 import { env } from "../src/env"
 
 let dir: string
+
+async function waitForDraft(
+  editorRef: { current: ReturnType<typeof useEnvironmentEditor> | null },
+  renderOnce: () => Promise<void>,
+) {
+  const deadline = Date.now() + 1_000
+  while (!editorRef.current?.draft) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for environment draft")
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await renderOnce()
+  }
+}
 
 function Harness({
   onEnvsChanged: onChanged,
@@ -298,7 +320,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       { width: 40, height: 12 },
     )
     await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     act(() => {
       ref.current!.setColor("warning")
@@ -313,6 +335,107 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
 
     expect(ref.current!.draft?.color).toBe("warning")
     expect(ref.current!.dirty).toBe(true)
+  })
+
+  it("keeps the current environment selected when a load fails and retries", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await waitForDraft(ref, renderOnce)
+
+    const originalLoad = env.loadEnvironment
+    let betaAttempts = 0
+    const loadSpy = spyOn(env, "loadEnvironment").mockImplementation(
+      (environmentDir, name) => {
+        if (name === "beta" && betaAttempts++ === 0) {
+          return Promise.reject(new Error("failed to load beta"))
+        }
+        return originalLoad(environmentDir, name)
+      },
+    )
+
+    try {
+      let firstSelection = true
+      await act(async () => {
+        firstSelection = await ref.current!.selectEnv("beta")
+      })
+      await renderOnce()
+
+      expect(firstSelection).toBe(false)
+      expect(ref.current!.selectedEnvName).toBe("alpha")
+      expect(ref.current!.draft?.name).toBe("alpha")
+
+      let retrySelection = false
+      await act(async () => {
+        retrySelection = await ref.current!.selectEnv("beta")
+      })
+      await renderOnce()
+
+      expect(retrySelection).toBe(true)
+      expect(ref.current!.selectedEnvName).toBe("beta")
+      expect(ref.current!.draft?.name).toBe("beta")
+    } finally {
+      loadSpy.mockRestore()
+    }
+  })
+
+  it("keeps the latest environment when overlapping loads resolve out of order", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await new Promise((r) => setTimeout(r, 30))
+
+    type LoadedEnvironment = Awaited<ReturnType<typeof env.loadEnvironment>>
+    const pending = new Map<string, (environment: LoadedEnvironment) => void>()
+    const loadSpy = spyOn(env, "loadEnvironment").mockImplementation(
+      (_dir, name) =>
+        new Promise((resolve) => {
+          pending.set(name, resolve)
+        }),
+    )
+
+    try {
+      const betaSelection = ref.current!.selectEnv("beta")
+      const gammaSelection = ref.current!.selectEnv("gamma")
+
+      let gammaIsCurrent = false
+      await act(async () => {
+        pending.get("gamma")!({ name: "gamma", vars: { key: "gamma" } })
+        gammaIsCurrent = await gammaSelection
+      })
+      await renderOnce()
+
+      expect(gammaIsCurrent).toBe(true)
+      expect(ref.current!.selectedEnvName).toBe("gamma")
+      expect(ref.current!.draft?.varRows[0]?.value).toBe("gamma")
+
+      let betaIsCurrent = true
+      await act(async () => {
+        pending.get("beta")!({ name: "beta", vars: { key: "beta" } })
+        betaIsCurrent = await betaSelection
+      })
+      await renderOnce()
+
+      expect(betaIsCurrent).toBe(false)
+      expect(ref.current!.selectedEnvName).toBe("gamma")
+      expect(ref.current!.draft?.varRows[0]?.value).toBe("gamma")
+    } finally {
+      loadSpy.mockRestore()
+    }
   })
 
   it("rejects rename to an existing env name", async () => {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -287,6 +287,34 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     expect(dataSpy).toHaveBeenCalledTimes(1)
   })
 
+  it("keeps an unsaved draft when selecting the current environment", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await new Promise((r) => setTimeout(r, 30))
+
+    act(() => {
+      ref.current!.setColor("warning")
+    })
+    await renderOnce()
+    expect(ref.current!.dirty).toBe(true)
+
+    await act(async () => {
+      await ref.current!.selectEnv("alpha")
+    })
+    await renderOnce()
+
+    expect(ref.current!.draft?.color).toBe("warning")
+    expect(ref.current!.dirty).toBe(true)
+  })
+
   it("rejects rename to an existing env name", async () => {
     const spy = mock(() => {})
     const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -438,6 +438,49 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     }
   })
 
+  it("keeps the loaded environment when cancelling a pending selection", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+    await waitForDraft(ref, renderOnce)
+
+    type LoadedEnvironment = Awaited<ReturnType<typeof env.loadEnvironment>>
+    let resolveBeta: ((environment: LoadedEnvironment) => void) | undefined
+    const loadSpy = spyOn(env, "loadEnvironment").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBeta = resolve
+        }),
+    )
+
+    try {
+      const betaSelection = ref.current!.selectEnv("beta")
+      const alphaSelection = await ref.current!.selectEnv("alpha")
+
+      expect(alphaSelection).toBe(true)
+
+      let betaIsCurrent = true
+      await act(async () => {
+        resolveBeta!({ name: "beta", vars: { key: "beta" } })
+        betaIsCurrent = await betaSelection
+      })
+      await renderOnce()
+
+      expect(betaIsCurrent).toBe(false)
+      expect(ref.current!.selectedEnvName).toBe("alpha")
+      expect(ref.current!.draft?.name).toBe("alpha")
+    } finally {
+      loadSpy.mockRestore()
+    }
+  })
+
   it("rejects rename to an existing env name", async () => {
     const spy = mock(() => {})
     const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a right-click context menu for environments in the environment editor (save/new/clone/delete via the command palette), and adds the cURL import action to the folder context menu.

### How did you verify your code works?

Ran `bun test tests/unit/commands.test.ts tests/unit/EnvSidebar.test.tsx` (42 pass). Updated unit tests cover right-click behavior and the new palette commands.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [ ] `bun run lint` passes
- [ ] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-click context menus for environments.
  * Added environment actions for saving, creating, cloning, and deleting environments.
  * Added cURL import to folder context menus.
  * Updated context-menu tips to include environments.

* **Bug Fixes**
  * Preserved environment selection and focus behavior for left-click interactions.
  * Prevented reselecting the active environment from clearing unsaved color changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->