### PR TITLE
feat(converters): add Insomnia import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ noodle import ./specs/api.yaml --output ./collections
 ```
 
 Noodle detects the supported format automatically. Use `--format openapi`,
-`--format swagger`, or `--format postman` when you need to choose explicitly. Imported valid JSON
+`--format swagger`, `--format postman`, or `--format insomnia` when you need to choose explicitly. Imported valid JSON
 request bodies are pretty-printed automatically.
 
 ## Automation CLI

--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ plus bearer, basic, and API-key authentication.
 
 ### Bring in and run existing work
 
-- OpenAPI 3.0, Swagger 2.0, and Postman collection imports.
+- OpenAPI 3.0, Swagger 2.0, Postman, and Insomnia collection imports.
 - A non-interactive CLI for collection inspection, validation, request runs,
   and agent workflows.
 
 ## Import an existing collection
 
-Bring an OpenAPI 3.0/Swagger 2.0 specification or Postman collection into Noodle:
+Bring an OpenAPI 3.0/Swagger 2.0 specification, Postman collection, or Insomnia export into Noodle:
 
 ```bash
 noodle import ./specs/api.yaml --output ./collections
@@ -135,7 +135,7 @@ are non-interactive and support `--json`, which emits one
 | `noodle workspace list`                                                | List registered collections.                             |
 | `noodle collection create <name>`                                      | Create and register a collection.                        |
 | `noodle collection inspect <path>`                                     | Inspect a collection's tree, metadata, and environments. |
-| `noodle collection format <path>`                                      | Canonicalize request YAML and pretty-print JSON bodies.   |
+| `noodle collection format <path>`                                      | Canonicalize request YAML and pretty-print JSON bodies.  |
 | `noodle collection audit <path>`                                       | Validate collection files.                               |
 | `noodle collection run <path>`                                         | Run every request in a collection.                       |
 | `noodle request create <id> --url <url> --collection <dir>`            | Create a minimal request.                                |

