### PR TITLE
feat(export): export collections as OpenAPI 3.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Noodle detects the supported format automatically. Use `--format openapi`,
 `--format swagger`, `--format postman`, or `--format insomnia` when you need to choose explicitly. Imported valid JSON
 request bodies are pretty-printed automatically.
 
+## Export a collection
+
+Export a collection as an OpenAPI 3.0.3 request catalog:
+
+```bash
+noodle export ./collections --format openapi --output ./specs/openapi.yml
+```
+
+The export includes requests, enabled parameters and headers, request-body
+examples, folders as tags, and supported authentication schemes. Environment
+values and response timeline data are never exported. The output file must be
+outside the collection directory.
+
 ## Automation CLI
 
 `noodle` without a subcommand opens the interactive TUI. The commands below
@@ -138,6 +151,7 @@ are non-interactive and support `--json`, which emits one
 | `noodle collection format <path>`                                      | Canonicalize request YAML and pretty-print JSON bodies.  |
 | `noodle collection audit <path>`                                       | Validate collection files.                               |
 | `noodle collection run <path>`                                         | Run every request in a collection.                       |
+| `noodle export <path> --format openapi --output <file>`                | Export a collection as an OpenAPI request catalog.       |
 | `noodle request create <id> --url <url> --collection <dir>`            | Create a minimal request.                                |
 | `noodle request run <id> --collection <dir>`                           | Run one request.                                         |
 | `noodle environment set <key> <value> --env <name> --collection <dir>` | Set an environment value.                                |

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -2,6 +2,7 @@
 import { defineCommand, createMain } from "citty"
 import pkg from "../../package.json" with { type: "json" }
 import defaultCommand from "./commands/default"
+import exportCommand from "./commands/export"
 import importCommand from "./commands/import"
 import updateCommand from "./commands/update"
 import { getUserArgsStart } from "./argv"
