### PR TITLE
fix(editor): handle wide chars and duplicate body editor interactions

### DIFF
--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -247,7 +247,8 @@ export function RequestPane({
                       : undefined
                   }
                   onEditorActivate={() => {
-                    if (!inEdit) onInteraction?.()
+                    if (inEdit) return
+                    onInteraction?.()
                     onPaneFocus?.()
                     onBodyEditorFocus?.(request.bodyType ?? "json")
                   }}

--- a/src/ui/editor/codeEditorHighlightRenderer.ts
+++ b/src/ui/editor/codeEditorHighlightRenderer.ts
@@ -86,7 +86,7 @@ export class CodeEditorHighlightRenderer {
       const result = await client.highlightOnce(content, filetype)
       if (!isCurrent()) return
       if (result.highlights?.length) {
-        this.applyTreeSitter(result.highlights, content)
+        this.applyTreeSitter(result.highlights, content, filetype)
         succeeded = true
       }
     } catch {
@@ -104,9 +104,10 @@ export class CodeEditorHighlightRenderer {
   private applyTreeSitter(
     highlights: SimpleHighlight[],
     content: string,
+    filetype: string,
   ): void {
-    this.host.clear()
-    this.host.setStyle(this._style)
+    if (filetype === "json") this.applyJson(content)
+    if (filetype === "yaml") this.applyYaml(content)
     this.host.applyRanges(
       buildTreeSitterHighlightRanges(highlights, content, this._style),
     )

--- a/src/ui/editor/codeEditorHighlighting.ts
+++ b/src/ui/editor/codeEditorHighlighting.ts
@@ -62,20 +62,29 @@ export function buildYamlHighlightRanges(
   style: SyntaxStyle,
 ): EditorHighlightRange[] {
   const ranges: EditorHighlightRange[] = []
-  let offset = 0
+  const displayOffsets = buildCharToDisplayOffsets(content)
+  let sourceOffset = 0
 
   for (const line of content.split("\n")) {
     const cleanLine = line.endsWith("\r") ? line.slice(0, -1) : line
+    let lineOffset = 0
     for (const span of tokenizeYamlLine(cleanLine, theme)) {
       if (span.text.length === 0) continue
       ranges.push({
-        start: offset,
-        end: offset + span.text.length,
+        start: charOffsetToDisplayOffset(
+          displayOffsets,
+          sourceOffset + lineOffset,
+        ),
+        end: charOffsetToDisplayOffset(
+          displayOffsets,
+          sourceOffset + lineOffset + span.text.length,
+        ),
         styleId: styleIdForYamlForeground(span.fg, theme, style),
         priority: 1,
       })
-      offset += span.text.length
+      lineOffset += span.text.length
     }
+    sourceOffset += line.length + 1
   }
 
   return ranges

--- a/src/ui/editor/codeEditorStyles.ts
+++ b/src/ui/editor/codeEditorStyles.ts
@@ -84,5 +84,5 @@ export function styleIdForYamlForeground(
   if (fg === theme.warning) return style.getStyleId("number") ?? 0
   if (fg === theme.info) return style.getStyleId("boolean") ?? 0
   if (fg === theme.textMuted) return style.getStyleId("comment") ?? 0
-  return style.getStyleId("string") ?? 0
+  return style.getStyleId("yaml.text") ?? 0
 }

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -292,7 +292,9 @@ export function BodySection({
         <box
           id="body-field"
           onMouseDown={(event) => {
-            if (event.button === MouseButton.LEFT) onEditorActivate?.()
+            if (event.button !== MouseButton.LEFT) return
+            onEditorActivate?.()
+            event.stopPropagation()
           }}
           style={{
             flexDirection: "column",

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { extend } from "@opentui/react"
@@ -47,6 +47,47 @@ const editStateEditingTimeout = {
   mode: "editing" as const,
   cursor: { field: "settings" as const, row: 0, addingRow: false },
   editingRow: 0,
+}
+
+function ActiveJsonEditorHarness({
+  onInteraction,
+  onPaneFocus,
+  onChange,
+}: {
+  onInteraction: () => void
+  onPaneFocus: () => void
+  onChange: (value: string) => void
+}) {
+  const [body, setBody] = useState(
+    JSON.stringify({ name: "hello", count: 42 }, null, 2),
+  )
+  const [editing, setEditing] = useState(true)
+
+  return (
+    <RequestPane
+      request={{ ...testRequest, body }}
+      editState={editing ? editStateEditing : editStateBrowse}
+      editKey=""
+      editValue={body}
+      setEditKey={() => {}}
+      setEditValue={() => {}}
+      focused
+      activeTab="body"
+      onBodyChange={(value) => {
+        onChange(value)
+        setBody(value)
+      }}
+      onBodyEditorFocus={() => setEditing(true)}
+      onInteraction={() => {
+        onInteraction()
+        setEditing(false)
+      }}
+      onPaneFocus={() => {
+        onPaneFocus()
+        setEditing(false)
+      }}
+    />
+  )
 }
 
 describe("BodySection — edit mode", () => {
@@ -142,6 +183,37 @@ describe("BodySection — edit mode", () => {
       await mockMouse.click(5, 5, MouseButtons.LEFT)
     })
     expect(editorActivations).toBe(1)
+    cleanup()
+  })
+
+  it("keeps an active JSON editor focused when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const changes: string[] = []
+    let interactions = 0
+    let paneFocuses = 0
+    const { renderOnce, mockInput, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={20}>
+            <ActiveJsonEditorHarness
+              onInteraction={() => interactions++}
+              onPaneFocus={() => paneFocuses++}
+              onChange={(value) => changes.push(value)}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(5, 5, MouseButtons.LEFT)
+    await renderOnce()
+    await act(async () => mockInput.typeText("X"))
+
+    expect(interactions).toBe(0)
+    expect(paneFocuses).toBe(0)
+    expect(changes.at(-1)).toContain("X")
     cleanup()
   })
 

--- a/tests/unit/codeEditorHighlightRenderer.test.ts
+++ b/tests/unit/codeEditorHighlightRenderer.test.ts
@@ -56,7 +56,7 @@ describe("CodeEditorHighlightRenderer", () => {
 
     const style = getStyle()!
     expect(calls).toEqual([['{\n  "name": "hello"\n}', "json"]])
-    expect(ranges).toEqual([
+    expect(ranges.slice(-3)).toEqual([
       {
         start: 0,
         end: 1,
@@ -103,6 +103,62 @@ describe("CodeEditorHighlightRenderer", () => {
       start: 12,
       end: 21,
       styleId: stringStyleId,
+      priority: 1,
+    })
+  })
+
+  it("keeps JSON fallback highlights when Tree-sitter returns partial output", async () => {
+    const { host, ranges, getStyle } = createHost()
+    const renderer = new CodeEditorHighlightRenderer(
+      opencodeTheme,
+      undefined,
+      host,
+    )
+    const client = {
+      highlightOnce: async () => ({
+        highlights: [[0, 1, "punctuation.bracket"]],
+      }),
+    } as unknown as TreeSitterClient
+
+    await renderer.highlight(
+      '{\r\n  "name": "María 😊',
+      "json",
+      client,
+      () => true,
+    )
+
+    expect(ranges).toContainEqual({
+      start: 11,
+      end: 19,
+      styleId: getStyle()!.getStyleId("json.string") ?? 0,
+      priority: 1,
+    })
+  })
+
+  it("keeps YAML fallback highlights when Tree-sitter returns partial output", async () => {
+    const { host, ranges, getStyle } = createHost()
+    const renderer = new CodeEditorHighlightRenderer(
+      opencodeTheme,
+      undefined,
+      host,
+    )
+    const client = {
+      highlightOnce: async () => ({
+        highlights: [[0, 5, "property"]],
+      }),
+    } as unknown as TreeSitterClient
+
+    await renderer.highlight(
+      'name: "María 😊\r\nnext: true',
+      "yaml",
+      client,
+      () => true,
+    )
+
+    expect(ranges).toContainEqual({
+      start: 6,
+      end: 14,
+      styleId: getStyle()!.getStyleId("yaml.text") ?? 0,
       priority: 1,
     })
   })


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix

### What does this PR do?

Two related editor fixes:

1. **Code editor highlighting with emoji/wide characters** — YAML/JSON fallback highlighting now maps source offsets to display offsets so highlighted ranges stay aligned when lines contain emoji, accented, or wide characters (previously ranges drifted right of the visible glyphs). Tree-sitter fallback (JSON/YAML) is preserved when Tree-sitter returns partial output, and YAML plain-text values use a dedicated `yaml.text` style instead of the string style.

2. **Duplicate interaction when clicking an active body editor** — clicking an already-focused, editing body editor no longer triggers `onInteraction` (which would exit edit mode) and mouse events no longer bubble to the pane, so focus stays in the editor and typing continues uninterrupted.

### How did you verify your code works?

Added tests covering wide-char/emoji fallback highlighting for both JSON and YAML, and a harness test asserting an active JSON editor stays focused (zero interactions/pane-focuses) while receiving keystrokes. Full suite passes with `bun test`.

### Screenshots / recordings

N/A (terminal TUI).

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON body editor interactions to prevent duplicate pane activation while editing.
  * Limited editor activation to left-clicks and preserved typing behavior.
  * Improved JSON and YAML syntax highlighting, including partial highlighting, Unicode text, and CRLF line endings.
  * Added more accurate YAML text styling when specific mappings are unavailable.

* **Tests**
  * Added regression coverage for editor focus behavior and syntax highlighting edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->