### PR TITLE
fix: add testRender wrapper with renderer cleanup

### DIFF
--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -275,9 +275,11 @@ export function ResponsePane({
 
   useEffect(() => {
     if (!queryVisible) return
-    const timer = setTimeout(() => setSettledQuery(query.trim()), 150)
+    const nextQuery = query.trim()
+    if (nextQuery === settledQuery) return
+    const timer = setTimeout(() => setSettledQuery(nextQuery), 150)
     return () => clearTimeout(timer)
-  }, [query, queryVisible])
+  }, [query, queryVisible, settledQuery])
 
   const borderColor = focused ? theme.primary : theme.borderSubtle
 

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -143,11 +143,11 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
 
     const handleTextareaChange = useCallback(() => {
       const ta = textareaRef.current
-      if (!ta) return
+      if (!ta || ta.plainText === value) return
       onChange?.(ta.plainText)
       setCompletionDismissed(false)
       applyHighlights()
-    }, [applyHighlights, onChange])
+    }, [applyHighlights, onChange, value])
 
     const handleInput = useCallback(
       (nextValue: string) => {

--- a/tests/JsonBodyViewer.test.tsx
+++ b/tests/JsonBodyViewer.test.tsx
@@ -1,10 +1,12 @@
 import { act, useState } from "react"
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "./testRender"
 import { RGBA } from "@opentui/core"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { ThemeProvider, THEMES } from "../src/ui/theme"
 import { JsonBodyViewer } from "../src/ui/editor/JsonBodyViewer"
+
+const testRender = createTestRender()
 
 describe("JsonBodyViewer", () => {
   it("keeps JSON syntax highlighting when variables make raw JSON invalid", async () => {

--- a/tests/RequestPane-body-editor.test.tsx
+++ b/tests/RequestPane-body-editor.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { act, useEffect, useState } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "./testRender"
 import { extend } from "@opentui/react"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { readFile } from "node:fs/promises"
@@ -22,6 +22,8 @@ import {
   type UseEditBrowseResult,
 } from "../src/hooks/useEditBrowse"
 import { setupKeymap } from "./unit/_helpers"
+
+const testRender = createTestRender()
 
 extend({
   "code-editor": CodeEditorRenderable,

--- a/tests/env-sidebar-update.test.tsx
+++ b/tests/env-sidebar-update.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
-import { useEffect, useState } from "react"
+import { createTestRender } from "./testRender"
+import { act, useEffect, useState } from "react"
 import { ThemeProvider } from "../src/ui/theme"
 import { EnvSidebar } from "../src/ui/env-editor/EnvSidebar"
+
+const testRender = createTestRender()
 
 function Harness({ initial, next }: { initial: string[]; next: string[] }) {
   const [names, setNames] = useState(initial)
@@ -37,7 +39,10 @@ describe("EnvSidebar list update", () => {
       { width: 40, height: 12 },
     )
     await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+    await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain("beta - Copy")
   })
@@ -53,7 +58,10 @@ describe("EnvSidebar list update", () => {
       { width: 40, height: 12 },
     )
     await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+    await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain("delta")
   })

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { act, useMemo, useState } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "./testRender"
 import { extend } from "@opentui/react"
 import { RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
@@ -26,6 +26,8 @@ import {
   CodeEditorScrollBarRenderable,
 } from "../src/ui/editor/CodeEditor"
 import { keyEvent } from "./unit/_helpers"
+
+const testRender = createTestRender()
 
 extend({
   "code-editor": CodeEditorRenderable,
@@ -398,18 +400,20 @@ describe("ResponsePane scrollbox", () => {
     const raw = createTestKeymap()
     const keymap = raw.keymap as unknown as OpenTuiKeymap
     keymap.setData("app.overlay", "none")
-    const { renderOnce, captureCharFrame, mockInput } = await testRender(
-      <KeymapProvider keymap={keymap}>
-        <ResponsePane state={state} focused initialTab="body" />
-      </KeymapProvider>,
-      { width: 80, height: 16 },
-    )
+    const { renderer, renderOnce, captureCharFrame, mockInput } =
+      await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ResponsePane state={state} focused initialTab="body" />
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
     await renderOnce()
     expect(captureCharFrame()).toContain("Sending")
     await act(async () => mockInput.pressKey("ARROW_RIGHT"))
     await act(async () => mockInput.pressKey("ARROW_RIGHT"))
     await renderOnce()
     expect(captureCharFrame()).toContain("GET example")
+    await act(async () => renderer.destroy())
   })
 
   it("renders trace events after a failed request", async () => {

--- a/tests/testRender.ts
+++ b/tests/testRender.ts
@@ -13,15 +13,21 @@ const actEnvironment = globalThis as typeof globalThis & {
 export function createTestRender() {
   const renderers = new Set<TestRendererSetup["renderer"]>()
 
-  afterEach(() => {
-    act(() => {
-      for (const renderer of renderers) {
-        if (!renderer.isDestroyed) renderer.destroy()
-        actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
-      }
-    })
-    actEnvironment.IS_REACT_ACT_ENVIRONMENT = false
-    renderers.clear()
+  afterEach(async () => {
+    const previousActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+    try {
+      await act(() => {
+        for (const renderer of renderers) {
+          actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+          if (!renderer.isDestroyed) renderer.destroy()
+          actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+        }
+      })
+    } finally {
+      actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+      renderers.clear()
+    }
   })
 
   return async function testRender(

--- a/tests/testRender.ts
+++ b/tests/testRender.ts
@@ -1,0 +1,35 @@
+import { afterEach } from "bun:test"
+import type {
+  TestRendererOptions,
+  TestRendererSetup,
+} from "@opentui/core/testing"
+import { testRender as openTuiTestRender } from "@opentui/react/test-utils"
+import { act, type ReactNode } from "react"
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+
+export function createTestRender() {
+  const renderers = new Set<TestRendererSetup["renderer"]>()
+
+  afterEach(() => {
+    act(() => {
+      for (const renderer of renderers) {
+        if (!renderer.isDestroyed) renderer.destroy()
+        actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+      }
+    })
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = false
+    renderers.clear()
+  })
+
+  return async function testRender(
+    node: ReactNode,
+    options: TestRendererOptions,
+  ): Promise<TestRendererSetup> {
+    const setup = await openTuiTestRender(node, options)
+    renderers.add(setup.renderer)
+    return setup
+  }
+}

--- a/tests/unit/AboutOverlay.test.tsx
+++ b/tests/unit/AboutOverlay.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { AboutOverlay } from "../../src/ui/overlays/AboutOverlay"
 import pkg from "../../package.json" with { type: "json" }
+
+const testRender = createTestRender()
 
 describe("AboutOverlay", () => {
   it("renders Noodle information and links", async () => {

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "bun:test"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { act } from "react"
 import { AuthEditor } from "../../src/ui/AuthEditor"
 import { initialEditState } from "../../src/ui/editMode"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 describe("AuthEditor", () => {
   it("activates the API key placement row before opening its select", async () => {

--- a/tests/unit/CenterText.test.tsx
+++ b/tests/unit/CenterText.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { CenterText, splitWords } from "../../src/ui/CenterText"
+
+const testRender = createTestRender()
 
 describe("splitWords", () => {
   it("splits single segment into words with trailing space", () => {

--- a/tests/unit/Checkbox.test.tsx
+++ b/tests/unit/Checkbox.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { RGBA } from "@opentui/core"
 import { Checkbox } from "../../src/ui/Checkbox"
 import { THEMES, type Theme } from "../../src/ui/theme"
+
+const testRender = createTestRender()
 
 const theme = THEMES[0]! as Theme
 

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -848,7 +848,7 @@ body_type: json`
           }}
           filetype="json"
           theme={opencodeTheme}
-          initialValue={content}
+          initialValue=""
           debounceMs={0}
           extraHighlights={(value) => {
             if (!editor) return []
@@ -872,8 +872,7 @@ body_type: json`
     )
 
     await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    await renderOnce()
+    editor!.value = content
     const highlights = editor!.getLineHighlights(1)
     expect(
       highlights.some(

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { extend } from "@opentui/react"
 import { LineNumberRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
@@ -11,6 +11,8 @@ import {
 import { syncCodeEditorGutter } from "../../src/ui/editor/codeEditorGutter"
 import { opencodeTheme } from "../../src/ui/theme-data"
 import { getHighlightCount, keyEvent } from "./_helpers"
+
+const testRender = createTestRender()
 
 extend({ "code-editor": CodeEditorRenderable })
 
@@ -517,7 +519,7 @@ body_type: json`
     expect(editor!.scrollY).toBeGreaterThan(0)
     expect(editor!.logicalCursor).toMatchObject({ row: 5, col: 0 })
     scrollbar.destroy()
-    renderer.destroy()
+    act(() => renderer.destroy())
   })
 
   it("tears down an editor before its scrollbar", async () => {
@@ -548,7 +550,7 @@ body_type: json`
       teardownError = error
     }
     scrollbar.destroy()
-    renderer.destroy()
+    act(() => renderer.destroy())
 
     expect(teardownError).toBeUndefined()
   })
@@ -782,7 +784,7 @@ body_type: json`
 
     lineNumber.destroy()
     editor.destroy()
-    renderer.destroy()
+    act(() => renderer.destroy())
   })
 
   it("collapses a nested JSON array without leaving blank editor rows", async () => {

--- a/tests/unit/CodeEditorCompletion.test.tsx
+++ b/tests/unit/CodeEditorCompletion.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { useState } from "react"
 import { extend } from "@opentui/react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
@@ -13,6 +13,8 @@ import { VariableCompletionInterceptor } from "../../src/ui/variable-completion/
 import { ThemeProvider } from "../../src/ui/theme"
 import type { Environment } from "../../src/schema"
 import { opencodeTheme } from "../../src/ui/theme-data"
+
+const testRender = createTestRender()
 
 extend({ "code-editor": CodeEditorRenderable })
 

--- a/tests/unit/CodeGeneratorOverlay.test.tsx
+++ b/tests/unit/CodeGeneratorOverlay.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
@@ -9,6 +9,8 @@ import { RendererProvider } from "../../src/ui/RendererContext"
 import { CodeGeneratorOverlay } from "../../src/ui/overlays/CodeGeneratorOverlay"
 import * as clipboard from "../../src/ui/clipboard"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 const baseRequest = {
   id: "users",

--- a/tests/unit/CollectionSwitcherOverlay.test.tsx
+++ b/tests/unit/CollectionSwitcherOverlay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerEnabledFields,
@@ -10,6 +10,8 @@ import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { CollectionSwitcherOverlay } from "../../src/ui/overlays/CollectionSwitcherOverlay"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/CommandPaletteOverlay.test.tsx
+++ b/tests/unit/CommandPaletteOverlay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerEnabledFields,
@@ -13,6 +13,8 @@ import {
   CommandPaletteOverlay,
   type CommandItem,
 } from "../../src/ui/overlays/CommandPaletteOverlay"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, host, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/DeleteConfirmation.test.tsx
+++ b/tests/unit/DeleteConfirmation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerEnabledFields,
@@ -11,6 +11,8 @@ import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { ConfirmOverlay } from "../../src/ui/overlays/ConfirmOverlay"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
+import { act } from "react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { EnvEditorPane } from "../../src/ui/env-editor/EnvEditorPane"
+
+const testRender = createTestRender()
 
 const inactive = {
   mode: "inactive" as const,
@@ -130,10 +133,12 @@ describe("EnvEditorPane", () => {
     )
     await renderOnce()
 
-    await mockMouse.click(10, 2, MouseButtons.LEFT)
-    await mockMouse.click(60, 2, MouseButtons.LEFT)
-    await mockMouse.click(2, 2, MouseButtons.LEFT)
-    await mockMouse.click(10, 3, MouseButtons.LEFT)
+    await act(async () => {
+      await mockMouse.click(10, 2, MouseButtons.LEFT)
+      await mockMouse.click(60, 2, MouseButtons.LEFT)
+      await mockMouse.click(2, 2, MouseButtons.LEFT)
+      await mockMouse.click(10, 3, MouseButtons.LEFT)
+    })
 
     expect(activations).toEqual([
       [0, false, "key"],

--- a/tests/unit/EnvHeaderPane.test.tsx
+++ b/tests/unit/EnvHeaderPane.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "bun:test"
 import { act, useState } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { EnvHeaderPane } from "../../src/ui/env-editor/EnvHeaderPane"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 describe("EnvHeaderPane", () => {
   it("renders name input and color select with placeholder", async () => {

--- a/tests/unit/EnvSidebar.test.tsx
+++ b/tests/unit/EnvSidebar.test.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
+import { act } from "react"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { EnvSidebar } from "../../src/ui/env-editor/EnvSidebar"
+
+const testRender = createTestRender()
 
 describe("EnvSidebar", () => {
   it("renders env names", async () => {
@@ -58,12 +61,16 @@ describe("EnvSidebar", () => {
     )
     await renderOnce()
 
-    await mockMouse.click(2, 3, MouseButtons.RIGHT)
+    await act(async () => {
+      await mockMouse.click(2, 3, MouseButtons.RIGHT)
+    })
     expect(selected).toBe("")
     expect(focused).toBe(0)
     expect(contextName).toBe("staging")
 
-    await mockMouse.click(2, 3, MouseButtons.LEFT)
+    await act(async () => {
+      await mockMouse.click(2, 3, MouseButtons.LEFT)
+    })
     expect(selected).toBe("staging")
     expect(focused).toBe(1)
   })

--- a/tests/unit/EnvironmentPickerOverlay.test.tsx
+++ b/tests/unit/EnvironmentPickerOverlay.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { EnvironmentPickerOverlay } from "../../src/ui/overlays/EnvironmentPickerOverlay"
 import { ThemeProvider } from "../../src/ui/theme"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 const environments = ["development", "staging", "production"]
 

--- a/tests/unit/EscapeClose.test.tsx
+++ b/tests/unit/EscapeClose.test.tsx
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { EscapeClose } from "../../src/ui/overlays/EscapeClose"
+
+const testRender = createTestRender()
 
 describe("EscapeClose", () => {
   it("closes when clicked", async () => {

--- a/tests/unit/ExportCollectionOverlay.test.tsx
+++ b/tests/unit/ExportCollectionOverlay.test.tsx
@@ -3,7 +3,7 @@ import { mkdtemp, rm, symlink } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { act, createRef } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import {
@@ -12,6 +12,8 @@ import {
 } from "../../src/ui/overlays/ExportCollectionOverlay"
 import type { ExportCollectionValues } from "../../src/ui/collectionExport"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 describe("ExportCollectionOverlay", () => {
   it("defaults to OpenAPI and previews the generated target", async () => {

--- a/tests/unit/FolderPane-clickCommit.test.tsx
+++ b/tests/unit/FolderPane-clickCommit.test.tsx
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider } from "../../src/ui/theme"
 import { THEMES } from "../../src/ui/theme-data"
 import { FolderPane } from "../../src/ui/FolderPane"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 describe("FolderPane blank click commit", () => {
   it("commits a metadata edit when clicking blank pane space", async () => {

--- a/tests/unit/Frame.test.tsx
+++ b/tests/unit/Frame.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { MouseButtons } from "@opentui/core/testing"
 import { Frame } from "../../src/ui/Frame"
+
+const testRender = createTestRender()
 
 describe("Frame", () => {
   it("focuses its pane only on a left click", async () => {

--- a/tests/unit/GradientBadge.test.tsx
+++ b/tests/unit/GradientBadge.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { RGBA } from "@opentui/core"
 import { GradientBadge } from "../../src/ui/GradientBadge"
+
+const testRender = createTestRender()
 
 function rgbaFromHex(hex: string): RGBA {
   return RGBA.fromHex(hex)

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import pkg from "../../package.json" with { type: "json" }
 import { Header } from "../../src/ui/Header"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
+
+const testRender = createTestRender()
 
 function textPosition(frame: string, text: string): [number, number] {
   const lines = frame.split("\n")

--- a/tests/unit/HeaderTable.test.tsx
+++ b/tests/unit/HeaderTable.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { HeaderTable } from "../../src/ui/HeaderTable"
 import { THEMES, type Theme } from "../../src/ui/theme"
+
+const testRender = createTestRender()
 
 const theme = THEMES[0]! as Theme
 

--- a/tests/unit/HelpOverlay.test.tsx
+++ b/tests/unit/HelpOverlay.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { HelpOverlay } from "../../src/ui/overlays/HelpOverlay"
 import { bindingDefaults } from "../../src/ui/keybind"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 describe("HelpOverlay", () => {
   it("keeps spacing between long key hints and descriptions", async () => {

--- a/tests/unit/ImportCollectionOverlay.test.tsx
+++ b/tests/unit/ImportCollectionOverlay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act, createRef } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import {
@@ -8,6 +8,8 @@ import {
   type ImportCollectionOverlayHandle,
 } from "../../src/ui/overlays/ImportCollectionOverlay"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 describe("ImportCollectionOverlay", () => {
   it("defaults to a new collection and exposes supported formats", async () => {

--- a/tests/unit/ImportCurlOverlay.test.tsx
+++ b/tests/unit/ImportCurlOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { act, createRef } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerDefaultKeys,
@@ -14,6 +14,8 @@ import {
   ImportCurlOverlay,
   type ImportCurlOverlayHandle,
 } from "../../src/ui/overlays/ImportCurlOverlay"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/NewEnvironmentOverlay.test.tsx
+++ b/tests/unit/NewEnvironmentOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { act, createRef, useEffect } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerDefaultKeys,
@@ -17,6 +17,8 @@ import {
   type NewEnvironmentValues,
 } from "../../src/ui/overlays/NewEnvironmentOverlay"
 import { useFormOverlayIntercept } from "../../src/ui/intercepts/useFormOverlayIntercept"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, host, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/Overlay.test.tsx
+++ b/tests/unit/Overlay.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider, opencodeTheme } from "../../src/ui/theme"
 import { Overlay } from "../../src/ui/overlays/Overlay"
+
+const testRender = createTestRender()
 
 function OverlayFrame({ visible }: { visible: boolean }) {
   return (

--- a/tests/unit/PickerOverlay.test.tsx
+++ b/tests/unit/PickerOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerEnabledFields,
@@ -11,6 +11,8 @@ import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { PickerOverlay } from "../../src/ui/overlays/PickerOverlay"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, host, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/RequestFinderOverlay.test.tsx
+++ b/tests/unit/RequestFinderOverlay.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerDefaultKeys,
@@ -9,6 +9,8 @@ import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { RequestFinderOverlay } from "../../src/ui/overlays/RequestFinderOverlay"
+
+const testRender = createTestRender()
 
 function setup() {
   const { keymap, host, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/RequestPane-clickCommit.test.tsx
+++ b/tests/unit/RequestPane-clickCommit.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -8,6 +8,8 @@ import { RequestPane } from "../../src/ui/RequestPane"
 import type { FieldKind } from "../../src/ui/editMode"
 import type { Request } from "../../src/schema"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 const request: Request = {
   id: "photo",

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { extend } from "@opentui/react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { TextAttributes } from "@opentui/core"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -16,6 +16,8 @@ import {
   getAvailableTargets,
   computeRequestTabLabels,
 } from "../../src/ui/useJumpMode"
+
+const testRender = createTestRender()
 
 extend({
   "code-editor": CodeEditorRenderable,

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { Select, type SelectItem } from "../../src/ui/Select"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 const testItems: SelectItem[] = [
   { id: "get", label: "GET" },
@@ -137,8 +139,8 @@ describe("Select", () => {
 
     await act(async () => {
       await mockMouse.click(1, 0, MouseButtons.LEFT)
+      await renderOnce()
     })
-    await renderOnce()
 
     expect(activated).toBe(0)
     expect(open).toBe(false)
@@ -167,14 +169,14 @@ describe("Select", () => {
 
     await act(async () => {
       await mockMouse.click(1, 0, MouseButtons.LEFT)
+      await renderOnce()
     })
-    await renderOnce()
     expect(open).toBe(true)
 
     await act(async () => {
       await mockMouse.click(1, 0, MouseButtons.LEFT)
+      await renderOnce()
     })
-    await renderOnce()
     expect(open).toBe(false)
     cleanup()
   })

--- a/tests/unit/Sidebar.test.tsx
+++ b/tests/unit/Sidebar.test.tsx
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test"
+import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { Sidebar } from "../../src/ui/Sidebar"
 import { ThemeProvider } from "../../src/ui/theme"
+
+const testRender = createTestRender()
 
 describe("Sidebar", () => {
   it("selects on left click and opens the request context menu on right click", async () => {
@@ -42,12 +45,16 @@ describe("Sidebar", () => {
     )
     await renderOnce()
 
-    await mockMouse.click(2, 1, MouseButtons.RIGHT)
+    await act(async () => {
+      await mockMouse.click(2, 1, MouseButtons.RIGHT)
+    })
     expect(selected).toBe("")
     expect(focused).toBe(0)
     expect(contextId).toBe("example")
 
-    await mockMouse.click(3, 1, MouseButtons.LEFT)
+    await act(async () => {
+      await mockMouse.click(3, 1, MouseButtons.LEFT)
+    })
     expect(selected).toBe("example")
     expect(focused).toBe(1)
   })
@@ -86,11 +93,15 @@ describe("Sidebar", () => {
     )
     await renderOnce()
 
-    await mockMouse.click(3, 1, MouseButtons.LEFT)
+    await act(async () => {
+      await mockMouse.click(3, 1, MouseButtons.LEFT)
+    })
     expect(toggled).toBe("api")
     expect(selected).toBe("")
 
-    await mockMouse.click(6, 1, MouseButtons.LEFT)
+    await act(async () => {
+      await mockMouse.click(6, 1, MouseButtons.LEFT)
+    })
     expect(selected).toBe("api")
   })
 
@@ -124,7 +135,9 @@ describe("Sidebar", () => {
     )
     await renderOnce()
 
-    await mockMouse.click(6, 1, MouseButtons.RIGHT)
+    await act(async () => {
+      await mockMouse.click(6, 1, MouseButtons.RIGHT)
+    })
     expect(contextId).toBe("api")
   })
 })

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -2,13 +2,14 @@ import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { StatusBar } from "../../src/ui/StatusBar"
 import { bindingDefaults } from "../../src/ui/keybind"
 import { getKeybindingHints } from "../../src/ui/keybindingHints"
 import type { HintSegment } from "../../src/ui/keybindingHints"
 
+const testRender = createTestRender()
 const kb = bindingDefaults()
 const emptyHints: HintSegment[] = []
 

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act, useState, type ComponentProps } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -10,6 +10,8 @@ import {
 } from "../../src/ui/overlays/TimelineDetailOverlay"
 import type { TimelineEntry } from "../../src/schema"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 function makeEntry(over: Partial<TimelineEntry> = {}): TimelineEntry {
   return {

--- a/tests/unit/TimelineTab.test.tsx
+++ b/tests/unit/TimelineTab.test.tsx
@@ -2,12 +2,14 @@ import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { RGBA, ScrollBoxRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { TimelineTab } from "../../src/ui/timeline/TimelineTab"
 import type { TimelineEntry } from "../../src/schema"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 function makeEntry(id: string): TimelineEntry {
   return {
@@ -23,7 +25,7 @@ function makeEntry(id: string): TimelineEntry {
   }
 }
 
-function renderTimeline(
+async function renderTimeline(
   entries: TimelineEntry[],
   focused: boolean,
   onOpenEntry: (entry: TimelineEntry) => void,
@@ -32,7 +34,7 @@ function renderTimeline(
   ;(
     keymap as unknown as { setData: (key: string, value: string) => void }
   ).setData("app.overlay", "none")
-  return testRender(
+  const render = await testRender(
     <KeymapProvider keymap={keymap}>
       <ThemeProvider activeIndex={0} previewIndex={null}>
         <TimelineTab
@@ -43,7 +45,13 @@ function renderTimeline(
       </ThemeProvider>
     </KeymapProvider>,
     { width: 80, height: 20 },
-  ).then((render) => ({ ...render, cleanup }))
+  )
+  await act(async () => {
+    await render.renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  })
+  await render.renderOnce()
+  return { ...render, cleanup }
 }
 
 describe("TimelineTab", () => {

--- a/tests/unit/TimelineTab.test.tsx
+++ b/tests/unit/TimelineTab.test.tsx
@@ -18,7 +18,7 @@ function makeEntry(id: string): TimelineEntry {
       id,
       name: id,
       method: "GET",
-      url: `https://example.com/${id}`,
+      url: `https://example.com/${id}/${"segment/".repeat(12)}`,
       headers: {},
       params: [],
     },
@@ -48,9 +48,22 @@ async function renderTimeline(
   )
   await act(async () => {
     await render.renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 20))
   })
-  await render.renderOnce()
+  if (entries.length > 0) {
+    await render.waitForFrame(async (frame) => {
+      if (frame.includes("...")) return true
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      await act(async () => {
+        await render.renderOnce()
+      })
+      return render.captureCharFrame().includes("...")
+    })
+  }
+  await act(async () => {
+    await render.renderOnce()
+  })
   return { ...render, cleanup }
 }
 

--- a/tests/unit/Toast.test.tsx
+++ b/tests/unit/Toast.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { showToast, Toast } from "../../src/ui/Toast"
+
+const testRender = createTestRender()
 
 describe("Toast", () => {
   it("renders above overlays", async () => {

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "bun:test"
 import { act, useState } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { UrlBar } from "../../src/ui/UrlBar"
 import type { Method } from "../../src/schema"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 function UrlBarHarness({
   subFocus = "text",

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -842,6 +842,7 @@ describe("VarInput — path completion", () => {
 
 describe("VarInput — textarea mode (isEditing=true, useTextarea=true)", () => {
   it("renders textarea with value", async () => {
+    const changes: string[] = []
     const { renderOnce, captureCharFrame } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
         <VarInput
@@ -849,7 +850,7 @@ describe("VarInput — textarea mode (isEditing=true, useTextarea=true)", () => 
           env={null}
           isEditing
           useTextarea
-          onChange={() => {}}
+          onChange={(value) => changes.push(value)}
         />
       </ThemeProvider>,
       { width: 80, height: 5 },
@@ -857,6 +858,7 @@ describe("VarInput — textarea mode (isEditing=true, useTextarea=true)", () => 
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame).toContain("multi")
+    expect(changes).toEqual([])
   })
 
   it("renders empty textarea without crash", async () => {

--- a/tests/unit/VarText.test.tsx
+++ b/tests/unit/VarText.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { RGBA } from "@opentui/core"
 import { VarText } from "../../src/ui/VarText"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import type { Environment } from "../../src/schema"
+
+const testRender = createTestRender()
 
 function env(vars: Record<string, string>): Environment {
   return { name: "test-env", vars }

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { extend } from "@opentui/react"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -17,6 +17,8 @@ import { CodeEditorRenderable } from "../../src/ui/editor/CodeEditor"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+
+const testRender = createTestRender()
 
 extend({ "code-editor": CodeEditorRenderable })
 
@@ -41,6 +43,35 @@ function setupKeymap() {
 const MOCK_YAML = "name: test\nmethod: GET\nurl: https://example.com\n"
 let testDir: string
 let filePath: string
+
+async function loadEditor(
+  renderOnce: () => Promise<void>,
+  delayMs = 20,
+): Promise<void> {
+  await act(async () => {
+    await renderOnce()
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+  })
+  await renderOnce()
+}
+
+async function waitForRow(
+  captureCharFrame: () => string,
+  renderOnce: () => Promise<void>,
+  predicate: (row: string) => boolean,
+): Promise<[string, number]> {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    const rows = captureCharFrame().split("\n")
+    const index = rows.findIndex(predicate)
+    if (index >= 0) return [rows[index]!, index]
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+    await renderOnce()
+  }
+  throw new Error("Expected YAML fold icon")
+}
 
 beforeEach(async () => {
   testDir = await mkdtemp(join(tmpdir(), "noodle-yaml-editor-"))
@@ -69,9 +100,7 @@ describe("YamlEditorOverlay", () => {
       </KeymapProvider>,
       { width: 100, height: 30 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 20))
-    await renderOnce()
+    await loadEditor(renderOnce)
     const frame = captureCharFrame()
     expect(frame).toContain("get-users.yml")
     expect(frame).toContain("esc")
@@ -94,9 +123,7 @@ describe("YamlEditorOverlay", () => {
       </KeymapProvider>,
       { width: 100, height: 30 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 20))
-    await renderOnce()
+    await loadEditor(renderOnce)
     const frame = captureCharFrame()
     expect(frame).toContain("^S")
     expect(frame).toContain("save")
@@ -130,9 +157,7 @@ describe("YamlEditorOverlay", () => {
       </KeymapProvider>,
       { width: 100, height: 30 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 20))
-    await renderOnce()
+    await loadEditor(renderOnce)
 
     const rows = captureCharFrame().split("\n")
     const y = rows.findIndex((row) => row.includes("save"))
@@ -169,22 +194,15 @@ describe("YamlEditorOverlay", () => {
       </KeymapProvider>,
       { width: 100, height: 30 },
     )
-    await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 250))
-    await renderOnce()
-
-    const rows = captureCharFrame().split("\n")
-    const row = rows.find(
+    await loadEditor(renderOnce)
+    const [row, rowIndex] = await waitForRow(
+      captureCharFrame,
+      renderOnce,
       (line) => line.includes("▼") && line.includes("headers:"),
     )
-    if (!row) throw new Error("Expected YAML fold icon")
 
     await act(async () => {
-      await mockMouse.click(
-        row.indexOf("▼"),
-        rows.indexOf(row),
-        MouseButtons.LEFT,
-      )
+      await mockMouse.click(row.indexOf("▼"), rowIndex, MouseButtons.LEFT)
     })
     await renderOnce()
     expect(captureCharFrame()).not.toContain("accept: application/json")
@@ -252,9 +270,7 @@ describe("YamlEditorOverlay", () => {
       </KeymapProvider>,
       { width: 100, height: 30 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 20))
-    await renderOnce()
+    await loadEditor(renderOnce)
     const frame = captureCharFrame()
     expect(frame).toMatch(/\^S.*save.*esc.*close/)
     cleanup()
@@ -278,12 +294,12 @@ describe("YamlEditorOverlay", () => {
       </KeymapProvider>,
       { width: 100, height: 30 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 20))
-    await renderOnce()
+    await loadEditor(renderOnce)
 
-    host.press("s", { ctrl: true })
-    await new Promise((r) => setTimeout(r, 20))
+    await act(async () => {
+      host.press("s", { ctrl: true })
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
     await renderOnce()
 
     const frame = captureCharFrame()

--- a/tests/unit/formOverlayActions.test.tsx
+++ b/tests/unit/formOverlayActions.test.tsx
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test"
 import { act } from "react"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { CloneRequestOverlay } from "../../src/ui/overlays/CloneRequestOverlay"
 import { NewFolderOverlay } from "../../src/ui/overlays/NewFolderOverlay"
+
+const testRender = createTestRender()
 
 describe("form overlay footer actions", () => {
   it("runs Clone Request actions without a separator", async () => {

--- a/tests/unit/newRequestOverlay.test.tsx
+++ b/tests/unit/newRequestOverlay.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test"
 import { act, createRef } from "react"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerEnabledFields,
@@ -17,6 +17,8 @@ import {
   NewRequestOverlay,
   type NewRequestOverlayHandle,
 } from "../../src/ui/overlays/NewRequestOverlay"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/rowMouseControls.test.tsx
+++ b/tests/unit/rowMouseControls.test.tsx
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { initialEditState } from "../../src/ui/editMode"
 import { KeyValueSection } from "../../src/ui/KeyValueSection"
 import { FormEditor } from "../../src/ui/FormEditor"
+
+const testRender = createTestRender()
 
 describe("request row mouse controls", () => {
   it("activates and toggles key/value rows independently", async () => {

--- a/tests/unit/tabs.test.tsx
+++ b/tests/unit/tabs.test.tsx
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { Tabs } from "../../src/ui/Tabs"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
+
+const testRender = createTestRender()
 
 describe("Tabs", () => {
   it("renders all tab labels", async () => {

--- a/tests/unit/theme-picker.test.tsx
+++ b/tests/unit/theme-picker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerEnabledFields,
@@ -8,6 +8,8 @@ import {
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { THEMES, ThemePickerOverlay, ThemeProvider } from "../../src/ui/theme"
+
+const testRender = createTestRender()
 
 function setupKeymap() {
   const { keymap, cleanup: hostCleanup } = createTestKeymap()

--- a/tests/unit/unsavedChangesRegression.test.tsx
+++ b/tests/unit/unsavedChangesRegression.test.tsx
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { useEffect, useRef, useState } from "react"
 import { useRequestDraft } from "../../src/hooks/useRequestDraft"
 import { useEditBrowse } from "../../src/hooks/useEditBrowse"
 import { useCollectionSwitcher } from "../../src/ui/useCollectionSwitcher"
 import { useReloadGuard } from "../../src/ui/useReloadGuard"
 import type { Request } from "../../src/schema"
+
+const testRender = createTestRender()
 
 const request: Request = {
   id: "request",

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { act, useEffect, useRef, useState } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import type {
   Collection,
   Folder,
@@ -12,6 +12,8 @@ import type {
 import type { UseFolderDraftResult } from "../../src/hooks/useFolderDraft"
 import { useCollectionFileActions } from "../../src/ui/useCollectionFileActions"
 import { lang } from "../../src/lang"
+
+const testRender = createTestRender()
 
 const initialFolder: Folder = {
   id: "api",

--- a/tests/unit/useEnvironments.test.tsx
+++ b/tests/unit/useEnvironments.test.tsx
@@ -3,11 +3,13 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { act, useEffect, useState } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import {
   useEnvironments,
   type UseEnvironmentsResult,
 } from "../../src/hooks/useEnvironments"
+
+const testRender = createTestRender()
 
 function Harness({
   dir,

--- a/tests/unit/useFolderEditBrowse.test.tsx
+++ b/tests/unit/useFolderEditBrowse.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act, useEffect, useRef, useState } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import {
   useFolderEditBrowse,
@@ -13,6 +13,8 @@ import { useJumpMode, type JumpTarget } from "../../src/ui/useJumpMode"
 import type { Focus } from "../../src/ui/focus"
 import type { EnvHeaderPaneHandle } from "../../src/ui/env-editor/EnvHeaderPane"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 const folder: Folder = {
   id: "folder",

--- a/tests/unit/useModalKeyboardShield.test.tsx
+++ b/tests/unit/useModalKeyboardShield.test.tsx
@@ -1,12 +1,15 @@
-import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { describe, expect, it, spyOn } from "bun:test"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
+import { act } from "react"
 import {
   HARD_BLOCKING_OVERLAYS,
   EDITABLE_OVERLAYS,
   useModalKeyboardShield,
 } from "../../src/ui/useModalKeyboardShield"
 import { setupKeymap } from "./_helpers"
+
+const testRender = createTestRender()
 
 function Shield({ activeOverlay }: { activeOverlay: string }) {
   useModalKeyboardShield(activeOverlay)
@@ -33,6 +36,7 @@ describe("useModalKeyboardShield", () => {
       expect(event.defaultPrevented).toBe(false)
       expect(event.propagationStopped).toBe(false)
       cleanup()
+      act(() => render.renderer.destroy())
     }
   })
 
@@ -57,10 +61,12 @@ describe("useModalKeyboardShield", () => {
       expect(backgroundKeys).toEqual([])
       dispose()
       cleanup()
+      act(() => render.renderer.destroy())
     }
   })
 
   it("does not hard-block unknown overlays", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {})
     const { keymap, host, cleanup } = setupKeymap()
     const render = await testRender(
       <KeymapProvider keymap={keymap}>
@@ -68,11 +74,18 @@ describe("useModalKeyboardShield", () => {
       </KeymapProvider>,
       { width: 1, height: 1 },
     )
-
-    await render.renderOnce()
-    const event = host.press("e")
-    expect(event.defaultPrevented).toBe(false)
-    expect(event.propagationStopped).toBe(false)
-    cleanup()
+    try {
+      await render.renderOnce()
+      const event = host.press("e")
+      expect(event.defaultPrevented).toBe(false)
+      expect(event.propagationStopped).toBe(false)
+      expect(warn).toHaveBeenCalledWith(
+        'useModalKeyboardShield: unknown overlay "future-overlay"; treating it as editable',
+      )
+    } finally {
+      cleanup()
+      act(() => render.renderer.destroy())
+      warn.mockRestore()
+    }
   })
 })

--- a/tests/unit/useRequestDraftHook.test.tsx
+++ b/tests/unit/useRequestDraftHook.test.tsx
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import { useEffect, useState } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { useRequestDraft } from "../../src/hooks/useRequestDraft"
 import { useFolderDraft } from "../../src/hooks/useFolderDraft"
 import type { Auth, Folder, Request } from "../../src/schema"
+
+const testRender = createTestRender()
 
 const request: Request = {
   id: "r1",

--- a/tests/unit/useTreeNavigation.test.tsx
+++ b/tests/unit/useTreeNavigation.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { useEffect, useState, type ReactNode } from "react"
-import { testRender } from "@opentui/react/test-utils"
+import { act, useEffect, useState, type ReactNode } from "react"
+import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { setupKeymap } from "./_helpers"
 import { useTreeNavigation } from "../../src/hooks/useTreeNavigation"
 import { getEditRequestYamlFile } from "../../src/ui/commandActions"
 import type { CollectionItem } from "../../src/schema"
+
+const testRender = createTestRender()
 
 function req(id: string): CollectionItem {
   return {
@@ -118,7 +120,9 @@ describe("useTreeNavigation", () => {
     await renderOnce()
 
     // Wait for the create flow to complete
-    await new Promise((r) => setTimeout(r, 30))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
     await renderOnce()
     const frame = captureCharFrame()
 
@@ -214,7 +218,9 @@ describe("useTreeNavigation", () => {
     )
 
     await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
     await renderOnce()
     const frame = captureCharFrame()
 
@@ -245,7 +251,9 @@ describe("useTreeNavigation", () => {
     )
 
     await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
     await renderOnce()
     const frame = captureCharFrame()
 

--- a/tests/unit/variableHighlight.test.tsx
+++ b/tests/unit/variableHighlight.test.tsx
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "../testRender"
 import { RGBA } from "@opentui/core"
 import { act, useState } from "react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { VarInput } from "../../src/ui/VarInput"
 import type { Environment } from "../../src/schema"
+
+const testRender = createTestRender()
 
 function env(vars: Record<string, string>): Environment {
   return { name: "test", vars }

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -7,7 +7,7 @@ import {
   mock,
   spyOn,
 } from "bun:test"
-import { testRender } from "@opentui/react/test-utils"
+import { createTestRender } from "./testRender"
 import { act, useEffect, useRef } from "react"
 import { mkdtemp, rm, readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -15,6 +15,8 @@ import { join } from "node:path"
 import { ThemeProvider } from "../src/ui/theme"
 import { useEnvironmentEditor } from "../src/hooks/useEnvironmentEditor"
 import { env } from "../src/env"
+
+const testRender = createTestRender()
 
 let dir: string
 
@@ -27,7 +29,9 @@ async function waitForDraft(
     if (Date.now() >= deadline) {
       throw new Error("Timed out waiting for environment draft")
     }
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
     await renderOnce()
   }
 }
@@ -89,10 +93,11 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
-    await ref.current!.cloneEnv("alpha-copy")
+    await act(async () => {
+      await ref.current!.cloneEnv("alpha-copy")
+    })
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
@@ -112,7 +117,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
     await waitForDraft(ref, renderOnce)
 
     await act(async () => {
@@ -146,7 +150,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
     await waitForDraft(ref, renderOnce)
 
     let first!: Promise<void>
@@ -175,7 +178,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
     await waitForDraft(ref, renderOnce)
     const alphaBefore = await readFile(join(dir, "alpha.env"), "utf8")
 
@@ -228,10 +230,11 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
-    await ref.current!.deleteEnv()
+    await act(async () => {
+      await ref.current!.deleteEnv()
+    })
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
@@ -246,8 +249,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await waitForDraft(ref, renderOnce)
 
     act(() => {
       ref.current!.activateVar(0)
@@ -297,8 +299,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await waitForDraft(ref, renderOnce)
 
     act(() => {
       ref.current!.activateVar(0)
@@ -336,8 +337,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await waitForDraft(ref, renderOnce)
 
     act(() => {
       ref.current!.activateVar(0)
@@ -367,8 +367,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     const filePath = join(dir, "alpha.env")
     const before = await readFile(filePath, "utf8")
@@ -376,8 +375,9 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       .catch(() => false)
     expect(before).toBe(true)
 
-    await ref.current!.deleteEnv()
-    await new Promise((r) => setTimeout(r, 30))
+    await act(async () => {
+      await ref.current!.deleteEnv()
+    })
 
     const after = await readFile(filePath, "utf8")
       .then(() => true)
@@ -397,13 +397,13 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     // Change name to trigger rename path
-    ref.current!.setName("alpha-renamed")
-    await ref.current!.save()
-    await renderOnce()
+    await act(async () => {
+      ref.current!.setName("alpha-renamed")
+      await ref.current!.save()
+    })
 
     act(() => {
       ref.current!.setColor("warning")
@@ -436,12 +436,13 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     // Edit without changing name (simulates color/vars edit)
-    ref.current!.setColor("warning")
-    await ref.current!.save()
+    await act(async () => {
+      ref.current!.setColor("warning")
+      await ref.current!.save()
+    })
     expect(dataSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -455,7 +456,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
     await waitForDraft(ref, renderOnce)
 
     act(() => {
@@ -483,7 +483,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
     await waitForDraft(ref, renderOnce)
 
     const originalLoad = env.loadEnvironment
@@ -532,8 +531,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     type LoadedEnvironment = Awaited<ReturnType<typeof env.loadEnvironment>>
     const pending = new Map<string, (environment: LoadedEnvironment) => void>()
@@ -545,8 +543,12 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     )
 
     try {
-      const betaSelection = ref.current!.selectEnv("beta")
-      const gammaSelection = ref.current!.selectEnv("gamma")
+      let betaSelection!: Promise<boolean>
+      let gammaSelection!: Promise<boolean>
+      act(() => {
+        betaSelection = ref.current!.selectEnv("beta")
+        gammaSelection = ref.current!.selectEnv("gamma")
+      })
 
       let gammaIsCurrent = false
       await act(async () => {
@@ -584,7 +586,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
     await waitForDraft(ref, renderOnce)
 
     type LoadedEnvironment = Awaited<ReturnType<typeof env.loadEnvironment>>
@@ -597,8 +598,12 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     )
 
     try {
-      const betaSelection = ref.current!.selectEnv("beta")
-      const alphaSelection = await ref.current!.selectEnv("alpha")
+      let betaSelection!: Promise<boolean>
+      let alphaSelection = false
+      await act(async () => {
+        betaSelection = ref.current!.selectEnv("beta")
+        alphaSelection = await ref.current!.selectEnv("alpha")
+      })
 
       expect(alphaSelection).toBe(true)
 
@@ -632,15 +637,13 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     // Rename "alpha" -> "beta" (beta already exists)
-    ref.current!.setName("beta")
-    await ref.current!.save()
-    // flush React state update from setError
-    await new Promise((r) => setTimeout(r, 10))
-    await renderOnce()
+    await act(async () => {
+      ref.current!.setName("beta")
+      await ref.current!.save()
+    })
 
     const editor = ref.current!
     expect(editor.error).not.toBeNull()
@@ -666,40 +669,35 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 30))
+    await waitForDraft(ref, renderOnce)
 
     // Close current editor, open new blank one
-    ref.current!.closeEditor()
-    await new Promise((r) => setTimeout(r, 10))
+    await act(async () => {
+      ref.current!.closeEditor()
+      await ref.current!.openEditor() // no name = blank draft
+    })
     await renderOnce()
-
-    ref.current!.openEditor() // no name = blank draft (sync in else branch)
-    await new Promise((r) => setTimeout(r, 10))
+    act(() => {
+      ref.current!.setName("new-env")
+      ref.current!.enterBrowse()
+    })
     await renderOnce()
-
-    ref.current!.setName("new-env")
+    act(() => {
+      ref.current!.enterEdit()
+    })
     await renderOnce()
-
-    ref.current!.enterBrowse()
+    act(() => {
+      ref.current!.setEditKey("key")
+      ref.current!.setEditValue("value")
+    })
     await renderOnce()
-
-    ref.current!.enterEdit()
+    act(() => {
+      ref.current!.commitEdit()
+    })
     await renderOnce()
-
-    ref.current!.setEditKey("key")
-    ref.current!.setEditValue("value")
-    await renderOnce()
-
-    ref.current!.commitEdit()
-    await renderOnce()
-
-    console.log("draft before save:", JSON.stringify(ref.current!.draft))
-    console.log("dirty:", ref.current!.dirty)
-
-    await ref.current!.save()
-    // flush setLocalNames state update
-    await new Promise((r) => setTimeout(r, 10))
+    await act(async () => {
+      await ref.current!.save()
+    })
     await renderOnce()
 
     const editor = ref.current!
@@ -718,25 +716,26 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       </ThemeProvider>,
       { width: 40, height: 12 },
     )
-    await renderOnce()
-    await new Promise((r) => setTimeout(r, 50))
-    await renderOnce()
+    await waitForDraft(ref, renderOnce)
 
-    ref.current!.enterBrowse()
-    await new Promise((r) => setTimeout(r, 10))
+    await act(async () => {
+      ref.current!.enterBrowse()
+    })
     await renderOnce()
 
     expect(ref.current!.editState.mode).toBe("browsing")
 
     // Go to last item (add row)
-    ref.current!.browseLast()
-    await new Promise((r) => setTimeout(r, 10))
+    await act(async () => {
+      ref.current!.browseLast()
+    })
     await renderOnce()
     expect(ref.current!.editState.addingRow).toBe(true)
 
     // Go to first item (row 0)
-    ref.current!.browseFirst()
-    await new Promise((r) => setTimeout(r, 10))
+    await act(async () => {
+      ref.current!.browseFirst()
+    })
     await renderOnce()
     expect(ref.current!.editState.row).toBe(0)
     expect(ref.current!.editState.addingRow).toBe(false)


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `createTestRender` wrapper around OpenTUI's `testRender` that destroys all renderers in `afterEach`, eliminating "act" / dangling-renderer warnings across the test suite. Also removes two React warnings in production components:

- `ResponsePane`: debounce effect no longer re-runs (and re-sets the timer) when the query is unchanged.
- `VarInput`: skips `onChange` when the textarea value hasn't actually changed.

### How did you verify your code works?

- `bun test` passes (whole suite, no dangling renderer/act warnings).
- `bun run lint` passes.
- `bun run typecheck` passes.

### Screenshots / recordings

N/A (test + internal React behavior changes).

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query handling by ignoring unchanged or whitespace-only input, reducing unnecessary updates.
  * Prevented textarea change callbacks from firing when displayed content is already synchronized.

* **Tests**
  * Strengthened coverage for asynchronous updates, editor loading, and interactive controls.
  * Improved rendering consistency and cleanup across the test suite.
  * Added regression coverage to ensure initial multiline values do not trigger unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->