### PR TITLE
feat(export): add Postman collection export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ bun run release:check -- --tag vX.Y.Z # validate code, docs site, and release re
 ```
 noodle [<path>] [--collection <dir>] [--env <name>]
 noodle import <source> [--format <format>] [--output <dir>]
+noodle export <collection> --format <openapi|postman> --output <file|dir>
 noodle update
 noodle workspace list [--json]
 noodle collection <create|init|list|inspect|format|audit|run> ... [--json]
@@ -31,6 +32,7 @@ noodle environment set <key> <value> --env <name> [--collection <dir>] [--json]
 
 - **Default command** (TUI mode): optional positional `<path>` (use `.` for current directory), `--collection/-c`, and `--env/-e`. Positional path overrides `--collection`; supplying both is invalid. Without either, the first existing registered collection in `~/.config/noodle/config.yml` is used, then the current directory.
 - **Import subcommand**: `source` (positional, required), `--format/-i` (openapi/postman, auto-detected if omitted), `--output/-o` (default: ./collections)
+- **Export subcommand**: `collection` (positional, required), `--format` (`openapi` or `postman`), and `--output/-o` (a file for OpenAPI, or a new/empty directory for Postman). Postman creates `collection.postman_collection.json` plus one redacted environment file per environment; it preserves literal request values, so review exports for secrets before sharing.
 - **Update subcommand**: Self-update. Reads `https://noodlerest.dev/update.json`, caches verified release metadata for one hour (with a seven-day stale fallback), and SHA-256 verifies standalone binaries before replacement. Detects Homebrew installs and runs `brew upgrade noodle`; unavailable in Bun development runtime.
 - **Automation commands**: `workspace list`, `workspace audit [--fix]`; `collection create`, `init`, `list`, `inspect`, `format`, `audit [--fix]`, `run [--env]`; `request create --url --method --collection`, `run [--env]`; and `environment set`. They are non-interactive and support `--json`, which writes one `{ status, data, errors }` envelope and uses a nonzero exit status for invalid input or failed runs. `collection format` canonicalizes request YAML and pretty-prints valid JSON bodies without lossy numeric conversion; imports run it automatically. `collection init` bootstraps missing collection markers in an existing directory and registers it. `workspace audit --fix` removes invalid registered paths.
 - **Automation environment selection**: `request run` and `collection run` use `--env` when supplied; otherwise they use the collection root's `settings.yml` environment.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ environment with an enabled, nonempty `base_url` becomes an OpenAPI server;
 other environment values and response timeline data are never exported. The
 output file must be outside the collection directory.
 
+Export to Postman Collection v2.1 as a bundle directory instead:
+
+```bash
+noodle export ./collections --format postman --output ./exports/postman
+```
+
+The output directory must be new or empty and is created with
+`collection.postman_collection.json` plus one
+`<environment>.postman_environment.json` file per Noodle environment. Environment
+values are always redacted to empty strings, while enabled/disabled states are
+preserved. Request literals in URLs, headers, parameters, bodies, file paths, and
+auth fields stay runnable and can contain secrets—review them before sharing an
+export. Response timeline data is never exported.
+
 ## Automation CLI
 
 `noodle` without a subcommand opens the interactive TUI. The commands below
@@ -152,7 +166,7 @@ are non-interactive and support `--json`, which emits one
 | `noodle collection format <path>`                                      | Canonicalize request YAML and pretty-print JSON bodies.  |
 | `noodle collection audit <path>`                                       | Validate collection files.                               |
 | `noodle collection run <path>`                                         | Run every request in a collection.                       |
-| `noodle export <path> --format openapi --output <file>`                | Export a collection as an OpenAPI request catalog.       |
+| `noodle export <path> --format <openapi\|postman> --output <path>`     | Export OpenAPI or a redacted Postman bundle.              |
 | `noodle request create <id> --url <url> --collection <dir>`            | Create a minimal request.                                |
 | `noodle request run <id> --collection <dir>`                           | Run one request.                                         |
 | `noodle environment set <key> <value> --env <name> --collection <dir>` | Set an environment value.                                |

