### PR TITLE
feat(export): export environment base_urls as OpenAPI servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ drafts
 .impeccable/critique/2026-08-03T00-20-36Z__src-ui-app-tsx.md
 AWS API Gateway.yaml
 api-docs.json
+openapi.yml

--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ noodle export ./collections --format openapi --output ./specs/openapi.yml
 ```
 
 The export includes requests, enabled parameters and headers, request-body
-examples, folders as tags, and supported authentication schemes. Environment
-values and response timeline data are never exported. The output file must be
-outside the collection directory.
+examples, folders as tags, and supported authentication schemes. Each
+environment with an enabled, nonempty `base_url` becomes an OpenAPI server;
+other environment values and response timeline data are never exported. The
+output file must be outside the collection directory.
 
 ## Automation CLI
 

--- a/src/app/export.ts
+++ b/src/app/export.ts
@@ -9,6 +9,7 @@ import {
   sep,
 } from "node:path"
 import { exportOpenApi } from "../converters/openapi"
+import { env } from "../env"
 import { filestore } from "../filestore"
 import { serializeOpenApiYaml } from "../lang/openApiYaml"
 
@@ -23,6 +24,29 @@ export interface ExportResult {
   name: string
   format: string
   operationCount: number
+}
+
+async function environmentServers(collectionPath: string) {
+  const directory = join(collectionPath, ".environments")
+  const names = await env.listEnvironments(directory)
+  const environments = await Promise.all(
+    names.map(async (name) => {
+      try {
+        return await env.loadEnvironment(directory, name)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(
+          `failed to load environment "${name}" for export: ${message}`,
+          { cause: error },
+        )
+      }
+    }),
+  )
+  return environments.flatMap(({ name, vars }) =>
+    vars.base_url === "" || vars.base_url === undefined
+      ? []
+      : [{ url: vars.base_url, description: name }],
+  )
 }
 
 async function resolvedOutputPath(path: string): Promise<string> {
@@ -83,7 +107,9 @@ export async function runExport(options: ExportOptions): Promise<ExportResult> {
   if (isWithin(collectionRoot, await resolvedOutputPath(outputPath))) {
     throw new Error("export output must be outside the collection directory")
   }
-  const exported = exportOpenApi(collection)
+  const exported = exportOpenApi(collection, {
+    servers: await environmentServers(collectionPath),
+  })
 
   try {
     await mkdir(dirname(outputPath), { recursive: true })

--- a/src/converters/openapi/export.ts
+++ b/src/converters/openapi/export.ts
@@ -395,8 +395,20 @@ export function exportOpenApi(
 
   if (servers.length > 0) {
     document.servers = servers
+    const serverUrls = new Set(
+      servers.flatMap(({ url }) =>
+        typeof url === "string" ? [url.replace(/\/+$/, "")] : [],
+      ),
+    )
     for (const { operation, server } of operations) {
-      if (server && server.url !== "{base_url}") operation.servers = [server]
+      const serverUrl = server?.url
+      if (
+        typeof serverUrl === "string" &&
+        serverUrl !== "{base_url}" &&
+        !serverUrls.has(serverUrl.replace(/\/+$/, ""))
+      ) {
+        operation.servers = [server]
+      }
     }
   } else {
     const keys = new Set(operations.map(({ server }) => serverKey(server)))

--- a/src/converters/openapi/export.ts
+++ b/src/converters/openapi/export.ts
@@ -28,6 +28,10 @@ export interface OpenApiExportResult {
   operationCount: number
 }
 
+export interface OpenApiExportOptions {
+  servers?: OpenApiObject[]
+}
+
 const SERVER_VAR_RE = /\$(\w+)/g
 const PATH_PARAM_RE = /:([\w-]+)(?=\/|\.|$)/g
 const BASE_VAR_URL_RE = /^(\$\w+)(\/[^?#]*)?(\?[^#]*)?(?:#.*)?$/
@@ -339,7 +343,10 @@ function serverKey(server: OpenApiObject | undefined): string | undefined {
   return server === undefined ? undefined : JSON.stringify(server)
 }
 
-export function exportOpenApi(collection: Collection): OpenApiExportResult {
+export function exportOpenApi(
+  collection: Collection,
+  { servers = [] }: OpenApiExportOptions = {},
+): OpenApiExportResult {
   const paths: Record<string, OpenApiObject> = {}
   const schemes: Record<string, OpenApiObject> = {}
   const operations: { operation: OpenApiObject; server?: OpenApiObject }[] = []
@@ -386,13 +393,20 @@ export function exportOpenApi(collection: Collection): OpenApiExportResult {
     document.components = { securitySchemes: schemes }
   }
 
-  const keys = new Set(operations.map(({ server }) => serverKey(server)))
-  if (keys.size === 1) {
-    const server = operations[0]?.server
-    if (server) document.servers = [server]
-  } else {
+  if (servers.length > 0) {
+    document.servers = servers
     for (const { operation, server } of operations) {
-      if (server) operation.servers = [server]
+      if (server && server.url !== "{base_url}") operation.servers = [server]
+    }
+  } else {
+    const keys = new Set(operations.map(({ server }) => serverKey(server)))
+    if (keys.size === 1) {
+      const server = operations[0]?.server
+      if (server) document.servers = [server]
+    } else {
+      for (const { operation, server } of operations) {
+        if (server) operation.servers = [server]
+      }
     }
   }
 

--- a/src/converters/openapi/index.ts
+++ b/src/converters/openapi/index.ts
@@ -11,7 +11,11 @@ export const openApiImporter = {
 }
 
 export { parseSpec } from "./parse"
-export { exportOpenApi, type OpenApiExportResult } from "./export"
+export {
+  exportOpenApi,
+  type OpenApiExportOptions,
+  type OpenApiExportResult,
+} from "./export"
 export {
   mapCollection,
   convertTpl,

--- a/tests/converters/openapi-export.test.ts
+++ b/tests/converters/openapi-export.test.ts
@@ -270,6 +270,10 @@ describe("exportOpenApi", () => {
         },
         {
           type: "request",
+          data: request({ id: "literal", url: "https://api.example/literal" }),
+        },
+        {
+          type: "request",
           data: request({
             id: "external",
             url: "https://other.example/status",
@@ -293,6 +297,7 @@ describe("exportOpenApi", () => {
       Record<string, Operation>
     >
     expect(paths["/health"].get.servers).toBeUndefined()
+    expect(paths["/literal"].get.servers).toBeUndefined()
     expect(paths["/status"].get.servers).toEqual([
       { url: "https://other.example" },
     ])

--- a/tests/converters/openapi-export.test.ts
+++ b/tests/converters/openapi-export.test.ts
@@ -261,6 +261,43 @@ describe("exportOpenApi", () => {
     expect(paths["/health"].get.servers).toBeUndefined()
   })
 
+  it("uses supplied environment servers for base_url requests", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({ id: "base", url: "$base_url/health" }),
+        },
+        {
+          type: "request",
+          data: request({
+            id: "external",
+            url: "https://other.example/status",
+          }),
+        },
+      ]),
+      {
+        servers: [
+          { url: "https://api.example", description: "production" },
+          { url: "https://api.example", description: "staging" },
+        ],
+      },
+    )
+
+    expect(result.document.servers).toEqual([
+      { url: "https://api.example", description: "production" },
+      { url: "https://api.example", description: "staging" },
+    ])
+    const paths = result.document.paths as Record<
+      string,
+      Record<string, Operation>
+    >
+    expect(paths["/health"].get.servers).toBeUndefined()
+    expect(paths["/status"].get.servers).toEqual([
+      { url: "https://other.example" },
+    ])
+  })
+
   it("exports variables in URL schemes and ports", () => {
     const result = exportOpenApi(
       collection([

--- a/tests/integration/export.test.ts
+++ b/tests/integration/export.test.ts
@@ -34,14 +34,14 @@ describe("export — integration", () => {
     return dir
   }
 
-  it("writes an OpenAPI YAML file without mutating requests or exporting environment data", async () => {
+  it("writes environment base URLs as OpenAPI servers without exporting other environment data", async () => {
     const collection = await tempDir()
     const output = join(await tempDir(), "nested", "openapi.yml")
     const requestPath = join(collection, "health.yml")
     const source = [
       "name: Health",
       "method: GET",
-      "url: https://$host/health",
+      "url: $base_url/health",
       "headers:",
       "  X-Token: $TOKEN",
       "",
@@ -50,7 +50,28 @@ describe("export — integration", () => {
     await mkdir(join(collection, ".environments"))
     await writeFile(
       join(collection, ".environments", "production.env"),
-      "host=api.example.com\nTOKEN=should-not-export\n",
+      [
+        "base_url=https://api.example.com",
+        "TOKEN=should-not-export",
+        "_color=success",
+        "#DISABLED=also-not-exported",
+        "",
+      ].join("\n"),
+      "utf8",
+    )
+    await writeFile(
+      join(collection, ".environments", "staging.env"),
+      "base_url=https://api.example.com\n",
+      "utf8",
+    )
+    await writeFile(
+      join(collection, ".environments", "empty.env"),
+      "base_url=\n",
+      "utf8",
+    )
+    await writeFile(
+      join(collection, ".environments", "disabled.env"),
+      "#base_url=https://disabled.example\n",
       "utf8",
     )
     await mkdir(join(collection, ".timeline"))
@@ -79,8 +100,12 @@ describe("export — integration", () => {
     expect(document.openapi).toBe("3.0.3")
     expect(document.servers).toEqual([
       {
-        url: "https://{host}",
-        variables: { host: { default: "" } },
+        url: "https://api.example.com",
+        description: "production",
+      },
+      {
+        url: "https://api.example.com",
+        description: "staging",
       },
     ])
     expect(document.paths["/health"]?.get.parameters).toContainEqual({
@@ -90,9 +115,32 @@ describe("export — integration", () => {
       schema: { type: "string" },
       example: "$TOKEN",
     })
-    expect(outputText).not.toContain("api.example.com")
     expect(outputText).not.toContain("should-not-export")
+    expect(outputText).not.toContain("also-not-exported")
+    expect(outputText).not.toContain("disabled.example")
     expect(outputText).not.toContain("timeline-secret")
+  })
+
+  it("fails with context when an environment cannot be parsed", async () => {
+    const collection = await tempDir()
+    const output = join(await tempDir(), "openapi.yml")
+    await writeFile(
+      join(collection, "health.yml"),
+      "name: Health\nmethod: GET\nurl: $base_url/health\n",
+      "utf8",
+    )
+    await mkdir(join(collection, ".environments"))
+    await writeFile(
+      join(collection, ".environments", "broken.env"),
+      "not a dotenv line\n",
+      "utf8",
+    )
+
+    await expect(
+      runExport({ collection, format: "openapi", output }),
+    ).rejects.toThrow(
+      'failed to load environment "broken" for export: env.load: invalid line (expected KEY=value): "not a dotenv line"',
+    )
   })
 
   it("rejects unsupported output formats", async () => {


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `noodle collection format <path>` automation command that canonicalizes request YAML and pretty-prints valid JSON request bodies. Imports run it automatically, so imported JSON bodies are formatted on arrival. Also fixes a few UI bugs found along the way:

- **format command**: rewrites each request file through the serializer and pretty-prints `body_type: json` bodies that parse successfully (invalid JSON is left untouched). Writes a per-request count of formatted bodies to the JSON output and human-readable output. Documented in README + AGENTS.md.
- **Sidebar**: scrollbox no longer steals focus on mouse click, so keyboard navigation after a click keeps the correct selection/cursor.
- **Keymap**: `request.edit-yaml` is disabled while an overlay is open, so a keybind can't open the YAML editor over a modal.
- **Body editor**: content changes only propagate as edits while the body editor is actually active, so browsing a request can't fire bogus dirty-state changes.
- **Refactor**: `selectedIdRef` is now owned by `useTreeNavigation` (kept in sync on all selection paths) so YAML edit commands target the right request before re-renders land. YAML editor line numbers widened from 3 to 4.

### How did you verify your code works?

- New unit/integration tests cover `collectionFormat` (formats valid JSON, leaves invalid JSON alone), the new automation command output, import-time formatting, the sidebar scrollbox focus fix, the overlay-gated edit-yaml keybind, and the `selectedIdRef` synchronization.
- `bun test` passes (added suites included), `bun run lint` passes, `bun run typecheck` passes.

### Screenshots / recordings

N/A — CLI/terminal change; output examples covered by `tests/humanOutput.test.ts`.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI exports now include configured environment base URLs as servers.
  * Requests using external origins retain operation-specific servers, while base-URL requests use document-level servers.
  * Environments without valid base URLs are excluded from exported server lists.

* **Bug Fixes**
  * Export errors now provide clearer context when environment files cannot be loaded.

* **Documentation**
  * Updated export documentation to describe environment and server handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->