### PR TITLE
refactor(commands): remove response commands from command palette

### DIFF
--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -21,8 +21,6 @@ import {
   cloneRequest,
   deleteRequest,
   deleteFolder,
-  copyResponseBody,
-  openResponseQuery,
   canGenerateClientCode,
   cycleEnvironment,
   openEnvironmentEditor,
@@ -283,24 +281,6 @@ export function buildCommandPaletteCommands(
         setRequestDeletePending(result.requestName)
         return true
       },
-    },
-  ]
-
-  const responseCommands: CommandItem[] = [
-    {
-      id: "response.query",
-      label: "Filter Response with JSONPath",
-      section: "Response",
-      keybinding: displayKey(keybinds.response_query),
-      run: () =>
-        c.responseQueryRef.current?.canOpen() ? openResponseQuery(c) : false,
-    },
-    {
-      id: "response.copy-body",
-      label: "Copy Response Body",
-      section: "Response",
-      keybinding: displayKey(keybinds.response_copy_body),
-      run: () => copyResponseBody(c),
     },
   ]
 
@@ -620,7 +600,6 @@ export function buildCommandPaletteCommands(
 
   return [
     ...(mode === "collection" ? requestCommands : []),
-    ...responseCommands,
     ...(mode === "collection" ? mainEnvCommands : []),
     ...(mode === "collection" ? workspaceCommands : readOnlyCommands),
     ...mainOnlyCommands,

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -84,13 +84,7 @@ describe("buildCommandPaletteCommands", () => {
   it("sections appear in correct order", () => {
     const commands = buildCommandPaletteCommands(minimalContext())
     const sections = [...new Set(commands.map((c) => c.section))]
-    expect(sections).toEqual([
-      "Request",
-      "Response",
-      "Environment",
-      "Workspace",
-      "System",
-    ])
+    expect(sections).toEqual(["Request", "Environment", "Workspace", "System"])
   })
 
   it("shows only request commands for a request context menu", () => {
@@ -159,32 +153,13 @@ describe("buildCommandPaletteCommands", () => {
     expect(opened).toBe(true)
   })
 
-  it("includes the JSONPath response query command", () => {
-    const command = buildCommandPaletteCommands(minimalContext()).find(
-      (item) => item.id === "response.query",
+  it("does not include response pane commands", () => {
+    const ids = buildCommandPaletteCommands(minimalContext()).map(
+      (command) => command.id,
     )
-    expect(command?.label).toBe("Filter Response with JSONPath")
-    expect(command?.keybinding).toBe("/")
-  })
 
-  it("keeps the palette open when response filtering is unavailable", () => {
-    const ctx = minimalContext()
-    let opened = false
-    ctx.responseQueryRef = {
-      current: {
-        canOpen: () => false,
-        open: () => {
-          opened = true
-          return true
-        },
-      },
-    } as never
-
-    const command = buildCommandPaletteCommands(ctx).find(
-      (item) => item.id === "response.query",
-    )!
-    expect(command.run()).toBe(false)
-    expect(opened).toBe(false)
+    expect(ids).not.toContain("response.query")
+    expect(ids).not.toContain("response.copy-body")
   })
 
   it("each section has contiguous commands", () => {
@@ -555,7 +530,7 @@ describe("buildCommandPaletteCommands", () => {
     const commands = buildCommandPaletteCommands(ctx)
     const sections = [...new Set(commands.map((c) => c.section))]
     expect(sections).not.toContain("Environment")
-    expect(sections).toEqual(["Response", "Collection", "Workspace", "System"])
+    expect(sections).toEqual(["Collection", "Workspace", "System"])
   })
 
   it("excludes env.editor-open command when mode is empty", () => {


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the "Filter Response with JSONPath" and "Copy Response Body" entries from the command palette. Both actions are still reachable through their keybindings (`/` and `Ctrl+B`) when the response pane is focused, so the palette only keeps commands that require the palette to invoke. This declutters the palette and keeps command logic centralized in `commandActions.ts`.

### How did you verify your code works?

- `bun test tests/unit/commands.test.ts` passes (30 tests)
- Updated `tests/unit/commands.test.ts` to assert response commands are absent and adjusted section ordering expectations

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [ ] `bun run lint` passes
- [ ] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed response query and response-body copy actions from the command palette.
  * Existing request, environment, workspace, and system commands remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->