### PR TITLE
fix(ui): stop treating query-string values as path tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ graphify-out/
 .husky/post-commit
 .husky/post-checkout
 .gitattributes
+drafts

--- a/src/ui/variable-completion/envHighlight.ts
+++ b/src/ui/variable-completion/envHighlight.ts
@@ -62,13 +62,19 @@ export function splitUrlPathVars(
 ): PathAwareSegment[] {
   const varSegments = splitEnvVars(text, env)
   const result: PathAwareSegment[] = []
+  let beforeQuery = true
 
   for (const seg of varSegments) {
     if (seg.isVar) {
       result.push({ ...seg, isPath: false })
       continue
     }
-    const remaining = seg.text
+    if (!beforeQuery) {
+      result.push({ ...seg, isPath: false })
+      continue
+    }
+    const queryIdx = seg.text.indexOf("?")
+    const remaining = queryIdx === -1 ? seg.text : seg.text.slice(0, queryIdx)
     let lastEnd = 0
     URL_PATH_TOKEN_RE.lastIndex = 0
     let match: RegExpExecArray | null
@@ -99,6 +105,15 @@ export function splitUrlPathVars(
         exists: false,
         isPath: false,
       })
+    }
+    if (queryIdx !== -1) {
+      result.push({
+        text: seg.text.slice(queryIdx),
+        isVar: false,
+        exists: false,
+        isPath: false,
+      })
+      beforeQuery = false
     }
   }
 

--- a/src/ui/variable-completion/variableHighlight.ts
+++ b/src/ui/variable-completion/variableHighlight.ts
@@ -38,9 +38,11 @@ export function highlightVariables(
     })
   }
 
+  const queryIdx = value.indexOf("?")
+  const pathText = queryIdx === -1 ? value : value.slice(0, queryIdx)
   URL_PATH_TOKEN_RE.lastIndex = 0
   let m: RegExpExecArray | null
-  while ((m = URL_PATH_TOKEN_RE.exec(value)) !== null) {
+  while ((m = URL_PATH_TOKEN_RE.exec(pathText)) !== null) {
     const name = m[1]!
     const resolved = isPathParamResolved(name, pathParams ?? [])
     const colonIdx = m.index + (m[0][0] === "/" ? 1 : 0)

--- a/tests/unit/envHighlight.test.ts
+++ b/tests/unit/envHighlight.test.ts
@@ -164,6 +164,27 @@ describe("splitUrlPathVars", () => {
     })
   })
 
+  it("marks a path token before query parameters", () => {
+    const url = "$base_url/v1/nsx-alb-clusters/:id?forceDelete=false"
+
+    for (const [value, exists] of [
+      ["cluster-123", true],
+      ["", false],
+    ] as Array<[string, boolean]>) {
+      const result = splitUrlPathVars(
+        url,
+        env({ base_url: "https://api.example.com" }),
+        [{ name: "id", value, enabled: true }],
+      )
+      expect(result.find((segment) => segment.isPath)).toEqual({
+        text: ":id",
+        isVar: false,
+        exists,
+        isPath: true,
+      })
+    }
+  })
+
   it("marks path token with empty value as unresolved", () => {
     const pathParams: ParamEntry[] = [{ name: "id", value: "", enabled: true }]
     const result = splitUrlPathVars("/:id", null, pathParams)
@@ -236,6 +257,15 @@ describe("splitUrlPathVars", () => {
     )
     const pathSegs = result.filter((s) => s.isPath)
     expect(pathSegs).toHaveLength(0)
+  })
+
+  it("does not highlight path-like query-string values", () => {
+    const result = splitUrlPathVars(
+      "https://api.example.com/search?redirect=/:id?next=true",
+      null,
+      [{ name: "id", value: "42", enabled: true }],
+    )
+    expect(result.filter((segment) => segment.isPath)).toHaveLength(0)
   })
 
   it("does not highlight tokens followed by unsupported characters", () => {

--- a/tests/unit/variableHighlight.test.tsx
+++ b/tests/unit/variableHighlight.test.tsx
@@ -126,4 +126,46 @@ describe("variableHighlight", () => {
     expect(hostSpan).toBeDefined()
     expect(portSpan).toBeDefined()
   })
+
+  it("highlights a path token before query parameters in edit mode", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$base_url/v1/nsx-alb-clusters/:id?forceDelete=false"
+          env={env({ base_url: "https://api.example.com" })}
+          isEditing
+          pathParams={[{ name: "id", value: "cluster-123", enabled: true }]}
+        />
+      </ThemeProvider>,
+      { width: 100, height: 5 },
+    )
+    await renderOnce()
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const pathSpan = spans.find((s) => s.text.includes(":id"))
+    expect(pathSpan).toBeDefined()
+    const t = await import("../../src/ui/theme")
+    expect(pathSpan!.fg.equals(hexToRgba(t.THEMES[0]!.primary))).toBe(true)
+  })
+
+  it("does not highlight a path-like query-string value in edit mode", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="https://api.example.com/search?redirect=/:id?next=true"
+          env={env({})}
+          isEditing
+          pathParams={[{ name: "id", value: "42", enabled: true }]}
+        />
+      </ThemeProvider>,
+      { width: 100, height: 5 },
+    )
+    await renderOnce()
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((l) => l.spans)
+    const pathSpan = spans.find((s) => s.text.includes(":id"))
+    expect(pathSpan).toBeDefined()
+    const t = await import("../../src/ui/theme")
+    expect(pathSpan!.fg.equals(hexToRgba(t.THEMES[0]!.text))).toBe(true)
+  })
 })


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes path-token highlighting leaking past the `?` in a URL. `:id` in the path is still highlighted as a path token, but `:id` (and other `:token`s) appearing in the query string are no longer treated as path params.

### How did you verify your code works?

Added unit tests covering both cases:
- `$base_url/v1/nsx-alb-clusters/:id?forceDelete=false` highlights `:id` as a path token when the param is set.
- `https://api.example.com/search?redirect=/:id?next=true` does not highlight the path-like `:id` in the query string.

`bun test`, `bun run lint`, and `bun run typecheck` all pass.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [ ] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL variable highlighting to distinguish path parameters from query-string content.
  * Prevented path-like text within query values from being incorrectly highlighted.
  * Ensured path parameters before query strings remain highlighted in both resolved and editing states.

* **Tests**
  * Added coverage for URLs with resolved and empty path parameters, as well as query-string edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->