### PR TITLE
feat(converters): add Swagger 2.0 import support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ graphify-out/
 drafts
 .impeccable/critique/2026-08-03T00-20-36Z__src-ui-app-tsx.md
 AWS API Gateway.yaml
+api-docs.json

--- a/README.md
+++ b/README.md
@@ -108,20 +108,20 @@ plus bearer, basic, and API-key authentication.
 
 ### Bring in and run existing work
 
-- OpenAPI 3.0 and Postman collection imports.
+- OpenAPI 3.0, Swagger 2.0, and Postman collection imports.
 - A non-interactive CLI for collection inspection, validation, request runs,
   and agent workflows.
 
 ## Import an existing collection
 
-Bring an OpenAPI 3.0 specification or Postman collection into Noodle:
+Bring an OpenAPI 3.0/Swagger 2.0 specification or Postman collection into Noodle:
 
 ```bash
 noodle import ./specs/api.yaml --output ./collections
 ```
 
-Noodle detects the supported format automatically. Use `--format openapi` or
-`--format postman` when you need to choose explicitly. Imported valid JSON
+Noodle detects the supported format automatically. Use `--format openapi`,
+`--format swagger`, or `--format postman` when you need to choose explicitly. Imported valid JSON
 request bodies are pretty-printed automatically.
 
 ## Automation CLI

