### PR TITLE
fix(keymap): prevent jump mode activation while response query is open

### DIFF
--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -297,6 +297,7 @@ export function ResponsePane({
     if (!responseQueryRef) return
     responseQueryRef.current = {
       canOpen: () => isDone && activeTab === "body" && !queryVisible,
+      isOpen: () => queryVisible,
       open: () => {
         if (!isDone || activeTab !== "body") return false
         setQueryVisible(true)

--- a/src/ui/keymap/globalLayers.ts
+++ b/src/ui/keymap/globalLayers.ts
@@ -219,7 +219,8 @@ export function createGlobalLayers(
             keymap.getData("app.mode") !== "edit" &&
             keymap.getData("app.jump") !== "active" &&
             !editingUrlText &&
-            !editingEnvName
+            !editingEnvName &&
+            !global.responseQueryRef.current?.isOpen()
           )
         },
         run: () => global.setJumpMode(true),

--- a/src/ui/responseQuery.ts
+++ b/src/ui/responseQuery.ts
@@ -11,6 +11,7 @@ export type ParsedResponseBody =
 
 export interface ResponseQueryController {
   canOpen: () => boolean
+  isOpen: () => boolean
   open: () => boolean
 }
 

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -97,7 +97,9 @@ describe("ResponsePane scrollbox", () => {
         status: 200,
         statusText: "OK",
         headers: {},
-        body: JSON.stringify({ data: { items: [{ id: 1 }, { id: 2 }] } }),
+        body: JSON.stringify({
+          data: { group: { items: [{ id: 1 }, { id: 2 }] } },
+        }),
         timeMs: 1,
       },
     } satisfies SendState
@@ -140,7 +142,7 @@ describe("ResponsePane scrollbox", () => {
     await renderOnce()
     expect(captureCharFrame()).toContain("JSONPath")
 
-    await act(async () => mockInput.typeText("$.data.items[*].id"))
+    await act(async () => mockInput.typeText("$.data.group.items[*].id"))
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 175))
     })

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -92,6 +92,7 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
       urlbarSubFocusRef: { current: "select" },
       viewRef: { current: "main" },
       expandedRef: { current: null },
+      responseQueryRef: { current: null },
       setFocus: (focus: string) => {
         calls.focus = focus
       },
@@ -478,6 +479,25 @@ describe("app keymap layers", () => {
     const { context, calls } = createContext(keymap)
     keymap.setData("app.view", "env-editor")
     keymap.setData("app.focus", "env-header")
+    const disposers = register(context)
+
+    host.press("g")
+
+    expect(calls.jumpMode).toBe(false)
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("does not enter jump mode while editing a response query", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    const responseQuery = {
+      canOpen: () => false,
+      open: () => false,
+      isOpen: () => true,
+    }
+    context.global.responseQueryRef.current = responseQuery
+    keymap.setData("app.focus", "response")
     const disposers = register(context)
 
     host.press("g")


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pressing `g` while the response JSONPath query overlay is open no longer activates jump mode, so typing a JSONPath can't accidentally enter jump mode mid-query.

### How did you verify your code works?

- `bun test` passes
- `bun run lint` passes
- `bun run typecheck` passes
- Added a unit test in `tests/unit/appKeymapLayers.test.ts` asserting jump mode does not activate while the response query is open.

### Screenshots / recordings

N/A (terminal UI; not a visual change).

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented jump mode from activating while the response JSON query overlay is open.
  - Improved keyboard interaction when the response pane is focused.

- **Tests**
  - Added coverage for jump-mode behavior with an open response query.
  - Updated response JSONPath test data and query paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->