### PR TITLE
feat(ui): add collection export overlay for OpenAPI and Postman

### DIFF
--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -69,7 +69,12 @@ import { useCollectionSwitcher } from "./useCollectionSwitcher"
 import { useReloadGuard } from "./useReloadGuard"
 import { useKeymapSync } from "./useKeymapSync"
 import { useEditModeSync } from "./useEditModeSync"
-import { openEnvironmentEditor, openEnvironmentPicker } from "./commandActions"
+import {
+  closeCollectionExport,
+  openEnvironmentEditor,
+  openEnvironmentPicker,
+} from "./commandActions"
+import { runCollectionExport } from "./collectionExport"
 
 export function AppInner({
   collectionDir,
@@ -156,6 +161,7 @@ export function AppInner({
   const jumpTargetsRef = useRef<Map<string, JumpTarget>>(new Map())
   const headerFieldRef = useRef<"name" | "color">("name")
   const pendingHeaderFieldRef = useRef<"name" | "color" | null>(null)
+  const exportPendingRef = useRef(false)
 
   // ── Collection ──────────────────────────────────────────────────────
   const isCollection = mode === "collection"
@@ -589,6 +595,9 @@ export function AppInner({
     setCommandPaletteVisible,
     codeGeneratorVisible,
     setCodeGeneratorVisible,
+    exportCollectionVisible,
+    setExportCollectionVisible,
+    exportCollectionRef,
     requestFinderVisible,
     setRequestFinderVisible,
     timelineDetailEntry,
@@ -904,6 +913,31 @@ export function AppInner({
         )
       }
     },
+    exportCollectionVisible,
+    exportCollectionRef,
+    onExportCollectionCancel: () =>
+      closeCollectionExport(exportPendingRef, setExportCollectionVisible),
+    onExportCollectionConfirm: (values) => {
+      const collectionName =
+        collection?.name ?? (basename(collectionDir) || "collection")
+      void runCollectionExport({
+        collectionDir,
+        collectionName,
+        values,
+        hasUnsavedChanges,
+        pending: exportPendingRef,
+      })
+        .then((result) => {
+          if (!result) return
+          setExportCollectionVisible(false)
+          showToast(`Collection exported to ${result.path}`, "success")
+        })
+        .catch((error: unknown) => {
+          exportCollectionRef.current?.setError(
+            error instanceof Error ? error.message : String(error),
+          )
+        })
+    },
     editRequestVisible,
     editRequestRef,
     setEditRequestVisible,
@@ -993,6 +1027,7 @@ export function AppInner({
         setCollectionSwitcherVisible,
         setRequestFinderVisible,
         setCodeGeneratorVisible,
+        setExportCollectionVisible,
         setYamlEditor,
         setView,
         setFocus,
@@ -1167,6 +1202,9 @@ export function AppInner({
           setCommandPaletteVisible={setCommandPaletteVisible}
           codeGeneratorVisible={codeGeneratorVisible}
           setCodeGeneratorVisible={setCodeGeneratorVisible}
+          exportCollectionVisible={exportCollectionVisible}
+          exportCollectionRef={exportCollectionRef}
+          exportCollectionActions={overlayActions.exportCollection}
           codeGeneratorRequest={draft.draft}
           codeGeneratorEnv={envState.activeEnv}
           codeGeneratorEnvName={envState.activeEnv?.name}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react"
+import { basename } from "node:path"
 import { HelpOverlay } from "./overlays/HelpOverlay"
 import { AboutOverlay } from "./overlays/AboutOverlay"
 import { ConfirmOverlay } from "./overlays/ConfirmOverlay"
@@ -31,6 +32,10 @@ import {
   ImportCurlOverlay,
   type ImportCurlOverlayHandle,
 } from "./overlays/ImportCurlOverlay"
+import {
+  ExportCollectionOverlay,
+  type ExportCollectionOverlayHandle,
+} from "./overlays/ExportCollectionOverlay"
 import type {
   Collection,
   Environment,
@@ -115,6 +120,9 @@ interface AppOverlaysProps {
   importCurlRef: RefObject<ImportCurlOverlayHandle | null>
   importCurlActions: { confirm: () => void; cancel: () => void }
   importCurlInitialFolder: string
+  exportCollectionVisible: boolean
+  exportCollectionRef: RefObject<ExportCollectionOverlayHandle | null>
+  exportCollectionActions: { confirm: () => void; cancel: () => void }
   activeEnv: Environment | null
   editRequestVisible: boolean
   selectedRequest: NoodleRequest | null
@@ -212,6 +220,9 @@ export function AppOverlays({
   importCurlRef,
   importCurlActions,
   importCurlInitialFolder,
+  exportCollectionVisible,
+  exportCollectionRef,
+  exportCollectionActions,
   activeEnv,
   editRequestVisible,
   selectedRequest,
@@ -403,6 +414,17 @@ export function AppOverlays({
           initialFolderPath={importCurlInitialFolder}
           onConfirm={importCurlActions.confirm}
           onClose={importCurlActions.cancel}
+        />
+      )}
+      {exportCollectionVisible && (
+        <ExportCollectionOverlay
+          visible
+          ref={exportCollectionRef}
+          collectionName={
+            collection?.name ?? (basename(collectionDir) || "collection")
+          }
+          onConfirm={exportCollectionActions.confirm}
+          onClose={exportCollectionActions.cancel}
         />
       )}
       {editRequestVisible && (

--- a/src/ui/collectionExport.ts
+++ b/src/ui/collectionExport.ts
@@ -1,0 +1,61 @@
+import { join } from "node:path"
+import type { ExportOptions, ExportResult } from "../app/export"
+import { expandUserPath } from "../userPath"
+
+export type ExportFormat = "openapi" | "postman"
+
+export interface ExportCollectionValues {
+  format: ExportFormat
+  outputDir: string
+}
+
+type ExportRunner = (options: ExportOptions) => Promise<ExportResult>
+
+export function getExportTargetPath(
+  outputDir: string,
+  collectionName: string,
+  format: ExportFormat,
+): string {
+  const name =
+    format === "openapi"
+      ? `${collectionName}.openapi.yml`
+      : `${collectionName}-postman`
+  return join(expandUserPath(outputDir), name)
+}
+
+export async function runCollectionExport({
+  collectionDir,
+  collectionName,
+  values,
+  hasUnsavedChanges,
+  pending,
+  runExport,
+}: {
+  collectionDir: string
+  collectionName: string
+  values: ExportCollectionValues
+  hasUnsavedChanges: boolean
+  pending: { current: boolean }
+  runExport?: ExportRunner
+}): Promise<ExportResult | null> {
+  if (hasUnsavedChanges) {
+    throw new Error("Save all changes before exporting")
+  }
+  if (pending.current) return null
+
+  pending.current = true
+  try {
+    const execute = runExport ?? (await import("../app/export")).runExport
+    return await execute({
+      collection: collectionDir,
+      format: values.format,
+      output: getExportTargetPath(
+        values.outputDir,
+        collectionName,
+        values.format,
+      ),
+    })
+  } finally {
+    pending.current = false
+  }
+}

--- a/src/ui/collectionExport.ts
+++ b/src/ui/collectionExport.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs"
 import { join } from "node:path"
 import type { ExportOptions, ExportResult } from "../app/export"
 import { expandUserPath } from "../userPath"
@@ -11,16 +12,31 @@ export interface ExportCollectionValues {
 
 type ExportRunner = (options: ExportOptions) => Promise<ExportResult>
 
+function isAvailablePostmanTarget(path: string): boolean {
+  try {
+    return readdirSync(path).length === 0
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+  }
+}
+
 export function getExportTargetPath(
   outputDir: string,
   collectionName: string,
   format: ExportFormat,
 ): string {
-  const name =
-    format === "openapi"
-      ? `${collectionName}.openapi.yml`
-      : `${collectionName}-postman`
-  return join(expandUserPath(outputDir), name)
+  const root = expandUserPath(outputDir)
+  if (format === "openapi") {
+    return join(root, `${collectionName}.openapi.yml`)
+  }
+
+  const name = `${collectionName}-postman`
+  let target = join(root, name)
+  let suffix = 2
+  while (!isAvailablePostmanTarget(target)) {
+    target = join(root, `${name}-${suffix++}`)
+  }
+  return target
 }
 
 export async function runCollectionExport({

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -288,6 +288,22 @@ export function openAbout(): boolean {
   return true
 }
 
+export function openCollectionExport(
+  setVisible: (visible: boolean) => void,
+): boolean {
+  setVisible(true)
+  return true
+}
+
+export function closeCollectionExport(
+  pending: RefObject<boolean>,
+  setVisible: (visible: boolean) => void,
+): boolean {
+  if (pending.current) return false
+  setVisible(false)
+  return true
+}
+
 export function openCollectionSwitcher(view: string): boolean {
   if (view === "env-editor") {
     showToast("Cannot switch collections from environment editor", "warning")

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -35,6 +35,7 @@ import {
   undoAll,
   openThemePicker,
   openAbout,
+  openCollectionExport,
   openCollectionSwitcher,
   type CommandActionsConfig,
 } from "./commandActions"
@@ -96,6 +97,9 @@ export interface CommandBuilderContext {
   ) => void
   setRequestFinderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setCodeGeneratorVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setExportCollectionVisible: (
+    v: boolean | ((prev: boolean) => boolean),
+  ) => void
   setYamlEditor: (
     v: YamlEditorState | ((prev: YamlEditorState) => YamlEditorState),
   ) => void
@@ -180,6 +184,7 @@ export function buildCommandPaletteCommands(
     setCollectionSwitcherVisible,
     setRequestFinderVisible,
     setCodeGeneratorVisible,
+    setExportCollectionVisible,
     setEnvDeletePending,
     getCollectionMode,
     triggerUpdateCheck,
@@ -368,6 +373,12 @@ export function buildCommandPaletteCommands(
   ]
 
   const workspaceCommands: CommandItem[] = [
+    {
+      id: "collection.export",
+      label: "Export Collection",
+      section: "Workspace",
+      run: () => openCollectionExport(setExportCollectionVisible),
+    },
     {
       id: "folder.new",
       label: "New Folder",

--- a/src/ui/overlays/ExportCollectionOverlay.tsx
+++ b/src/ui/overlays/ExportCollectionOverlay.tsx
@@ -1,0 +1,231 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react"
+import { MouseButton } from "@opentui/core"
+import {
+  getExportTargetPath,
+  type ExportCollectionValues,
+  type ExportFormat,
+} from "../collectionExport"
+import { Select, type SelectItem } from "../Select"
+import { useTheme } from "../theme"
+import { VarInput, type VarInputHandle } from "../VarInput"
+import { EscapeClose } from "./EscapeClose"
+import { Overlay } from "./Overlay"
+
+export interface ExportCollectionOverlayHandle {
+  cycleFocus: (direction: 1 | -1) => void
+  commitField: () => void
+  confirm: () => ExportCollectionValues | null
+  getFocus: () => "format" | "output"
+  setError: (message: string | null) => void
+}
+
+interface ExportCollectionOverlayProps {
+  visible: boolean
+  collectionName: string
+  pathCompletionRoot?: string
+  onConfirm?: () => void
+  onClose?: () => void
+}
+
+const FORMAT_ITEMS: SelectItem[] = [
+  { id: "openapi", label: "OpenAPI" },
+  { id: "postman", label: "Postman" },
+]
+
+export const ExportCollectionOverlay = forwardRef<
+  ExportCollectionOverlayHandle,
+  ExportCollectionOverlayProps
+>(function ExportCollectionOverlay(
+  { visible, collectionName, pathCompletionRoot, onConfirm, onClose },
+  ref,
+) {
+  const theme = useTheme()
+  const [format, setFormat] = useState<ExportFormat>("openapi")
+  const [outputDir, setOutputDir] = useState("@/")
+  const [focus, setFocus] = useState<"format" | "output">("format")
+  const [errorText, setErrorText] = useState<string | null>(null)
+  const [selectOpen, setSelectOpen] = useState(false)
+  const [hoveredAction, setHoveredAction] = useState<"export" | "close" | null>(
+    null,
+  )
+  const outputRef = useRef<VarInputHandle | null>(null)
+
+  useImperativeHandle(ref, () => ({
+    cycleFocus: () => {
+      setErrorText(null)
+      setFocus((current) => (current === "format" ? "output" : "format"))
+    },
+    commitField: () => setFocus("output"),
+    confirm: () => {
+      if (outputDir.trim() === "") {
+        setErrorText("Output folder is required")
+        return null
+      }
+      setErrorText(null)
+      return { format, outputDir }
+    },
+    getFocus: () => focus,
+    setError: setErrorText,
+  }))
+
+  useEffect(() => {
+    if (!visible) return
+    setFormat("openapi")
+    setOutputDir("@/")
+    setFocus("format")
+    setErrorText(null)
+  }, [visible])
+
+  useEffect(() => {
+    if (focus === "output") outputRef.current?.focus()
+  }, [focus])
+
+  const target = getExportTargetPath(outputDir, collectionName, format)
+
+  return (
+    <Overlay visible={visible} width={68} padding={1} gap={1}>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingBottom: 1,
+          paddingX: 2,
+        }}
+      >
+        <text fg={theme.text}>Export Collection</text>
+        <EscapeClose onClose={() => onClose?.()} />
+      </box>
+
+      <box
+        style={{
+          paddingX: 2,
+          flexDirection: "column",
+          gap: 1,
+          paddingBottom: 1,
+        }}
+      >
+        <box
+          style={{
+            flexDirection: "column",
+            zIndex: selectOpen ? 1 : undefined,
+          }}
+        >
+          <text fg={theme.textMuted}>Format</text>
+          <Select
+            items={FORMAT_ITEMS}
+            value={format}
+            onChange={(value) => {
+              setFormat(value as ExportFormat)
+              setErrorText(null)
+            }}
+            focused={focus === "format"}
+            onOpenChange={setSelectOpen}
+            onActivate={() => setFocus("format")}
+            triggerPriority={110}
+          />
+        </box>
+
+        <box style={{ flexDirection: "column" }}>
+          <text fg={theme.textMuted}>Output Folder</text>
+          <box
+            onMouseDown={(event) => {
+              if (event.button === MouseButton.LEFT) setFocus("output")
+            }}
+          >
+            <VarInput
+              ref={outputRef}
+              value={outputDir}
+              env={null}
+              isEditing
+              isFocused={focus === "output"}
+              onChange={(value) => {
+                setOutputDir(value)
+                setErrorText(null)
+              }}
+              pathCompletion={{
+                kind: "directory",
+                root: pathCompletionRoot,
+              }}
+              placeholder="@/Exports"
+              backgroundColor={theme.backgroundElement}
+              focusedBackgroundColor={theme.borderSubtle}
+              paddingX={1}
+              style={{ flexGrow: 1, flexShrink: 1 }}
+            />
+          </box>
+          <text fg={theme.textMuted} wrapMode="word">
+            Target: {target}
+          </text>
+        </box>
+
+        {format === "postman" && (
+          <text fg={theme.warning} wrapMode="word">
+            Postman exports keep literal request values and expand local file
+            paths. Review the bundle before sharing.
+          </text>
+        )}
+        {errorText && (
+          <text fg={theme.error} wrapMode="word">
+            {errorText}
+          </text>
+        )}
+      </box>
+
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "flex-end",
+          gap: 1,
+          paddingX: 2,
+        }}
+      >
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("export")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "export" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>^S</text>
+          <text fg={theme.textMuted}> export</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onClose?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("close")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "close" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>esc</text>
+          <text fg={theme.textMuted}> close</text>
+        </box>
+      </box>
+    </Overlay>
+  )
+})

--- a/src/ui/overlays/ExportCollectionOverlay.tsx
+++ b/src/ui/overlays/ExportCollectionOverlay.tsx
@@ -63,12 +63,13 @@ export const ExportCollectionOverlay = forwardRef<
     },
     commitField: () => setFocus("output"),
     confirm: () => {
-      if (outputDir.trim() === "") {
+      const trimmed = outputDir.trim()
+      if (trimmed === "") {
         setErrorText("Output folder is required")
         return null
       }
       setErrorText(null)
-      return { format, outputDir }
+      return { format, outputDir: trimmed }
     },
     getFocus: () => focus,
     setError: setErrorText,

--- a/src/ui/useModalKeyboardShield.ts
+++ b/src/ui/useModalKeyboardShield.ts
@@ -11,6 +11,7 @@ export const EDITABLE_OVERLAYS = new Set([
   "new-environment",
   "new-request",
   "import-curl",
+  "export-collection",
   "edit-request",
   "clone-request",
   "new-folder",

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -7,6 +7,8 @@ import type { NewRequestOverlayHandle } from "./overlays/NewRequestOverlay"
 import type { CloneRequestOverlayHandle } from "./overlays/CloneRequestOverlay"
 import type { NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
 import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
+import type { ExportCollectionOverlayHandle } from "./overlays/ExportCollectionOverlay"
+import type { ExportCollectionValues } from "./collectionExport"
 import type {
   NewEnvironmentOverlayHandle,
   NewEnvironmentValues,
@@ -74,6 +76,10 @@ export function useOverlayIntercepts(opts: {
     name: string
     folderPath: string
   }) => void
+  exportCollectionVisible: boolean
+  exportCollectionRef: RefObject<ExportCollectionOverlayHandle | null>
+  onExportCollectionCancel: () => void
+  onExportCollectionConfirm: (values: ExportCollectionValues) => void
   editRequestVisible: boolean
   editRequestRef: RefObject<NewRequestOverlayHandle | null>
   setEditRequestVisible: (v: boolean) => void
@@ -141,6 +147,14 @@ export function useOverlayIntercepts(opts: {
     onCancel: () => opts.setImportCurlVisible(false),
   })
 
+  const exportCollectionActions = useFormOverlayIntercept({
+    visible: opts.exportCollectionVisible,
+    handleRef: opts.exportCollectionRef,
+    onConfirm: opts.onExportCollectionConfirm,
+    onCancel: opts.onExportCollectionCancel,
+    passThroughFocuses: ["format"],
+  })
+
   const editRequestActions = useFormOverlayIntercept({
     visible: opts.editRequestVisible,
     handleRef: opts.editRequestRef,
@@ -170,6 +184,7 @@ export function useOverlayIntercepts(opts: {
     newEnvironment: newEnvironmentActions,
     newRequest: newRequestActions,
     importCurl: importCurlActions,
+    exportCollection: exportCollectionActions,
     editRequest: editRequestActions,
     cloneRequest: cloneRequestActions,
     newFolder: newFolderActions,

--- a/src/ui/useOverlayState.ts
+++ b/src/ui/useOverlayState.ts
@@ -7,10 +7,12 @@ import type { CloneRequestOverlayHandle } from "./overlays/CloneRequestOverlay"
 import type { NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
 import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
 import type { NewEnvironmentOverlayHandle } from "./overlays/NewEnvironmentOverlay"
+import type { ExportCollectionOverlayHandle } from "./overlays/ExportCollectionOverlay"
 
 export type ActiveOverlay =
   | "command-palette"
   | "code-generator"
+  | "export-collection"
   | "request-finder"
   | "help"
   | "about"
@@ -81,6 +83,8 @@ export function useOverlayState({
   const [initPending, setInitPending] = useState(false)
   const [commandPaletteVisible, setCommandPaletteVisible] = useState(false)
   const [codeGeneratorVisible, setCodeGeneratorVisible] = useState(false)
+  const [exportCollectionVisible, setExportCollectionVisible] = useState(false)
+  const exportCollectionRef = useRef<ExportCollectionOverlayHandle>(null)
   const [requestFinderVisible, setRequestFinderVisible] = useState(false)
   const [timelineDetailEntry, setTimelineDetailEntry] =
     useState<TimelineEntry | null>(null)
@@ -92,6 +96,7 @@ export function useOverlayState({
   const activeOverlay = useMemo((): ActiveOverlay => {
     if (commandPaletteVisible) return "command-palette"
     if (codeGeneratorVisible) return "code-generator"
+    if (exportCollectionVisible) return "export-collection"
     if (requestFinderVisible) return "request-finder"
     if (helpVisible) return "help"
     if (aboutVisible) return "about"
@@ -118,6 +123,7 @@ export function useOverlayState({
   }, [
     commandPaletteVisible,
     codeGeneratorVisible,
+    exportCollectionVisible,
     requestFinderVisible,
     helpVisible,
     aboutVisible,
@@ -185,6 +191,9 @@ export function useOverlayState({
     setCommandPaletteVisible,
     codeGeneratorVisible,
     setCodeGeneratorVisible,
+    exportCollectionVisible,
+    setExportCollectionVisible,
+    exportCollectionRef,
     requestFinderVisible,
     setRequestFinderVisible,
     timelineDetailEntry,

--- a/tests/unit/ExportCollectionOverlay.test.tsx
+++ b/tests/unit/ExportCollectionOverlay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { mkdir, mkdtemp, rm } from "node:fs/promises"
-import { homedir, tmpdir } from "node:os"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { act, createRef, useEffect } from "react"
 import { MouseButtons } from "@opentui/core/testing"
@@ -83,7 +83,7 @@ describe("ExportCollectionOverlay", () => {
     expect(frame).toContain("Export Collection")
     expect(frame).toContain("OpenAPI")
     expect(frame).toContain("Output Folder")
-    expect(frame).toContain(join(homedir(), "orders.openapi.yml"))
+    expect(frame).toContain("orders.openapi.yml")
     expect(ref.current?.getFocus()).toBe("format")
     let result: ExportCollectionValues | null | undefined
     act(() => {
@@ -112,7 +112,7 @@ describe("ExportCollectionOverlay", () => {
     await render.renderOnce()
 
     const frame = render.captureCharFrame()
-    expect(frame).toContain(join(homedir(), "orders-postman"))
+    expect(frame).toContain("orders-postman")
     expect(frame).toContain("literal request values")
     let result: ExportCollectionValues | null | undefined
     act(() => {
@@ -148,6 +148,12 @@ describe("ExportCollectionOverlay", () => {
     expect(result).toBeNull()
     await render.renderOnce()
     expect(render.captureCharFrame()).toContain("Output folder is required")
+
+    await act(async () => render.mockInput.typeText("  /exports  "))
+    act(() => {
+      result = ref.current?.confirm()
+    })
+    expect(result).toEqual({ format: "openapi", outputDir: "/exports" })
 
     act(() => ref.current?.setError("Save all changes before exporting"))
     await render.renderOnce()

--- a/tests/unit/ExportCollectionOverlay.test.tsx
+++ b/tests/unit/ExportCollectionOverlay.test.tsx
@@ -186,6 +186,7 @@ describe("ExportCollectionOverlay", () => {
         { width: 90, height: 22 },
       )
       await render.renderOnce()
+      await render.renderOnce()
       await act(async () => host.press("tab"))
       expect(ref.current?.getFocus()).toBe("output")
       await render.waitForFrame((frame) => frame.includes("Exports/"))

--- a/tests/unit/ExportCollectionOverlay.test.tsx
+++ b/tests/unit/ExportCollectionOverlay.test.tsx
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "bun:test"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { homedir, tmpdir } from "node:os"
+import { join } from "node:path"
+import { act, createRef, useEffect } from "react"
+import { MouseButtons } from "@opentui/core/testing"
+import { testRender } from "@opentui/react/test-utils"
+import { KeymapProvider, useKeymap } from "@opentui/keymap/react"
+import { ThemeProvider } from "../../src/ui/theme"
+import {
+  ExportCollectionOverlay,
+  type ExportCollectionOverlayHandle,
+} from "../../src/ui/overlays/ExportCollectionOverlay"
+import type { ExportCollectionValues } from "../../src/ui/collectionExport"
+import { useFormOverlayIntercept } from "../../src/ui/intercepts/useFormOverlayIntercept"
+import { VariableCompletionInterceptor } from "../../src/ui/variable-completion/variableCompletionInterceptor"
+import { setupKeymap } from "./_helpers"
+
+function Harness({
+  overlayRef,
+  onConfirm,
+  onCancel,
+  collectionName = "orders",
+  pathCompletionRoot,
+}: {
+  overlayRef: React.RefObject<ExportCollectionOverlayHandle | null>
+  onConfirm: (values: ExportCollectionValues) => void
+  onCancel: () => void
+  collectionName?: string
+  pathCompletionRoot?: string
+}) {
+  const keymap = useKeymap()
+  const actions = useFormOverlayIntercept({
+    visible: true,
+    handleRef: overlayRef,
+    onConfirm,
+    onCancel,
+    passThroughFocuses: ["format"],
+  })
+
+  useEffect(
+    () =>
+      keymap.intercept(
+        "key",
+        (ctx) => {
+          if (ctx.event.name === "x") throw new Error("background key leaked")
+        },
+        { priority: 0 },
+      ),
+    [keymap],
+  )
+
+  return (
+    <>
+      <VariableCompletionInterceptor />
+      <ExportCollectionOverlay
+        visible
+        ref={overlayRef}
+        collectionName={collectionName}
+        pathCompletionRoot={pathCompletionRoot}
+        onConfirm={actions.confirm}
+        onClose={actions.cancel}
+      />
+    </>
+  )
+}
+
+describe("ExportCollectionOverlay", () => {
+  it("defaults to OpenAPI and previews the generated target", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ExportCollectionOverlayHandle>()
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ExportCollectionOverlay visible ref={ref} collectionName="orders" />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 22 },
+    )
+    await render.renderOnce()
+
+    const frame = render.captureCharFrame()
+    expect(frame).toContain("Export Collection")
+    expect(frame).toContain("OpenAPI")
+    expect(frame).toContain("Output Folder")
+    expect(frame).toContain(join(homedir(), "orders.openapi.yml"))
+    expect(ref.current?.getFocus()).toBe("format")
+    let result: ExportCollectionValues | null | undefined
+    act(() => {
+      result = ref.current?.confirm()
+    })
+    expect(result).toEqual({ format: "openapi", outputDir: "@/" })
+    cleanup()
+  })
+
+  it("switches to Postman and shows its disclosure warning", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const ref = createRef<ExportCollectionOverlayHandle>()
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ExportCollectionOverlay visible ref={ref} collectionName="orders" />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 22 },
+    )
+    await render.renderOnce()
+    act(() => host.press("return"))
+    await render.renderOnce()
+    act(() => host.press("down"))
+    act(() => host.press("return"))
+    await render.renderOnce()
+
+    const frame = render.captureCharFrame()
+    expect(frame).toContain(join(homedir(), "orders-postman"))
+    expect(frame).toContain("literal request values")
+    let result: ExportCollectionValues | null | undefined
+    act(() => {
+      result = ref.current?.confirm()
+    })
+    expect(result).toEqual({ format: "postman", outputDir: "@/" })
+    cleanup()
+  })
+
+  it("validates the output folder and keeps external errors inline", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ExportCollectionOverlayHandle>()
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ExportCollectionOverlay visible ref={ref} collectionName="orders" />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 22 },
+    )
+    await render.renderOnce()
+    act(() => ref.current?.cycleFocus(1))
+    await render.renderOnce()
+    await act(async () => {
+      await render.mockInput.pressKey("BACKSPACE")
+      await render.mockInput.pressKey("BACKSPACE")
+    })
+    await render.renderOnce()
+    let result: ExportCollectionValues | null | undefined
+    act(() => {
+      result = ref.current?.confirm()
+    })
+    expect(result).toBeNull()
+    await render.renderOnce()
+    expect(render.captureCharFrame()).toContain("Output folder is required")
+
+    act(() => ref.current?.setError("Save all changes before exporting"))
+    await render.renderOnce()
+    expect(render.captureCharFrame()).toContain(
+      "Save all changes before exporting",
+    )
+    cleanup()
+  })
+
+  it("uses directory completion and owns form/footer actions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-export-overlay-"))
+    await mkdir(join(root, "Exports"))
+    const { keymap, host, cleanup } = setupKeymap()
+    const ref = createRef<ExportCollectionOverlayHandle>()
+    const confirmed: ExportCollectionValues[] = []
+    let closed = 0
+
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <Harness
+              overlayRef={ref}
+              pathCompletionRoot={root}
+              onConfirm={(values) => confirmed.push(values)}
+              onCancel={() => closed++}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 90, height: 22 },
+      )
+      await render.renderOnce()
+      await act(async () => host.press("tab"))
+      expect(ref.current?.getFocus()).toBe("output")
+      await render.waitForFrame((frame) => frame.includes("Exports/"))
+      await render.renderOnce()
+      await render.renderOnce()
+      await act(async () => host.press("return"))
+      await render.renderOnce()
+      let result: ExportCollectionValues | null | undefined
+      act(() => {
+        result = ref.current?.confirm()
+      })
+      expect(result).toEqual({
+        format: "openapi",
+        outputDir: "@/Exports",
+      })
+
+      await act(async () => host.press("tab", { shift: true }))
+      await act(async () => host.press("x"))
+      await act(async () => host.press("tab"))
+      await act(async () => host.press("s", { ctrl: true }))
+      expect(confirmed).toEqual([{ format: "openapi", outputDir: "@/Exports" }])
+
+      const rows = render.captureCharFrame().split("\n")
+      const footerY = rows.findIndex((row) => row.includes("export"))
+      await act(async () => {
+        await render.mockMouse.click(
+          rows[footerY]!.lastIndexOf("export"),
+          footerY,
+          MouseButtons.LEFT,
+        )
+        await render.mockMouse.click(
+          rows[footerY]!.indexOf("close"),
+          footerY,
+          MouseButtons.LEFT,
+        )
+      })
+      expect(confirmed).toHaveLength(2)
+      expect(closed).toBe(1)
+    } finally {
+      cleanup()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { afterEach, describe, it, expect } from "bun:test"
+import { testRender as openTUITestRender } from "@opentui/react/test-utils"
 import { RGBA } from "@opentui/core"
 import { act } from "react"
 import { useState } from "react"
@@ -16,6 +16,20 @@ import {
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+
+let renderer: Awaited<ReturnType<typeof openTUITestRender>>["renderer"] | null =
+  null
+
+async function testRender(...args: Parameters<typeof openTUITestRender>) {
+  const setup = await openTUITestRender(...args)
+  renderer = setup.renderer
+  return setup
+}
+
+afterEach(() => {
+  act(() => renderer?.destroy())
+  renderer = null
+})
 
 function env(vars: Record<string, string>): Environment {
   return { name: "test-env", vars }

--- a/tests/unit/collectionExport.test.ts
+++ b/tests/unit/collectionExport.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { runCollectionExport } from "../../src/ui/collectionExport"
+import {
+  getExportTargetPath,
+  runCollectionExport,
+} from "../../src/ui/collectionExport"
 import type { ExportOptions, ExportResult } from "../../src/app/export"
 
 const RESULT: ExportResult = {
@@ -11,6 +16,22 @@ const RESULT: ExportResult = {
 }
 
 describe("runCollectionExport", () => {
+  it("increments populated Postman targets for repeat exports", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "noodle-export-target-"))
+
+    try {
+      const firstTarget = join(outputDir, "orders-postman")
+      await mkdir(firstTarget)
+      await writeFile(join(firstTarget, "collection.json"), "{}")
+
+      expect(getExportTargetPath(outputDir, "orders", "postman")).toBe(
+        join(outputDir, "orders-postman-2"),
+      )
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
   it("rejects unsaved edits before export", async () => {
     let called = false
     const pending = { current: false }

--- a/tests/unit/collectionExport.test.ts
+++ b/tests/unit/collectionExport.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test"
+import { join } from "node:path"
+import { runCollectionExport } from "../../src/ui/collectionExport"
+import type { ExportOptions, ExportResult } from "../../src/app/export"
+
+const RESULT: ExportResult = {
+  path: "/exports/orders.openapi.yml",
+  name: "orders",
+  format: "openapi",
+  operationCount: 1,
+}
+
+describe("runCollectionExport", () => {
+  it("rejects unsaved edits before export", async () => {
+    let called = false
+    const pending = { current: false }
+
+    await expect(
+      runCollectionExport({
+        collectionDir: "/collections/orders",
+        collectionName: "orders",
+        values: { format: "openapi", outputDir: "/exports" },
+        hasUnsavedChanges: true,
+        pending,
+        runExport: async () => {
+          called = true
+          return RESULT
+        },
+      }),
+    ).rejects.toThrow("Save all changes before exporting")
+    expect(called).toBe(false)
+    expect(pending.current).toBe(false)
+  })
+
+  it("generates format targets and ignores duplicate submissions", async () => {
+    const calls: ExportOptions[] = []
+    const pending = { current: false }
+    let finish: ((result: ExportResult) => void) | undefined
+    const runExport = (options: ExportOptions) => {
+      calls.push(options)
+      return new Promise<ExportResult>((resolve) => {
+        finish = resolve
+      })
+    }
+    const options = {
+      collectionDir: "/collections/orders",
+      collectionName: "orders",
+      values: { format: "openapi", outputDir: "/exports" } as const,
+      hasUnsavedChanges: false,
+      pending,
+      runExport,
+    }
+
+    const first = runCollectionExport(options)
+    expect(pending.current).toBe(true)
+    expect(await runCollectionExport(options)).toBeNull()
+    expect(calls).toEqual([
+      {
+        collection: "/collections/orders",
+        format: "openapi",
+        output: join("/exports", "orders.openapi.yml"),
+      },
+    ])
+
+    finish?.(RESULT)
+    expect(await first).toBe(RESULT)
+    expect(pending.current).toBe(false)
+
+    await runCollectionExport({
+      ...options,
+      values: { format: "postman", outputDir: "/exports" },
+      runExport: async (call) => {
+        calls.push(call)
+        return { ...RESULT, format: "postman" }
+      },
+    })
+    expect(calls[1]?.output).toBe(join("/exports", "orders-postman"))
+  })
+
+  it("clears the pending guard after failures", async () => {
+    const pending = { current: false }
+    await expect(
+      runCollectionExport({
+        collectionDir: "/collections/orders",
+        collectionName: "orders",
+        values: { format: "openapi", outputDir: "/exports" },
+        hasUnsavedChanges: false,
+        pending,
+        runExport: async () => {
+          throw new Error("write failed")
+        },
+      }),
+    ).rejects.toThrow("write failed")
+    expect(pending.current).toBe(false)
+  })
+})

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -5,6 +5,7 @@ import type { CommandBuilderContext } from "../../src/ui/commands"
 import { bindingDefaults } from "../../src/ui/keybind"
 import type { Collection } from "../../src/schema"
 import {
+  closeCollectionExport,
   cloneRequest,
   getEditRequestYamlFile,
   saveFolder,
@@ -57,6 +58,7 @@ function minimalContext(): CommandBuilderContext {
     setCollectionSwitcherVisible: () => {},
     setRequestFinderVisible: () => {},
     setCodeGeneratorVisible: () => {},
+    setExportCollectionVisible: () => {},
     setYamlEditor: () => {},
     setView: () => {},
     setFocus: () => {},
@@ -72,6 +74,18 @@ function minimalContext(): CommandBuilderContext {
 }
 
 describe("buildCommandPaletteCommands", () => {
+  it("keeps collection export open while an export is pending", () => {
+    let visible = true
+    const setVisible = (value: boolean) => {
+      visible = value
+    }
+
+    expect(closeCollectionExport({ current: true }, setVisible)).toBe(false)
+    expect(visible).toBe(true)
+    expect(closeCollectionExport({ current: false }, setVisible)).toBe(true)
+    expect(visible).toBe(false)
+  })
+
   it("returns all commands with required fields", () => {
     const commands = buildCommandPaletteCommands(minimalContext())
     expect(commands.length).toBeGreaterThanOrEqual(23)
@@ -253,6 +267,42 @@ describe("buildCommandPaletteCommands", () => {
     )
     expect(command?.run()).toBe(true)
     expect(opened).toBe(true)
+  })
+
+  it("opens collection export only from the full collection palette", () => {
+    const ctx = minimalContext()
+    let opened = false
+    ctx.setExportCollectionVisible = (value) => {
+      opened = value === true
+    }
+
+    const command = buildCommandPaletteCommands(ctx).find(
+      (item) => item.id === "collection.export",
+    )
+    expect(command?.run()).toBe(true)
+    expect(opened).toBe(true)
+
+    ctx.getView = () => "env-editor"
+    expect(
+      buildCommandPaletteCommands(ctx).some(
+        (item) => item.id === "collection.export",
+      ),
+    ).toBe(true)
+
+    ctx.getCollectionMode = () => "browse"
+    expect(
+      buildCommandPaletteCommands(ctx).some(
+        (item) => item.id === "collection.export",
+      ),
+    ).toBe(false)
+
+    ctx.getCollectionMode = () => "collection"
+    ctx.paletteTarget = "request"
+    expect(
+      buildCommandPaletteCommands(ctx).some(
+        (item) => item.id === "collection.export",
+      ),
+    ).toBe(false)
   })
 
   it("opens the edit request overlay for the selected request", () => {

--- a/tests/unit/useModalKeyboardShield.test.tsx
+++ b/tests/unit/useModalKeyboardShield.test.tsx
@@ -14,6 +14,10 @@ function Shield({ activeOverlay }: { activeOverlay: string }) {
 }
 
 describe("useModalKeyboardShield", () => {
+  it("treats collection export as editable", () => {
+    expect(EDITABLE_OVERLAYS).toContain("export-collection")
+  })
+
   it("allows input for every editable overlay", async () => {
     for (const activeOverlay of EDITABLE_OVERLAYS) {
       const { keymap, host, cleanup } = setupKeymap()


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an "Export Collection" command that opens an overlay to export the current collection as OpenAPI or Postman, with a live target-path preview, `@/`-home directory expansion, and directory path completion.

### How did you verify your code works?

Added unit tests for `runCollectionExport` (unsaved-changes guard, duplicate-submission lock, target naming) and `ExportCollectionOverlay` (defaults, format switch, validation, directory completion, footer actions). Existing overlay/keyboard-shield tests updated.

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collection export support through the command palette.
  * Export collections as OpenAPI or Postman files.
  * Added an export dialog with output-folder selection, validation, target-path preview, and Postman format guidance.
  * Added keyboard navigation and directory completion support.
  * Displays success notifications and actionable export errors.

* **Bug Fixes**
  * Prevents exports with unsaved changes or duplicate submissions.
  * Prevents closing the export dialog while an export is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->