@@ -20,6 +21,7 @@ if (rawArgs.length === 1 && ["-v", "--version"].includes(rawArgs[0])) {
 
 const KNOWN_SUBCOMMANDS = new Set([
   "import",
+  "export",
   "update",
   "workspace",
   "collection",
@@ -64,6 +66,7 @@ const main = defineCommand({
   subCommands: {
     noodle: defaultCommand,
     import: importCommand,
+    export: exportCommand,
     update: updateCommand,
     workspace,
     collection,

--- a/src/app/commands/export.ts
+++ b/src/app/commands/export.ts
@@ -1,0 +1,47 @@
+import { defineCommand } from "citty"
+import { emitCommand } from "../commandResult"
+import { formatExport } from "../humanOutput"
+
+export default defineCommand({
+  meta: {
+    name: "export",
+    description: "Export a Noodle collection to an API specification",
+  },
+  args: {
+    collection: {
+      type: "positional",
+      required: true,
+      description: "Collection directory",
+    },
+    format: {
+      type: "string",
+      required: true,
+      description: 'Export format ("openapi")',
+    },
+    output: {
+      type: "string",
+      alias: "o",
+      required: true,
+      description: "Output specification file",
+    },
+    json: {
+      type: "boolean",
+      default: false,
+      description: "Write one JSON result envelope to stdout",
+    },
+  },
+  async run({ args }) {
+    const { runExport } = await import("../export")
+    await emitCommand(
+      args.json,
+      async () => ({
+        data: await runExport({
+          collection: args.collection,
+          format: args.format,
+          output: args.output,
+        }),
+      }),
+      formatExport,
+    )
+  },
+})

--- a/src/app/export.ts
+++ b/src/app/export.ts
@@ -1,0 +1,113 @@
+import { mkdir, realpath, writeFile } from "node:fs/promises"
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path"
+import yaml from "js-yaml"
+import { exportOpenApi } from "../converters/openapi"
+import { filestore } from "../filestore"
+import { isRawJsonNumber } from "../lang/formatJson"
+
+export interface ExportOptions {
+  collection: string
+  format: string
+  output: string
+}
+
+export interface ExportResult {
+  path: string
+  name: string
+  format: string
+  operationCount: number
+}
+
+const RAW_JSON_INT_RE = /^-?(?:0|[1-9]\d*)$/
+
+const rawJsonIntType = new yaml.Type("tag:yaml.org,2002:int", {
+  kind: "scalar",
+  resolve: () => false,
+  predicate: (value: object) =>
+    isRawJsonNumber(value) && RAW_JSON_INT_RE.test(value.rawJSON),
+  represent: (value: object) => (value as { rawJSON: string }).rawJSON,
+})
+
+const rawJsonFloatType = new yaml.Type("tag:yaml.org,2002:float", {
+  kind: "scalar",
+  resolve: () => false,
+  predicate: (value: object) =>
+    isRawJsonNumber(value) && !RAW_JSON_INT_RE.test(value.rawJSON),
+  represent: (value: object) => (value as { rawJSON: string }).rawJSON,
+})
+
+const openApiYamlSchema = yaml.DEFAULT_SCHEMA.extend({
+  implicit: [rawJsonIntType, rawJsonFloatType],
+})
+
+async function resolvedOutputPath(path: string): Promise<string> {
+  const suffix: string[] = []
+  let current = path
+  while (true) {
+    try {
+      return join(await realpath(current), ...suffix.reverse())
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      const parent = dirname(current)
+      if (parent === current) throw error
+      suffix.push(basename(current))
+      current = parent
+    }
+  }
+}
+
+function isWithin(root: string, path: string): boolean {
+  const pathRelative = relative(root, path)
+  return (
+    pathRelative === "" ||
+    (!pathRelative.startsWith(`..${sep}`) &&
+      pathRelative !== ".." &&
+      !isAbsolute(pathRelative))
+  )
+}
+
+export async function runExport(options: ExportOptions): Promise<ExportResult> {
+  if (options.format !== "openapi") {
+    throw new Error(
+      `unknown export format "${options.format}". Supported: openapi`,
+    )
+  }
+
+  const collectionPath = resolve(options.collection)
+  const outputPath = resolve(options.output)
+  const collection = await filestore.loadCollection(collectionPath, {
+    readOnly: true,
+  })
+  const collectionRoot = await realpath(collectionPath)
+  if (isWithin(collectionRoot, await resolvedOutputPath(outputPath))) {
+    throw new Error("export output must be outside the collection directory")
+  }
+  const exported = exportOpenApi(collection)
+
+  try {
+    await mkdir(dirname(outputPath), { recursive: true })
+    await writeFile(
+      outputPath,
+      yaml.dump(exported.document, { noRefs: true, schema: openApiYamlSchema }),
+      "utf8",
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`failed to write export: ${message}`, { cause: error })
+  }
+
+  return {
+    path: outputPath,
+    name: collection.name,
+    format: options.format,
+    operationCount: exported.operationCount,
+  }
+}

--- a/src/app/export.ts
+++ b/src/app/export.ts
@@ -8,10 +8,9 @@ import {
   resolve,
   sep,
 } from "node:path"
-import yaml from "js-yaml"
 import { exportOpenApi } from "../converters/openapi"
 import { filestore } from "../filestore"
-import { isRawJsonNumber } from "../lang/formatJson"
+import { serializeOpenApiYaml } from "../lang/openApiYaml"
 
 export interface ExportOptions {
   collection: string
@@ -26,28 +25,6 @@ export interface ExportResult {
   operationCount: number
 }
 
-const RAW_JSON_INT_RE = /^-?(?:0|[1-9]\d*)$/
-
-const rawJsonIntType = new yaml.Type("tag:yaml.org,2002:int", {
-  kind: "scalar",
-  resolve: () => false,
-  predicate: (value: object) =>
-    isRawJsonNumber(value) && RAW_JSON_INT_RE.test(value.rawJSON),
-  represent: (value: object) => (value as { rawJSON: string }).rawJSON,
-})
-
-const rawJsonFloatType = new yaml.Type("tag:yaml.org,2002:float", {
-  kind: "scalar",
-  resolve: () => false,
-  predicate: (value: object) =>
-    isRawJsonNumber(value) && !RAW_JSON_INT_RE.test(value.rawJSON),
-  represent: (value: object) => (value as { rawJSON: string }).rawJSON,
-})
-
-const openApiYamlSchema = yaml.DEFAULT_SCHEMA.extend({
-  implicit: [rawJsonIntType, rawJsonFloatType],
-})
-
 async function resolvedOutputPath(path: string): Promise<string> {
   const suffix: string[] = []
   let current = path
@@ -55,9 +32,25 @@ async function resolvedOutputPath(path: string): Promise<string> {
     try {
       return join(await realpath(current), ...suffix.reverse())
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(
+          `failed to resolve export output path "${path}": ${message}`,
+          {
+            cause: error,
+          },
+        )
+      }
       const parent = dirname(current)
-      if (parent === current) throw error
+      if (parent === current) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(
+          `failed to resolve export output path "${path}": ${message}`,
+          {
+            cause: error,
+          },
+        )
+      }
       suffix.push(basename(current))
       current = parent
     }
@@ -94,11 +87,7 @@ export async function runExport(options: ExportOptions): Promise<ExportResult> {
 
   try {
     await mkdir(dirname(outputPath), { recursive: true })
-    await writeFile(
-      outputPath,
-      yaml.dump(exported.document, { noRefs: true, schema: openApiYamlSchema }),
-      "utf8",
-    )
+    await writeFile(outputPath, serializeOpenApiYaml(exported.document), "utf8")
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`failed to write export: ${message}`, { cause: error })

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -186,6 +186,19 @@ export function formatImport(data: {
   ].join("\n")
 }
 
+export function formatExport(data: {
+  path: string
+  name: string
+  format: string
+  operationCount: number
+}): string {
+  return [
+    `${color("✓", "green")} Exported ${data.name} as ${data.format}`,
+    `  ${data.path}`,
+    `  ${data.operationCount} operation${data.operationCount === 1 ? "" : "s"}`,
+  ].join("\n")
+}
+
 export interface RunProgressReporter {
   update(completed: number, total: number): void
   finish(): void

--- a/src/converters/openapi/export.ts
+++ b/src/converters/openapi/export.ts
@@ -1,0 +1,379 @@
+import type {
+  Auth,
+  Collection,
+  CollectionItem,
+  FormEntry,
+  ParamEntry,
+  Request,
+} from "../../schema"
+import { parseJsonPreservingNumbers } from "../../lang/formatJson"
+import { mergeFolderOverrides } from "../../requests/mergeFolderOverrides"
+import { withDefaultHttpsScheme } from "../../requests/url"
+
+type OpenApiObject = Record<string, unknown>
+
+interface CollectedRequest {
+  request: Request
+  tag?: string
+}
+
+interface RequestLocation {
+  path: string
+  query: ParamEntry[]
+  server?: OpenApiObject
+}
+
+export interface OpenApiExportResult {
+  document: OpenApiObject
+  operationCount: number
+}
+
+const SERVER_VAR_RE = /\$(\w+)/g
+const PATH_PARAM_RE = /:([\w-]+)(?=\/|\.|$)/g
+const BASE_VAR_URL_RE = /^(\$\w+)(\/[^?#]*)?(\?[^#]*)?(?:#.*)?$/
+const SCHEME_VAR_RE = /^(\$\w+):\/\//
+const PORT_VAR_RE = /:(\$\w+)(?=\/|[?#]|$)/g
+
+interface ParseableUrl {
+  value: string
+  restore(value: string): string
+}
+
+function collectRequests(
+  items: CollectionItem[],
+  tag?: string,
+): CollectedRequest[] {
+  return items.flatMap((item) =>
+    item.type === "request"
+      ? [{ request: item.data, tag }]
+      : collectRequests(item.data.children, item.data.name),
+  )
+}
+
+function serverFor(url: string): OpenApiObject {
+  const names = new Set<string>()
+  const template = url.replace(SERVER_VAR_RE, (_, name: string) => {
+    names.add(name)
+    return `{${name}}`
+  })
+  if (names.size === 0) return { url: template }
+  return {
+    url: template,
+    variables: Object.fromEntries(
+      [...names].map((name) => [name, { default: "" }]),
+    ),
+  }
+}
+
+function queryEntries(search: string): ParamEntry[] {
+  const entries = new Map<string, ParamEntry>()
+  for (const [name, value] of new URLSearchParams(search)) {
+    if (name !== "") entries.set(name, { name, value, enabled: true })
+  }
+  return [...entries.values()]
+}
+
+function makeParseableUrl(url: string, relative = false): ParseableUrl {
+  let value = url
+  let schemeVariable: string | undefined
+  if (!relative) {
+    value = value.replace(SCHEME_VAR_RE, (_, variable: string) => {
+      schemeVariable = variable
+      return "https://"
+    })
+    if (!schemeVariable) value = withDefaultHttpsScheme(value)
+  }
+
+  const replacements = new Map<string, string>()
+  let markerIndex = 0
+  const textMarker = (variable: string): string => {
+    let marker: string
+    do {
+      marker = `noodleexportvar${markerIndex++}`
+    } while (url.includes(marker))
+    replacements.set(marker, variable)
+    return marker
+  }
+  const portMarker = (variable: string): string => {
+    let marker: string
+    do {
+      marker = String(10000 + markerIndex++)
+    } while (url.includes(marker))
+    replacements.set(marker, variable)
+    return marker
+  }
+
+  value = value.replace(
+    PORT_VAR_RE,
+    (_, variable: string) => `:${portMarker(variable)}`,
+  )
+  value = value.replace(SERVER_VAR_RE, (_, variable: string) =>
+    textMarker(`$${variable}`),
+  )
+
+  return {
+    value,
+    restore(parsed: string): string {
+      let restored = parsed
+      for (const [marker, variable] of replacements) {
+        restored = restored.replaceAll(marker, variable)
+      }
+      return schemeVariable
+        ? restored.replace(/^https:/, `${schemeVariable}:`)
+        : restored
+    },
+  }
+}
+
+function requestLocation(request: Request): RequestLocation {
+  const dynamicBase = request.url.match(BASE_VAR_URL_RE)
+  if (dynamicBase) {
+    return {
+      path: dynamicBase[2] || "/",
+      query: queryEntries(dynamicBase[3] || ""),
+      server: serverFor(dynamicBase[1]),
+    }
+  }
+
+  if (request.url.startsWith("/")) {
+    const template = makeParseableUrl(request.url, true)
+    const parsed = new URL(template.value, "https://noodle.invalid")
+    return {
+      path: template.restore(parsed.pathname) || "/",
+      query: queryEntries(template.restore(parsed.search)),
+    }
+  }
+
+  let parsed: URL
+  let template: ParseableUrl
+  try {
+    template = makeParseableUrl(request.url)
+    parsed = new URL(template.value)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `converters.openapi.export: invalid URL for request "${request.id}": ${message}`,
+      { cause: error },
+    )
+  }
+  return {
+    path: template.restore(parsed.pathname) || "/",
+    query: queryEntries(template.restore(parsed.search)),
+    server: serverFor(template.restore(parsed.origin)),
+  }
+}
+
+function parameter(
+  name: string,
+  location: "path" | "query" | "header",
+  value: string,
+): OpenApiObject {
+  const result: OpenApiObject = {
+    name,
+    in: location,
+    required: location === "path",
+    schema: { type: "string" },
+  }
+  if (value !== "") result.example = value
+  return result
+}
+
+function parametersFor(
+  request: Request,
+  location: RequestLocation,
+): OpenApiObject[] {
+  const query = new Map(location.query.map((entry) => [entry.name, entry]))
+  for (const entry of request.params) {
+    if (entry.enabled) query.set(entry.name, entry)
+  }
+
+  const pathValues = new Map(
+    (request.pathParams ?? []).map((entry) => [entry.name, entry.value]),
+  )
+  PATH_PARAM_RE.lastIndex = 0
+  const pathNames = Array.from(
+    new Set(
+      Array.from(location.path.matchAll(PATH_PARAM_RE), (match) => match[1]!),
+    ),
+  )
+
+  const result = pathNames.map((name) =>
+    parameter(name, "path", pathValues.get(name) ?? ""),
+  )
+  result.push(
+    ...[...query.values()].map((entry) =>
+      parameter(entry.name, "query", entry.value),
+    ),
+  )
+  for (const [name, entry] of Object.entries(request.headers)) {
+    if (entry.enabled && name.toLowerCase() !== "content-type") {
+      result.push(parameter(name, "header", entry.value))
+    }
+  }
+  return result
+}
+
+function formSchema(entries: FormEntry[], multipart: boolean): OpenApiObject {
+  const properties: Record<string, OpenApiObject> = {}
+  for (const entry of entries) {
+    if (!entry.enabled) continue
+    if (multipart && entry.type === "file") {
+      properties[entry.name] = { type: "string", format: "binary" }
+    } else {
+      const property: OpenApiObject = { type: "string" }
+      if (entry.value !== "") property.example = entry.value
+      properties[entry.name] = property
+    }
+  }
+  return { type: "object", properties }
+}
+
+function requestBodyFor(request: Request): OpenApiObject | undefined {
+  const type =
+    request.bodyType ?? (request.body === undefined ? "none" : "json")
+  if (type === "none") return undefined
+
+  if (type === "json") {
+    if (request.body === undefined) return undefined
+    let example: unknown
+    try {
+      example = parseJsonPreservingNumbers(request.body)
+    } catch (error) {
+      throw new Error(
+        `converters.openapi.export: invalid JSON body for request "${request.id}"`,
+        { cause: error },
+      )
+    }
+    return { content: { "application/json": { example } } }
+  }
+
+  if (type === "urlencoded") {
+    return {
+      content: {
+        "application/x-www-form-urlencoded": {
+          schema: formSchema(request.formData ?? [], false),
+        },
+      },
+    }
+  }
+
+  if (type === "multipart") {
+    return {
+      content: {
+        "multipart/form-data": {
+          schema: formSchema(request.formData ?? [], true),
+        },
+      },
+    }
+  }
+
+  return {
+    content: {
+      "application/octet-stream": {
+        schema: { type: "string", format: "binary" },
+      },
+    },
+  }
+}
+
+function securityFor(
+  auth: Auth | undefined,
+  schemes: Record<string, OpenApiObject>,
+): OpenApiObject | undefined {
+  if (!auth || auth.type === "none" || auth.type === "inherit") return undefined
+
+  let name: string
+  if (auth.type === "bearer") {
+    name = "bearerAuth"
+    schemes[name] ??= { type: "http", scheme: "bearer" }
+  } else if (auth.type === "basic") {
+    name = "basicAuth"
+    schemes[name] ??= { type: "http", scheme: "basic" }
+  } else {
+    const suffix = auth.key
+      .replace(/[^a-zA-Z0-9]+/g, " ")
+      .trim()
+      .replace(/\s+(.)/g, (_, char: string) => char.toUpperCase())
+    const baseName = `apiKey${auth.placement === "query" ? "Query" : "Header"}${suffix || "Auth"}`
+    name = baseName
+    let index = 2
+    while (true) {
+      const existing = schemes[name]
+      if (!existing) {
+        schemes[name] = {
+          type: "apiKey",
+          name: auth.key,
+          in: auth.placement,
+        }
+        break
+      }
+      if (existing.name === auth.key && existing.in === auth.placement) break
+      name = `${baseName}${index++}`
+    }
+  }
+  return { security: [{ [name]: [] }] }
+}
+
+function serverKey(server: OpenApiObject | undefined): string | undefined {
+  return server === undefined ? undefined : JSON.stringify(server)
+}
+
+export function exportOpenApi(collection: Collection): OpenApiExportResult {
+  const paths: Record<string, OpenApiObject> = {}
+  const schemes: Record<string, OpenApiObject> = {}
+  const operations: { operation: OpenApiObject; server?: OpenApiObject }[] = []
+  const seenOperations = new Map<string, string>()
+
+  for (const { request, tag } of collectRequests(collection.items)) {
+    const effective = mergeFolderOverrides(request, collection, request.id)
+    const location = requestLocation(effective)
+    const path = location.path.replace(PATH_PARAM_RE, "{$1}")
+    const method = effective.method.toLowerCase()
+    const operationKey = `${method} ${path}`
+    const priorId = seenOperations.get(operationKey)
+    if (priorId) {
+      throw new Error(
+        `converters.openapi.export: duplicate operation "${operationKey}" for requests "${priorId}" and "${effective.id}"`,
+      )
+    }
+    seenOperations.set(operationKey, effective.id)
+
+    const operation: OpenApiObject = {
+      operationId: effective.id,
+      summary: effective.name,
+      responses: { default: { description: "Response" } },
+    }
+    if (tag) operation.tags = [tag]
+    const parameters = parametersFor(effective, location)
+    if (parameters.length > 0) operation.parameters = parameters
+    const requestBody = requestBodyFor(effective)
+    if (requestBody) operation.requestBody = requestBody
+    const security = securityFor(effective.auth, schemes)
+    if (security) Object.assign(operation, security)
+
+    const pathItem = (paths[path] ??= {})
+    pathItem[method] = operation
+    operations.push({ operation, server: location.server })
+  }
+
+  const document: OpenApiObject = {
+    openapi: "3.0.3",
+    info: { title: collection.name, version: "1.0.0" },
+    paths,
+  }
+  if (Object.keys(schemes).length > 0) {
+    document.components = { securitySchemes: schemes }
+  }
+
+  const keys = new Set(operations.map(({ server }) => serverKey(server)))
+  if (keys.size === 1) {
+    const server = operations[0]?.server
+    if (server) document.servers = [server]
+  } else {
+    for (const { operation, server } of operations) {
+      if (server) operation.servers = [server]
+    }
+  }
+
+  return { document, operationCount: operations.length }
+}

--- a/src/converters/openapi/export.ts
+++ b/src/converters/openapi/export.ts
@@ -66,11 +66,9 @@ function serverFor(url: string): OpenApiObject {
 }
 
 function queryEntries(search: string): ParamEntry[] {
-  const entries = new Map<string, ParamEntry>()
-  for (const [name, value] of new URLSearchParams(search)) {
-    if (name !== "") entries.set(name, { name, value, enabled: true })
-  }
-  return [...entries.values()]
+  return [...new URLSearchParams(search)]
+    .filter(([name]) => name !== "")
+    .map(([name, value]) => ({ name, value, enabled: true }))
 }
 
 function makeParseableUrl(url: string, relative = false): ParseableUrl {
@@ -166,15 +164,24 @@ function requestLocation(request: Request): RequestLocation {
 function parameter(
   name: string,
   location: "path" | "query" | "header",
-  value: string,
+  value: string | string[],
 ): OpenApiObject {
+  const repeated = Array.isArray(value)
   const result: OpenApiObject = {
     name,
     in: location,
     required: location === "path",
-    schema: { type: "string" },
+    schema: repeated
+      ? { type: "array", items: { type: "string" } }
+      : { type: "string" },
   }
-  if (value !== "") result.example = value
+  if (repeated) {
+    result.style = "form"
+    result.explode = true
+    result.example = value
+  } else if (value !== "") {
+    result.example = value
+  }
   return result
 }
 
@@ -182,9 +189,20 @@ function parametersFor(
   request: Request,
   location: RequestLocation,
 ): OpenApiObject[] {
-  const query = new Map(location.query.map((entry) => [entry.name, entry]))
-  for (const entry of request.params) {
-    if (entry.enabled) query.set(entry.name, entry)
+  const requestParams = request.params.filter((entry) => entry.enabled)
+  const requestParamNames = new Set(requestParams.map((entry) => entry.name))
+  const query = [
+    ...location.query.filter((entry) => !requestParamNames.has(entry.name)),
+    ...requestParams,
+  ]
+  const queryValues = new Map<string, string[]>()
+  for (const entry of query) {
+    const values = queryValues.get(entry.name)
+    if (values) {
+      values.push(entry.value)
+    } else {
+      queryValues.set(entry.name, [entry.value])
+    }
   }
 
   const pathValues = new Map(
@@ -201,12 +219,15 @@ function parametersFor(
     parameter(name, "path", pathValues.get(name) ?? ""),
   )
   result.push(
-    ...[...query.values()].map((entry) =>
-      parameter(entry.name, "query", entry.value),
+    ...[...queryValues].map(([name, values]) =>
+      parameter(name, "query", values.length === 1 ? values[0]! : values),
     ),
   )
   for (const [name, entry] of Object.entries(request.headers)) {
-    if (entry.enabled && name.toLowerCase() !== "content-type") {
+    if (
+      entry.enabled &&
+      !["content-type", "accept", "authorization"].includes(name.toLowerCase())
+    ) {
       result.push(parameter(name, "header", entry.value))
     }
   }

--- a/src/converters/openapi/index.ts
+++ b/src/converters/openapi/index.ts
@@ -11,6 +11,7 @@ export const openApiImporter = {
 }
 
 export { parseSpec } from "./parse"
+export { exportOpenApi, type OpenApiExportResult } from "./export"
 export {
   mapCollection,
   convertTpl,

--- a/src/filestore/index.ts
+++ b/src/filestore/index.ts
@@ -1,5 +1,10 @@
 import type { Collection, CollectionSettings, Request } from "../schema"
-import { loadCollection, loadCollectionBrowse, loadSettings } from "./load"
+import {
+  loadCollection,
+  loadCollectionBrowse,
+  loadSettings,
+  type LoadOptions,
+} from "./load"
 import {
   saveRequest,
   saveSettings,
@@ -40,7 +45,7 @@ export {
 export type { CollectionSettings }
 
 export interface Filestore {
-  loadCollection(dir: string): Promise<Collection>
+  loadCollection(dir: string, options?: LoadOptions): Promise<Collection>
   saveRequest(dir: string, req: Request): Promise<void>
 }
 

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -252,7 +252,10 @@ async function walk(
   return [...folders.map((f) => f.item), ...requests.map((r) => r.item)]
 }
 
-export async function loadCollection(dir: string): Promise<Collection> {
+export async function loadCollection(
+  dir: string,
+  options: LoadOptions = {},
+): Promise<Collection> {
   try {
     await readdir(dir, { withFileTypes: true })
   } catch (e) {
@@ -271,7 +274,7 @@ export async function loadCollection(dir: string): Promise<Collection> {
   const id = basename(dir)
   const root = await realpath(dir)
   const fileErrors: CollectionFileError[] = []
-  const items = await walk(dir, "", new Set(), root, {}, fileErrors)
+  const items = await walk(dir, "", new Set(), root, options, fileErrors)
 
   if (fileErrors.length > 0) {
     const first = fileErrors[0]

--- a/src/lang/formatJson.ts
+++ b/src/lang/formatJson.ts
@@ -6,19 +6,33 @@ type JsonWithRawValues = typeof JSON & {
 
 const json = JSON as JsonWithRawValues
 
+export interface RawJsonNumber {
+  rawJSON: string
+}
+
 const preserveNumberSource = (
   _key: string,
   value: unknown,
   context: { source: string },
 ): unknown => (typeof value === "number" ? json.rawJSON(context.source) : value)
 
+export function parseJsonPreservingNumbers(value: string): unknown {
+  return JSON.parse(value, preserveNumberSource as JsonReviver)
+}
+
+export function isRawJsonNumber(value: unknown): value is RawJsonNumber {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.getPrototypeOf(value) === null &&
+    Object.keys(value).length === 1 &&
+    typeof (value as RawJsonNumber).rawJSON === "string"
+  )
+}
+
 export function formatJson(value: string): string {
   try {
-    return JSON.stringify(
-      JSON.parse(value, preserveNumberSource as JsonReviver),
-      null,
-      2,
-    )
+    return JSON.stringify(parseJsonPreservingNumbers(value), null, 2)
   } catch {
     return value
   }

--- a/src/lang/openApiYaml.ts
+++ b/src/lang/openApiYaml.ts
@@ -1,0 +1,28 @@
+import yaml from "js-yaml"
+import { isRawJsonNumber } from "./formatJson"
+
+const RAW_JSON_INT_RE = /^-?(?:0|[1-9]\d*)$/
+
+const rawJsonIntType = new yaml.Type("tag:yaml.org,2002:int", {
+  kind: "scalar",
+  resolve: () => false,
+  predicate: (value: object) =>
+    isRawJsonNumber(value) && RAW_JSON_INT_RE.test(value.rawJSON),
+  represent: (value: object) => (value as { rawJSON: string }).rawJSON,
+})
+
+const rawJsonFloatType = new yaml.Type("tag:yaml.org,2002:float", {
+  kind: "scalar",
+  resolve: () => false,
+  predicate: (value: object) =>
+    isRawJsonNumber(value) && !RAW_JSON_INT_RE.test(value.rawJSON),
+  represent: (value: object) => (value as { rawJSON: string }).rawJSON,
+})
+
+const openApiYamlSchema = yaml.DEFAULT_SCHEMA.extend({
+  implicit: [rawJsonIntType, rawJsonFloatType],
+})
+
+export function serializeOpenApiYaml(document: object): string {
+  return yaml.dump(document, { noRefs: true, schema: openApiYamlSchema })
+}

--- a/src/lang/openApiYaml.ts
+++ b/src/lang/openApiYaml.ts
@@ -3,7 +3,7 @@ import { isRawJsonNumber } from "./formatJson"
 
 const RAW_JSON_INT_RE = /^-?(?:0|[1-9]\d*)$/
 
-const rawJsonIntType = new yaml.Type("tag:yaml.org,2002:int", {
+const rawJsonIntType = new yaml.Type("tag:noodle.dev,2026:raw-json-int", {
   kind: "scalar",
   resolve: () => false,
   predicate: (value: object) =>
@@ -11,7 +11,7 @@ const rawJsonIntType = new yaml.Type("tag:yaml.org,2002:int", {
   represent: (value: object) => (value as { rawJSON: string }).rawJSON,
 })
 
-const rawJsonFloatType = new yaml.Type("tag:yaml.org,2002:float", {
+const rawJsonFloatType = new yaml.Type("tag:noodle.dev,2026:raw-json-float", {
   kind: "scalar",
   resolve: () => false,
   predicate: (value: object) =>

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import type { CommandMeta, ArgsDef, StringArgDef } from "citty"
 import defaultCommand from "../src/app/commands/default"
+import exportCommand from "../src/app/commands/export"
 import importCommand from "../src/app/commands/import"
 import updateCommand from "../src/app/commands/update"
 import { classifyPath, resolveStartupCollectionDir } from "../src/app/main"
@@ -14,6 +15,8 @@ const defaultMeta = defaultCommand.meta as CommandMeta | undefined
 const defaultArgs = defaultCommand.args as ArgsDef | undefined
 const importMeta = importCommand.meta as CommandMeta | undefined
 const importArgs = importCommand.args as ArgsDef | undefined
+const exportMeta = exportCommand.meta as CommandMeta | undefined
+const exportArgs = exportCommand.args as ArgsDef | undefined
 const updateMeta = updateCommand.meta as CommandMeta | undefined
 
 describe("default command (noodle)", () => {
@@ -102,6 +105,19 @@ describe("import command", () => {
   })
 })
 
+describe("export command", () => {
+  it("has the required collection, format, and output arguments", () => {
+    expect(exportMeta?.name).toBe("export")
+    expect(exportArgs?.collection).toMatchObject({
+      type: "positional",
+      required: true,
+    })
+    expect(exportArgs?.format).toMatchObject({ type: "string", required: true })
+    expect(exportArgs?.output).toMatchObject({ type: "string", required: true })
+    expect((exportArgs?.output as StringArgDef)?.alias).toBe("o")
+  })
+})
+
 describe("CLI integration", () => {
   it("finds user args after source and compiled Bun entrypoints", () => {
     expect(getUserArgsStart(["bun", "src/app/cli.ts", "--help"])).toBe(2)
@@ -136,6 +152,7 @@ describe("CLI integration", () => {
     const out = proc.stdout.toString()
     expect(out).toContain("noodle")
     expect(out).toContain("import")
+    expect(out).toContain("export")
     expect(out).toContain("update")
   })
 
@@ -156,6 +173,44 @@ describe("CLI integration", () => {
     expect(out).toContain("insomnia")
     expect(out).toContain("format")
     expect(out).toContain("output")
+  })
+
+  it("exports a collection and preserves the JSON result envelope", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-cli-export-"))
+    const dir = join(root, "collection")
+    const output = join(root, "out", "openapi.yml")
+    try {
+      await mkdir(dir)
+      await writeFile(
+        join(dir, "ping.yml"),
+        "name: Ping\nmethod: GET\nurl: https://example.com/ping\n",
+      )
+      const proc = Bun.spawnSync([
+        "bun",
+        CLI,
+        "export",
+        dir,
+        "--format",
+        "openapi",
+        "--output",
+        output,
+        "--json",
+      ])
+      expect(proc.exitCode).toBe(0)
+      expect(JSON.parse(proc.stdout.toString())).toEqual({
+        status: "success",
+        data: {
+          path: output,
+          name: basename(dir),
+          format: "openapi",
+          operationCount: 1,
+        },
+        errors: [],
+      })
+      expect(await readFile(output, "utf8")).toContain("openapi: 3.0.3")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it("shows help for update subcommand with update --help", () => {

--- a/tests/converters/openapi-export.test.ts
+++ b/tests/converters/openapi-export.test.ts
@@ -1,0 +1,443 @@
+import { describe, expect, it } from "bun:test"
+import { exportOpenApi } from "../../src/converters/openapi"
+import type { Collection, Request } from "../../src/schema"
+
+type Operation = { requestBody?: unknown; servers?: unknown }
+
+function request(overrides: Partial<Request> = {}): Request {
+  return {
+    id: "request",
+    name: "Request",
+    method: "GET",
+    url: "https://api.example.com/request",
+    timeout: 0,
+    headers: {},
+    params: [],
+    auth: { type: "none" },
+    bodyType: "none",
+    ...overrides,
+  }
+}
+
+function collection(items: Collection["items"]): Collection {
+  return { id: "example", name: "Example API", items }
+}
+
+describe("exportOpenApi", () => {
+  it("exports resolved folder settings, enabled parameters, tags, and a server variable", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "folder",
+          data: {
+            id: "users",
+            name: "Users",
+            path: "users",
+            overrides: {
+              headers: {
+                "X-Folder": { value: "$FOLDER", enabled: true },
+                "X-Disabled": { value: "hidden", enabled: false },
+              },
+              auth: { type: "bearer", token: "$TOKEN" },
+            },
+            children: [
+              {
+                type: "request",
+                data: request({
+                  id: "users/get-user",
+                  name: "Get user",
+                  url: "https://$host/v1/users/:id?source=inline",
+                  params: [
+                    { name: "source", value: "request", enabled: true },
+                    { name: "limit", value: "$LIMIT", enabled: true },
+                    { name: "skip", value: "no", enabled: false },
+                  ],
+                  pathParams: [
+                    { name: "id", value: "$USER_ID", enabled: true },
+                  ],
+                  headers: {
+                    "X-Request": { value: "request", enabled: true },
+                    "Content-Type": {
+                      value: "application/json",
+                      enabled: true,
+                    },
+                  },
+                  auth: { type: "inherit" },
+                }),
+              },
+            ],
+          },
+        },
+      ]),
+    )
+
+    expect(result.operationCount).toBe(1)
+    expect(result.document).toMatchObject({
+      openapi: "3.0.3",
+      info: { title: "Example API", version: "1.0.0" },
+      servers: [
+        {
+          url: "https://{host}",
+          variables: { host: { default: "" } },
+        },
+      ],
+      components: {
+        securitySchemes: {
+          bearerAuth: { type: "http", scheme: "bearer" },
+        },
+      },
+    })
+    expect(result.document.paths).toEqual({
+      "/v1/users/{id}": {
+        get: {
+          operationId: "users/get-user",
+          summary: "Get user",
+          tags: ["Users"],
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              example: "$USER_ID",
+            },
+            {
+              name: "source",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              example: "request",
+            },
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              example: "$LIMIT",
+            },
+            {
+              name: "X-Folder",
+              in: "header",
+              required: false,
+              schema: { type: "string" },
+              example: "$FOLDER",
+            },
+            {
+              name: "X-Request",
+              in: "header",
+              required: false,
+              schema: { type: "string" },
+              example: "request",
+            },
+          ],
+          security: [{ bearerAuth: [] }],
+          responses: { default: { description: "Response" } },
+        },
+      },
+    })
+    expect(JSON.stringify(result.document)).not.toContain("$TOKEN")
+  })
+
+  it("exports JSON, urlencoded, multipart, and binary request bodies", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            id: "json",
+            method: "POST",
+            url: "https://api.example.com/json",
+            bodyType: "json",
+            body: '{"id":"$ID"}',
+          }),
+        },
+        {
+          type: "request",
+          data: request({
+            id: "form",
+            method: "POST",
+            url: "https://api.example.com/form",
+            bodyType: "urlencoded",
+            formData: [
+              { name: "enabled", value: "$VALUE", enabled: true, type: "text" },
+              { name: "disabled", value: "no", enabled: false, type: "text" },
+            ],
+          }),
+        },
+        {
+          type: "request",
+          data: request({
+            id: "multipart",
+            method: "POST",
+            url: "https://api.example.com/multipart",
+            bodyType: "multipart",
+            formData: [
+              {
+                name: "file",
+                value: "/secret/file",
+                enabled: true,
+                type: "file",
+              },
+              { name: "title", value: "photo", enabled: true, type: "text" },
+            ],
+          }),
+        },
+        {
+          type: "request",
+          data: request({
+            id: "binary",
+            method: "PUT",
+            url: "https://api.example.com/binary",
+            bodyType: "binary",
+            filePath: "/secret/file",
+          }),
+        },
+      ]),
+    )
+
+    const paths = result.document.paths as Record<
+      string,
+      Record<string, Operation>
+    >
+    expect(paths["/json"].post.requestBody).toEqual({
+      content: { "application/json": { example: { id: "$ID" } } },
+    })
+    expect(paths["/form"].post.requestBody).toEqual({
+      content: {
+        "application/x-www-form-urlencoded": {
+          schema: {
+            type: "object",
+            properties: {
+              enabled: { type: "string", example: "$VALUE" },
+            },
+          },
+        },
+      },
+    })
+    expect(paths["/multipart"].post.requestBody).toEqual({
+      content: {
+        "multipart/form-data": {
+          schema: {
+            type: "object",
+            properties: {
+              file: { type: "string", format: "binary" },
+              title: { type: "string", example: "photo" },
+            },
+          },
+        },
+      },
+    })
+    expect(paths["/binary"].put.requestBody).toEqual({
+      content: {
+        "application/octet-stream": {
+          schema: { type: "string", format: "binary" },
+        },
+      },
+    })
+  })
+
+  it("uses operation servers for mixed origins and no server for relative URLs", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({ id: "one", url: "https://one.example/a" }),
+        },
+        {
+          type: "request",
+          data: request({ id: "two", url: "https://two.example/b" }),
+        },
+        { type: "request", data: request({ id: "local", url: "/health" }) },
+      ]),
+    )
+
+    expect(result.document.servers).toBeUndefined()
+    const paths = result.document.paths as Record<
+      string,
+      Record<string, Operation>
+    >
+    expect(paths["/a"].get.servers).toEqual([{ url: "https://one.example" }])
+    expect(paths["/b"].get.servers).toEqual([{ url: "https://two.example" }])
+    expect(paths["/health"].get.servers).toBeUndefined()
+  })
+
+  it("exports variables in URL schemes and ports", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            url: "$SCHEME://$HOST:$PORT/v1/$VERSION?region=$REGION",
+          }),
+        },
+      ]),
+    )
+
+    expect(result.document).toMatchObject({
+      servers: [
+        {
+          url: "{SCHEME}://{HOST}:{PORT}",
+          variables: {
+            SCHEME: { default: "" },
+            HOST: { default: "" },
+            PORT: { default: "" },
+          },
+        },
+      ],
+      paths: {
+        "/v1/$VERSION": {
+          get: {
+            parameters: [
+              {
+                name: "region",
+                in: "query",
+                required: false,
+                schema: { type: "string" },
+                example: "$REGION",
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  it("preserves exact JSON number literals", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            method: "POST",
+            bodyType: "json",
+            body: '{"integer":9007199254740993,"decimal":0.12345678901234567890}',
+          }),
+        },
+      ]),
+    )
+
+    expect(JSON.stringify(result.document)).toContain("9007199254740993")
+    expect(JSON.stringify(result.document)).toContain("0.12345678901234567890")
+  })
+
+  it("exports basic and API-key security without credentials", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            id: "basic",
+            url: "https://api.example/basic",
+            auth: { type: "basic", user: "user", pass: "super-secret" },
+          }),
+        },
+        {
+          type: "request",
+          data: request({
+            id: "key",
+            url: "https://api.example/key",
+            auth: {
+              type: "api_key",
+              key: "X-API-Key",
+              value: "super-secret",
+              placement: "header",
+            },
+          }),
+        },
+      ]),
+    )
+
+    expect(result.document.components).toEqual({
+      securitySchemes: {
+        basicAuth: { type: "http", scheme: "basic" },
+        apiKeyHeaderXAPIKey: {
+          type: "apiKey",
+          name: "X-API-Key",
+          in: "header",
+        },
+      },
+    })
+    expect(JSON.stringify(result.document)).not.toContain("super-secret")
+  })
+
+  it("does not merge API-key schemes whose sanitized names collide", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            id: "first",
+            url: "https://api.example/first",
+            auth: {
+              type: "api_key",
+              key: "X API Key",
+              value: "$FIRST",
+              placement: "header",
+            },
+          }),
+        },
+        {
+          type: "request",
+          data: request({
+            id: "second",
+            url: "https://api.example/second",
+            auth: {
+              type: "api_key",
+              key: "X-API-Key",
+              value: "$SECOND",
+              placement: "header",
+            },
+          }),
+        },
+      ]),
+    )
+
+    expect(result.document.components).toEqual({
+      securitySchemes: {
+        apiKeyHeaderXAPIKey: {
+          type: "apiKey",
+          name: "X API Key",
+          in: "header",
+        },
+        apiKeyHeaderXAPIKey2: {
+          type: "apiKey",
+          name: "X-API-Key",
+          in: "header",
+        },
+      },
+    })
+  })
+
+  it("exports an empty collection and rejects invalid JSON and duplicate operations", () => {
+    expect(exportOpenApi(collection([]))).toMatchObject({
+      operationCount: 0,
+      document: { paths: {} },
+    })
+    expect(() =>
+      exportOpenApi(
+        collection([
+          {
+            type: "request",
+            data: request({ bodyType: "json", body: "{not json}" }),
+          },
+        ]),
+      ),
+    ).toThrow(
+      'converters.openapi.export: invalid JSON body for request "request"',
+    )
+    expect(() =>
+      exportOpenApi(
+        collection([
+          {
+            type: "request",
+            data: request({ id: "one", url: "https://one.example/x" }),
+          },
+          {
+            type: "request",
+            data: request({ id: "two", url: "https://two.example/x" }),
+          },
+        ]),
+      ),
+    ).toThrow('converters.openapi.export: duplicate operation "get /x"')
+  })
+})

--- a/tests/converters/openapi-export.test.ts
+++ b/tests/converters/openapi-export.test.ts
@@ -302,6 +302,64 @@ describe("exportOpenApi", () => {
     })
   })
 
+  it("preserves repeated query values and filters protected headers", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            url: "https://api.example.com/search?source=stale&tag=url-one&tag=url-two",
+            params: [
+              { name: "source", value: "first", enabled: true },
+              { name: "source", value: "second", enabled: true },
+            ],
+            headers: {
+              Authorization: { value: "Bearer super-secret", enabled: true },
+              aCcEpT: { value: "application/json", enabled: true },
+              "Content-Type": { value: "application/json", enabled: true },
+              "X-Request": { value: "kept", enabled: true },
+            },
+          }),
+        },
+      ]),
+    )
+
+    const parameters = (
+      result.document.paths as Record<
+        string,
+        Record<string, { parameters: Record<string, unknown>[] }>
+      >
+    )["/search"].get.parameters
+    expect(parameters).toEqual([
+      {
+        name: "tag",
+        in: "query",
+        required: false,
+        style: "form",
+        explode: true,
+        schema: { type: "array", items: { type: "string" } },
+        example: ["url-one", "url-two"],
+      },
+      {
+        name: "source",
+        in: "query",
+        required: false,
+        style: "form",
+        explode: true,
+        schema: { type: "array", items: { type: "string" } },
+        example: ["first", "second"],
+      },
+      {
+        name: "X-Request",
+        in: "header",
+        required: false,
+        schema: { type: "string" },
+        example: "kept",
+      },
+    ])
+    expect(JSON.stringify(result.document)).not.toContain("super-secret")
+  })
+
   it("preserves exact JSON number literals", () => {
     const result = exportOpenApi(
       collection([

--- a/tests/formatRequest.test.ts
+++ b/tests/formatRequest.test.ts
@@ -109,11 +109,13 @@ describe("formatBody", () => {
   it("pretty-prints valid compact JSON (2-space indent)", () => {
     expect(formatBody('{"b":1,"a":2}')).toBe('{\n  "b": 1,\n  "a": 2\n}')
   })
-  it("preserves unsafe integer literals", () => {
+  it("preserves JSON numeric literal source", () => {
     expect(
-      formatBody('{"positive":9007199254740993,"negative":-9007199254740993}'),
+      formatBody(
+        '{"positive":9007199254740993,"negative":-9007199254740993,"decimal":1.50,"exponent":1e3}',
+      ),
     ).toBe(
-      '{\n  "positive": 9007199254740993,\n  "negative": -9007199254740993\n}',
+      '{\n  "positive": 9007199254740993,\n  "negative": -9007199254740993,\n  "decimal": 1.50,\n  "exponent": 1e3\n}',
     )
   })
   it("returns raw body when JSON.parse fails", () => {

--- a/tests/integration/export.test.ts
+++ b/tests/integration/export.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import yaml from "js-yaml"
+import { runExport } from "../../src/app/export"
+
+type OpenApiDocument = {
+  openapi: string
+  servers?: unknown
+  paths: Record<string, Record<string, { parameters?: unknown[] }>>
+}
+
+describe("export — integration", () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    for (const dir of tempDirs) {
+      await rm(dir, { recursive: true, force: true })
+    }
+    tempDirs.length = 0
+  })
+
+  async function tempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-export-test-"))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  it("writes an OpenAPI YAML file without mutating requests or exporting environment data", async () => {
+    const collection = await tempDir()
+    const output = join(await tempDir(), "nested", "openapi.yml")
+    const requestPath = join(collection, "health.yml")
+    const source = [
+      "name: Health",
+      "method: GET",
+      "url: https://$host/health",
+      "headers:",
+      "  X-Token: $TOKEN",
+      "",
+    ].join("\n")
+    await writeFile(requestPath, source, "utf8")
+    await mkdir(join(collection, ".environments"))
+    await writeFile(
+      join(collection, ".environments", "production.env"),
+      "host=api.example.com\nTOKEN=should-not-export\n",
+      "utf8",
+    )
+    await mkdir(join(collection, ".timeline"))
+    await writeFile(
+      join(collection, ".timeline", "health.yml"),
+      "timeline-secret\n",
+      "utf8",
+    )
+
+    const result = await runExport({
+      collection,
+      format: "openapi",
+      output,
+    })
+
+    expect(result).toEqual({
+      path: output,
+      name: basename(collection),
+      format: "openapi",
+      operationCount: 1,
+    })
+    expect(await readFile(requestPath, "utf8")).toBe(source)
+
+    const outputText = await readFile(output, "utf8")
+    const document = yaml.load(outputText) as OpenApiDocument
+    expect(document.openapi).toBe("3.0.3")
+    expect(document.servers).toEqual([
+      {
+        url: "https://{host}",
+        variables: { host: { default: "" } },
+      },
+    ])
+    expect(document.paths["/health"]?.get.parameters).toContainEqual({
+      name: "X-Token",
+      in: "header",
+      required: false,
+      schema: { type: "string" },
+      example: "$TOKEN",
+    })
+    expect(outputText).not.toContain("api.example.com")
+    expect(outputText).not.toContain("should-not-export")
+    expect(outputText).not.toContain("timeline-secret")
+  })
+
+  it("rejects unsupported output formats", async () => {
+    const collection = await tempDir()
+    await expect(
+      runExport({
+        collection,
+        format: "postman",
+        output: join(collection, "export.yml"),
+      }),
+    ).rejects.toThrow('unknown export format "postman". Supported: openapi')
+  })
+
+  it("rejects outputs inside the collection without changing requests", async () => {
+    const collection = await tempDir()
+    const requestPath = join(collection, "health.yml")
+    const source =
+      "name: Health\nmethod: GET\nurl: https://example.com/health\n"
+    await writeFile(requestPath, source, "utf8")
+
+    for (const output of [
+      requestPath,
+      join(collection, "specs", "openapi.yml"),
+    ]) {
+      await expect(
+        runExport({ collection, format: "openapi", output }),
+      ).rejects.toThrow(
+        "export output must be outside the collection directory",
+      )
+    }
+
+    const link = join(await tempDir(), "collection-link")
+    await symlink(collection, link, "dir")
+    await expect(
+      runExport({
+        collection,
+        format: "openapi",
+        output: join(link, "openapi.yml"),
+      }),
+    ).rejects.toThrow("export output must be outside the collection directory")
+
+    expect(await readFile(requestPath, "utf8")).toBe(source)
+    expect(
+      await Bun.file(join(collection, "specs", "openapi.yml")).exists(),
+    ).toBe(false)
+  })
+
+  it("preserves exact JSON number literals in exported YAML", async () => {
+    const collection = await tempDir()
+    const output = join(await tempDir(), "openapi.yml")
+    await writeFile(
+      join(collection, "numbers.yml"),
+      [
+        "name: Numbers",
+        "method: POST",
+        "url: https://example.com/numbers",
+        'body: \'{"integer":9007199254740993,"decimal":0.12345678901234567890}\'',
+        "",
+      ].join("\n"),
+      "utf8",
+    )
+
+    await runExport({ collection, format: "openapi", output })
+
+    const outputText = await readFile(output, "utf8")
+    expect(outputText).toContain("9007199254740993")
+    expect(outputText).toContain("0.12345678901234567890")
+    expect(outputText).not.toContain("9007199254740992")
+  })
+})

--- a/tests/integration/export.test.ts
+++ b/tests/integration/export.test.ts
@@ -140,6 +140,20 @@ describe("export — integration", () => {
     ).toBe(false)
   })
 
+  it("adds context when the export output cannot be resolved", async () => {
+    const collection = await tempDir()
+    const outputParent = join(await tempDir(), "not-a-directory")
+    await writeFile(outputParent, "", "utf8")
+
+    await expect(
+      runExport({
+        collection,
+        format: "openapi",
+        output: join(outputParent, "openapi.yml"),
+      }),
+    ).rejects.toThrow("failed to resolve export output path")
+  })
+
   it("preserves exact JSON number literals in exported YAML", async () => {
     const collection = await tempDir()
     const output = join(await tempDir(), "openapi.yml")

--- a/tests/unit/openApiYaml.test.ts
+++ b/tests/unit/openApiYaml.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test"
+import yaml from "js-yaml"
+import { serializeOpenApiYaml } from "../../src/lang/openApiYaml"
+
+describe("serializeOpenApiYaml", () => {
+  it("round-trips ordinary numbers and numeric-looking strings", () => {
+    const value = {
+      integer: 42,
+      decimal: 1.5,
+      decimalString: "1.50",
+      exponentString: "1e3",
+    }
+
+    const serialized = serializeOpenApiYaml(value)
+
+    expect(serialized).toContain("integer: 42")
+    expect(serialized).toContain("decimal: 1.5")
+    expect(serialized).toContain("decimalString: '1.50'")
+    expect(serialized).toContain("exponentString: '1e3'")
+    expect(yaml.load(serialized)).toEqual(value)
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `noodle export <collection> --format openapi --output <file>` to export a collection as an OpenAPI 3.0.3 request catalog. It includes requests, enabled params/headers, request-body examples, folders as tags, and supported auth schemes. Environment values and response timeline data are never exported, and the output file must be outside the collection directory.

### How did you verify your code works?

New unit + integration tests (`tests/converters/openapi-export.test.ts`, `tests/integration/export.test.ts`, `tests/cli.test.ts`). Full suite, `bun run lint`, and `bun run typecheck` all pass.

### Screenshots / recordings

N/A (CLI-only change)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CLI command to export collections as OpenAPI 3.0.3 catalogs in YAML format.
  - Supports custom output paths, JSON-formatted command results, recursive requests, authentication, parameters, tags, servers, and request bodies.
  - Preserves numeric values while excluding environment and timeline data.
  - Creates missing output directories and validates safe output locations.
  - Reports invalid formats, URLs, request bodies, and duplicate operations with clear errors.

- **Documentation**
  - Added CLI usage, export contents, exclusions, and output restrictions to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->