--- a/src/app/commands/export.ts
+++ b/src/app/commands/export.ts
@@ -5,7 +5,8 @@ import { formatExport } from "../humanOutput"
 export default defineCommand({
   meta: {
     name: "export",
-    description: "Export a Noodle collection to an API specification",
+    description:
+      "Export a Noodle collection to an API specification or Postman bundle",
   },
   args: {
     collection: {
@@ -16,13 +17,13 @@ export default defineCommand({
     format: {
       type: "string",
       required: true,
-      description: 'Export format ("openapi")',
+      description: 'Export format ("openapi" or "postman")',
     },
     output: {
       type: "string",
       alias: "o",
       required: true,
-      description: "Output specification file",
+      description: "Output file (OpenAPI) or empty directory (Postman)",
     },
     json: {
       type: "boolean",

--- a/src/app/export.ts
+++ b/src/app/export.ts
@@ -1,4 +1,4 @@
-import { mkdir, realpath, writeFile } from "node:fs/promises"
+import { mkdir, readdir, realpath, stat, writeFile } from "node:fs/promises"
 import {
   basename,
   dirname,
@@ -9,9 +9,11 @@ import {
   sep,
 } from "node:path"
 import { exportOpenApi } from "../converters/openapi"
+import { exportPostman, exportPostmanEnvironment } from "../converters/postman"
 import { env } from "../env"
 import { filestore } from "../filestore"
 import { serializeOpenApiYaml } from "../lang/openApiYaml"
+import type { Environment } from "../schema"
 
 export interface ExportOptions {
   collection: string
@@ -24,9 +26,13 @@ export interface ExportResult {
   name: string
   format: string
   operationCount: number
+  environmentCount?: number
+  files?: string[]
 }
 
-async function environmentServers(collectionPath: string) {
+async function exportEnvironments(
+  collectionPath: string,
+): Promise<Environment[]> {
   const directory = join(collectionPath, ".environments")
   const names = await env.listEnvironments(directory)
   const environments = await Promise.all(
@@ -42,11 +48,34 @@ async function environmentServers(collectionPath: string) {
       }
     }),
   )
+  return environments.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+async function environmentServers(collectionPath: string) {
+  const environments = await exportEnvironments(collectionPath)
   return environments.flatMap(({ name, vars }) =>
     vars.base_url === "" || vars.base_url === undefined
       ? []
       : [{ url: vars.base_url, description: name }],
   )
+}
+
+async function ensureEmptyDirectory(path: string): Promise<void> {
+  try {
+    const output = await stat(path)
+    if (!output.isDirectory()) {
+      throw new Error("postman export output must be a directory")
+    }
+    if ((await readdir(path)).length > 0) {
+      throw new Error("postman export output directory must be empty")
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      await mkdir(path, { recursive: true })
+      return
+    }
+    throw error
+  }
 }
 
 async function resolvedOutputPath(path: string): Promise<string> {
@@ -92,9 +121,9 @@ function isWithin(root: string, path: string): boolean {
 }
 
 export async function runExport(options: ExportOptions): Promise<ExportResult> {
-  if (options.format !== "openapi") {
+  if (options.format !== "openapi" && options.format !== "postman") {
     throw new Error(
-      `unknown export format "${options.format}". Supported: openapi`,
+      `unknown export format "${options.format}". Supported: openapi, postman`,
     )
   }
 
@@ -107,6 +136,49 @@ export async function runExport(options: ExportOptions): Promise<ExportResult> {
   if (isWithin(collectionRoot, await resolvedOutputPath(outputPath))) {
     throw new Error("export output must be outside the collection directory")
   }
+
+  if (options.format === "postman") {
+    const exported = exportPostman(collection)
+    const environments = await exportEnvironments(collectionPath)
+    const files = [
+      join(outputPath, "collection.postman_collection.json"),
+      ...environments.map((environment) =>
+        join(outputPath, `${environment.name}.postman_environment.json`),
+      ),
+    ]
+
+    try {
+      await ensureEmptyDirectory(outputPath)
+      await writeFile(
+        files[0]!,
+        JSON.stringify(exported.document, null, 2) + "\n",
+        "utf8",
+      )
+      await Promise.all(
+        environments.map((environment, index) =>
+          writeFile(
+            files[index + 1]!,
+            JSON.stringify(exportPostmanEnvironment(environment), null, 2) +
+              "\n",
+            "utf8",
+          ),
+        ),
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`failed to write export: ${message}`, { cause: error })
+    }
+
+    return {
+      path: outputPath,
+      name: collection.name,
+      format: options.format,
+      operationCount: exported.operationCount,
+      environmentCount: environments.length,
+      files,
+    }
+  }
+
   const exported = exportOpenApi(collection, {
     servers: await environmentServers(collectionPath),
   })

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -191,11 +191,19 @@ export function formatExport(data: {
   name: string
   format: string
   operationCount: number
+  environmentCount?: number
 }): string {
+  const isPostman = data.format === "postman"
+  const noun = isPostman ? "request" : "operation"
   return [
     `${color("✓", "green")} Exported ${data.name} as ${data.format}`,
-    `  ${data.path}`,
-    `  ${data.operationCount} operation${data.operationCount === 1 ? "" : "s"}`,
+    `  ${isPostman ? "Bundle" : "Output"}: ${data.path}`,
+    `  ${data.operationCount} ${noun}${data.operationCount === 1 ? "" : "s"}`,
+    ...(data.environmentCount === undefined
+      ? []
+      : [
+          `  ${data.environmentCount} environment${data.environmentCount === 1 ? "" : "s"}`,
+        ]),
   ].join("\n")
 }
 

--- a/src/converters/postman/export.ts
+++ b/src/converters/postman/export.ts
@@ -1,0 +1,250 @@
+import type {
+  Auth,
+  Collection,
+  CollectionItem,
+  Environment,
+  FormEntry,
+  Request,
+} from "../../schema"
+import { Url as PmUrl } from "postman-collection"
+import { mergeFolderOverrides } from "../../requests/mergeFolderOverrides"
+
+type PostmanObject = Record<string, unknown>
+
+export interface PostmanExportResult {
+  document: PostmanObject
+  operationCount: number
+}
+
+const POSTMAN_SCHEMA =
+  "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+
+export function toPostmanTpl(value: string): string {
+  return value.replace(/\$\$(\w+)|\$(\w+)/g, (_, dynamic, variable) =>
+    dynamic ? `{{$${dynamic}}}` : `{{${variable}}}`,
+  )
+}
+
+function postmanAuth(auth: Auth | undefined): PostmanObject | undefined {
+  if (!auth || auth.type === "inherit") return undefined
+  if (auth.type === "none") return { type: "noauth" }
+  if (auth.type === "bearer") {
+    return {
+      type: "bearer",
+      bearer: [
+        { key: "token", value: toPostmanTpl(auth.token), type: "string" },
+      ],
+    }
+  }
+  if (auth.type === "basic") {
+    return {
+      type: "basic",
+      basic: [
+        { key: "username", value: toPostmanTpl(auth.user), type: "string" },
+        { key: "password", value: toPostmanTpl(auth.pass), type: "string" },
+      ],
+    }
+  }
+  return {
+    type: "apikey",
+    apikey: [
+      { key: "key", value: toPostmanTpl(auth.key), type: "string" },
+      { key: "value", value: toPostmanTpl(auth.value), type: "string" },
+      { key: "in", value: auth.placement, type: "string" },
+    ],
+  }
+}
+
+function folderAuth(auth: Auth | undefined): PostmanObject | undefined {
+  return auth?.type === "none" ? undefined : postmanAuth(auth)
+}
+
+function decodedQueryKey(value: string): string {
+  return [...new URLSearchParams(`${value}=`).keys()][0] ?? value
+}
+
+function postmanUrl(request: Request): PostmanObject {
+  const original = new PmUrl(request.url)
+  const converted = new PmUrl(toPostmanTpl(request.url))
+  const originalParams = original.query.all()
+  const enabledNames = new Set(
+    request.params.filter((param) => param.enabled).map((param) => param.name),
+  )
+  const query = [
+    ...converted.query
+      .all()
+      .filter(
+        (_, index) =>
+          !enabledNames.has(decodedQueryKey(originalParams[index]?.key ?? "")),
+      )
+      .map((param) => ({
+        key: param.key,
+        value: param.value,
+        disabled: false,
+      })),
+    ...request.params.map((param) => ({
+      key: toPostmanTpl(param.name),
+      value: toPostmanTpl(param.value),
+      disabled: !param.enabled,
+    })),
+  ]
+  const variable = request.pathParams?.length
+    ? request.pathParams.map((param) => ({
+        key: toPostmanTpl(param.name),
+        value: toPostmanTpl(param.value),
+      }))
+    : undefined
+  const definition = {
+    ...converted.toJSON(),
+    query,
+    ...(variable ? { variable } : {}),
+  }
+  const url = new PmUrl(definition)
+  const serialized = url.toJSON() as PostmanObject
+  if (query.length === 0) delete serialized.query
+  if (variable) {
+    serialized.variable = variable
+  } else {
+    delete serialized.variable
+  }
+  return {
+    raw: new PmUrl({ ...definition, variable: [] }).toString(),
+    ...serialized,
+  }
+}
+
+function postmanFormData(
+  entries: FormEntry[],
+  multipart: boolean,
+): PostmanObject[] {
+  return entries.map((entry) => {
+    const result: PostmanObject = {
+      key: toPostmanTpl(entry.name),
+      disabled: !entry.enabled,
+      type: entry.type,
+    }
+    if (multipart && entry.type === "file") {
+      result.src = toPostmanTpl(entry.value)
+    } else {
+      result.value = toPostmanTpl(entry.value)
+    }
+    return result
+  })
+}
+
+function postmanBody(request: Request): PostmanObject | undefined {
+  const type =
+    request.bodyType ?? (request.body === undefined ? "none" : "json")
+  if (type === "none") return undefined
+  if (type === "json") {
+    return {
+      mode: "raw",
+      raw: toPostmanTpl(request.body ?? ""),
+      options: { raw: { language: "json" } },
+    }
+  }
+  if (type === "urlencoded") {
+    return {
+      mode: "urlencoded",
+      urlencoded: postmanFormData(request.formData ?? [], false),
+    }
+  }
+  if (type === "multipart") {
+    return {
+      mode: "formdata",
+      formdata: postmanFormData(request.formData ?? [], true),
+    }
+  }
+  return {
+    mode: "file",
+    file: { src: toPostmanTpl(request.filePath ?? "") },
+  }
+}
+
+function postmanRequest(
+  request: Request,
+  headers: Request["headers"],
+): PostmanObject {
+  const body = postmanBody(request)
+  const auth = postmanAuth(request.auth)
+  const result: PostmanObject = {
+    method: request.method,
+    header: Object.entries(headers).map(([key, entry]) => ({
+      key: toPostmanTpl(key),
+      value: toPostmanTpl(entry.value),
+      disabled: !entry.enabled,
+    })),
+    url: postmanUrl(request),
+  }
+  if (body) result.body = body
+  if (auth) result.auth = auth
+  return result
+}
+
+export function exportPostman(collection: Collection): PostmanExportResult {
+  let operationCount = 0
+
+  const items = (entries: CollectionItem[]): PostmanObject[] =>
+    entries.map((entry) => {
+      if (entry.type === "folder") {
+        const auth = folderAuth(entry.data.overrides?.auth)
+        const result: PostmanObject = {
+          name: entry.data.name,
+          item: items(entry.data.children),
+        }
+        if (auth) result.auth = auth
+        return result
+      }
+
+      operationCount++
+      const effective = mergeFolderOverrides(
+        entry.data,
+        collection,
+        entry.data.id,
+      )
+      return {
+        name: entry.data.name,
+        request: postmanRequest(entry.data, effective.headers),
+        protocolProfileBehavior: {
+          followRedirects: entry.data.followRedirects ?? true,
+          maxRedirects: entry.data.maxRedirects ?? 5,
+        },
+      }
+    })
+
+  return {
+    document: {
+      info: { name: collection.name, schema: POSTMAN_SCHEMA },
+      item: items(collection.items),
+    },
+    operationCount,
+  }
+}
+
+export function exportPostmanEnvironment(
+  environment: Environment,
+): PostmanObject {
+  const values = [
+    ...Object.entries(environment.vars).map(([key]) => ({
+      key,
+      value: "",
+      type: "default",
+      enabled: true,
+    })),
+    ...Object.entries(environment.disabledVars ?? {}).map(([key]) => ({
+      key,
+      value: "",
+      type: "default",
+      enabled: false,
+    })),
+  ].sort(
+    (a, b) =>
+      a.key.localeCompare(b.key) || Number(b.enabled) - Number(a.enabled),
+  )
+
+  return {
+    name: environment.name,
+    values,
+    _postman_variable_scope: "environment",
+  }
+}

--- a/src/converters/postman/export.ts
+++ b/src/converters/postman/export.ts
@@ -56,7 +56,7 @@ function postmanAuth(auth: Auth | undefined): PostmanObject | undefined {
 }
 
 function folderAuth(auth: Auth | undefined): PostmanObject | undefined {
-  return auth?.type === "none" ? undefined : postmanAuth(auth)
+  return postmanAuth(auth)
 }
 
 function decodedQueryKey(value: string): string {

--- a/src/converters/postman/index.ts
+++ b/src/converters/postman/index.ts
@@ -2,6 +2,13 @@ import { Collection as PmCollection } from "postman-collection"
 import { detectPostman } from "./detect"
 import { mapCollection } from "./map"
 
+export {
+  exportPostman,
+  exportPostmanEnvironment,
+  toPostmanTpl,
+  type PostmanExportResult,
+} from "./export"
+
 export const postmanImporter = {
   type: "postman" as const,
   detect: detectPostman,

--- a/src/converters/postman/map.ts
+++ b/src/converters/postman/map.ts
@@ -44,14 +44,8 @@ function extractAuthParams(
     if (raw) {
       const items = raw.all()
       if (items.length > 0) {
-        const byKey = new Map(items.map((p) => [p.key, p.value]))
-
-        if (byKey.has("key") && byKey.has("value")) {
-          params.set(byKey.get("key")!, byKey.get("value")!)
-        } else {
-          for (const p of items) {
-            params.set(p.key, p.value)
-          }
+        for (const p of items) {
+          params.set(p.key, p.value)
         }
       }
     }
@@ -62,8 +56,11 @@ function extractAuthParams(
   return params.size > 0 ? params : undefined
 }
 
-function mapAuth(auth: AuthMember | undefined): Auth {
-  if (!auth) return { type: "none" }
+function mapAuth(
+  auth: AuthMember | undefined,
+  inheritWhenMissing = false,
+): Auth {
+  if (!auth) return inheritWhenMissing ? { type: "inherit" } : { type: "none" }
   const type = auth.type
 
   if (type === "noauth") return { type: "none" }
@@ -79,18 +76,19 @@ function mapAuth(auth: AuthMember | undefined): Auth {
   if (type === "basic") {
     return {
       type: "basic",
-      user: params?.get("username") ?? "",
-      pass: params?.get("password") ?? "",
+      user: convertTpl(params?.get("username") ?? ""),
+      pass: convertTpl(params?.get("password") ?? ""),
     }
   }
 
   if (type === "apikey") {
     const key = params?.get("key") ?? ""
     const value = params?.get("value") ?? ""
-    const rawPlacement = params?.get("placement") ?? "header"
+    const rawPlacement =
+      params?.get("in") ?? params?.get("placement") ?? "header"
     return {
       type: "api_key" as const,
-      key,
+      key: convertTpl(key),
       value: convertTpl(value),
       placement: rawPlacement.includes("query") ? "query" : "header",
     }
@@ -127,8 +125,9 @@ function mapParams(query: PropertyList<QueryParam> | undefined): ParamEntry[] {
 
 function mapBody(req: { body?: BodyMember }): {
   body?: string
-  bodyType?: "json" | "urlencoded" | "multipart"
+  bodyType?: "json" | "urlencoded" | "multipart" | "binary"
   formData?: FormEntry[]
+  filePath?: string
 } {
   const b = req.body
   if (!b) return {}
@@ -140,7 +139,7 @@ function mapBody(req: { body?: BodyMember }): {
     const lang = b.options?.raw?.language
     const bodyType =
       lang === undefined || lang === "json" ? ("json" as const) : undefined
-    return { body: raw, ...(bodyType ? { bodyType } : {}) }
+    return { body: convertTpl(raw), ...(bodyType ? { bodyType } : {}) }
   }
 
   if (mode === "urlencoded") {
@@ -148,14 +147,12 @@ function mapBody(req: { body?: BodyMember }): {
     if (b.urlencoded) {
       b.urlencoded.each(
         (e: { key: string; value: string; disabled?: boolean }) => {
-          if (!e.disabled) {
-            formData.push({
-              name: e.key,
-              value: convertTpl(e.value),
-              enabled: true,
-              type: "text",
-            })
-          }
+          formData.push({
+            name: e.key,
+            value: convertTpl(e.value),
+            enabled: !e.disabled,
+            type: "text",
+          })
         },
       )
     }
@@ -166,17 +163,22 @@ function mapBody(req: { body?: BodyMember }): {
     const formData: FormEntry[] = []
     if (b.formdata) {
       b.formdata.each((e: FormParam) => {
-        if (!e.disabled) {
-          formData.push({
-            name: e.key,
-            value: convertTpl(e.value),
-            enabled: true,
-            type: e.type === "file" ? "file" : "text",
-          })
-        }
+        formData.push({
+          name: e.key,
+          value: convertTpl(e.type === "file" ? (e.src ?? e.value) : e.value),
+          enabled: !e.disabled,
+          type: e.type === "file" ? "file" : "text",
+        })
       })
     }
     return { bodyType: "multipart", formData }
+  }
+
+  if (mode === "file") {
+    return {
+      bodyType: "binary",
+      filePath: convertTpl(b.file?.src ?? ""),
+    }
   }
 
   return {}
@@ -302,7 +304,10 @@ function mapRequest(
     (req.url as { query?: PropertyList<QueryParam> })?.query,
   )
   const bodyMapping = mapBody(req as { body?: BodyMember })
-  const auth = mapAuth(req.auth as AuthMember | undefined)
+  const auth = mapAuth(req.auth as AuthMember | undefined, true)
+  const behavior = item.protocolProfileBehavior
+  const followRedirects = behavior?.followRedirects
+  const maxRedirects = behavior?.maxRedirects
 
   const rawId = slugify(`${method}-${item.name}`)
   const id = uniqueId(`${parentPath}${rawId || `request-${index}`}`, usedIds)
@@ -319,6 +324,10 @@ function mapRequest(
     pathParams,
     ...bodyMapping,
     auth,
+    ...(typeof followRedirects === "boolean" ? { followRedirects } : {}),
+    ...(typeof maxRedirects === "number" && maxRedirects >= 0
+      ? { maxRedirects }
+      : {}),
   }
 }
 
@@ -350,7 +359,7 @@ function mapItems(
         data: {
           id: folderId,
           name,
-          path: folderId,
+          path: path.slice(0, -1),
           overrides,
           children: mapItems(itemGroup.items, path, usedIds),
         },

--- a/src/converters/postman/types.d.ts
+++ b/src/converters/postman/types.d.ts
@@ -2,6 +2,7 @@ declare module "postman-collection" {
   interface Url {
     getRaw(): string
     toString(): string
+    toJSON(): Record<string, unknown>
     host?: string[]
     path?: string[]
     port?: string
@@ -24,6 +25,7 @@ declare module "postman-collection" {
   interface FormParam {
     key: string
     value: string
+    src?: string
     type?: "text" | "file"
     disabled?: boolean
   }
@@ -37,6 +39,7 @@ declare module "postman-collection" {
       disabled?: boolean
     }>
     formdata?: PropertyList<FormParam>
+    file?: { src?: string }
     options?: { raw?: { language?: string } }
   }
 
@@ -79,6 +82,10 @@ declare module "postman-collection" {
     request?: Request
     response?: unknown[]
     auth?: AuthMember
+    protocolProfileBehavior?: {
+      followRedirects?: boolean
+      maxRedirects?: number
+    }
   }
 
   interface ItemGroup {
@@ -100,7 +107,11 @@ declare module "postman-collection" {
     new (definition: Record<string, unknown>): Collection
   }
 
-  export { Collection }
+  const Url: {
+    new (definition: string | Record<string, unknown>): Url
+  }
+
+  export { Collection, Url }
   export type {
     Url,
     QueryParam,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -115,6 +115,7 @@ describe("export command", () => {
     expect(exportArgs?.format).toMatchObject({ type: "string", required: true })
     expect(exportArgs?.output).toMatchObject({ type: "string", required: true })
     expect((exportArgs?.output as StringArgDef)?.alias).toBe("o")
+    expect(exportMeta?.description).toContain("Postman")
   })
 })
 
@@ -175,6 +176,14 @@ describe("CLI integration", () => {
     expect(out).toContain("output")
   })
 
+  it("shows Postman bundle requirements in export help", () => {
+    const proc = Bun.spawnSync(["bun", CLI, "export", "--help"])
+    expect(proc.exitCode).toBe(0)
+    const out = proc.stdout.toString()
+    expect(out).toContain("postman")
+    expect(out).toContain("empty directory")
+  })
+
   it("exports a collection and preserves the JSON result envelope", async () => {
     const root = await mkdtemp(join(tmpdir(), "noodle-cli-export-"))
     const dir = join(root, "collection")
@@ -208,6 +217,66 @@ describe("CLI integration", () => {
         errors: [],
       })
       expect(await readFile(output, "utf8")).toContain("openapi: 3.0.3")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("exports a Postman bundle and reports its generated files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-cli-postman-export-"))
+    const dir = join(root, "collection")
+    const output = join(root, "out")
+    try {
+      await mkdir(dir)
+      await writeFile(
+        join(dir, "ping.yml"),
+        "name: Ping\nmethod: GET\nurl: https://example.com/ping\n",
+      )
+      const proc = Bun.spawnSync([
+        "bun",
+        CLI,
+        "export",
+        dir,
+        "--format",
+        "postman",
+        "--output",
+        output,
+        "--json",
+      ])
+      expect(proc.exitCode).toBe(0)
+      expect(JSON.parse(proc.stdout.toString())).toEqual({
+        status: "success",
+        data: {
+          path: output,
+          name: basename(dir),
+          format: "postman",
+          operationCount: 1,
+          environmentCount: 0,
+          files: [join(output, "collection.postman_collection.json")],
+        },
+        errors: [],
+      })
+      expect(
+        await readFile(
+          join(output, "collection.postman_collection.json"),
+          "utf8",
+        ),
+      ).toContain("collection/v2.1.0")
+      const humanOutput = join(root, "human")
+      const human = Bun.spawnSync([
+        "bun",
+        CLI,
+        "export",
+        dir,
+        "--format",
+        "postman",
+        "--output",
+        humanOutput,
+      ])
+      expect(human.exitCode).toBe(0)
+      expect(human.stdout.toString()).toContain("1 request")
+      expect(human.stdout.toString()).toContain("0 environments")
+      expect(human.stdout.toString()).toContain(`Bundle: ${humanOutput}`)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/tests/converters/postman-export.test.ts
+++ b/tests/converters/postman-export.test.ts
@@ -166,6 +166,58 @@ describe("Postman export", () => {
     }
   })
 
+  it("exports noauth for a nested folder override", () => {
+    const collection: Collection = {
+      id: "api",
+      name: "API",
+      items: [
+        {
+          type: "folder",
+          data: {
+            id: "parent",
+            name: "Parent",
+            path: "parent",
+            overrides: { auth: { type: "bearer", token: "parent-token" } },
+            children: [
+              {
+                type: "folder",
+                data: {
+                  id: "parent/child",
+                  name: "Child",
+                  path: "parent/child",
+                  overrides: { auth: { type: "none" } },
+                  children: [
+                    {
+                      type: "request",
+                      data: request("parent/child/health", "Health", {
+                        auth: { type: "inherit" },
+                      }),
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }
+
+    const parent = (
+      exportPostman(collection).document.item as Record<string, unknown>[]
+    )[0]!
+    const child = (parent.item as Record<string, unknown>[])[0]!
+    const requestItem = (child.item as Record<string, unknown>[])[0]!
+
+    expect(parent.auth).toEqual({
+      type: "bearer",
+      bearer: [{ key: "token", value: "parent-token", type: "string" }],
+    })
+    expect(child.auth).toEqual({ type: "noauth" })
+    expect(
+      (requestItem.request as Record<string, unknown>).auth,
+    ).toBeUndefined()
+  })
+
   it("exports every supported body and auth type", () => {
     const collection: Collection = {
       id: "bodies",

--- a/tests/converters/postman-export.test.ts
+++ b/tests/converters/postman-export.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "bun:test"
+import { Collection as PmCollection } from "postman-collection"
+import {
+  exportPostman,
+  exportPostmanEnvironment,
+  toPostmanTpl,
+} from "../../src/converters/postman"
+import { mapCollection } from "../../src/converters/postman/map"
+import type { Collection, Request } from "../../src/schema"
+
+function request(
+  id: string,
+  name: string,
+  extra: Partial<Request> = {},
+): Request {
+  return {
+    id,
+    name,
+    method: "POST",
+    url: "https://api.example.com/users/:user?inline=keep&replace=old#section",
+    timeout: 1234,
+    headers: {},
+    params: [],
+    ...extra,
+  }
+}
+
+describe("Postman export", () => {
+  it("converts Noodle and dynamic templates to Postman syntax", () => {
+    expect(toPostmanTpl("$base/$$randomUUID/$user-id")).toBe(
+      "{{base}}/{{$randomUUID}}/{{user}}-id",
+    )
+  })
+
+  it("preserves scheme-less URL structure and encoded dollar literals", () => {
+    const collection: Collection = {
+      id: "urls",
+      name: "URLs",
+      items: [
+        {
+          type: "request",
+          data: request("health", "Health", {
+            method: "GET",
+            url: "localhost:3000/health?literal=%24token&template=$token#frag",
+          }),
+        },
+      ],
+    }
+
+    const exported = exportPostman(collection)
+    const item = (exported.document.item as Record<string, unknown>[])[0]!
+    const url = (item.request as Record<string, unknown>).url as Record<
+      string,
+      unknown
+    >
+
+    expect(url).toMatchObject({
+      raw: "localhost:3000/health?literal=%24token&template={{token}}#frag",
+      host: ["localhost"],
+      port: "3000",
+      path: ["health"],
+      hash: "frag",
+      query: [
+        { key: "literal", value: "%24token", disabled: false },
+        { key: "template", value: "{{token}}", disabled: false },
+      ],
+    })
+    const roundTripItem = new PmCollection(exported.document).items.all()[0]!
+    expect(
+      "request" in roundTripItem
+        ? roundTripItem.request?.url.toString()
+        : undefined,
+    ).toBe("localhost:3000/health?literal=%24token&template={{token}}#frag")
+  })
+
+  it("preserves nested folders, effective headers, URL parts, and inherited auth", () => {
+    const collection: Collection = {
+      id: "api",
+      name: "API",
+      items: [
+        {
+          type: "folder",
+          data: {
+            id: "admin",
+            name: "Admin",
+            path: "admin",
+            overrides: {
+              headers: {
+                "X-Folder": { value: "$token", enabled: true },
+                "X-Request": { value: "parent", enabled: true },
+              },
+              auth: { type: "bearer", token: "$token" },
+            },
+            children: [
+              {
+                type: "request",
+                data: request("admin/list", "List", {
+                  auth: { type: "inherit" },
+                  headers: {
+                    "X-Request": { value: "child", enabled: false },
+                  },
+                  params: [
+                    { name: "replace", value: "$new", enabled: true },
+                    { name: "repeat", value: "one", enabled: true },
+                    { name: "repeat", value: "two", enabled: false },
+                  ],
+                  pathParams: [
+                    { name: "user", value: "$userId", enabled: true },
+                  ],
+                  followRedirects: false,
+                  maxRedirects: 2,
+                }),
+              },
+            ],
+          },
+        },
+      ],
+    }
+
+    const exported = exportPostman(collection)
+    const folder = (exported.document.item as Record<string, unknown>[])[0]!
+    const item = (folder.item as Record<string, unknown>[])[0]!
+    const req = item.request as Record<string, unknown>
+    const url = req.url as Record<string, unknown>
+
+    expect(folder.auth).toEqual({
+      type: "bearer",
+      bearer: [{ key: "token", value: "{{token}}", type: "string" }],
+    })
+    expect(req.auth).toBeUndefined()
+    expect(req.header).toEqual([
+      { key: "X-Folder", value: "{{token}}", disabled: false },
+      { key: "X-Request", value: "child", disabled: true },
+    ])
+    expect(url.raw).toBe(
+      "https://api.example.com/users/:user?inline=keep&replace={{new}}&repeat=one#section",
+    )
+    expect(url.query).toEqual([
+      { key: "inline", value: "keep", disabled: false },
+      { key: "replace", value: "{{new}}", disabled: false },
+      { key: "repeat", value: "one", disabled: false },
+      { key: "repeat", value: "two", disabled: true },
+    ])
+    expect(url.variable).toEqual([{ key: "user", value: "{{userId}}" }])
+    expect(item.protocolProfileBehavior).toEqual({
+      followRedirects: false,
+      maxRedirects: 2,
+    })
+
+    const roundTrip = mapCollection(new PmCollection(exported.document))
+    const nested = roundTrip.collection.items[0]!
+    expect(nested.type).toBe("folder")
+    if (nested.type === "folder") {
+      expect(nested.data.children[0]!.data).toMatchObject({
+        auth: { type: "inherit" },
+        followRedirects: false,
+        maxRedirects: 2,
+        params: [
+          { name: "inline", value: "keep", enabled: true },
+          { name: "replace", value: "$new", enabled: true },
+          { name: "repeat", value: "one", enabled: true },
+          { name: "repeat", value: "two", enabled: false },
+        ],
+        pathParams: [{ name: "user", value: "$userId", enabled: true }],
+      })
+    }
+  })
+
+  it("exports every supported body and auth type", () => {
+    const collection: Collection = {
+      id: "bodies",
+      name: "Bodies",
+      items: [
+        {
+          type: "request",
+          data: request("none", "None", {
+            method: "GET",
+            bodyType: "none",
+            auth: { type: "none" },
+          }),
+        },
+        {
+          type: "request",
+          data: request("json", "JSON", {
+            body: '{"token":"$token"}',
+            auth: { type: "basic", user: "$user", pass: "$pass" },
+          }),
+        },
+        {
+          type: "request",
+          data: request("url", "URL", {
+            bodyType: "urlencoded",
+            formData: [
+              { name: "active", value: "$value", enabled: true, type: "text" },
+              { name: "disabled", value: "no", enabled: false, type: "text" },
+            ],
+          }),
+        },
+        {
+          type: "request",
+          data: request("multipart", "Multipart", {
+            bodyType: "multipart",
+            formData: [
+              { name: "file", value: "$path", enabled: false, type: "file" },
+            ],
+          }),
+        },
+        {
+          type: "request",
+          data: request("binary", "Binary", {
+            bodyType: "binary",
+            filePath: "$path",
+            auth: {
+              type: "api_key",
+              key: "$key",
+              value: "$$randomUUID",
+              placement: "query",
+            },
+          }),
+        },
+      ],
+    }
+
+    const items = exportPostman(collection).document.item as Record<
+      string,
+      unknown
+    >[]
+    expect((items[0]!.request as Record<string, unknown>).body).toBeUndefined()
+    expect((items[1]!.request as Record<string, unknown>).body).toEqual({
+      mode: "raw",
+      raw: '{"token":"{{token}}"}',
+      options: { raw: { language: "json" } },
+    })
+    expect((items[2]!.request as Record<string, unknown>).body).toEqual({
+      mode: "urlencoded",
+      urlencoded: [
+        { key: "active", disabled: false, type: "text", value: "{{value}}" },
+        { key: "disabled", disabled: true, type: "text", value: "no" },
+      ],
+    })
+    expect((items[3]!.request as Record<string, unknown>).body).toEqual({
+      mode: "formdata",
+      formdata: [
+        { key: "file", disabled: true, type: "file", src: "{{path}}" },
+      ],
+    })
+    expect((items[4]!.request as Record<string, unknown>).body).toEqual({
+      mode: "file",
+      file: { src: "{{path}}" },
+    })
+    expect((items[4]!.request as Record<string, unknown>).auth).toEqual({
+      type: "apikey",
+      apikey: [
+        { key: "key", value: "{{key}}", type: "string" },
+        { key: "value", value: "{{$randomUUID}}", type: "string" },
+        { key: "in", value: "query", type: "string" },
+      ],
+    })
+  })
+
+  it("redacts and deterministically orders environment values", () => {
+    expect(
+      exportPostmanEnvironment({
+        name: "production",
+        color: "danger",
+        vars: { TOKEN: "secret", BASE_URL: "https://api.example.com" },
+        disabledVars: { OLD_TOKEN: "also-secret" },
+      }),
+    ).toEqual({
+      name: "production",
+      values: [
+        { key: "BASE_URL", value: "", type: "default", enabled: true },
+        { key: "OLD_TOKEN", value: "", type: "default", enabled: false },
+        { key: "TOKEN", value: "", type: "default", enabled: true },
+      ],
+      _postman_variable_scope: "environment",
+    })
+  })
+})

--- a/tests/converters/postman-map.test.ts
+++ b/tests/converters/postman-map.test.ts
@@ -76,7 +76,7 @@ describe("mapCollection — flat collection, single request", () => {
     expect(r.params).toEqual([])
     expect(r.body).toBeUndefined()
     expect(r.bodyType).toBeUndefined()
-    expect(r.auth).toEqual({ type: "none" })
+    expect(r.auth).toEqual({ type: "inherit" })
   })
 })
 
@@ -126,6 +126,37 @@ describe("mapCollection — auth variants", () => {
     })
     const r = reqs(result)[0] as Record<string, unknown>
     expect(r.auth).toEqual({ type: "basic", user: "admin", pass: "pass" })
+  })
+
+  it("maps standard API key fields and templates", () => {
+    const result = makeCollection({
+      info: { name: "Auth" },
+      item: [
+        {
+          name: "API Key Req",
+          request: {
+            method: "GET",
+            url: "http://example.com",
+            header: [],
+            auth: {
+              type: "apikey",
+              apikey: [
+                { key: "key", value: "{{keyName}}", type: "string" },
+                { key: "value", value: "{{$randomUUID}}", type: "string" },
+                { key: "in", value: "query", type: "string" },
+              ],
+            },
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    expect(r.auth).toEqual({
+      type: "api_key",
+      key: "$keyName",
+      value: "$$randomUUID",
+      placement: "query",
+    })
   })
 
   it("maps noauth to none", () => {
@@ -282,6 +313,47 @@ describe("mapCollection — body variants", () => {
       value: "",
       enabled: true,
       type: "file",
+    })
+  })
+
+  it("preserves disabled fields and file references", () => {
+    const result = makeCollection({
+      info: { name: "Body" },
+      item: [
+        {
+          name: "Multipart Req",
+          request: {
+            method: "POST",
+            url: "http://example.com",
+            header: [],
+            body: {
+              mode: "formdata",
+              formdata: [
+                { key: "disabled", value: "no", disabled: true },
+                { key: "avatar", src: "{{filePath}}", type: "file" },
+              ],
+            },
+          },
+        },
+        {
+          name: "Binary Req",
+          request: {
+            method: "POST",
+            url: "http://example.com",
+            header: [],
+            body: { mode: "file", file: { src: "{{filePath}}" } },
+          },
+        },
+      ],
+    })
+    const [multipart, binary] = reqs(result) as Record<string, unknown>[]
+    expect(multipart.formData).toEqual([
+      { name: "disabled", value: "no", enabled: false, type: "text" },
+      { name: "avatar", value: "$filePath", enabled: true, type: "file" },
+    ])
+    expect(binary).toMatchObject({
+      bodyType: "binary",
+      filePath: "$filePath",
     })
   })
 })
@@ -515,6 +587,26 @@ describe("mapCollection — edge cases", () => {
       .overrides
     expect(overrides).toBeDefined()
     expect(overrides!.auth).toEqual({ type: "bearer", token: "$folderToken" })
+  })
+
+  it("reads redirect behavior from item metadata", () => {
+    const result = makeCollection({
+      info: { name: "Behavior" },
+      item: [
+        {
+          name: "No Redirect",
+          protocolProfileBehavior: {
+            followRedirects: false,
+            maxRedirects: 2,
+          },
+          request: { method: "GET", url: "http://example.com", header: [] },
+        },
+      ],
+    })
+    expect(reqs(result)[0]).toMatchObject({
+      followRedirects: false,
+      maxRedirects: 2,
+    })
   })
 
   it("ignores unknown body mode (graphql)", () => {

--- a/tests/integration/export.test.ts
+++ b/tests/integration/export.test.ts
@@ -148,10 +148,86 @@ describe("export — integration", () => {
     await expect(
       runExport({
         collection,
-        format: "postman",
+        format: "invalid",
         output: join(collection, "export.yml"),
       }),
-    ).rejects.toThrow('unknown export format "postman". Supported: openapi')
+    ).rejects.toThrow(
+      'unknown export format "invalid". Supported: openapi, postman',
+    )
+  })
+
+  it("writes a Postman bundle with redacted environment values", async () => {
+    const collection = await tempDir()
+    const output = join(await tempDir(), "postman")
+    await writeFile(
+      join(collection, "health.yml"),
+      [
+        "name: Health",
+        "method: GET",
+        "url: $base_url/health?source=noodle",
+        "headers:",
+        "  Authorization: Bearer $TOKEN",
+        "",
+      ].join("\n"),
+      "utf8",
+    )
+    await mkdir(join(collection, ".environments"))
+    await writeFile(
+      join(collection, ".environments", "production.env"),
+      "base_url=https://api.example.com\nTOKEN=should-not-export\n#OLD=also-not-export\n_color=success\n",
+      "utf8",
+    )
+    await mkdir(join(collection, ".timeline"))
+    await writeFile(
+      join(collection, ".timeline", "health.yml"),
+      "timeline-secret",
+    )
+
+    const result = await runExport({ collection, format: "postman", output })
+    const collectionFile = join(output, "collection.postman_collection.json")
+    const environmentFile = join(output, "production.postman_environment.json")
+    expect(result).toEqual({
+      path: output,
+      name: basename(collection),
+      format: "postman",
+      operationCount: 1,
+      environmentCount: 1,
+      files: [collectionFile, environmentFile],
+    })
+    expect(JSON.parse(await readFile(collectionFile, "utf8"))).toMatchObject({
+      info: {
+        schema:
+          "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      },
+    })
+    const environmentText = await readFile(environmentFile, "utf8")
+    expect(environmentText).toContain('"value": ""')
+    expect(environmentText).not.toContain("should-not-export")
+    expect(environmentText).not.toContain("also-not-export")
+    expect(environmentText).not.toContain("success")
+    expect(environmentText).not.toContain("timeline-secret")
+  })
+
+  it("requires a new or empty Postman output directory", async () => {
+    const collection = await tempDir()
+    await writeFile(
+      join(collection, "health.yml"),
+      "name: Health\nmethod: GET\nurl: https://example.com/health\n",
+      "utf8",
+    )
+    const root = await tempDir()
+    const nonempty = join(root, "nonempty")
+    const file = join(root, "file")
+    await mkdir(nonempty)
+    await writeFile(join(nonempty, "existing"), "")
+    await writeFile(file, "")
+
+    await expect(
+      runExport({ collection, format: "postman", output: nonempty }),
+    ).rejects.toThrow("postman export output directory must be empty")
+    await expect(
+      runExport({ collection, format: "postman", output: file }),
+    ).rejects.toThrow("postman export output must be a directory")
   })
 
   it("rejects outputs inside the collection without changing requests", async () => {
@@ -179,6 +255,14 @@ describe("export — integration", () => {
         collection,
         format: "openapi",
         output: join(link, "openapi.yml"),
+      }),
+    ).rejects.toThrow("export output must be outside the collection directory")
+
+    await expect(
+      runExport({
+        collection,
+        format: "postman",
+        output: join(collection, "postman"),
       }),
     ).rejects.toThrow("export output must be outside the collection directory")
 

--- a/tests/integration/export.test.ts
+++ b/tests/integration/export.test.ts
@@ -194,7 +194,8 @@ describe("export — integration", () => {
       environmentCount: 1,
       files: [collectionFile, environmentFile],
     })
-    expect(JSON.parse(await readFile(collectionFile, "utf8"))).toMatchObject({
+    const collectionText = await readFile(collectionFile, "utf8")
+    expect(JSON.parse(collectionText)).toMatchObject({
       info: {
         schema:
           "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -206,6 +207,7 @@ describe("export — integration", () => {
     expect(environmentText).not.toContain("also-not-export")
     expect(environmentText).not.toContain("success")
     expect(environmentText).not.toContain("timeline-secret")
+    expect(collectionText).not.toContain("timeline-secret")
   })
 
   it("requires a new or empty Postman output directory", async () => {


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `postman` format to `noodle export`, producing a Postman Collection v2.1 bundle directory (`collection.postman_collection.json` plus one `<environment>.postman_environment.json` per Noodle environment). Environment values are redacted to empty strings while preserving enabled/disabled state; request literals (URLs, headers, params, bodies, file paths, auth) are preserved as-is. Response timeline data is never exported. Also extends the shared Postman mapping used by the importer and refactors the export command plumbing to dispatch on format.

### How did you verify your code works?

- New unit suites: `tests/converters/postman-export.test.ts` (279 lines), expanded `tests/converters/postman-map.test.ts`, new CLI tests in `tests/cli.test.ts`
- Extended integration export coverage in `tests/integration/export.test.ts`
- `bun test` (93 tests across the affected files) passes; `bun run lint` and `bun run typecheck` pass

### Screenshots / recordings

N/A (CLI export)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Postman Collection v2.1 bundle export alongside OpenAPI export.
  - Exports include collections, redacted environment files, request variables, authentication, parameters, bodies, folders, and redirect settings.
  - Postman bundles are written to new or empty output directories.
  - CLI output identifies bundle details and reports exported environments.

- **Documentation**
  - Added CLI and README guidance covering Postman formats, output requirements, bundle contents, preserved request values, and export restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->