### PR TITLE
fix(ui): preserve folds, add mouse completion, simplify toasts

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -166,12 +166,11 @@ export function App({
         try {
           const s = await stat(normalized)
           if (!s.isDirectory()) {
-            showToast(`Not a directory: ${normalized}`, "error")
+            showToast("Not a directory", "error")
             return
           }
-        } catch (e: unknown) {
-          const msg = e instanceof Error ? e.message : String(e)
-          showToast(`Failed to open collection: ${msg}`, "error")
+        } catch {
+          showToast("Failed to open collection", "error")
           return
         }
 

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -366,7 +366,12 @@ export function AppInner({
 
   useEffect(() => {
     if (saveState.kind === "success" || saveState.kind === "error") {
-      showToast(saveState.message, saveState.kind)
+      showToast(
+        saveState.kind === "success"
+          ? "Operation completed"
+          : "Operation failed",
+        saveState.kind,
+      )
     }
   }, [saveState])
 
@@ -930,7 +935,7 @@ export function AppInner({
         .then((result) => {
           if (!result) return
           setExportCollectionVisible(false)
-          showToast(`Collection exported to ${result.path}`, "success")
+          showToast("Collection exported", "success")
         })
         .catch((error: unknown) => {
           exportCollectionRef.current?.setError(

--- a/src/ui/Frame.tsx
+++ b/src/ui/Frame.tsx
@@ -9,6 +9,7 @@ export const FrameInteractionContext = createContext(false)
 
 export interface FrameProps {
   children?: ReactNode
+  visible?: boolean
   titleLeft?: ReactNode
   titleRight?: ReactNode
   bottomRight?: ReactNode
@@ -30,6 +31,7 @@ export interface FrameProps {
 
 export function Frame({
   children,
+  visible = true,
   titleLeft,
   titleRight,
   bottomRight,
@@ -50,6 +52,7 @@ export function Frame({
 }: FrameProps) {
   return (
     <box
+      visible={visible}
       style={style}
       border={border}
       customBorderChars={customBorderChars}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -22,6 +22,7 @@ import type { CodeEditorRenderable } from "./editor/CodeEditor"
 
 interface Props {
   request: Request | null
+  visible?: boolean
   error?: Error | null
   editState: EditState
   editKey: string
@@ -65,6 +66,7 @@ const BASE_TAB_DEFS: TabDef[] = [
 
 export function RequestPane({
   request,
+  visible = true,
   error,
   editState,
   editKey,
@@ -153,6 +155,7 @@ export function RequestPane({
   }, [request, jumpMode])
   return (
     <Frame
+      visible={visible}
       style={{
         flexDirection: "column",
         flexGrow: 1,

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -84,18 +84,20 @@ export function RequestResponseView({
   onRequestFieldToggle,
   onRequestInteraction,
 }: RequestResponseViewProps) {
+  const requestVisible = expanded !== "response"
+  const responseVisible = expanded !== "request"
   const content = (
     <>
       <RequestPane
         request={draft.draft}
-        visible={expanded !== "response"}
+        visible={requestVisible}
         error={error}
         editState={eb.editState}
         editKey={eb.editKey}
         editValue={eb.editValue}
         setEditKey={eb.setEditKey}
         setEditValue={eb.setEditValue}
-        focused={focus === "request"}
+        focused={requestVisible && focus === "request"}
         activeTab={eb.activeTab}
         activeEnv={activeEnv}
         onAuthTypeChange={draft.setAuthType}
@@ -118,8 +120,8 @@ export function RequestResponseView({
       <ResponsePane
         key={responseKey}
         state={responseState}
-        visible={expanded !== "request"}
-        focused={focus === "response"}
+        visible={responseVisible}
+        focused={responseVisible && focus === "response"}
         timelineEntries={timelineEntries}
         initialTab={initialResponseTab}
         onTabChange={onResponseTabChange}

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -86,56 +86,54 @@ export function RequestResponseView({
 }: RequestResponseViewProps) {
   const content = (
     <>
-      {expanded !== "response" && (
-        <RequestPane
-          request={draft.draft}
-          error={error}
-          editState={eb.editState}
-          editKey={eb.editKey}
-          editValue={eb.editValue}
-          setEditKey={eb.setEditKey}
-          setEditValue={eb.setEditValue}
-          focused={focus === "request"}
-          activeTab={eb.activeTab}
-          activeEnv={activeEnv}
-          onAuthTypeChange={draft.setAuthType}
-          onApiKeyPlacementChange={draft.setApiKeyPlacement}
-          onBodyTypeChange={draft.setBodyType}
-          onBodyChange={draft.setBody}
-          onSelectOpenChange={setSelectOpen}
-          jumpMode={jumpMode}
-          onPaneFocus={() => onPaneFocus("request")}
-          onTabChange={onRequestTabChange}
-          onBodyTypeFocus={onRequestBodyTypeFocus}
-          onAuthFocusRow={onRequestAuthFocusRow}
-          onBodyEditorFocus={onRequestBodyEditorFocus}
-          onFieldActivate={onRequestFieldActivate}
-          onFieldSubfieldFocus={eb.focusSubfield}
-          onFieldToggle={onRequestFieldToggle}
-          onInteraction={onRequestInteraction}
-          interactive={urlbarInteractive}
-        />
-      )}
-      {expanded !== "request" && (
-        <ResponsePane
-          key={responseKey}
-          state={responseState}
-          focused={focus === "response"}
-          timelineEntries={timelineEntries}
-          initialTab={initialResponseTab}
-          onTabChange={onResponseTabChange}
-          onOpenTimelineEntry={onOpenTimelineEntry}
-          responseKey={responseKey}
-          responseQueryRef={responseQueryRef}
-          responseBodyForCopyRef={responseBodyForCopyRef}
-          layout={layout}
-          expanded={expanded}
-          jumpMode={jumpMode && draft.draft !== null}
-          onQueryVisibleChange={onQueryVisibleChange}
-          onBodyEditorAvailableChange={onResponseBodyEditorAvailableChange}
-          onPaneFocus={() => onPaneFocus("response")}
-        />
-      )}
+      <RequestPane
+        request={draft.draft}
+        visible={expanded !== "response"}
+        error={error}
+        editState={eb.editState}
+        editKey={eb.editKey}
+        editValue={eb.editValue}
+        setEditKey={eb.setEditKey}
+        setEditValue={eb.setEditValue}
+        focused={focus === "request"}
+        activeTab={eb.activeTab}
+        activeEnv={activeEnv}
+        onAuthTypeChange={draft.setAuthType}
+        onApiKeyPlacementChange={draft.setApiKeyPlacement}
+        onBodyTypeChange={draft.setBodyType}
+        onBodyChange={draft.setBody}
+        onSelectOpenChange={setSelectOpen}
+        jumpMode={jumpMode}
+        onPaneFocus={() => onPaneFocus("request")}
+        onTabChange={onRequestTabChange}
+        onBodyTypeFocus={onRequestBodyTypeFocus}
+        onAuthFocusRow={onRequestAuthFocusRow}
+        onBodyEditorFocus={onRequestBodyEditorFocus}
+        onFieldActivate={onRequestFieldActivate}
+        onFieldSubfieldFocus={eb.focusSubfield}
+        onFieldToggle={onRequestFieldToggle}
+        onInteraction={onRequestInteraction}
+        interactive={urlbarInteractive}
+      />
+      <ResponsePane
+        key={responseKey}
+        state={responseState}
+        visible={expanded !== "request"}
+        focused={focus === "response"}
+        timelineEntries={timelineEntries}
+        initialTab={initialResponseTab}
+        onTabChange={onResponseTabChange}
+        onOpenTimelineEntry={onOpenTimelineEntry}
+        responseKey={responseKey}
+        responseQueryRef={responseQueryRef}
+        responseBodyForCopyRef={responseBodyForCopyRef}
+        layout={layout}
+        expanded={expanded}
+        jumpMode={jumpMode && draft.draft !== null}
+        onQueryVisibleChange={onQueryVisibleChange}
+        onBodyEditorAvailableChange={onResponseBodyEditorAvailableChange}
+        onPaneFocus={() => onPaneFocus("response")}
+      />
     </>
   )
 
@@ -161,7 +159,6 @@ export function RequestResponseView({
         sending={responseState.status === "sending"}
       />
       <box
-        key={layout}
         style={{
           flexDirection: layout === "side-by-side" ? "row" : "column",
           flexGrow: 1,

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -45,6 +45,7 @@ const TAB_DEFS: TabDef[] = [
 
 export function ResponsePane({
   state,
+  visible = true,
   focused = false,
   timelineEntries,
   initialTab,
@@ -61,6 +62,7 @@ export function ResponsePane({
   onPaneFocus,
 }: {
   state: SendState
+  visible?: boolean
   focused?: boolean
   timelineEntries?: TimelineEntry[]
   initialTab?: ResponseTabKind
@@ -405,6 +407,7 @@ export function ResponsePane({
 
   return (
     <Frame
+      visible={visible}
       style={{
         flexGrow: 1,
         flexDirection: "column",

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -104,12 +104,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
     const inputFocused = isFocused ?? true
 
-    const { completion, makeHandleKey } = useVariableCompletion({
-      getEditor: getEditable,
-      variableNames: suggestionNames,
-      value,
-      isEditing: isEditing && inputFocused,
-    })
+    const { completion, makeHandleKey, acceptSuggestion } =
+      useVariableCompletion({
+        getEditor: getEditable,
+        variableNames: suggestionNames,
+        value,
+        isEditing: isEditing && inputFocused,
+      })
 
     const applyHighlights = useCallback(() => {
       const editable = getEditable()
@@ -162,6 +163,25 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       applyHighlights()
     }, [applyHighlights, isEditing, value])
 
+    const handleCompletionAccepted = useCallback(() => {
+      const editable = getEditable()
+      if (editable) {
+        const text = editable.plainText
+        onChange?.(text)
+        highlightVariables(editable, text, theme, env, pathParams)
+      }
+    }, [env, getEditable, onChange, pathParams, theme])
+
+    const selectCompletion = useCallback(
+      (name: string): boolean => {
+        if (!acceptSuggestion(name)) return false
+        setCompletionDismissed(true)
+        handleCompletionAccepted()
+        return true
+      },
+      [acceptSuggestion, handleCompletionAccepted],
+    )
+
     const handleCompletionKey = useMemo(
       () =>
         makeHandleKey({
@@ -169,24 +189,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
           completionIndex,
           setCompletionIndex,
           setCompletionDismissed,
-          onAccept: () => {
-            const editable = getEditable()
-            if (editable) {
-              const text = editable.plainText
-              onChange?.(text)
-              highlightVariables(editable, text, theme, env, pathParams)
-            }
-          },
+          onAccept: handleCompletionAccepted,
         }),
       [
         completionDismissed,
         completionIndex,
-        env,
-        getEditable,
+        handleCompletionAccepted,
         makeHandleKey,
-        onChange,
-        theme,
-        pathParams,
       ],
     )
 
@@ -247,6 +256,8 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         isEditing={isEditing && inputFocused}
         getEditable={getEditable}
         value={value}
+        onSelect={pathCompletionState.selectItem}
+        onHighlight={pathCompletionState.setSelectedIndex}
       />
     ) : showCompletion ? (
       <CompletionPopup
@@ -256,6 +267,8 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         isEditing={isEditing && inputFocused}
         getEditable={getEditable}
         value={value}
+        onSelect={(index) => selectCompletion(suggestions[index]!)}
+        onHighlight={setCompletionIndex}
       />
     ) : null
 
@@ -373,6 +386,8 @@ function CompletionPopup({
   isEditing,
   getEditable,
   value,
+  onSelect,
+  onHighlight,
 }: {
   id: string
   items: { key: string; label: string }[]
@@ -381,6 +396,8 @@ function CompletionPopup({
   isEditing: boolean
   getEditable: () => (InputRenderable | TextareaRenderable) | null
   value: string
+  onSelect?: (index: number) => boolean
+  onHighlight?: (index: number) => void
 }) {
   const renderer = useRenderer()
   const { width: terminalWidth, height: terminalHeight } =
@@ -449,6 +466,17 @@ function CompletionPopup({
       {items.slice(0, MAX_COMPLETION_VISIBLE).map((item, index) => (
         <box
           key={item.key}
+          onMouseDown={
+            onSelect
+              ? (event) => {
+                  if (event.button !== MouseButton.LEFT || !onSelect(index))
+                    return
+                  event.preventDefault()
+                  event.stopPropagation()
+                }
+              : undefined
+          }
+          onMouseOver={onHighlight ? () => onHighlight(index) : undefined}
           style={{
             backgroundColor:
               index === completionIndex ? theme.backgroundElement : undefined,

--- a/src/ui/collectionExport.ts
+++ b/src/ui/collectionExport.ts
@@ -15,8 +15,10 @@ type ExportRunner = (options: ExportOptions) => Promise<ExportResult>
 function isAvailablePostmanTarget(path: string): boolean {
   try {
     return readdirSync(path).length === 0
-  } catch {
-    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT" || code === "ENOTDIR") return true
+    throw error
   }
 }
 

--- a/src/ui/collectionExport.ts
+++ b/src/ui/collectionExport.ts
@@ -15,8 +15,8 @@ type ExportRunner = (options: ExportOptions) => Promise<ExportResult>
 function isAvailablePostmanTarget(path: string): boolean {
   try {
     return readdirSync(path).length === 0
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT"
+  } catch {
+    return true
   }
 }
 

--- a/src/ui/editor/CodeEditorCompletion.tsx
+++ b/src/ui/editor/CodeEditorCompletion.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { MouseButton } from "@opentui/core"
 import type { CodeEditorRenderable } from "./CodeEditor"
 import type { Environment } from "../../schema"
 import { registerVariableCompletion } from "../variable-completion/variableCompletionInterceptor"
@@ -38,12 +39,23 @@ export function CodeEditorCompletion({
 
   const variableNames = useMemo(() => Object.keys(env?.vars ?? {}), [env?.vars])
 
-  const { completion, makeHandleKey } = useVariableCompletion({
-    getEditor,
-    variableNames,
-    value,
-    isEditing,
-  })
+  const { completion, makeHandleKey, acceptSuggestion } = useVariableCompletion(
+    {
+      getEditor,
+      variableNames,
+      value,
+      isEditing,
+    },
+  )
+
+  const selectCompletion = useCallback(
+    (name: string): boolean => {
+      if (!acceptSuggestion(name)) return false
+      setCompletionDismissed(true)
+      return true
+    },
+    [acceptSuggestion],
+  )
 
   const handleKey = useMemo(
     () =>
@@ -127,6 +139,13 @@ export function CodeEditorCompletion({
         .map((name, index) => (
           <box
             key={name}
+            onMouseDown={(event) => {
+              if (event.button !== MouseButton.LEFT || !selectCompletion(name))
+                return
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onMouseOver={() => setCompletionIndex(index)}
             style={{
               backgroundColor:
                 index === completionIndex ? theme.backgroundElement : undefined,

--- a/src/ui/overlays/ExportCollectionOverlay.tsx
+++ b/src/ui/overlays/ExportCollectionOverlay.tsx
@@ -92,7 +92,8 @@ export const ExportCollectionOverlay = forwardRef<
   try {
     target = getExportTargetPath(outputDir, collectionName, format)
   } catch (error: unknown) {
-    targetError = error instanceof Error ? error.message : String(error)
+    const message = error instanceof Error ? error.message : String(error)
+    targetError = `Unable to preview target: ${message}`
   }
   const displayedError = errorText ?? targetError
 

--- a/src/ui/overlays/ExportCollectionOverlay.tsx
+++ b/src/ui/overlays/ExportCollectionOverlay.tsx
@@ -87,7 +87,14 @@ export const ExportCollectionOverlay = forwardRef<
     if (focus === "output") outputRef.current?.focus()
   }, [focus])
 
-  const target = getExportTargetPath(outputDir, collectionName, format)
+  let target: string | null = null
+  let targetError: string | null = null
+  try {
+    target = getExportTargetPath(outputDir, collectionName, format)
+  } catch (error: unknown) {
+    targetError = error instanceof Error ? error.message : String(error)
+  }
+  const displayedError = errorText ?? targetError
 
   return (
     <Overlay visible={visible} width={68} padding={1} gap={1}>
@@ -161,7 +168,7 @@ export const ExportCollectionOverlay = forwardRef<
             />
           </box>
           <text fg={theme.textMuted} wrapMode="word">
-            Target: {target}
+            Target: {target ?? "unavailable"}
           </text>
         </box>
 
@@ -171,9 +178,9 @@ export const ExportCollectionOverlay = forwardRef<
             paths. Review the bundle before sharing.
           </text>
         )}
-        {errorText && (
+        {displayedError && (
           <text fg={theme.error} wrapMode="word">
-            {errorText}
+            {displayedError}
           </text>
         )}
       </box>

--- a/src/ui/path-completion/usePathCompletion.ts
+++ b/src/ui/path-completion/usePathCompletion.ts
@@ -21,6 +21,8 @@ export interface PathCompletionState {
   items: PathCompletionItem[]
   selectedIndex: number
   message?: string
+  selectItem: (index: number) => boolean
+  setSelectedIndex: (index: number) => void
 }
 
 export function usePathCompletion({
@@ -84,6 +86,46 @@ export function usePathCompletion({
   }, [dismissed, kind, query, root, value])
 
   const active = Boolean(query && !dismissed)
+  const selectItem = useCallback(
+    (index: number, finalizeDirectory = true): boolean => {
+      const editor = getEditor()
+      if (
+        !active ||
+        !isEditing ||
+        !kind ||
+        !editor ||
+        editor.isDestroyed ||
+        !editor.focused
+      ) {
+        return false
+      }
+
+      const item = items.slice(0, MAX_COMPLETION_VISIBLE)[index]
+      if (!item) return false
+
+      const selectingDirectory =
+        item.type === "directory" && kind === "directory" && finalizeDirectory
+      let nextValue = selectingDirectory
+        ? item.value.replace(/\/$/, "")
+        : item.value
+      if (item.type === "file" && wrapFileSelection) {
+        nextValue = `@file(${nextValue})`
+      }
+
+      editor.replaceText(nextValue)
+      editor.cursorOffset = nextValue.length
+      onChange?.(nextValue)
+      setSelectedIndex(0)
+
+      if (item.type === "file" || selectingDirectory) {
+        acceptedValue.current = nextValue
+        setDismissed(true)
+      }
+      return true
+    },
+    [active, getEditor, isEditing, items, kind, onChange, wrapFileSelection],
+  )
+
   const handleKey = useCallback(
     (key: CompletionKeyEvent): boolean => {
       const editor = getEditor()
@@ -122,40 +164,9 @@ export function usePathCompletion({
       }
 
       if (key.name !== "tab" && key.name !== "return") return false
-
-      const item = visibleItems[selectedIndex] ?? visibleItems[0]!
-      const selectingDirectory =
-        item.type === "directory" &&
-        kind === "directory" &&
-        key.name === "return"
-      let nextValue = selectingDirectory
-        ? item.value.replace(/\/$/, "")
-        : item.value
-      if (item.type === "file" && wrapFileSelection) {
-        nextValue = `@file(${nextValue})`
-      }
-
-      editor.replaceText(nextValue)
-      editor.cursorOffset = nextValue.length
-      onChange?.(nextValue)
-      setSelectedIndex(0)
-
-      if (item.type === "file" || selectingDirectory) {
-        acceptedValue.current = nextValue
-        setDismissed(true)
-      }
-      return true
+      return selectItem(selectedIndex, key.name === "return")
     },
-    [
-      active,
-      getEditor,
-      isEditing,
-      items,
-      kind,
-      onChange,
-      selectedIndex,
-      wrapFileSelection,
-    ],
+    [active, getEditor, isEditing, items, kind, selectedIndex, selectItem],
   )
 
   useEffect(() => {
@@ -163,5 +174,5 @@ export function usePathCompletion({
     return registerCompletion(handleKey)
   }, [active, handleKey])
 
-  return { active, items, selectedIndex, message }
+  return { active, items, selectedIndex, message, selectItem, setSelectedIndex }
 }

--- a/src/ui/useTimelineActions.ts
+++ b/src/ui/useTimelineActions.ts
@@ -36,8 +36,8 @@ export function useTimelineActions(
       kind: "request" | "response",
       body?: string,
     ) => {
-      const path = await exportTimelineEntry(collectionDir, entry, kind, body)
-      showToast(`Timeline entry exported to ${path}`, "success")
+      await exportTimelineEntry(collectionDir, entry, kind, body)
+      showToast("Timeline entry exported", "success")
     },
     [collectionDir],
   )

--- a/src/ui/useUpdateFlow.ts
+++ b/src/ui/useUpdateFlow.ts
@@ -38,7 +38,7 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
           setUpdateAvailable(null)
           showToast("Noodle is up to date", "success")
         } else if (status.kind === "error") {
-          showToast(status.message, "error")
+          showToast("Update check failed", "error")
         } else if (status.kind === "update_available") {
           setUpdateFlow({
             phase: "confirm",
@@ -53,8 +53,8 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
           })
         }
       })
-      .catch((error: unknown) => {
-        if (!cancelled) showToast(getErrorMessage(error), "error")
+      .catch(() => {
+        if (!cancelled) showToast("Update check failed", "error")
       })
     return () => {
       cancelled = true
@@ -70,7 +70,7 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
         .then((result) => {
           if (token !== installTokenRef.current) return
           if (result.data.status === "homebrew_updated") {
-            showToast("Updated via Homebrew", "success")
+            showToast("Update completed", "success")
             setUpdateFlow({
               phase: "done",
               version: update.version || "latest",
@@ -81,14 +81,14 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
             const message = result.data.exit_code
               ? `Homebrew upgrade failed (exit ${result.data.exit_code})`
               : "Homebrew upgrade failed"
-            showToast(message, "error")
+            showToast("Update failed", "error")
             setUpdateFlow({ phase: "failed", message })
           }
         })
         .catch((error: unknown) => {
           if (token !== installTokenRef.current) return
           const message = getErrorMessage(error)
-          showToast(message, "error")
+          showToast("Update failed", "error")
           setUpdateFlow({ phase: "failed", message })
         })
       return
@@ -107,21 +107,21 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
           if (token !== installTokenRef.current) return
           if (result.data.status === "updated") {
             const version = result.data.version ?? update.version
-            showToast(`Updated to ${version}`, "success")
+            showToast("Update completed", "success")
             setUpdateFlow({ phase: "done", version })
             setRestartVersion(version)
             setUpdateAvailable(null)
           } else {
             const message =
               (result.data as Record<string, string>).reason ?? "Update failed"
-            showToast(message, "error")
+            showToast("Update failed", "error")
             setUpdateFlow({ phase: "failed", message })
           }
         })
         .catch((error: unknown) => {
           if (token !== installTokenRef.current) return
           const message = getErrorMessage(error)
-          showToast(message, "error")
+          showToast("Update failed", "error")
           setUpdateFlow({ phase: "failed", message })
         })
       return
@@ -137,8 +137,8 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
           setUpdateAvailable(status.latestVersion)
         }
       })
-      .catch((error: unknown) => {
-        if (!cancelled) showToast(getErrorMessage(error), "error")
+      .catch(() => {
+        if (!cancelled) showToast("Update check failed", "error")
       })
     return () => {
       cancelled = true

--- a/src/ui/variable-completion/useVariableCompletion.ts
+++ b/src/ui/variable-completion/useVariableCompletion.ts
@@ -58,6 +58,31 @@ export function useVariableCompletion({
 
   const completion = useMemo(() => getCompletion(), [getCompletion])
 
+  const acceptSuggestion = useCallback(
+    (name: string): boolean => {
+      const editor = getEditor()
+      if (!isEditing || !editor || editor.isDestroyed || !editor.focused) {
+        return false
+      }
+
+      const { token, suggestions, isComplete } = getCompletion()
+      if (
+        !token ||
+        suggestions.length === 0 ||
+        isComplete ||
+        !suggestions.includes(name)
+      ) {
+        return false
+      }
+
+      const result = replaceVariableToken(editor.plainText, token, name)
+      editor.replaceText(result.value)
+      editor.cursorOffset = result.cursorOffset
+      return true
+    },
+    [getCompletion, getEditor, isEditing],
+  )
+
   const makeHandleKey = useCallback(
     ({
       completionDismissed,
@@ -102,9 +127,7 @@ export function useVariableCompletion({
             Math.min(suggestions.length, MAX_COMPLETION_VISIBLE) - 1,
           )
           const name = suggestions[idx] ?? suggestions[0]!
-          const result = replaceVariableToken(editor.plainText, token, name)
-          editor.replaceText(result.value)
-          editor.cursorOffset = result.cursorOffset
+          if (!acceptSuggestion(name)) return false
           setCompletionDismissed(true)
           onAccept(name)
           return true
@@ -117,8 +140,8 @@ export function useVariableCompletion({
 
         return false
       },
-    [getEditor, getCompletion, isEditing],
+    [acceptSuggestion, getEditor, getCompletion, isEditing],
   )
 
-  return { completion, getCompletion, makeHandleKey }
+  return { completion, getCompletion, makeHandleKey, acceptSuggestion }
 }

--- a/tests/unit/CodeEditorCompletion.test.tsx
+++ b/tests/unit/CodeEditorCompletion.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react"
 import { useState } from "react"
 import { extend } from "@opentui/react"
 import { testRender } from "@opentui/react/test-utils"
+import { MouseButtons } from "@opentui/core/testing"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
@@ -20,6 +21,7 @@ function Harness({ env }: { env: Environment }) {
   return (
     <box width={60} height={10}>
       <code-editor
+        id="test-editor"
         ref={(next) => {
           setEditor(next)
           next?.focus()
@@ -62,5 +64,30 @@ describe("CodeEditorCompletion", () => {
     await renderOnce()
     expect(captureCharFrame()).toContain("$host")
     cleanup()
+  })
+
+  it("accepts a suggestion with the mouse", async () => {
+    const { renderer, renderOnce, captureCharFrame, mockMouse } =
+      await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness
+            env={{ name: "test", vars: { host: "localhost", token: "secret" } }}
+          />
+        </ThemeProvider>,
+        { width: 60, height: 10 },
+      )
+
+    await renderOnce()
+    const rows = captureCharFrame().split("\n")
+    const y = rows.findIndex((row) => row.includes("$host"))
+    await act(async () => {
+      await mockMouse.click(rows[y]!.indexOf("$host"), y, MouseButtons.LEFT)
+    })
+    await renderOnce()
+
+    const editor = renderer.root.findDescendantById(
+      "test-editor",
+    ) as CodeEditorRenderable
+    expect(editor.plainText).toBe("$host")
   })
 })

--- a/tests/unit/ExportCollectionOverlay.test.tsx
+++ b/tests/unit/ExportCollectionOverlay.test.tsx
@@ -146,7 +146,8 @@ describe("ExportCollectionOverlay", () => {
 
       const frame = render.captureCharFrame()
       expect(frame).toContain("Export Collection")
-      expect(frame).toContain("ELOOP")
+      expect(frame).toContain("Target: unavailable")
+      expect(frame).toContain("Unable to preview target")
     } finally {
       cleanup()
       await rm(outputDir, { recursive: true, force: true })

--- a/tests/unit/ExportCollectionOverlay.test.tsx
+++ b/tests/unit/ExportCollectionOverlay.test.tsx
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test"
+import { mkdtemp, rm, symlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { act, createRef } from "react"
 import { testRender } from "@opentui/react/test-utils"
 import { KeymapProvider } from "@opentui/keymap/react"
@@ -106,5 +109,47 @@ describe("ExportCollectionOverlay", () => {
       "Save all changes before exporting",
     )
     cleanup()
+  })
+
+  it("keeps target preview errors inline", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "noodle-export-preview-"))
+    await symlink("orders-postman", join(outputDir, "orders-postman"))
+    const { keymap, host, cleanup } = setupKeymap()
+    const ref = createRef<ExportCollectionOverlayHandle>()
+
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <ExportCollectionOverlay
+              visible
+              ref={ref}
+              collectionName="orders"
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 90, height: 22 },
+      )
+      await render.renderOnce()
+      act(() => ref.current?.cycleFocus(1))
+      await render.renderOnce()
+      await act(async () => {
+        await render.mockInput.pressKey("BACKSPACE")
+        await render.mockInput.pressKey("BACKSPACE")
+        await render.mockInput.typeText(outputDir)
+      })
+      act(() => ref.current?.cycleFocus(1))
+      act(() => host.press("return"))
+      act(() => host.press("down"))
+      act(() => host.press("return"))
+      await render.renderOnce()
+
+      const frame = render.captureCharFrame()
+      expect(frame).toContain("Export Collection")
+      expect(frame).toContain("ELOOP")
+    } finally {
+      cleanup()
+      await rm(outputDir, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -205,6 +205,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
 
   it("keeps request and response folds through layout and expand changes", async () => {
     const { keymap, draft, eb } = createTestProps()
+    keymap.keymap.setData("app.overlay", "none")
     const body = JSON.stringify(
       {
         object: { nested: true },
@@ -225,6 +226,10 @@ describe("ResponsePane status text truncation and layout tests", () => {
     }
     let changeLayout = (_layout: "stacked" | "side-by-side") => {}
     let changeExpanded = (_expanded: "request" | "response" | null) => {}
+    let responseTabChanges = 0
+    const onResponseTabChange = () => {
+      responseTabChanges += 1
+    }
 
     function FoldPersistenceHarness() {
       const [layout, setLayout] = useState<"stacked" | "side-by-side">(
@@ -252,7 +257,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
           activeEnv={null}
           responseState={responseOK}
           timelineEntries={[]}
-          onResponseTabChange={() => {}}
+          onResponseTabChange={onResponseTabChange}
           setSelectOpen={() => {}}
           urlbarSubFocus="text"
           urlbarInteractive={true}
@@ -261,20 +266,21 @@ describe("ResponsePane status text truncation and layout tests", () => {
       )
     }
 
-    const { renderer, renderOnce, captureCharFrame } = await testRender(
-      <KeymapProvider
-        keymap={
-          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
-        }
-      >
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <box style={{ width: 100, height: 24, flexDirection: "column" }}>
-            <FoldPersistenceHarness />
-          </box>
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 100, height: 24 },
-    )
+    const { renderer, renderOnce, captureCharFrame, mockInput } =
+      await testRender(
+        <KeymapProvider
+          keymap={
+            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+          }
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box style={{ width: 100, height: 24, flexDirection: "column" }}>
+              <FoldPersistenceHarness />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 24 },
+      )
     await renderOnce()
     await new Promise((resolve) => setTimeout(resolve, 250))
     await renderOnce()
@@ -311,6 +317,10 @@ describe("ResponsePane status text truncation and layout tests", () => {
     await renderOnce()
     expect(captureCharFrame()).toContain("Request")
     expect(captureCharFrame()).not.toContain("Response")
+    expect(responseEditor.focused).toBe(false)
+    await act(async () => mockInput.pressKey("RIGHT"))
+    await renderOnce()
+    expect(responseTabChanges).toBe(0)
     act(() => changeExpanded(null))
     await renderOnce()
     expect(renderer.root.findDescendantById("response-body-editor")).toBe(

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -203,6 +203,133 @@ describe("ResponsePane status text truncation and layout tests", () => {
     expect(tailLines[responseBottom - 1]).toMatch(/\]\s/)
   })
 
+  it("keeps request and response folds through layout and expand changes", async () => {
+    const { keymap, draft, eb } = createTestProps()
+    const body = JSON.stringify(
+      {
+        object: { nested: true },
+        array: [1, 2],
+      },
+      null,
+      2,
+    )
+    const responseOK: SendState = {
+      status: "done",
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body,
+        timeMs: 123,
+      },
+    }
+    let changeLayout = (_layout: "stacked" | "side-by-side") => {}
+    let changeExpanded = (_expanded: "request" | "response" | null) => {}
+
+    function FoldPersistenceHarness() {
+      const [layout, setLayout] = useState<"stacked" | "side-by-side">(
+        "stacked",
+      )
+      const [expanded, setExpanded] = useState<"request" | "response" | null>(
+        null,
+      )
+      changeLayout = setLayout
+      changeExpanded = setExpanded
+
+      return (
+        <RequestResponseView
+          draft={
+            {
+              ...draft,
+              draft: { ...draft.draft, id: "folds", body },
+            } as unknown as Parameters<typeof RequestResponseView>[0]["draft"]
+          }
+          eb={eb as unknown as Parameters<typeof RequestResponseView>[0]["eb"]}
+          error={null}
+          focus="response"
+          layout={layout}
+          expanded={expanded}
+          activeEnv={null}
+          responseState={responseOK}
+          timelineEntries={[]}
+          onResponseTabChange={() => {}}
+          setSelectOpen={() => {}}
+          urlbarSubFocus="text"
+          urlbarInteractive={true}
+          responseKey="folds"
+        />
+      )
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider
+        keymap={
+          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+        }
+      >
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ width: 100, height: 24, flexDirection: "column" }}>
+            <FoldPersistenceHarness />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 24 },
+    )
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    await renderOnce()
+
+    const requestEditor = renderer.root.findDescendantById(
+      "request-body-editor",
+    ) as CodeEditorRenderable
+    const responseEditor = renderer.root.findDescendantById(
+      "response-body-editor",
+    ) as CodeEditorRenderable
+    for (const editor of [requestEditor, responseEditor]) {
+      editor.toggleFold(4)
+      editor.toggleFold(1)
+    }
+    await renderOnce()
+
+    const expectFolds = (editor: CodeEditorRenderable) => {
+      expect(editor.getFolds().get(1)?.folded).toBe(true)
+      expect(editor.getFolds().get(4)?.folded).toBe(true)
+    }
+
+    act(() => changeLayout("side-by-side"))
+    await renderOnce()
+    expect(renderer.root.findDescendantById("request-body-editor")).toBe(
+      requestEditor,
+    )
+    expect(renderer.root.findDescendantById("response-body-editor")).toBe(
+      responseEditor,
+    )
+    expectFolds(requestEditor)
+    expectFolds(responseEditor)
+
+    act(() => changeExpanded("request"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Request")
+    expect(captureCharFrame()).not.toContain("Response")
+    act(() => changeExpanded(null))
+    await renderOnce()
+    expect(renderer.root.findDescendantById("response-body-editor")).toBe(
+      responseEditor,
+    )
+    expectFolds(responseEditor)
+
+    act(() => changeExpanded("response"))
+    await renderOnce()
+    expect(captureCharFrame()).not.toContain("Request")
+    expect(captureCharFrame()).toContain("Response")
+    act(() => changeExpanded(null))
+    await renderOnce()
+    expect(renderer.root.findDescendantById("request-body-editor")).toBe(
+      requestEditor,
+    )
+    expectFolds(requestEditor)
+  })
+
   it("truncates status text > 13 chars with ellipsis", async () => {
     const { keymap, draft, eb } = createTestProps()
     const responseErr: SendState = {

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, it, expect } from "bun:test"
 import { testRender as openTUITestRender } from "@opentui/react/test-utils"
 import { RGBA } from "@opentui/core"
+import { MouseButtons } from "@opentui/core/testing"
 import { act } from "react"
 import { useState } from "react"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -76,6 +77,12 @@ function hexToRgba(hex: string): RGBA {
     Number.parseInt(hex.slice(3, 5), 16),
     Number.parseInt(hex.slice(5, 7), 16),
   )
+}
+
+function findTextPosition(frame: string, text: string) {
+  const rows = frame.split("\n")
+  const y = rows.findIndex((row) => row.includes(text))
+  return { x: rows[y]!.indexOf(text), y }
 }
 
 describe("VarInput — display mode (isEditing=false)", () => {
@@ -364,6 +371,32 @@ describe("VarInput — edit mode (isEditing=true)", () => {
     cleanup()
   })
 
+  it("accepts a suggestion with the mouse", async () => {
+    const { renderOnce, captureCharFrame, mockInput, mockMouse } =
+      await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CompletionHarness
+            environment={env({ host: "localhost", token: "secret" })}
+          />
+        </ThemeProvider>,
+        { width: 80, height: 8 },
+      )
+    await renderOnce()
+    await act(async () => {
+      await mockInput.typeText("$")
+    })
+    await renderOnce()
+
+    const { x, y } = findTextPosition(captureCharFrame(), "$token")
+    await act(async () => {
+      await mockMouse.click(x, y, MouseButtons.LEFT)
+    })
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("$token")
+    expect(captureCharFrame()).not.toContain("┌")
+  })
+
   it("dismisses completion with Escape, reopens on new $ token", async () => {
     const { keymap, host, cleanup } = createTestKeymap()
     const { renderOnce, captureCharFrame, mockInput } = await testRender(
@@ -519,6 +552,39 @@ describe("VarInput — edit mode (isEditing=true)", () => {
 })
 
 describe("VarInput — path completion", () => {
+  it("accepts a path suggestion with the mouse", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-var-path-"))
+    await writeFile(join(root, "avatar.png"), "avatar")
+
+    try {
+      const {
+        renderOnce,
+        captureCharFrame,
+        mockInput,
+        mockMouse,
+        waitForFrame,
+      } = await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <PathCompletionHarness root={root} wrapFileSelection />
+        </ThemeProvider>,
+        { width: 100, height: 12 },
+      )
+      await renderOnce()
+      await act(async () => mockInput.typeText("@"))
+      await waitForFrame((frame) => frame.includes("avatar.png"))
+
+      const { x, y } = findTextPosition(captureCharFrame(), "avatar.png")
+      await act(async () => {
+        await mockMouse.click(x, y, MouseButtons.LEFT)
+      })
+      await renderOnce()
+
+      expect(captureCharFrame()).toContain("@file(@/avatar.png)")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it("marks an accepted file as explicit file input when requested", async () => {
     const root = await mkdtemp(join(tmpdir(), "noodle-var-path-"))
     await writeFile(join(root, "avatar.png"), "avatar")

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -85,6 +85,25 @@ function findTextPosition(frame: string, text: string) {
   return { x: rows[y]!.indexOf(text), y }
 }
 
+async function waitForAsyncFrame(
+  renderOnce: () => Promise<void>,
+  captureCharFrame: () => string,
+  predicate: (frame: string) => boolean,
+): Promise<string> {
+  const deadline = Date.now() + 2000
+  while (true) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      await renderOnce()
+    })
+    const frame = captureCharFrame()
+    if (predicate(frame)) return frame
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for async frame:\n${frame}`)
+    }
+  }
+}
+
 describe("VarInput — display mode (isEditing=false)", () => {
   it("renders plain text without variables", async () => {
     const { renderOnce, captureSpans } = await testRender(
@@ -557,21 +576,18 @@ describe("VarInput — path completion", () => {
     await writeFile(join(root, "avatar.png"), "avatar")
 
     try {
-      const {
-        renderOnce,
-        captureCharFrame,
-        mockInput,
-        mockMouse,
-        waitForFrame,
-      } = await testRender(
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <PathCompletionHarness root={root} wrapFileSelection />
-        </ThemeProvider>,
-        { width: 100, height: 12 },
-      )
+      const { renderOnce, captureCharFrame, mockInput, mockMouse } =
+        await testRender(
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <PathCompletionHarness root={root} wrapFileSelection />
+          </ThemeProvider>,
+          { width: 100, height: 12 },
+        )
       await renderOnce()
       await act(async () => mockInput.typeText("@"))
-      await waitForFrame((frame) => frame.includes("avatar.png"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("avatar.png"),
+      )
 
       const { x, y } = findTextPosition(captureCharFrame(), "avatar.png")
       await act(async () => {
@@ -591,21 +607,22 @@ describe("VarInput — path completion", () => {
     const { keymap, host, cleanup } = createTestKeymap()
 
     try {
-      const { renderOnce, captureCharFrame, mockInput, waitForFrame } =
-        await testRender(
-          <KeymapProvider
-            keymap={keymap as unknown as KeymapProviderProps["keymap"]}
-          >
-            <ThemeProvider activeIndex={0} previewIndex={null}>
-              <VariableCompletionInterceptor />
-              <PathCompletionHarness root={root} wrapFileSelection />
-            </ThemeProvider>
-          </KeymapProvider>,
-          { width: 100, height: 12 },
-        )
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
+        <KeymapProvider
+          keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <VariableCompletionInterceptor />
+            <PathCompletionHarness root={root} wrapFileSelection />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 12 },
+      )
       await renderOnce()
       await act(async () => mockInput.typeText("@"))
-      await waitForFrame((frame) => frame.includes("avatar.png"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("avatar.png"),
+      )
       await act(async () => host.press("return"))
       await renderOnce()
 
@@ -622,21 +639,22 @@ describe("VarInput — path completion", () => {
     const { keymap, host, cleanup } = createTestKeymap()
 
     try {
-      const { renderOnce, captureCharFrame, mockInput, waitForFrame } =
-        await testRender(
-          <KeymapProvider
-            keymap={keymap as unknown as KeymapProviderProps["keymap"]}
-          >
-            <ThemeProvider activeIndex={0} previewIndex={null}>
-              <VariableCompletionInterceptor />
-              <PathCompletionHarness root={root} wrapFileSelection />
-            </ThemeProvider>
-          </KeymapProvider>,
-          { width: 100, height: 12 },
-        )
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
+        <KeymapProvider
+          keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <VariableCompletionInterceptor />
+            <PathCompletionHarness root={root} wrapFileSelection />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 12 },
+      )
       await renderOnce()
       await act(async () => mockInput.typeText("@file(@"))
-      await waitForFrame((frame) => frame.includes("avatar.png"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("avatar.png"),
+      )
       await act(async () => host.press("return"))
       await renderOnce()
 
@@ -654,26 +672,29 @@ describe("VarInput — path completion", () => {
     const { keymap, host, cleanup } = createTestKeymap()
 
     try {
-      const { renderOnce, captureCharFrame, mockInput, waitForFrame } =
-        await testRender(
-          <KeymapProvider
-            keymap={keymap as unknown as KeymapProviderProps["keymap"]}
-          >
-            <ThemeProvider activeIndex={0} previewIndex={null}>
-              <VariableCompletionInterceptor />
-              <PathCompletionHarness root={root} />
-            </ThemeProvider>
-          </KeymapProvider>,
-          { width: 100, height: 12 },
-        )
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
+        <KeymapProvider
+          keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <VariableCompletionInterceptor />
+            <PathCompletionHarness root={root} />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 12 },
+      )
       await renderOnce()
       await act(async () => mockInput.typeText("@"))
-      await waitForFrame((frame) => frame.includes("Documents/"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("Documents/"),
+      )
       await renderOnce()
       await renderOnce()
 
       await act(async () => host.press("return"))
-      await waitForFrame((frame) => frame.includes("report final.pdf"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("report final.pdf"),
+      )
       await renderOnce()
       await renderOnce()
 
@@ -693,21 +714,22 @@ describe("VarInput — path completion", () => {
     const { keymap, host, cleanup } = createTestKeymap()
 
     try {
-      const { renderOnce, captureCharFrame, mockInput, waitForFrame } =
-        await testRender(
-          <KeymapProvider
-            keymap={keymap as unknown as KeymapProviderProps["keymap"]}
-          >
-            <ThemeProvider activeIndex={0} previewIndex={null}>
-              <VariableCompletionInterceptor />
-              <PathCompletionHarness root={root} />
-            </ThemeProvider>
-          </KeymapProvider>,
-          { width: 100, height: 12 },
-        )
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
+        <KeymapProvider
+          keymap={keymap as unknown as KeymapProviderProps["keymap"]}
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <VariableCompletionInterceptor />
+            <PathCompletionHarness root={root} />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 12 },
+      )
       await renderOnce()
       await act(async () => mockInput.typeText("@"))
-      await waitForFrame(
+      await waitForAsyncFrame(
+        renderOnce,
+        captureCharFrame,
         (frame) => frame.includes("alpha.txt") && frame.includes("zulu.txt"),
       )
       await renderOnce()
@@ -723,7 +745,9 @@ describe("VarInput — path completion", () => {
         await act(async () => mockInput.pressKey("BACKSPACE"))
       }
       await act(async () => mockInput.typeText("@alp"))
-      await waitForFrame((frame) => frame.includes("alpha.txt"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("alpha.txt"),
+      )
       expect(captureCharFrame()).not.toContain("zulu.txt")
 
       await renderOnce()
@@ -739,7 +763,7 @@ describe("VarInput — path completion", () => {
   it("shows a no-results state", async () => {
     const root = await mkdtemp(join(tmpdir(), "noodle-var-path-"))
     try {
-      const { renderOnce, mockInput, waitForFrame } = await testRender(
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
         <ThemeProvider activeIndex={0} previewIndex={null}>
           <PathCompletionHarness root={root} />
         </ThemeProvider>,
@@ -747,7 +771,9 @@ describe("VarInput — path completion", () => {
       )
       await renderOnce()
       await act(async () => mockInput.typeText("@nothing"))
-      await waitForFrame((frame) => frame.includes("No matching paths"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("No matching paths"),
+      )
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -790,16 +816,17 @@ describe("VarInput — path completion", () => {
   it("shows unavailable folders and keeps dollar completion working", async () => {
     const root = await mkdtemp(join(tmpdir(), "noodle-var-path-"))
     try {
-      const { renderOnce, captureCharFrame, mockInput, waitForFrame } =
-        await testRender(
-          <ThemeProvider activeIndex={0} previewIndex={null}>
-            <PathCompletionHarness root={root} />
-          </ThemeProvider>,
-          { width: 100, height: 12 },
-        )
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <PathCompletionHarness root={root} />
+        </ThemeProvider>,
+        { width: 100, height: 12 },
+      )
       await renderOnce()
       await act(async () => mockInput.typeText("@/missing/"))
-      await waitForFrame((frame) => frame.includes("Folder unavailable"))
+      await waitForAsyncFrame(renderOnce, captureCharFrame, (frame) =>
+        frame.includes("Folder unavailable"),
+      )
 
       for (let i = 0; i < "@/missing/".length; i++) {
         await act(async () => mockInput.pressKey("BACKSPACE"))

--- a/tests/unit/collectionExport.test.ts
+++ b/tests/unit/collectionExport.test.ts
@@ -32,6 +32,21 @@ describe("runCollectionExport", () => {
     }
   })
 
+  it("stops suffixing after filesystem errors on a Postman target", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "noodle-export-target-"))
+    const file = join(outputDir, "not-a-directory")
+
+    try {
+      await writeFile(file, "")
+
+      expect(getExportTargetPath(file, "orders", "postman")).toBe(
+        join(file, "orders-postman"),
+      )
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
   it("rejects unsaved edits before export", async () => {
     let called = false
     const pending = { current: false }

--- a/tests/unit/collectionExport.test.ts
+++ b/tests/unit/collectionExport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -42,6 +42,24 @@ describe("runCollectionExport", () => {
       expect(getExportTargetPath(file, "orders", "postman")).toBe(
         join(file, "orders-postman"),
       )
+    } finally {
+      await rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  it("propagates unexpected filesystem errors from Postman targets", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "noodle-export-target-"))
+    const target = join(outputDir, "orders-postman")
+
+    try {
+      await symlink("orders-postman", target)
+      let code: string | undefined
+      try {
+        getExportTargetPath(outputDir, "orders", "postman")
+      } catch (error) {
+        code = (error as NodeJS.ErrnoException).code
+      }
+      expect(code).toBe("ELOOP")
     } finally {
       await rm(outputDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement

### What does this PR do?

- Preserve request/response fold state through layout and expand changes (request/response panes are now hidden via `visible` instead of unmounted, so fold state and editor instances survive layout changes)
- Add mouse support for completion popups (variable, path, and code editor completions can be clicked to select)
- Simplify toast messages to static text instead of leaking raw error/path details
- Simplify the Postman target availability check in collection export
- Add unit tests covering the new behavior

### How did you verify your code works?

- `bun test` passes (2235 tests, 0 fail)
- `bun run lint` passes
- `bun run typecheck` passes
- New unit tests cover fold persistence, mouse-based completion selection, and Postman target error handling

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mouse-based selection for variable, file, and code-completion suggestions.
  - Preserved request and response editor content and fold states when switching layouts or visibility.
  - Improved collection export handling for inaccessible output paths.

- **Bug Fixes**
  - Simplified error and update notifications to avoid exposing paths or technical details.
  - Standardized save and export success messages.
  - Improved completion selection, highlighting, and editor cursor updates.
  - Fixed focus and visibility behavior when switching between request and response panes.
  - Improved error previews for unavailable export targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->