--- a/src/app/commands/import.ts
+++ b/src/app/commands/import.ts
@@ -6,7 +6,7 @@ export default defineCommand({
   meta: {
     name: "import",
     description:
-      "Import OpenAPI, Swagger, or Postman spec into collection files",
+      "Import OpenAPI, Swagger, Postman, or Insomnia spec into collection files",
   },
   args: {
     source: {
@@ -18,7 +18,7 @@ export default defineCommand({
       type: "string",
       alias: "i",
       description:
-        'Import format ("openapi", "swagger", "postman") — auto-detected if omitted',
+        'Import format ("openapi", "swagger", "postman", "insomnia") — auto-detected if omitted',
     },
     output: {
       type: "string",

--- a/src/app/import.ts
+++ b/src/app/import.ts
@@ -61,9 +61,11 @@ export async function runImport(
     const { openApiImporter } = await import("../converters/openapi/index")
     const { swaggerImporter } = await import("../converters/swagger/index")
     const { postmanImporter } = await import("../converters/postman/index")
+    const { insomniaImporter } = await import("../converters/insomnia/index")
     registerImporter(openApiImporter)
     registerImporter(swaggerImporter)
     registerImporter(postmanImporter)
+    registerImporter(insomniaImporter)
     _importersRegistered = true
   }
   const { source, format, outputDir = "./collections" } = options

--- a/src/converters/insomnia/detect.ts
+++ b/src/converters/insomnia/detect.ts
@@ -1,0 +1,19 @@
+export function detectInsomnia(content: string): boolean {
+  let doc: unknown
+  try {
+    doc = JSON.parse(content)
+  } catch {
+    return false
+  }
+
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+    return false
+  }
+
+  const root = doc as Record<string, unknown>
+  return (
+    root._type === "export" &&
+    (root.__export_format === 4 || root.__export_format === 5) &&
+    Array.isArray(root.resources)
+  )
+}

--- a/src/converters/insomnia/index.ts
+++ b/src/converters/insomnia/index.ts
@@ -1,0 +1,36 @@
+import { detectInsomnia } from "./detect"
+import { mapExport } from "./map"
+
+export const insomniaImporter = {
+  type: "insomnia" as const,
+  detect: detectInsomnia,
+  import(content: string) {
+    let root: unknown
+    try {
+      root = JSON.parse(content)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      throw new Error(`converters.insomnia.import: invalid JSON: ${msg}`, {
+        cause: e,
+      })
+    }
+    if (typeof root !== "object" || root === null || Array.isArray(root)) {
+      throw new Error(
+        "converters.insomnia.import: export root must be an object",
+      )
+    }
+    const doc = root as Record<string, unknown>
+    if (
+      doc._type !== "export" ||
+      (doc.__export_format !== 4 && doc.__export_format !== 5)
+    ) {
+      throw new Error(
+        "converters.insomnia.import: expected an Insomnia JSON v4 or v5 export",
+      )
+    }
+    return mapExport(doc)
+  },
+}
+
+export { detectInsomnia } from "./detect"
+export { mapExport } from "./map"

--- a/src/converters/insomnia/map.ts
+++ b/src/converters/insomnia/map.ts
@@ -149,7 +149,9 @@ function mapRequest(resource: RawResource, id: string): Request {
 }
 
 function envValue(value: unknown): string | undefined {
-  return typeof value === "string" ? convertTpl(value) : JSON.stringify(value)
+  return typeof value === "string"
+    ? convertTpl(value).replace(/\r\n?|\n/g, "\\n")
+    : JSON.stringify(value)
 }
 
 function mapEnvironmentVars(
@@ -254,25 +256,33 @@ export function mapExport(root: RawResource): ImportResult {
   }
 
   const usedIds = new Set<string>()
-  function mapItems(parentId: string, parentPath: string): CollectionItem[] {
+  function mapItems(
+    parentId: string,
+    parentPath: string,
+    ancestorIds = new Set<string>(),
+  ): CollectionItem[] {
     const items: CollectionItem[] = []
     let index = 0
     for (const resource of children.get(parentId) ?? []) {
       index++
       if (resource._type === "request_group" || resource._type === "folder") {
+        const resourceId = stringValue(resource._id)
+        if (resourceId && ancestorIds.has(resourceId)) continue
         const folderId = uniqueId(
           slugify(stringValue(resource.name)) || `folder-${index}`,
           usedIds,
         )
         usedIds.add(folderId)
         const path = parentPath ? `${parentPath}/${folderId}` : folderId
+        const childAncestorIds = new Set(ancestorIds)
+        if (resourceId) childAncestorIds.add(resourceId)
         items.push({
           type: "folder",
           data: {
             id: folderId,
             name: stringValue(resource.name) || folderId,
             path,
-            children: mapItems(stringValue(resource._id), path),
+            children: mapItems(resourceId, path, childAncestorIds),
           },
         })
       } else if (resource._type === "request") {

--- a/src/converters/insomnia/map.ts
+++ b/src/converters/insomnia/map.ts
@@ -23,7 +23,7 @@ function stringValue(value: unknown): string {
 }
 
 export function convertTpl(value: string): string {
-  return value.replace(/\{\{\s*(\w+)\s*\}\}/g, "$$$1")
+  return value.replace(/\{\{\s*(?:_\.\s*)?(\w+)\s*\}\}/g, "$$$1")
 }
 
 function uniqueId(candidate: string, usedIds: Set<string>): string {
@@ -128,9 +128,19 @@ function mapFormData(value: unknown): FormEntry[] {
   })
 }
 
-function mapRequest(resource: RawResource, id: string): Request {
-  const method =
-    METHOD_UPPER[stringValue(resource.method).toLowerCase()] ?? "GET"
+function mapRequest(resource: RawResource, id: string): Request | undefined {
+  const rawMethod = resource.method
+  if (
+    rawMethod !== undefined &&
+    rawMethod !== null &&
+    typeof rawMethod !== "string"
+  ) {
+    return undefined
+  }
+  const methodKey =
+    typeof rawMethod === "string" ? rawMethod.trim().toLowerCase() : ""
+  const method = methodKey === "" ? "GET" : METHOD_UPPER[methodKey]
+  if (!method) return undefined
   const followRedirects = resource.settingFollowRedirects
   return {
     id,
@@ -152,6 +162,10 @@ function envValue(value: unknown): string | undefined {
   return typeof value === "string"
     ? convertTpl(value).replace(/\r\n?|\n/g, "\\n")
     : JSON.stringify(value)
+}
+
+function metaSortKey(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
 }
 
 function mapEnvironmentVars(
@@ -254,6 +268,15 @@ export function mapExport(root: RawResource): ImportResult {
     items.push(resource)
     children.set(parentId, items)
   }
+  for (const items of children.values()) {
+    items.sort((a, b) => {
+      const aKey = metaSortKey(a.metaSortKey)
+      const bKey = metaSortKey(b.metaSortKey)
+      if (aKey === undefined) return bKey === undefined ? 0 : 1
+      if (bKey === undefined) return -1
+      return aKey - bKey
+    })
+  }
 
   const usedIds = new Set<string>()
   function mapItems(
@@ -295,8 +318,10 @@ export function mapExport(root: RawResource): ImportResult {
             : baseId || `request-${index}`,
           usedIds,
         )
+        const request = mapRequest(resource, requestId)
+        if (!request) continue
         usedIds.add(requestId)
-        items.push({ type: "request", data: mapRequest(resource, requestId) })
+        items.push({ type: "request", data: request })
       }
     }
     return items

--- a/src/converters/insomnia/map.ts
+++ b/src/converters/insomnia/map.ts
@@ -1,0 +1,304 @@
+import type {
+  Auth,
+  CollectionItem,
+  Environment,
+  FormEntry,
+  KvEntry,
+  ParamEntry,
+  Request,
+} from "../../schema"
+import type { ImportResult } from "../index"
+import { METHOD_UPPER, slugify } from "../shared"
+
+type RawResource = Record<string, unknown>
+
+function asRecord(value: unknown): RawResource | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as RawResource)
+    : undefined
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : ""
+}
+
+export function convertTpl(value: string): string {
+  return value.replace(/\{\{\s*(\w+)\s*\}\}/g, "$$$1")
+}
+
+function uniqueId(candidate: string, usedIds: Set<string>): string {
+  if (!usedIds.has(candidate)) return candidate
+  let n = 2
+  while (usedIds.has(`${candidate}-${n}`)) n++
+  return `${candidate}-${n}`
+}
+
+function mapPairs(value: unknown): ParamEntry[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    const pair = asRecord(item)
+    const name = stringValue(pair?.name).trim()
+    if (!name) return []
+    return [
+      {
+        name,
+        value: convertTpl(stringValue(pair?.value)),
+        enabled: pair?.disabled !== true,
+      },
+    ]
+  })
+}
+
+function mapHeaders(value: unknown): Record<string, KvEntry> {
+  const headers: Record<string, KvEntry> = {}
+  for (const pair of mapPairs(value)) {
+    headers[pair.name] = { value: pair.value, enabled: pair.enabled }
+  }
+  return headers
+}
+
+function mapAuth(value: unknown): Auth {
+  const auth = asRecord(value)
+  if (!auth || auth.disabled === true) return { type: "none" }
+
+  if (auth.type === "bearer") {
+    return { type: "bearer", token: convertTpl(stringValue(auth.token)) }
+  }
+  if (auth.type === "basic") {
+    return {
+      type: "basic",
+      user: convertTpl(stringValue(auth.username)),
+      pass: convertTpl(stringValue(auth.password)),
+    }
+  }
+  if (auth.type === "apikey") {
+    return {
+      type: "api_key",
+      key: stringValue(auth.key),
+      value: convertTpl(stringValue(auth.value)),
+      placement: auth.addTo === "query" ? "query" : "header",
+    }
+  }
+  return { type: "none" }
+}
+
+function mapBody(
+  value: unknown,
+): Pick<Request, "body" | "bodyType" | "formData" | "filePath"> {
+  const body = asRecord(value)
+  if (!body) return {}
+  const mimeType = stringValue(body.mimeType).toLowerCase()
+
+  if (typeof body.fileName === "string") {
+    return { bodyType: "binary", filePath: convertTpl(body.fileName) }
+  }
+
+  if (mimeType === "application/x-www-form-urlencoded") {
+    return { bodyType: "urlencoded", formData: mapFormData(body.params) }
+  }
+  if (mimeType === "multipart/form-data") {
+    return { bodyType: "multipart", formData: mapFormData(body.params) }
+  }
+
+  const text = typeof body.text === "string" ? convertTpl(body.text) : undefined
+  if (text === undefined) return {}
+  if (mimeType === "application/json" || mimeType.endsWith("+json")) {
+    return { body: text, bodyType: "json" }
+  }
+  return { body: text }
+}
+
+function mapFormData(value: unknown): FormEntry[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    const pair = asRecord(item)
+    const name = stringValue(pair?.name).trim()
+    if (!name) return []
+    const isFile = pair?.type === "file" || typeof pair?.fileName === "string"
+    return [
+      {
+        name,
+        value: convertTpl(
+          stringValue(isFile ? (pair?.fileName ?? pair?.value) : pair?.value),
+        ),
+        enabled: pair?.disabled !== true,
+        type: isFile ? "file" : "text",
+      },
+    ]
+  })
+}
+
+function mapRequest(resource: RawResource, id: string): Request {
+  const method =
+    METHOD_UPPER[stringValue(resource.method).toLowerCase()] ?? "GET"
+  const followRedirects = resource.settingFollowRedirects
+  return {
+    id,
+    name: stringValue(resource.name) || "Untitled Request",
+    method,
+    url: convertTpl(stringValue(resource.url) || "$base_url"),
+    timeout: 0,
+    ...(followRedirects === "always" ? { followRedirects: true } : {}),
+    ...(followRedirects === "never" ? { followRedirects: false } : {}),
+    headers: mapHeaders(resource.headers),
+    params: mapPairs(resource.parameters),
+    pathParams: mapPairs(resource.pathParameters),
+    ...mapBody(resource.body),
+    auth: mapAuth(resource.authentication),
+  }
+}
+
+function envValue(value: unknown): string | undefined {
+  return typeof value === "string" ? convertTpl(value) : JSON.stringify(value)
+}
+
+function mapEnvironmentVars(
+  resource: RawResource,
+  byId: Map<string, RawResource>,
+): Record<string, string> {
+  const chain: RawResource[] = []
+  const seen = new Set<string>()
+  let current: RawResource | undefined = resource
+
+  while (current) {
+    const id = stringValue(current._id)
+    if (id && seen.has(id)) break
+    if (id) seen.add(id)
+    chain.push(current)
+
+    const parent = byId.get(stringValue(current.parentId))
+    current = parent?._type === "environment" ? parent : undefined
+  }
+
+  const vars: Record<string, string> = {}
+  for (const environment of chain.reverse()) {
+    const data = asRecord(environment.data)
+    if (!data) continue
+    for (const [key, value] of Object.entries(data)) {
+      const serialized = envValue(value)
+      if (serialized !== undefined) vars[key] = serialized
+    }
+  }
+  return vars
+}
+
+function mapEnvironments(
+  resources: RawResource[],
+  workspaceId: string,
+): Environment[] {
+  const byId = new Map(
+    resources.flatMap((resource) => {
+      const id = resource._id
+      return typeof id === "string" ? [[id, resource] as const] : []
+    }),
+  )
+  const envs: Environment[] = []
+  const usedNames = new Set<string>()
+  for (const resource of resources) {
+    if (resource._type !== "environment" || typeof resource._id !== "string") {
+      continue
+    }
+    const parentId = stringValue(resource.parentId)
+    const parent = byId.get(parentId)
+    if (parentId !== workspaceId && parent?._type !== "environment") continue
+    const vars = mapEnvironmentVars(resource, byId)
+    if (Object.keys(vars).length > 0) {
+      const name = uniqueId(
+        (stringValue(resource.name) || "default")
+          .replace(/\.\./g, "-")
+          .replace(/[\\/]/g, "-") || "default",
+        usedNames,
+      )
+      usedNames.add(name)
+      envs.push({
+        name,
+        vars,
+      })
+    }
+  }
+  return envs
+}
+
+export function mapExport(root: RawResource): ImportResult {
+  const rawResources = root.resources
+  if (
+    !Array.isArray(rawResources) ||
+    rawResources.some((item) => !asRecord(item))
+  ) {
+    throw new Error(
+      "converters.insomnia.import: resources must be an array of objects",
+    )
+  }
+  const resources = rawResources as RawResource[]
+  const workspaces = resources.filter(
+    (resource) => resource._type === "workspace",
+  )
+  if (workspaces.length !== 1) {
+    throw new Error(
+      "converters.insomnia.import: expected exactly one workspace; export a single project instead",
+    )
+  }
+  const workspace = workspaces[0]!
+  const workspaceId = stringValue(workspace._id)
+  if (!workspaceId) {
+    throw new Error("converters.insomnia.import: workspace is missing _id")
+  }
+
+  const children = new Map<string, RawResource[]>()
+  for (const resource of resources) {
+    const parentId = stringValue(resource.parentId)
+    if (!parentId) continue
+    const items = children.get(parentId) ?? []
+    items.push(resource)
+    children.set(parentId, items)
+  }
+
+  const usedIds = new Set<string>()
+  function mapItems(parentId: string, parentPath: string): CollectionItem[] {
+    const items: CollectionItem[] = []
+    let index = 0
+    for (const resource of children.get(parentId) ?? []) {
+      index++
+      if (resource._type === "request_group" || resource._type === "folder") {
+        const folderId = uniqueId(
+          slugify(stringValue(resource.name)) || `folder-${index}`,
+          usedIds,
+        )
+        usedIds.add(folderId)
+        const path = parentPath ? `${parentPath}/${folderId}` : folderId
+        items.push({
+          type: "folder",
+          data: {
+            id: folderId,
+            name: stringValue(resource.name) || folderId,
+            path,
+            children: mapItems(stringValue(resource._id), path),
+          },
+        })
+      } else if (resource._type === "request") {
+        const baseId = slugify(
+          `${stringValue(resource.method) || "GET"}-${stringValue(resource.name)}`,
+        )
+        const requestId = uniqueId(
+          parentPath
+            ? `${parentPath}/${baseId || `request-${index}`}`
+            : baseId || `request-${index}`,
+          usedIds,
+        )
+        usedIds.add(requestId)
+        items.push({ type: "request", data: mapRequest(resource, requestId) })
+      }
+    }
+    return items
+  }
+
+  const name = stringValue(workspace.name) || "insomnia-import"
+  return {
+    collection: {
+      id: slugify(name) || "insomnia-import",
+      name,
+      items: mapItems(workspaceId, ""),
+    },
+    environments: mapEnvironments(resources, workspaceId),
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -153,6 +153,7 @@ describe("CLI integration", () => {
     const out = proc.stdout.toString()
     expect(out).toContain("SOURCE")
     expect(out).toContain("swagger")
+    expect(out).toContain("insomnia")
     expect(out).toContain("format")
     expect(out).toContain("output")
   })

--- a/tests/converters/insomnia-detect.test.ts
+++ b/tests/converters/insomnia-detect.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test"
+import { detectInsomnia } from "../../src/converters/insomnia/detect"
+
+describe("detectInsomnia", () => {
+  it("detects Insomnia v4 and v5 exports", () => {
+    for (const format of [4, 5]) {
+      expect(
+        detectInsomnia(
+          JSON.stringify({
+            _type: "export",
+            __export_format: format,
+            resources: [],
+          }),
+        ),
+      ).toBe(true)
+    }
+  })
+
+  it("rejects malformed and non-Insomnia JSON", () => {
+    expect(detectInsomnia("not json")).toBe(false)
+    expect(
+      detectInsomnia(
+        JSON.stringify({ _type: "export", __export_format: 3, resources: [] }),
+      ),
+    ).toBe(false)
+    expect(
+      detectInsomnia(JSON.stringify({ _type: "export", __export_format: 4 })),
+    ).toBe(false)
+    expect(detectInsomnia(JSON.stringify([]))).toBe(false)
+  })
+})

--- a/tests/insomnia.test.ts
+++ b/tests/insomnia.test.ts
@@ -274,11 +274,19 @@ describe("insomniaImporter", () => {
           method: "GET",
           url: "https://example.com",
         },
+        {
+          _id: "also-unkeyed",
+          _type: "request",
+          parentId: "wrk",
+          name: "Also Unkeyed",
+          method: "GET",
+          url: "https://example.com",
+        },
       ]),
     )
     expect(
       requests(result.collection.items).map((request) => request.name),
-    ).toEqual(["Early", "Late", "Unkeyed"])
+    ).toEqual(["Early", "Late", "Unkeyed", "Also Unkeyed"])
   })
 
   it("uses safe unique names for environment files", () => {

--- a/tests/insomnia.test.ts
+++ b/tests/insomnia.test.ts
@@ -8,7 +8,7 @@ function requests(items: CollectionItem[]): Request[] {
   )
 }
 
-function exportJson(resources: object[]): string {
+function exportJson(resources: unknown[]): string {
   return JSON.stringify({ _type: "export", __export_format: 4, resources })
 }
 
@@ -22,7 +22,7 @@ describe("insomniaImporter", () => {
           parentId: "fld_nested",
           name: "Create Widget",
           method: "POST",
-          url: "https://{{ host }}/widgets/:id",
+          url: "https://{{ _.host }}/widgets/:id",
           headers: [{ name: "X-Token", value: "{{ token }}" }],
           parameters: [
             { name: "page", value: "2" },
@@ -191,6 +191,96 @@ describe("insomniaImporter", () => {
     })
   })
 
+  it("skips unsupported methods while keeping missing and blank methods as GET", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "Methods" },
+        {
+          _id: "trace",
+          _type: "request",
+          parentId: "wrk",
+          name: "Trace",
+          method: "TRACE",
+          url: "https://example.com",
+        },
+        {
+          _id: "missing",
+          _type: "request",
+          parentId: "wrk",
+          name: "Missing",
+          url: "https://example.com",
+        },
+        {
+          _id: "blank",
+          _type: "request",
+          parentId: "wrk",
+          name: "Blank",
+          method: " ",
+          url: "https://example.com",
+        },
+        {
+          _id: "number",
+          _type: "request",
+          parentId: "wrk",
+          name: "Number",
+          method: 42,
+          url: "https://example.com",
+        },
+        {
+          _id: "post",
+          _type: "request",
+          parentId: "wrk",
+          name: "Post",
+          method: " POST ",
+          url: "https://example.com",
+        },
+      ]),
+    )
+    expect(
+      requests(result.collection.items).map((request) => request.name),
+    ).toEqual(["Missing", "Blank", "Post"])
+    expect(
+      requests(result.collection.items).map((request) => request.method),
+    ).toEqual(["GET", "GET", "POST"])
+  })
+
+  it("uses ascending metaSortKey order before export order", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "Order" },
+        {
+          _id: "late",
+          _type: "request",
+          parentId: "wrk",
+          name: "Late",
+          method: "GET",
+          url: "https://example.com",
+          metaSortKey: 20,
+        },
+        {
+          _id: "early",
+          _type: "request",
+          parentId: "wrk",
+          name: "Early",
+          method: "GET",
+          url: "https://example.com",
+          metaSortKey: 10,
+        },
+        {
+          _id: "unkeyed",
+          _type: "request",
+          parentId: "wrk",
+          name: "Unkeyed",
+          method: "GET",
+          url: "https://example.com",
+        },
+      ]),
+    )
+    expect(
+      requests(result.collection.items).map((request) => request.name),
+    ).toEqual(["Early", "Late", "Unkeyed"])
+  })
+
   it("uses safe unique names for environment files", () => {
     const result = insomniaImporter.import(
       exportJson([
@@ -287,6 +377,19 @@ describe("insomniaImporter", () => {
     expect(() => insomniaImporter.import(exportJson([]))).toThrow(
       "expected exactly one workspace; export a single project instead",
     )
+    expect(() =>
+      insomniaImporter.import(
+        exportJson([
+          { _id: "wrk", _type: "workspace", name: "Invalid" },
+          "not a resource",
+        ]),
+      ),
+    ).toThrow("resources must be an array of objects")
+    expect(() =>
+      insomniaImporter.import(
+        exportJson([{ _type: "workspace", name: "Missing ID" }]),
+      ),
+    ).toThrow("workspace is missing _id")
     expect(() =>
       insomniaImporter.import(
         exportJson([

--- a/tests/insomnia.test.ts
+++ b/tests/insomnia.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "bun:test"
+import { insomniaImporter } from "../src/converters/insomnia"
+import type { CollectionItem, Request } from "../src/schema"
+
+function requests(items: CollectionItem[]): Request[] {
+  return items.flatMap((item) =>
+    item.type === "request" ? [item.data] : requests(item.data.children),
+  )
+}
+
+function exportJson(resources: object[]): string {
+  return JSON.stringify({ _type: "export", __export_format: 4, resources })
+}
+
+describe("insomniaImporter", () => {
+  it("maps folders, HTTP requests, variables, bodies, auth, and environments", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        {
+          _id: "req_nested",
+          _type: "request",
+          parentId: "fld_nested",
+          name: "Create Widget",
+          method: "POST",
+          url: "https://{{ host }}/widgets/:id",
+          headers: [{ name: "X-Token", value: "{{ token }}" }],
+          parameters: [
+            { name: "page", value: "2" },
+            { name: "hidden", value: "x", disabled: true },
+          ],
+          pathParameters: [{ name: "id", value: "widget-1" }],
+          body: { mimeType: "application/json", text: '{"name":"{{ name }}"}' },
+          authentication: {
+            type: "apikey",
+            key: "X-Key",
+            value: "{{ key }}",
+            addTo: "header",
+          },
+          settingFollowRedirects: "never",
+        },
+        {
+          _id: "fld_nested",
+          _type: "folder",
+          parentId: "fld_root",
+          name: "Nested",
+        },
+        {
+          _id: "env_dev",
+          _type: "environment",
+          parentId: "env_base",
+          name: "Development",
+          data: { host: "api.example.com", config: { retries: 2 } },
+        },
+        { _id: "wrk", _type: "workspace", parentId: null, name: "Example API" },
+        {
+          _id: "fld_root",
+          _type: "request_group",
+          parentId: "wrk",
+          name: "Widgets",
+        },
+        {
+          _id: "env_base",
+          _type: "environment",
+          parentId: "wrk",
+          name: "Base Environment",
+          data: { token: "{{ secret }}", host: "base.example.com" },
+        },
+        {
+          _id: "grpc",
+          _type: "grpc_request",
+          parentId: "wrk",
+          name: "Ignored",
+        },
+      ]),
+    )
+
+    expect(result.collection).toMatchObject({
+      id: "example-api",
+      name: "Example API",
+    })
+    const root = result.collection.items[0]!
+    expect(root.type).toBe("folder")
+    if (root.type !== "folder") throw new Error("expected folder")
+    expect(root.data.path).toBe("widgets")
+    const nested = root.data.children[0]!
+    expect(nested.type).toBe("folder")
+    if (nested.type !== "folder") throw new Error("expected nested folder")
+    expect(nested.data.path).toBe("widgets/nested")
+
+    const request = requests(result.collection.items)[0]!
+    expect(request).toMatchObject({
+      id: "widgets/nested/post-create-widget",
+      url: "https://$host/widgets/:id",
+      bodyType: "json",
+      body: '{"name":"$name"}',
+      followRedirects: false,
+      auth: {
+        type: "api_key",
+        key: "X-Key",
+        value: "$key",
+        placement: "header",
+      },
+    })
+    expect(request.headers).toEqual({
+      "X-Token": { value: "$token", enabled: true },
+    })
+    expect(request.params).toEqual([
+      { name: "page", value: "2", enabled: true },
+      { name: "hidden", value: "x", enabled: false },
+    ])
+    expect(request.pathParams).toEqual([
+      { name: "id", value: "widget-1", enabled: true },
+    ])
+    expect(result.environments).toEqual([
+      {
+        name: "Development",
+        vars: {
+          token: "$secret",
+          host: "api.example.com",
+          config: '{"retries":2}',
+        },
+      },
+      {
+        name: "Base Environment",
+        vars: { token: "$secret", host: "base.example.com" },
+      },
+    ])
+  })
+
+  it("maps form and binary bodies plus compatible authentication", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "Bodies" },
+        {
+          _id: "basic",
+          _type: "request",
+          parentId: "wrk",
+          name: "Basic",
+          method: "PUT",
+          url: "https://x",
+          body: {
+            mimeType: "application/x-www-form-urlencoded",
+            params: [{ name: "q", value: "{{ q }}" }],
+          },
+          authentication: {
+            type: "basic",
+            username: "{{ user }}",
+            password: "pass",
+          },
+        },
+        {
+          _id: "file",
+          _type: "request",
+          parentId: "wrk",
+          name: "File",
+          method: "POST",
+          url: "https://x",
+          body: {
+            mimeType: "multipart/form-data",
+            params: [{ name: "upload", fileName: "{{ file }}", type: "file" }],
+          },
+          authentication: { type: "oauth2" },
+        },
+        {
+          _id: "binary",
+          _type: "request",
+          parentId: "wrk",
+          name: "Binary",
+          method: "POST",
+          url: "https://x",
+          body: { fileName: "./payload.bin" },
+        },
+      ]),
+    )
+    const [basic, file, binary] = requests(result.collection.items)
+    expect(basic).toMatchObject({
+      bodyType: "urlencoded",
+      formData: [{ name: "q", value: "$q", enabled: true, type: "text" }],
+      auth: { type: "basic", user: "$user", pass: "pass" },
+    })
+    expect(file).toMatchObject({
+      bodyType: "multipart",
+      formData: [
+        { name: "upload", value: "$file", enabled: true, type: "file" },
+      ],
+      auth: { type: "none" },
+    })
+    expect(binary).toMatchObject({
+      bodyType: "binary",
+      filePath: "./payload.bin",
+    })
+  })
+
+  it("uses safe unique names for environment files", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "Environments" },
+        {
+          _id: "one",
+          _type: "environment",
+          parentId: "wrk",
+          name: "../Development",
+          data: { one: "1" },
+        },
+        {
+          _id: "two",
+          _type: "environment",
+          parentId: "wrk",
+          name: "--Development",
+          data: { two: "2" },
+        },
+      ]),
+    )
+    expect(result.environments.map((environment) => environment.name)).toEqual([
+      "--Development",
+      "--Development-2",
+    ])
+  })
+
+  it("handles cyclic environment parents without recursing forever", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "Cycles" },
+        {
+          _id: "one",
+          _type: "environment",
+          parentId: "two",
+          name: "One",
+          data: { one: "1" },
+        },
+        {
+          _id: "two",
+          _type: "environment",
+          parentId: "one",
+          name: "Two",
+          data: { two: "2" },
+        },
+      ]),
+    )
+    expect(result.environments).toEqual([
+      { name: "One", vars: { two: "2", one: "1" } },
+      { name: "Two", vars: { one: "1", two: "2" } },
+    ])
+  })
+
+  it("rejects invalid exports and leaves no HTTP requests for the caller to reject", () => {
+    expect(() => insomniaImporter.import("{}")).toThrow(
+      "expected an Insomnia JSON v4 or v5 export",
+    )
+    expect(() => insomniaImporter.import(exportJson([]))).toThrow(
+      "expected exactly one workspace; export a single project instead",
+    )
+    expect(() =>
+      insomniaImporter.import(
+        exportJson([
+          { _id: "one", _type: "workspace", name: "One" },
+          { _id: "two", _type: "workspace", name: "Two" },
+        ]),
+      ),
+    ).toThrow("expected exactly one workspace; export a single project instead")
+    expect(
+      insomniaImporter.import(
+        exportJson([
+          { _id: "wrk", _type: "workspace", name: "Empty" },
+          { _id: "ws", _type: "web_socket_request", parentId: "wrk" },
+        ]),
+      ).collection.items,
+    ).toEqual([])
+  })
+})