--- a/src/app/commands/import.ts
+++ b/src/app/commands/import.ts
@@ -5,7 +5,8 @@ import { formatImport } from "../humanOutput"
 export default defineCommand({
   meta: {
     name: "import",
-    description: "Import OpenAPI or Postman spec into collection files",
+    description:
+      "Import OpenAPI, Swagger, or Postman spec into collection files",
   },
   args: {
     source: {
@@ -17,7 +18,7 @@ export default defineCommand({
       type: "string",
       alias: "i",
       description:
-        'Import format ("openapi", "postman") — auto-detected if omitted',
+        'Import format ("openapi", "swagger", "postman") — auto-detected if omitted',
     },
     output: {
       type: "string",

--- a/src/app/import.ts
+++ b/src/app/import.ts
@@ -59,8 +59,10 @@ export async function runImport(
 ): Promise<{ path: string; name: string; formattedJsonBodies: number }> {
   if (!_importersRegistered) {
     const { openApiImporter } = await import("../converters/openapi/index")
+    const { swaggerImporter } = await import("../converters/swagger/index")
     const { postmanImporter } = await import("../converters/postman/index")
     registerImporter(openApiImporter)
+    registerImporter(swaggerImporter)
     registerImporter(postmanImporter)
     _importersRegistered = true
   }

--- a/src/converters/openapi/detect.ts
+++ b/src/converters/openapi/detect.ts
@@ -1,15 +1,11 @@
-import yaml from "js-yaml"
+import { parseJsonOrYaml } from "../shared"
 
 export function detectOpenApi(content: string): boolean {
   let doc: unknown
   try {
-    doc = JSON.parse(content)
+    doc = parseJsonOrYaml(content)
   } catch {
-    try {
-      doc = yaml.load(content)
-    } catch {
-      return false
-    }
+    return false
   }
 
   if (typeof doc !== "object" || doc === null || Array.isArray(doc))

--- a/src/converters/openapi/parse.ts
+++ b/src/converters/openapi/parse.ts
@@ -1,22 +1,18 @@
-import yaml from "js-yaml"
 import type { Normalized } from "./map"
 import { resolveSpecRefs } from "./refs"
+import { parseJsonOrYaml } from "../shared"
 
 export function parseSpec(spec: string | object): Normalized {
   let doc: unknown
   if (typeof spec === "string") {
     try {
-      doc = JSON.parse(spec)
-    } catch {
-      try {
-        doc = yaml.load(spec)
-      } catch (eYaml) {
-        const msg = eYaml instanceof Error ? eYaml.message : String(eYaml)
-        throw new Error(
-          `converters.openapi.import: failed to parse spec (not valid JSON or YAML): ${msg}`,
-          { cause: eYaml },
-        )
-      }
+      doc = parseJsonOrYaml(spec)
+    } catch (eYaml) {
+      const msg = eYaml instanceof Error ? eYaml.message : String(eYaml)
+      throw new Error(
+        `converters.openapi.import: failed to parse spec (not valid JSON or YAML): ${msg}`,
+        { cause: eYaml },
+      )
     }
   } else {
     doc = spec

--- a/src/converters/shared.ts
+++ b/src/converters/shared.ts
@@ -1,3 +1,4 @@
+import yaml from "js-yaml"
 import type { Method } from "../schema"
 
 export const METHOD_UPPER: Record<string, Method> = {
@@ -16,4 +17,12 @@ export function slugify(s: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .replace(/-{2,}/g, "-")
+}
+
+export function parseJsonOrYaml(content: string): unknown {
+  try {
+    return JSON.parse(content)
+  } catch {
+    return yaml.load(content)
+  }
 }

--- a/src/converters/swagger/detect.ts
+++ b/src/converters/swagger/detect.ts
@@ -1,6 +1,6 @@
 import yaml from "js-yaml"
 
-export function detectOpenApi(content: string): boolean {
+export function detectSwagger(content: string): boolean {
   let doc: unknown
   try {
     doc = JSON.parse(content)
@@ -12,13 +12,12 @@ export function detectOpenApi(content: string): boolean {
     }
   }
 
-  if (typeof doc !== "object" || doc === null || Array.isArray(doc))
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
     return false
+  }
   const root = doc as Record<string, unknown>
-  const version = root.openapi
-  if (typeof version !== "string") return false
-
   return (
+    root.swagger === "2.0" &&
     typeof root.paths === "object" &&
     root.paths !== null &&
     !Array.isArray(root.paths)

--- a/src/converters/swagger/detect.ts
+++ b/src/converters/swagger/detect.ts
@@ -1,15 +1,11 @@
-import yaml from "js-yaml"
+import { parseJsonOrYaml } from "../shared"
 
 export function detectSwagger(content: string): boolean {
   let doc: unknown
   try {
-    doc = JSON.parse(content)
+    doc = parseJsonOrYaml(content)
   } catch {
-    try {
-      doc = yaml.load(content)
-    } catch {
-      return false
-    }
+    return false
   }
 
   if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {

--- a/src/converters/swagger/index.ts
+++ b/src/converters/swagger/index.ts
@@ -1,0 +1,13 @@
+import { detectSwagger } from "./detect"
+import { parseSwaggerSpec } from "./parse"
+import { mapCollection } from "../openapi/map"
+
+export const swaggerImporter = {
+  type: "swagger" as const,
+  detect: detectSwagger,
+  import(content: string) {
+    return mapCollection(parseSwaggerSpec(content))
+  },
+}
+
+export { parseSwaggerSpec } from "./parse"

--- a/src/converters/swagger/parse.ts
+++ b/src/converters/swagger/parse.ts
@@ -1,0 +1,203 @@
+import yaml from "js-yaml"
+import type { Normalized } from "../openapi/map"
+import { resolveSpecRefs } from "../openapi/refs"
+
+const HTTP_METHODS = new Set([
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "head",
+  "options",
+])
+const SUPPORTED_MEDIA = new Set([
+  "application/json",
+  "multipart/form-data",
+  "application/x-www-form-urlencoded",
+])
+
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : []
+}
+
+function normalizeBasePath(value: unknown): string {
+  if (typeof value !== "string" || value === "" || value === "/") return ""
+  const path = value.startsWith("/") ? value : `/${value}`
+  return path.replace(/\/+$/, "")
+}
+
+function normalizeParameter(parameter: Record<string, unknown>) {
+  const result = { ...parameter }
+  if (parameter.default !== undefined) {
+    result.schema = isMapping(parameter.schema)
+      ? { ...parameter.schema, default: parameter.default }
+      : { default: parameter.default }
+  }
+  return result
+}
+
+function requestBody(
+  parameters: Record<string, unknown>[],
+  consumes: string[],
+): Record<string, unknown> | undefined {
+  const body = parameters.findLast((parameter) => parameter.in === "body")
+  if (body) {
+    const media = consumes.find((value) => SUPPORTED_MEDIA.has(value))
+    if (!media) return undefined
+    return {
+      content: {
+        [media]: isMapping(body.schema) ? { schema: body.schema } : {},
+      },
+    }
+  }
+
+  const formData = parameters.filter((parameter) => parameter.in === "formData")
+  if (formData.length === 0) return undefined
+
+  const properties: Record<string, unknown> = {}
+  let hasFile = false
+  for (const parameter of formData) {
+    const name = parameter.name
+    if (typeof name !== "string" || name === "") continue
+    if (parameter.type === "file") {
+      properties[name] = { type: "string", format: "binary" }
+      hasFile = true
+    } else {
+      properties[name] = {
+        type: typeof parameter.type === "string" ? parameter.type : "string",
+      }
+    }
+  }
+  const media =
+    hasFile || consumes.includes("multipart/form-data")
+      ? "multipart/form-data"
+      : "application/x-www-form-urlencoded"
+  return { content: { [media]: { schema: { properties } } } }
+}
+
+function normalizePaths(
+  paths: Record<string, unknown>,
+  consumes: string[],
+  basePath: string,
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {}
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!isMapping(pathItem)) continue
+    const pathParameters = Array.isArray(pathItem.parameters)
+      ? pathItem.parameters.filter(isMapping)
+      : []
+    const item: Record<string, unknown> = {
+      ...pathItem,
+      parameters: pathParameters
+        .filter(
+          (parameter) => parameter.in !== "body" && parameter.in !== "formData",
+        )
+        .map(normalizeParameter),
+    }
+
+    for (const [key, value] of Object.entries(pathItem)) {
+      if (!HTTP_METHODS.has(key) || !isMapping(value)) continue
+      const operationParameters = Array.isArray(value.parameters)
+        ? value.parameters.filter(isMapping)
+        : []
+      const operationConsumes = strings(value.consumes)
+      const allParameters = [...pathParameters, ...operationParameters]
+      const body = requestBody(
+        allParameters,
+        operationConsumes.length > 0 ? operationConsumes : consumes,
+      )
+      item[key] = {
+        ...value,
+        parameters: operationParameters
+          .filter(
+            (parameter) =>
+              parameter.in !== "body" && parameter.in !== "formData",
+          )
+          .map(normalizeParameter),
+        ...(body ? { requestBody: body } : {}),
+      }
+    }
+    normalized[
+      basePath ? `${basePath}${path.startsWith("/") ? path : `/${path}`}` : path
+    ] = item
+  }
+  return normalized
+}
+
+function normalizeSecurityDefinitions(value: unknown): Record<string, unknown> {
+  if (!isMapping(value)) return {}
+  const schemes: Record<string, unknown> = {}
+  for (const [name, definition] of Object.entries(value)) {
+    if (!isMapping(definition)) continue
+    if (definition.type === "basic") {
+      schemes[name] = { type: "http", scheme: "basic" }
+    } else if (definition.type === "apiKey") {
+      schemes[name] = definition
+    }
+  }
+  return schemes
+}
+
+export function parseSwaggerSpec(spec: string | object): Normalized {
+  let doc: unknown
+  if (typeof spec === "string") {
+    try {
+      doc = JSON.parse(spec)
+    } catch {
+      try {
+        doc = yaml.load(spec)
+      } catch (eYaml) {
+        const msg = eYaml instanceof Error ? eYaml.message : String(eYaml)
+        throw new Error(
+          `converters.swagger.import: failed to parse spec (not valid JSON or YAML): ${msg}`,
+          { cause: eYaml },
+        )
+      }
+    }
+  } else {
+    doc = spec
+  }
+
+  if (!isMapping(doc)) {
+    throw new Error("converters.swagger.import: spec root must be a mapping")
+  }
+  if (doc.swagger !== "2.0") {
+    throw new Error(
+      'converters.swagger.import: unsupported or missing "swagger" version, expected "2.0"',
+    )
+  }
+  if (!isMapping(doc.paths)) {
+    throw new Error('converters.swagger.import: missing or invalid "paths"')
+  }
+
+  const root = resolveSpecRefs(doc) as Record<string, unknown>
+  const basePath = normalizeBasePath(root.basePath)
+  const host =
+    typeof root.host === "string" && root.host !== "" ? root.host : null
+  const scheme =
+    strings(root.schemes).find(
+      (value) => value === "http" || value === "https",
+    ) ?? "https"
+
+  return {
+    openapi: "3.0.0",
+    info: root.info as Normalized["info"],
+    servers: host ? [{ url: `${scheme}://${host}${basePath || "/"}` }] : [],
+    paths: normalizePaths(
+      root.paths as Record<string, unknown>,
+      strings(root.consumes),
+      host ? "" : basePath,
+    ),
+    security: root.security,
+    components: {
+      securitySchemes: normalizeSecurityDefinitions(root.securityDefinitions),
+    },
+  }
+}

--- a/src/converters/swagger/parse.ts
+++ b/src/converters/swagger/parse.ts
@@ -1,6 +1,6 @@
-import yaml from "js-yaml"
 import type { Normalized } from "../openapi/map"
 import { resolveSpecRefs } from "../openapi/refs"
+import { parseJsonOrYaml } from "../shared"
 
 const HTTP_METHODS = new Set([
   "get",
@@ -149,17 +149,13 @@ export function parseSwaggerSpec(spec: string | object): Normalized {
   let doc: unknown
   if (typeof spec === "string") {
     try {
-      doc = JSON.parse(spec)
-    } catch {
-      try {
-        doc = yaml.load(spec)
-      } catch (eYaml) {
-        const msg = eYaml instanceof Error ? eYaml.message : String(eYaml)
-        throw new Error(
-          `converters.swagger.import: failed to parse spec (not valid JSON or YAML): ${msg}`,
-          { cause: eYaml },
-        )
-      }
+      doc = parseJsonOrYaml(spec)
+    } catch (eYaml) {
+      const msg = eYaml instanceof Error ? eYaml.message : String(eYaml)
+      throw new Error(
+        `converters.swagger.import: failed to parse spec (not valid JSON or YAML): ${msg}`,
+        { cause: eYaml },
+      )
     }
   } else {
     doc = spec

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -250,6 +250,7 @@ export function AuthEditor({
                   <Select
                     items={PLACEMENT_ITEMS}
                     value={fieldValue || "header"}
+                    width={16}
                     onChange={(id) =>
                       onApiKeyPlacementChange(id as "header" | "query")
                     }

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -247,7 +247,8 @@ export function RequestPane({
                       : undefined
                   }
                   onEditorActivate={() => {
-                    if (!inEdit) onInteraction?.()
+                    if (inEdit) return
+                    onInteraction?.()
                     onPaneFocus?.()
                     onBodyEditorFocus?.(request.bodyType ?? "json")
                   }}

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -292,7 +292,9 @@ export function BodySection({
         <box
           id="body-field"
           onMouseDown={(event) => {
-            if (event.button === MouseButton.LEFT) onEditorActivate?.()
+            if (event.button !== MouseButton.LEFT) return
+            onEditorActivate?.()
+            event.stopPropagation()
           }}
           style={{
             flexDirection: "column",

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { MouseButtons } from "@opentui/core/testing"
 import { testRender } from "@opentui/react/test-utils"
 import { extend } from "@opentui/react"
@@ -47,6 +47,47 @@ const editStateEditingTimeout = {
   mode: "editing" as const,
   cursor: { field: "settings" as const, row: 0, addingRow: false },
   editingRow: 0,
+}
+
+function ActiveJsonEditorHarness({
+  onInteraction,
+  onPaneFocus,
+  onChange,
+}: {
+  onInteraction: () => void
+  onPaneFocus: () => void
+  onChange: (value: string) => void
+}) {
+  const [body, setBody] = useState(
+    JSON.stringify({ name: "hello", count: 42 }, null, 2),
+  )
+  const [editing, setEditing] = useState(true)
+
+  return (
+    <RequestPane
+      request={{ ...testRequest, body }}
+      editState={editing ? editStateEditing : editStateBrowse}
+      editKey=""
+      editValue={body}
+      setEditKey={() => {}}
+      setEditValue={() => {}}
+      focused
+      activeTab="body"
+      onBodyChange={(value) => {
+        onChange(value)
+        setBody(value)
+      }}
+      onBodyEditorFocus={() => setEditing(true)}
+      onInteraction={() => {
+        onInteraction()
+        setEditing(false)
+      }}
+      onPaneFocus={() => {
+        onPaneFocus()
+        setEditing(false)
+      }}
+    />
+  )
 }
 
 describe("BodySection — edit mode", () => {
@@ -142,6 +183,37 @@ describe("BodySection — edit mode", () => {
       await mockMouse.click(5, 5, MouseButtons.LEFT)
     })
     expect(editorActivations).toBe(1)
+    cleanup()
+  })
+
+  it("keeps an active JSON editor focused when clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const changes: string[] = []
+    let interactions = 0
+    let paneFocuses = 0
+    const { renderOnce, mockInput, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={80} height={20}>
+            <ActiveJsonEditorHarness
+              onInteraction={() => interactions++}
+              onPaneFocus={() => paneFocuses++}
+              onChange={(value) => changes.push(value)}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+
+    await mockMouse.click(5, 5, MouseButtons.LEFT)
+    await renderOnce()
+    await act(async () => mockInput.typeText("X"))
+
+    expect(interactions).toBe(0)
+    expect(paneFocuses).toBe(0)
+    expect(changes.at(-1)).toContain("X")
     cleanup()
   })
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -152,6 +152,7 @@ describe("CLI integration", () => {
     expect(proc.exitCode).toBe(0)
     const out = proc.stdout.toString()
     expect(out).toContain("SOURCE")
+    expect(out).toContain("swagger")
     expect(out).toContain("format")
     expect(out).toContain("output")
   })

--- a/tests/converters/openapi-detect.test.ts
+++ b/tests/converters/openapi-detect.test.ts
@@ -16,13 +16,13 @@ describe("detectOpenApi", () => {
     expect(detectOpenApi(spec)).toBe(true)
   })
 
-  it("detects Swagger 2.0 by swagger field", () => {
+  it("rejects Swagger 2.0", () => {
     const spec = JSON.stringify({
       swagger: "2.0",
       info: { title: "Test" },
       paths: { "/x": { get: {} } },
     })
-    expect(detectOpenApi(spec)).toBe(true)
+    expect(detectOpenApi(spec)).toBe(false)
   })
 
   it("rejects non-object roots", () => {
@@ -30,7 +30,7 @@ describe("detectOpenApi", () => {
     expect(detectOpenApi("[1,2,3]")).toBe(false)
   })
 
-  it("rejects missing openapi/swagger field", () => {
+  it("rejects missing openapi field", () => {
     expect(detectOpenApi(JSON.stringify({ info: {}, paths: {} }))).toBe(false)
   })
 

--- a/tests/converters/swagger-detect.test.ts
+++ b/tests/converters/swagger-detect.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test"
+import { detectSwagger } from "../../src/converters/swagger/detect"
+
+describe("detectSwagger", () => {
+  it("detects Swagger 2.0 JSON and YAML", () => {
+    expect(detectSwagger('{"swagger":"2.0","paths":{}}')).toBe(true)
+    expect(detectSwagger('swagger: "2.0"\npaths: {}\n')).toBe(true)
+  })
+
+  it("rejects other versions and invalid paths", () => {
+    expect(detectSwagger('{"swagger":"2.1","paths":{}}')).toBe(false)
+    expect(detectSwagger('{"swagger":"2.0","paths":[]}')).toBe(false)
+    expect(detectSwagger("not: [valid")).toBe(false)
+  })
+})

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -163,6 +163,27 @@ describe("import — integration", () => {
     expect(existsSync(join(collDir, "get-x.yml"))).toBe(true)
   })
 
+  it("auto-detects Swagger 2.0 and writes requests and its environment", async () => {
+    const outDir = tempDir()
+    const specDir = tempDir()
+    const specPath = join(specDir, "swagger.yaml")
+    await writeFile(
+      specPath,
+      'swagger: "2.0"\ninfo:\n  title: Swagger API\nhost: api.example.com\npaths:\n  /ping:\n    get:\n      operationId: ping\n',
+    )
+
+    const { runImport } = await import("../../src/app/import")
+    await runImport({ source: specPath, outputDir: outDir })
+
+    expect(existsSync(join(outDir, "swagger-api", "get-ping.yml"))).toBe(true)
+    expect(
+      readFileSync(
+        join(outDir, "swagger-api", ".environments", "default.env"),
+        "utf-8",
+      ),
+    ).toContain("base_url=https://api.example.com/")
+  })
+
   it("preserves large JSON integers in imported Postman request bodies", async () => {
     const outDir = tempDir()
     const specDir = tempDir()

--- a/tests/swagger.test.ts
+++ b/tests/swagger.test.ts
@@ -9,6 +9,20 @@ function requests(items: CollectionItem[]): Request[] {
 }
 
 describe("parseSwaggerSpec", () => {
+  it("wraps invalid JSON and YAML with the Swagger import error", () => {
+    let error: Error | undefined
+    try {
+      parseSwaggerSpec(": : :")
+    } catch (e) {
+      error = e as Error
+    }
+
+    expect(error?.message).toContain(
+      "converters.swagger.import: failed to parse spec (not valid JSON or YAML):",
+    )
+    expect(error?.cause).toBeDefined()
+  })
+
   it("validates the Swagger 2.0 document shape", () => {
     expect(() => parseSwaggerSpec({ swagger: "2.1", paths: {} })).toThrow(
       'converters.swagger.import: unsupported or missing "swagger" version, expected "2.0"',

--- a/tests/swagger.test.ts
+++ b/tests/swagger.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "bun:test"
+import { swaggerImporter, parseSwaggerSpec } from "../src/converters/swagger"
+import type { CollectionItem, Request } from "../src/schema"
+
+function requests(items: CollectionItem[]): Request[] {
+  return items.flatMap((item) =>
+    item.type === "request" ? [item.data] : requests(item.data.children),
+  )
+}
+
+describe("parseSwaggerSpec", () => {
+  it("validates the Swagger 2.0 document shape", () => {
+    expect(() => parseSwaggerSpec({ swagger: "2.1", paths: {} })).toThrow(
+      'converters.swagger.import: unsupported or missing "swagger" version, expected "2.0"',
+    )
+    expect(() => parseSwaggerSpec({ swagger: "2.0" })).toThrow(
+      'converters.swagger.import: missing or invalid "paths"',
+    )
+  })
+})
+
+describe("swaggerImporter", () => {
+  it("imports refs, params, JSON and form bodies, tags, auth, and HTTPS defaults", () => {
+    const result = swaggerImporter.import(`swagger: "2.0"
+info:
+  title: Pet API
+host: api.example.com
+basePath: /v1
+consumes: [application/json]
+security:
+  - api_key: []
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: X-API-Key
+    in: header
+  basic_auth:
+    type: basic
+parameters:
+  limit:
+    name: limit
+    in: query
+    default: 20
+definitions:
+  Pet:
+    type: object
+    properties:
+      name:
+        type: string
+paths:
+  /pets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        default: 42
+    get:
+      operationId: getPet
+      tags: [pets]
+      parameters:
+        - $ref: '#/parameters/limit'
+    post:
+      operationId: createPet
+      security:
+        - basic_auth: []
+      parameters:
+        - name: body
+          in: body
+          schema:
+            $ref: '#/definitions/Pet'
+  /upload:
+    post:
+      consumes: [multipart/form-data]
+      parameters:
+        - name: photo
+          in: formData
+          type: file
+        - name: label
+          in: formData
+          type: string
+  /login:
+    post:
+      consumes: [application/x-www-form-urlencoded]
+      parameters:
+        - name: email
+          in: formData
+          type: string
+`)
+
+    const imported = requests(result.collection.items)
+    const getPet = imported.find((request) => request.name === "getPet")!
+    const createPet = imported.find((request) => request.name === "createPet")!
+    const upload = imported.find((request) => request.name === "POST /upload")!
+    const login = imported.find((request) => request.name === "POST /login")!
+
+    expect(result.collection.name).toBe("Pet API")
+    expect(result.environments).toEqual([
+      {
+        name: "default",
+        vars: {
+          base_url: "https://api.example.com/v1",
+          api_key: "",
+          user: "",
+          pass: "",
+          name: "",
+          label: "",
+          email: "",
+        },
+      },
+    ])
+    expect(getPet.url).toBe("$base_url/pets/:id")
+    expect(getPet.params).toEqual([
+      { name: "limit", value: "20", enabled: true },
+    ])
+    expect(getPet.pathParams).toEqual([
+      { name: "id", value: "42", enabled: true },
+    ])
+    expect(getPet.auth).toEqual({
+      type: "api_key",
+      key: "X-API-Key",
+      value: "$api_key",
+      placement: "header",
+    })
+    expect(createPet.bodyType).toBe("json")
+    expect(createPet.body).toBe('{"name":"$name"}')
+    expect(createPet.auth).toEqual({
+      type: "basic",
+      user: "$user",
+      pass: "$pass",
+    })
+    expect(upload.bodyType).toBe("multipart")
+    expect(upload.formData).toEqual([
+      { name: "photo", value: "", enabled: true, type: "file" },
+      { name: "label", value: "$label", enabled: true, type: "text" },
+    ])
+    expect(login.bodyType).toBe("urlencoded")
+    expect(login.formData).toEqual([
+      { name: "email", value: "$email", enabled: true, type: "text" },
+    ])
+  })
+
+  it("uses basePath in relative URLs when host is absent", () => {
+    const result = swaggerImporter.import(
+      '{"swagger":"2.0","basePath":"v2","paths":{"/pets":{"get":{}}}}',
+    )
+    expect(requests(result.collection.items)[0]?.url).toBe("/v2/pets")
+  })
+
+  it("prefers an operation body parameter over a path-item body parameter", () => {
+    const result = swaggerImporter.import(`swagger: "2.0"
+consumes: [application/json]
+paths:
+  /items:
+    parameters:
+      - name: body
+        in: body
+        schema:
+          properties:
+            pathValue: { type: string }
+    post:
+      parameters:
+        - name: body
+          in: body
+          schema:
+            properties:
+              operationValue: { type: string }
+`)
+
+    expect(requests(result.collection.items)[0]?.body).toBe(
+      '{"operationValue":"$operationValue"}',
+    )
+  })
+
+  it("omits bodies with unsupported media types", () => {
+    const result = swaggerImporter.import(`swagger: "2.0"
+consumes: [application/xml]
+paths:
+  /items:
+    post:
+      parameters:
+        - name: body
+          in: body
+          schema:
+            properties:
+              value: { type: string }
+`)
+
+    const request = requests(result.collection.items)[0]!
+    expect(request.body).toBeUndefined()
+    expect(request.bodyType).toBeUndefined()
+  })
+})

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -12,35 +12,44 @@ describe("AuthEditor", () => {
   it("activates the API key placement row before opening its select", async () => {
     const { keymap, cleanup } = setupKeymap()
     let focusedRow = -1
-    const { renderOnce, mockMouse } = await testRender(
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <AuthEditor
-            auth={{
-              type: "api_key",
-              key: "X-API-Key",
-              value: "secret",
-              placement: "header",
-            }}
-            editState={initialEditState()}
-            inEdit={false}
-            browseActive={false}
-            setEditValue={() => {}}
-            theme={THEMES[0]!}
-            onAuthTypeChange={() => {}}
-            onApiKeyPlacementChange={() => {}}
-            onFocusRow={(row) => {
-              focusedRow = row
-            }}
-          />
+          <box width={60} height={10}>
+            <AuthEditor
+              auth={{
+                type: "api_key",
+                key: "X-API-Key",
+                value: "secret",
+                placement: "header",
+              }}
+              editState={initialEditState()}
+              inEdit={false}
+              browseActive={false}
+              setEditValue={() => {}}
+              theme={THEMES[0]!}
+              onAuthTypeChange={() => {}}
+              onApiKeyPlacementChange={() => {}}
+              onFocusRow={(row) => {
+                focusedRow = row
+              }}
+            />
+          </box>
         </ThemeProvider>
       </KeymapProvider>,
       { width: 60, height: 10 },
     )
     await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("Header"))
 
     await act(async () => {
-      await mockMouse.click(10, 6, MouseButtons.LEFT)
+      await mockMouse.click(50, y, MouseButtons.LEFT)
+    })
+    expect(focusedRow).toBe(-1)
+
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("Header"), y, MouseButtons.LEFT)
     })
     expect(focusedRow).toBe(3)
     cleanup()


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Swagger 2.0 import support to `noodle import` (alongside OpenAPI 3.0 and Postman). Auto-detects `swagger: "2.0"` specs, normalizes them to the OpenAPI 3 shape (paths, basePath, consumes, body/formData params, securityDefinitions), and reuses the existing OpenAPI mapper. Also fixes a couple of body-editor mouse interaction regressions so an active JSON editor keeps focus when clicked.

### How did you verify your code works?

Added `tests/swagger.test.ts` (parser + detection coverage), `tests/converters/swagger-detect.test.ts`, integration coverage in `tests/integration/import.test.ts`, and a body-editor click-focus test in `tests/RequestPane-body-editor.test.tsx`. Ran `bun test`, `bun run lint`, and `bun run typecheck` locally.

### Screenshots / recordings

N/A (CLI feature)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing Swagger 2.0 specifications in JSON and YAML formats.
  * Swagger documents are automatically detected and converted for use in the application.
  * Added explicit `--format swagger` support to the import command.
  * Swagger imports support paths, parameters, request bodies, authentication, references, and base URLs.

* **Bug Fixes**
  * Improved request body editor interactions to prevent unintended pane focus changes while editing.
  * Improved specification parsing and validation for clearer handling of invalid documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->