### PR TITLE
fix(scrollbox): render path params after switching from headers

### DIFF
--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -147,6 +147,7 @@ export function KeyValueSection({
                 id={`${prefix}-${i}`}
                 style={{
                   flexDirection: "row",
+                  height: 1,
                   gap: 0,
                   backgroundColor: rowBg,
                 }}

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -621,12 +621,14 @@ describe("RequestPane scrollbox", () => {
     await renderOnce()
 
     await act(async () => {
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 22; i++) {
         await mockMouse.scroll(20, 4, "down")
       }
     })
     await renderOnce()
-    expect(captureCharFrame()).toContain("X-Header-")
+    const headersFrame = captureCharFrame()
+    expect(headersFrame).not.toContain("X-Header-0")
+    expect(headersFrame).toContain("X-Header-29")
 
     await act(async () => setTab?.("pathParams"))
     await renderOnce()

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { RGBA, TextAttributes } from "@opentui/core"
 import type { Request, KvEntry, CollectionItem } from "../src/schema"
@@ -9,7 +9,7 @@ import { RequestPane } from "../src/ui/RequestPane"
 import { ResponsePane } from "../src/ui/ResponsePane"
 import type { SendState } from "../src/ui/sendState"
 import { initialEditState } from "../src/ui/editMode"
-import type { EditState } from "../src/ui/editMode"
+import type { EditState, FieldKind } from "../src/ui/editMode"
 import type { ResponseQueryController } from "../src/ui/responseQuery"
 
 import { ThemeProvider } from "../src/ui/theme"
@@ -566,6 +566,74 @@ describe("RequestPane scrollbox", () => {
     await renderOnce()
 
     expect(captureCharFrame()).toContain("post_id")
+  })
+
+  it("renders every path param after switching from headers", async () => {
+    const headers: Record<string, KvEntry> = {}
+    for (let i = 0; i < 30; i++) {
+      headers[`X-Header-${i}`] = { value: `value-${i}`, enabled: true }
+    }
+    const request: Request = {
+      id: "compliance-audit-items",
+      name: "Get compliance audit items for a domain",
+      method: "GET",
+      url: "$base_url/v1/domains/:id/compliance-audits/:complianceAuditId/compliance-audit-items",
+      headers,
+      params: [],
+      pathParams: [
+        { name: "id", value: "", enabled: true },
+        { name: "complianceAuditId", value: "", enabled: true },
+      ],
+      body: "",
+      timeout: 0,
+    }
+    let setTab: ((tab: FieldKind) => void) | undefined
+
+    function SwitchingPane() {
+      const [activeTab, setActiveTab] = useState<FieldKind>("headers")
+      setTab = setActiveTab
+      return (
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <RequestPane
+              request={request}
+              editState={initialEditState()}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              focused
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+            />
+          </ThemeProvider>
+        </KeymapProvider>
+      )
+    }
+
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <SwitchingPane />,
+      { width: 80, height: 12 },
+    )
+    await renderOnce()
+
+    await act(async () => {
+      for (let i = 0; i < 10; i++) {
+        await mockMouse.scroll(20, 4, "down")
+      }
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("X-Header-")
+
+    await act(async () => setTab?.("pathParams"))
+    await renderOnce()
+
+    const frame = captureCharFrame()
+    expect(frame).toContain("id")
+    expect(frame).toContain("complianceAuditId")
   })
 })
 


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes path params not rendering in the RequestPane after switching from the Headers tab. The path-param rows in `KeyValueSection` had no explicit `height`, so they collapsed inside the scrollbox when the view switched from headers (which had tall rows). Setting `height: 1` on the row style ensures each path-param row always has its display height.

### How did you verify your code works?

- Added a regression test in `tests/scrollbox.test.tsx` that renders a request with 30 headers plus path params, scrolls through headers, then switches to the path params tab and asserts both params (`id`, `complianceAuditId`) are visible.
- `bun test tests/scrollbox.test.tsx` passes (17 pass, 0 fail).
- `bun run lint` and `bun run typecheck` both pass.

### Screenshots / recordings

N/A — terminal UI change, no screenshots.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key-value row sizing for more consistent display.
  * Fixed an issue where URL path parameters could become hidden after switching tabs and scrolling.

* **Tests**
  * Added regression coverage for scrolling and tab switching in request views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->