--- a/tests/insomnia.test.ts
+++ b/tests/insomnia.test.ts
@@ -243,6 +243,43 @@ describe("insomniaImporter", () => {
     ])
   })
 
+  it("skips a cyclic folder edge while retaining reachable requests", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "Folders" },
+        {
+          _id: "root",
+          _type: "request_group",
+          parentId: "wrk",
+          name: "Root",
+        },
+        {
+          _id: "child",
+          _type: "request_group",
+          parentId: "root",
+          name: "Child",
+        },
+        {
+          _id: "root",
+          _type: "request_group",
+          parentId: "child",
+          name: "Cycle",
+        },
+        {
+          _id: "request",
+          _type: "request",
+          parentId: "child",
+          name: "Ping",
+          method: "GET",
+          url: "https://example.com/ping",
+        },
+      ]),
+    )
+    expect(
+      requests(result.collection.items).map((request) => request.name),
+    ).toEqual(["Ping"])
+  })
+
   it("rejects invalid exports and leaves no HTTP requests for the caller to reject", () => {
     expect(() => insomniaImporter.import("{}")).toThrow(
       "expected an Insomnia JSON v4 or v5 export",

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -184,6 +184,71 @@ describe("import — integration", () => {
     ).toContain("base_url=https://api.example.com/")
   })
 
+  it("auto-detects an Insomnia export and writes nested requests and environments", async () => {
+    const outDir = tempDir()
+    const specDir = tempDir()
+    const specPath = join(specDir, "insomnia.json")
+    await writeFile(
+      specPath,
+      JSON.stringify({
+        _type: "export",
+        __export_format: 4,
+        resources: [
+          {
+            _id: "req_ping",
+            _type: "request",
+            parentId: "folder_health",
+            name: "Ping",
+            method: "GET",
+            url: "https://{{ host }}/ping",
+            headers: [],
+            parameters: [],
+            body: {},
+            authentication: { type: "bearer", token: "{{ token }}" },
+          },
+          {
+            _id: "folder_health",
+            _type: "request_group",
+            parentId: "workspace",
+            name: "Health",
+          },
+          {
+            _id: "environment",
+            _type: "environment",
+            parentId: "workspace",
+            name: "Development",
+            data: { host: "api.example.com", token: "secret" },
+          },
+          {
+            _id: "workspace",
+            _type: "workspace",
+            parentId: null,
+            name: "Insomnia API",
+          },
+        ],
+      }),
+    )
+
+    const { runImport } = await import("../../src/app/import")
+    await runImport({ source: specPath, outputDir: outDir })
+
+    expect(
+      existsSync(join(outDir, "insomnia-api", "health", "folder.yml")),
+    ).toBe(true)
+    expect(
+      readFileSync(
+        join(outDir, "insomnia-api", "health", "get-ping.yml"),
+        "utf-8",
+      ),
+    ).toContain("url: https://$host/ping")
+    expect(
+      readFileSync(
+        join(outDir, "insomnia-api", ".environments", "Development.env"),
+        "utf-8",
+      ),
+    ).toContain("token=secret")
+  })
+
   it("preserves large JSON integers in imported Postman request bodies", async () => {
     const outDir = tempDir()
     const specDir = tempDir()

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -217,7 +217,11 @@ describe("import — integration", () => {
             _type: "environment",
             parentId: "workspace",
             name: "Development",
-            data: { host: "api.example.com", token: "secret" },
+            data: {
+              host: "api.example.com",
+              token: "secret",
+              note: "first\r\nsecond\nthird\rfourth",
+            },
           },
           {
             _id: "workspace",
@@ -247,6 +251,12 @@ describe("import — integration", () => {
         "utf-8",
       ),
     ).toContain("token=secret")
+    const { env } = await import("../../src/env")
+    const environment = await env.loadEnvironment(
+      join(outDir, "insomnia-api", ".environments"),
+      "Development",
+    )
+    expect(environment.vars.note).toBe("first\\nsecond\\nthird\\nfourth")
   })
 
   it("preserves large JSON integers in imported Postman request bodies", async () => {

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -239,12 +239,12 @@ describe("import — integration", () => {
     expect(
       existsSync(join(outDir, "insomnia-api", "health", "folder.yml")),
     ).toBe(true)
-    expect(
-      readFileSync(
-        join(outDir, "insomnia-api", "health", "get-ping.yml"),
-        "utf-8",
-      ),
-    ).toContain("url: https://$host/ping")
+    const pingYml = readFileSync(
+      join(outDir, "insomnia-api", "health", "get-ping.yml"),
+      "utf-8",
+    )
+    expect(pingYml).toContain("url: https://$host/ping")
+    expect(pingYml).toContain("auth:\n  type: bearer\n  token: $token")
     expect(
       readFileSync(
         join(outDir, "insomnia-api", ".environments", "Development.env"),


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for importing Insomnia exports (JSON v4 and v5) into noodle collections via `noodle import`. New `src/converters/insomnia/` module with auto-detection, request/folder/body/auth mapping, and environment conversion (including inherited `{{ var }}` → `$var` template substitution).

### How did you verify your code works?

- Ran `bun test tests/insomnia.test.ts tests/converters/insomnia-detect.test.ts tests/integration/import.test.ts` — 14 pass.
- Imported an Insomnia export end-to-end into a temp collection directory.

### Screenshots / recordings

N/A — CLI import.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing Insomnia v4 and v5 exports.
  * Converts requests, folders, variables, headers, parameters, authentication, request bodies, redirects, and environments.
  * Added automatic detection of valid Insomnia export files.
  * Added `insomnia` as a selectable format for the import command.

* **Bug Fixes**
  * Invalid or unsupported Insomnia exports now produce clear validation errors.

* **Tests**
  * Added coverage for Insomnia detection, conversion, environment handling, and CLI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->