### PR TITLE
feat(proxy): add HTTP proxy support with CLI flag, config, collection settings, and settings overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ it reads a file or creates an export.
 ### Inspect and iterate
 
 - Formatted response bodies, headers, clipboard copy, and JSONPath filtering.
-- Live network traces for requests, redirects, responses, and failures.
+- Live network traces for proxies, requests, redirects, responses, and failures.
 - Per-request response history with a timeline for revisiting prior work.
 - Fuzzy request and folder search, and a side-by-side or stacked layout.
 
@@ -111,6 +111,19 @@ it reads a file or creates an export.
 - More than 30 built-in themes and customizable keybindings.
 - Keyboard-first navigation, jump mode, and mouse controls including sidebar
   context menus.
+
+### Route through a proxy
+
+Open **Proxy Settings** from the `Ctrl+P` command palette to use the system
+`HTTP_PROXY`/`HTTPS_PROXY` settings, set an app-wide custom proxy, or override
+the current collection in `settings.yml`. Custom proxy credentials can use
+active-environment variables, for example
+`http://$PROXY_USER:$PROXY_PASSWORD@proxy.example:8080`; literal credentials
+are rejected. Bypass entries are comma-separated and support `*`, hosts,
+`.domain` suffixes, IP addresses, and optional ports.
+
+Use `--noproxy` with the TUI, `collection run`, or `request run` to force
+direct connections for that invocation.
 
 ### Bring in and run existing work
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -36,6 +36,7 @@ function isTuiFlag(arg: string): boolean {
   return (
     arg === "-c" ||
     arg === "-e" ||
+    arg === "--noproxy" ||
     arg.startsWith("-c=") ||
     arg.startsWith("-e=") ||
     arg === "--collection" ||

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -30,6 +30,7 @@ import {
   workspaceList,
 } from "../services"
 import type { Method } from "../../schema"
+import { takeSystemProxyFromEnv } from "../../proxy"
 
 const jsonArg = {
   type: "boolean" as const,
@@ -179,6 +180,7 @@ const collection = defineCommand({
       args: {
         path: { type: "positional", required: true },
         env: { type: "string", alias: "e" },
+        noproxy: { type: "boolean", default: false },
         json: jsonArg,
       },
       run: ({ args }) =>
@@ -191,6 +193,8 @@ const collection = defineCommand({
                 args.path,
                 args.env,
                 progress?.update,
+                args.noproxy,
+                takeSystemProxyFromEnv(),
               )
               return { data, failed: data.failed }
             } finally {
@@ -238,6 +242,7 @@ const request = defineCommand({
         id: { type: "positional", required: true },
         collection: collectionArg,
         env: { type: "string", alias: "e" },
+        noproxy: { type: "boolean", default: false },
         json: jsonArg,
       },
       run: ({ args }) =>
@@ -251,6 +256,8 @@ const request = defineCommand({
                 args.collection,
                 args.env,
                 progress?.update,
+                args.noproxy,
+                takeSystemProxyFromEnv(),
               )
               return { data, failed: data.failed }
             } finally {

--- a/src/app/commands/default.ts
+++ b/src/app/commands/default.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from "citty"
 import { resolve } from "node:path"
 import { bootstrap } from "../main"
+import { takeSystemProxyFromEnv } from "../../proxy"
 
 export default defineCommand({
   meta: {
@@ -25,6 +26,11 @@ export default defineCommand({
       alias: "e",
       description: "Initial environment name",
     },
+    noproxy: {
+      type: "boolean" as const,
+      default: false,
+      description: "Disable proxy use for this session",
+    },
   },
   async run({ args }) {
     if (args.targetPath && args.collection) {
@@ -38,6 +44,8 @@ export default defineCommand({
       targetPath: args.targetPath ? resolve(args.targetPath) : undefined,
       collectionDir: args.collection ? resolve(args.collection) : undefined,
       envName: args.env,
+      noProxy: args.noproxy,
+      systemProxy: takeSystemProxyFromEnv(),
     })
   },
 })

--- a/src/app/commands/default.ts
+++ b/src/app/commands/default.ts
@@ -1,7 +1,6 @@
 import { defineCommand } from "citty"
 import { resolve } from "node:path"
 import { bootstrap } from "../main"
-import { takeSystemProxyFromEnv } from "../../proxy"
 
 export default defineCommand({
   meta: {
@@ -45,7 +44,6 @@ export default defineCommand({
       collectionDir: args.collection ? resolve(args.collection) : undefined,
       envName: args.env,
       noProxy: args.noproxy,
-      systemProxy: takeSystemProxyFromEnv(),
     })
   },
 })

--- a/src/app/commands/updateCheck.ts
+++ b/src/app/commands/updateCheck.ts
@@ -20,7 +20,10 @@ export interface UpdateDependencies {
   runProcess: (
     args: string[],
     captureOutput: boolean,
-    options?: { signal?: AbortSignal },
+    options?: {
+      signal?: AbortSignal
+      env?: Record<string, string | undefined>
+    },
   ) => Promise<ProcessResult>
   execPath: string
   platform: string
@@ -41,12 +44,16 @@ export interface ProcessResult {
 async function runProcess(
   args: string[],
   captureOutput: boolean,
-  options?: { signal?: AbortSignal },
+  options?: {
+    signal?: AbortSignal
+    env?: Record<string, string | undefined>
+  },
 ): Promise<ProcessResult> {
   const child = Bun.spawn(args, {
     stdout: captureOutput ? "pipe" : "inherit",
     stderr: captureOutput ? "pipe" : "inherit",
     signal: options?.signal,
+    env: options?.env,
   })
   if (!captureOutput) return { exitCode: await child.exited }
   const [stdout] = await Promise.all([
@@ -136,6 +143,7 @@ export async function checkForUpdates(
           signal: AbortSignal.timeout(
             deps.updateCheckTimeoutMs ?? UPDATE_CHECK_TIMEOUT_MS,
           ),
+          env: deps.env,
         },
       )
       if (result.exitCode !== 0) {

--- a/src/app/commands/updateInstall.ts
+++ b/src/app/commands/updateInstall.ts
@@ -34,7 +34,13 @@ async function runHomebrewUpdate(
   }
   output("Updating noodle via Homebrew...")
   try {
-    const result = await deps.runProcess(["brew", "upgrade", "noodle"], silent)
+    const result = await deps.runProcess(
+      ["brew", "upgrade", "noodle"],
+      silent,
+      {
+        env: deps.env,
+      },
+    )
     if (result.exitCode !== 0) {
       output(`Homebrew upgrade failed (exit code ${result.exitCode}).`)
       return {

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -15,6 +15,8 @@ import { existsSync, readdirSync, statSync } from "node:fs"
 import * as yaml from "js-yaml"
 import { readFileSync } from "node:fs"
 import { loadConfig } from "../hooks/useConfig"
+import { systemProxyFromEnv, type SystemProxySettings } from "../proxy"
+import type { CollectionSettings } from "../schema"
 import {
   CodeEditorRenderable,
   CodeEditorScrollBarRenderable,
@@ -36,6 +38,8 @@ export interface BootstrapOptions {
   targetPath?: string
   collectionDir?: string
   envName?: string
+  noProxy?: boolean
+  systemProxy?: SystemProxySettings
 }
 
 function isDirectoryPath(dir: string): boolean {
@@ -157,11 +161,10 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
     initialEnvName = options.envName
   }
 
-  let settingsEnv: string | undefined
+  let initialSettings: CollectionSettings = {}
   if (mode === "collection") {
     try {
-      const settings = await loadSettings(collectionDir)
-      settingsEnv = settings.environment
+      initialSettings = await loadSettings(collectionDir)
     } catch {
       // settings.yml missing or invalid — ignore, use defaults
     }
@@ -224,7 +227,9 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
           collectionDir={collectionDir}
           envList={envList}
           initialEnvName={initialEnvName}
-          settingsEnv={settingsEnv}
+          initialSettings={initialSettings}
+          noProxy={options.noProxy}
+          systemProxy={options.systemProxy ?? systemProxyFromEnv()}
           keybinds={keybinds}
           lastRequestId={lastRequestId}
           shouldRegister={shouldRegister}

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -15,7 +15,7 @@ import { existsSync, readdirSync, statSync } from "node:fs"
 import * as yaml from "js-yaml"
 import { readFileSync } from "node:fs"
 import { loadConfig } from "../hooks/useConfig"
-import { systemProxyFromEnv, type SystemProxySettings } from "../proxy"
+import { takeSystemProxyFromEnv, type SystemProxySettings } from "../proxy"
 import type { CollectionSettings } from "../schema"
 import {
   CodeEditorRenderable,
@@ -121,6 +121,7 @@ export function resolveStartupCollectionDir(
 }
 
 export async function bootstrap(options: BootstrapOptions): Promise<void> {
+  const capturedSystemProxy = takeSystemProxyFromEnv()
   let collectionPaths: string[] = []
   try {
     collectionPaths = loadConfig(CONFIG_DIR).collections
@@ -229,7 +230,7 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
           initialEnvName={initialEnvName}
           initialSettings={initialSettings}
           noProxy={options.noProxy}
-          systemProxy={options.systemProxy ?? systemProxyFromEnv()}
+          systemProxy={options.systemProxy ?? capturedSystemProxy}
           keybinds={keybinds}
           lastRequestId={lastRequestId}
           shouldRegister={shouldRegister}

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -22,6 +22,13 @@ import { formatJson } from "../lang/formatJson"
 import { lang } from "../lang"
 import { executor, substitute } from "../requests"
 import { withDefaultHttpsScheme } from "../requests/url"
+import {
+  parseCollectionProxy,
+  resolveProxyPolicy,
+  takeSystemProxyFromEnv,
+  type ProxyPolicy,
+  type SystemProxySettings,
+} from "../proxy"
 import type {
   Collection,
   CollectionItem,
@@ -360,20 +367,26 @@ async function auditFile(
   try {
     if (name === "settings.yml") {
       const raw = yaml.load(content)
+      const settings = raw as { environment?: unknown; proxy?: unknown }
+      const proxy = parseCollectionProxy(settings?.proxy)
       if (
         !raw ||
         typeof raw !== "object" ||
         Array.isArray(raw) ||
-        Object.keys(raw as object).some((key) => key !== "environment") ||
-        ((raw as { environment?: unknown }).environment !== undefined &&
-          typeof (raw as { environment?: unknown }).environment !== "string")
+        Object.keys(raw as object).some(
+          (key) => key !== "environment" && key !== "proxy",
+        ) ||
+        (settings.environment !== undefined &&
+          typeof settings.environment !== "string") ||
+        (settings.proxy !== undefined && proxy === undefined)
       )
         throw new Error(
-          "expected settings mapping with optional string environment",
+          "expected settings mapping with optional string environment and valid proxy",
         )
       if (fix) {
         await saveSettings(root, {
-          environment: (raw as { environment?: string }).environment,
+          environment: settings.environment as string | undefined,
+          proxy,
         })
         issues.push({
           path: rel,
@@ -516,9 +529,9 @@ export type RunProgress = (completed: number, total: number) => void
 
 async function runRequest(
   collection: Collection,
-  dir: string,
   request: Request,
   environment?: Environment,
+  proxyPolicy?: ProxyPolicy,
 ): Promise<RequestRunResult> {
   try {
     const response = await executor.send(
@@ -527,6 +540,8 @@ async function runRequest(
       undefined,
       collection,
       request.id,
+      undefined,
+      proxyPolicy,
     )
     const effective = environment ? substitute(request, environment) : request
     return {
@@ -556,15 +571,22 @@ export async function collectionRun(
   path: string,
   environmentName?: string,
   onProgress?: RunProgress,
+  noProxy = false,
+  systemProxy?: SystemProxySettings,
 ): Promise<CollectionRunResult> {
   const dir = await requireCollectionRoot(path)
   const collection = await filestore.loadCollection(dir)
   const environment = await environmentFor(dir, environmentName)
+  const policy = await proxyPolicyFor(
+    dir,
+    noProxy,
+    systemProxy ?? takeSystemProxyFromEnv(),
+  )
   const requests = flattenRequests(collection.items)
   const results: RequestRunResult[] = []
   onProgress?.(0, requests.length)
   for (const request of requests) {
-    results.push(await runRequest(collection, dir, request, environment))
+    results.push(await runRequest(collection, request, environment, policy))
     onProgress?.(results.length, requests.length)
   }
   return { results, failed: results.some((result) => result.ok === false) }
@@ -597,6 +619,8 @@ export async function requestRun(
   collectionDir: string,
   environmentName?: string,
   onProgress?: RunProgress,
+  noProxy = false,
+  systemProxy?: SystemProxySettings,
 ): Promise<{ result: RequestRunResult; failed: boolean }> {
   validateId(id)
   const dir = await requireCollectionRoot(collectionDir)
@@ -608,12 +632,26 @@ export async function requestRun(
   onProgress?.(0, 1)
   const result = await runRequest(
     collection,
-    dir,
     request,
     await environmentFor(dir, environmentName),
+    await proxyPolicyFor(dir, noProxy, systemProxy ?? takeSystemProxyFromEnv()),
   )
   onProgress?.(1, 1)
   return { result, failed: result.ok === false }
+}
+
+async function proxyPolicyFor(
+  dir: string,
+  noProxy: boolean,
+  systemProxy: SystemProxySettings,
+): Promise<ProxyPolicy> {
+  const [settings] = await Promise.all([loadSettings(dir)])
+  return resolveProxyPolicy({
+    noProxy,
+    appProxy: loadConfig(CONFIG_DIR).proxy,
+    collectionProxy: settings.proxy,
+    systemProxy,
+  })
 }
 export async function environmentSet(
   key: string,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,8 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import * as yaml from "js-yaml"
+import type { AppProxySettings } from "../schema"
+import { parseAppProxy } from "../proxy"
 
 export const CONFIG_FILE_NAME = "config.yml"
 export interface NoodleConfig {
@@ -8,6 +10,7 @@ export interface NoodleConfig {
   layout: "stacked" | "side-by-side"
   confirm_undo_all: boolean
   collections: string[]
+  proxy?: AppProxySettings
 }
 export const DEFAULT_CONFIG: NoodleConfig = {
   theme: "catppuccin",
@@ -43,10 +46,12 @@ export function appendCollectionPath(paths: string[], path: string): string[] {
   return normalizeCollectionPaths([...paths, path])
 }
 export function normalizeConfig(config: NoodleConfig): NoodleConfig {
-  return {
+  const normalized: NoodleConfig = {
     ...config,
     collections: normalizeCollectionPaths(config.collections),
   }
+  if (config.proxy !== undefined) normalized.proxy = config.proxy
+  return normalized
 }
 export function loadConfig(configDir: string): NoodleConfig {
   try {
@@ -66,6 +71,7 @@ export function loadConfig(configDir: string): NoodleConfig {
       collections: Array.isArray(obj.collections)
         ? obj.collections.filter((v): v is string => typeof v === "string")
         : [],
+      proxy: parseAppProxy(obj.proxy),
     })
   } catch {
     return { ...DEFAULT_CONFIG }

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -9,6 +9,7 @@ import type {
   Folder,
   Request,
 } from "../schema"
+import { parseCollectionProxy } from "../proxy"
 
 export interface CollectionFileError {
   file: string
@@ -323,10 +324,13 @@ export async function loadSettings(dir: string): Promise<CollectionSettings> {
     const data = yaml.load(raw)
     if (!data || typeof data !== "object") return {}
     const obj = data as Record<string, unknown>
-    return {
-      environment:
-        typeof obj.environment === "string" ? obj.environment : undefined,
+    const settings: CollectionSettings = {}
+    if (typeof obj.environment === "string") {
+      settings.environment = obj.environment
     }
+    const proxy = parseCollectionProxy(obj.proxy)
+    if (proxy !== undefined) settings.proxy = proxy
+    return settings
   } catch {
     return {}
   }

--- a/src/filestore/save.ts
+++ b/src/filestore/save.ts
@@ -115,6 +115,9 @@ export async function saveSettings(
   if (settings.environment !== undefined) {
     data.environment = settings.environment
   }
+  if (settings.proxy !== undefined) {
+    data.proxy = settings.proxy
+  }
 
   try {
     await writeFile(join(dir, "settings.yml"), yaml.dump(data), "utf8")

--- a/src/hooks/useResponse.ts
+++ b/src/hooks/useResponse.ts
@@ -7,6 +7,7 @@ import type {
   Request,
   Response,
 } from "../schema"
+import type { ProxyPolicy } from "../proxy"
 import { executor } from "../requests"
 import {
   startSend,
@@ -35,6 +36,7 @@ export function useResponse(
   onComplete?: (req: Request, result: SendCompleteResult) => void,
   collection?: Collection,
   requestPath?: string,
+  proxyPolicy?: ProxyPolicy,
 ): UseResponseResult {
   const [state, setState] = useState<SendState>({ status: "idle" })
   const cacheRef = useRef<Map<string, CachedResult>>(new Map())
@@ -77,10 +79,11 @@ export function useResponse(
         onCompleteRef,
         collection,
         requestPath,
+        proxyPolicy,
       )
       return startSend(prev, req)
     })
-  }, [selectedRequest, env, collection, requestPath])
+  }, [selectedRequest, env, collection, requestPath, proxyPolicy])
 
   const cancelSend = useCallback(() => {
     abortRef.current?.abort()
@@ -101,6 +104,7 @@ async function runSend(
   >,
   collection?: Collection,
   requestPath?: string,
+  proxyPolicy?: ProxyPolicy,
 ): Promise<void> {
   try {
     const res = await executor.send(
@@ -116,6 +120,7 @@ async function runSend(
             : prev,
         )
       },
+      proxyPolicy,
     )
     cacheRef.current.set(req.id, { status: "done", response: res })
     setState((prev) => finishSend(prev, req, res))

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -123,8 +123,37 @@ export function createProxyFetcher(
     const route = proxyForUrl(policy, target, env ?? undefined)
     const fetchInit: BunFetchRequestInit = { ...init }
     if (route.kind === "proxy") fetchInit.proxy = route.url
+    else delete fetchInit.proxy
     return fetcher(input, fetchInit)
   }
+}
+
+export function environmentForProxyPolicy(
+  policy: ProxyPolicy,
+  env?: Environment | null,
+  baseEnv: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> {
+  const result = { ...baseEnv }
+  for (const key of PROXY_ENV_KEYS) delete result[key]
+  if (policy.kind === "direct") return result
+
+  if (policy.kind === "system") {
+    setProxyEnvironment(result, policy.settings)
+    return result
+  }
+
+  let url = policy.url
+  try {
+    url = resolveProxyUrl(url, env ?? undefined)
+  } catch {
+    // Keep the template so the subprocess reports the same unresolved proxy.
+  }
+  setProxyEnvironment(result, {
+    http: url,
+    https: url,
+    bypass: policy.bypass,
+  })
+  return result
 }
 
 export function resolveProxyPolicy({
@@ -371,6 +400,17 @@ function effectivePort(url: URL): string {
 
 function splitBypass(value: string | undefined): string[] {
   return value ? normalizeBypass(value.split(",")) : []
+}
+
+function setProxyEnvironment(
+  env: Record<string, string | undefined>,
+  settings: SystemProxySettings,
+): void {
+  if (settings.http) env.HTTP_PROXY = env.http_proxy = settings.http
+  if (settings.https) env.HTTPS_PROXY = env.https_proxy = settings.https
+  if (settings.bypass.length > 0) {
+    env.NO_PROXY = env.no_proxy = settings.bypass.join(",")
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,278 @@
+import type {
+  AppProxySettings,
+  CollectionProxySettings,
+  Environment,
+} from "./schema"
+
+const VAR_RE = /\$(\w+)/g
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+] as const
+
+export interface SystemProxySettings {
+  http?: string
+  https?: string
+  bypass: string[]
+}
+
+export type ProxyPolicy =
+  | { kind: "direct"; source: "cli" | "global" | "collection" }
+  | {
+      kind: "custom"
+      source: "global" | "collection"
+      url: string
+      bypass: string[]
+    }
+  | { kind: "system"; source: "system"; settings: SystemProxySettings }
+
+export type ProxyRoute =
+  | { kind: "direct"; reason: "cli" | "off" | "bypass" | "unconfigured" }
+  | { kind: "proxy"; source: "global" | "collection" | "system"; url: string }
+
+export function normalizeBypass(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const item of value) {
+    if (typeof item !== "string") continue
+    const trimmed = item.trim()
+    if (!trimmed) continue
+    const normalized = trimmed.toLowerCase()
+    if (!seen.has(normalized)) {
+      seen.add(normalized)
+      out.push(trimmed)
+    }
+  }
+  return out
+}
+
+export function parseAppProxy(value: unknown): AppProxySettings | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value) || typeof value.mode !== "string") return undefined
+  if (value.mode === "system") return { mode: "system" }
+  if (value.mode === "off") return { mode: "off" }
+  if (value.mode !== "custom" || typeof value.url !== "string") return undefined
+  const url = value.url.trim()
+  if (validateProxyTemplate(url) !== null) return undefined
+  return customProxy(url, normalizeBypass(value.bypass))
+}
+
+export function parseCollectionProxy(
+  value: unknown,
+): CollectionProxySettings | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value) || typeof value.mode !== "string") return undefined
+  if (value.mode === "inherit") return { mode: "inherit" }
+  if (value.mode === "off") return { mode: "off" }
+  if (value.mode !== "custom" || typeof value.url !== "string") return undefined
+  const url = value.url.trim()
+  if (validateProxyTemplate(url) !== null) return undefined
+  return customProxy(url, normalizeBypass(value.bypass))
+}
+
+export function systemProxyFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): SystemProxySettings {
+  return {
+    http: env.HTTP_PROXY || env.http_proxy,
+    https:
+      env.HTTPS_PROXY || env.https_proxy || env.HTTP_PROXY || env.http_proxy,
+    bypass: splitBypass(env.NO_PROXY || env.no_proxy),
+  }
+}
+
+export function takeSystemProxyFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): SystemProxySettings {
+  const settings = systemProxyFromEnv(env)
+  for (const key of PROXY_ENV_KEYS) delete env[key]
+  return settings
+}
+
+export function resolveProxyPolicy({
+  noProxy = false,
+  appProxy,
+  collectionProxy,
+  systemProxy,
+}: {
+  noProxy?: boolean
+  appProxy?: AppProxySettings
+  collectionProxy?: CollectionProxySettings
+  systemProxy: SystemProxySettings
+}): ProxyPolicy {
+  if (noProxy) return { kind: "direct", source: "cli" }
+  if (collectionProxy?.mode === "off") {
+    return { kind: "direct", source: "collection" }
+  }
+  if (collectionProxy?.mode === "custom") {
+    return {
+      kind: "custom",
+      source: "collection",
+      url: collectionProxy.url,
+      bypass: collectionProxy.bypass ?? [],
+    }
+  }
+  if (appProxy?.mode === "off") return { kind: "direct", source: "global" }
+  if (appProxy?.mode === "custom") {
+    return {
+      kind: "custom",
+      source: "global",
+      url: appProxy.url,
+      bypass: appProxy.bypass ?? [],
+    }
+  }
+  return { kind: "system", source: "system", settings: systemProxy }
+}
+
+export function proxyForUrl(
+  policy: ProxyPolicy | undefined,
+  target: string,
+  env?: Environment,
+): ProxyRoute {
+  if (!policy) return { kind: "direct", reason: "unconfigured" }
+  if (policy.kind === "direct") {
+    return { kind: "direct", reason: policy.source === "cli" ? "cli" : "off" }
+  }
+
+  let url: URL
+  try {
+    url = new URL(target)
+  } catch {
+    return { kind: "direct", reason: "unconfigured" }
+  }
+
+  if (policy.kind === "custom") {
+    if (matchesBypass(url, policy.bypass))
+      return { kind: "direct", reason: "bypass" }
+    return {
+      kind: "proxy",
+      source: policy.source,
+      url: resolveProxyUrl(policy.url, env),
+    }
+  }
+
+  if (matchesBypass(url, policy.settings.bypass)) {
+    return { kind: "direct", reason: "bypass" }
+  }
+  const proxy =
+    url.protocol === "https:" ? policy.settings.https : policy.settings.http
+  return proxy
+    ? { kind: "proxy", source: "system", url: proxy }
+    : { kind: "direct", reason: "unconfigured" }
+}
+
+export function resolveProxyUrl(template: string, env?: Environment): string {
+  const url = template.replace(VAR_RE, (_, name: string) => {
+    if (!env || !Object.hasOwn(env.vars, name)) {
+      throw new Error(`proxy: unresolved variable "${name}" in proxy.url`)
+    }
+    return env.vars[name]
+  })
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    throw new Error(`proxy: invalid proxy URL: ${message}`, { cause: e })
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("proxy: URL must use http or https")
+  }
+  return url
+}
+
+export function validateProxyTemplate(template: string): string | null {
+  const value = template.trim()
+  if (!value) return "Proxy URL is required"
+  try {
+    const parsed = new URL(value.replace(VAR_RE, "proxy-variable"))
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "Proxy URL must use http or https"
+    }
+    const authority = value.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1]
+    const at = authority?.lastIndexOf("@") ?? -1
+    const userInfo = at >= 0 ? authority?.slice(0, at) : undefined
+    if (userInfo && userInfo.replace(VAR_RE, "").replaceAll(":", "")) {
+      return "Use $VARNAME for proxy credentials"
+    }
+    return null
+  } catch {
+    return "Proxy URL is invalid"
+  }
+}
+
+function customProxy<T extends AppProxySettings | CollectionProxySettings>(
+  url: string,
+  bypass: string[],
+): T {
+  return (
+    bypass.length > 0
+      ? { mode: "custom", url, bypass }
+      : { mode: "custom", url }
+  ) as T
+}
+
+export function redactProxyUrl(value: string): string {
+  try {
+    const url = new URL(value)
+    if (url.username || url.password) {
+      url.username = "***"
+      url.password = "***"
+    }
+    return url.toString()
+  } catch {
+    return "[invalid proxy]"
+  }
+}
+
+function matchesBypass(url: URL, entries: string[]): boolean {
+  return entries.some((entry) => matchesBypassEntry(url, entry))
+}
+
+function matchesBypassEntry(url: URL, rawEntry: string): boolean {
+  const entry = rawEntry.trim().toLowerCase()
+  if (!entry) return false
+  if (entry === "*") return true
+
+  const { host, port } = splitHostPort(entry)
+  if (!host || (port && port !== effectivePort(url))) return false
+  const hostname = url.hostname.toLowerCase()
+  if (host.startsWith("[")) {
+    return hostname.replace(/^\[|\]$/g, "") === host.slice(1, -1)
+  }
+  const normalizedHost = host.startsWith(".") ? host.slice(1) : host
+  return hostname === normalizedHost || hostname.endsWith(`.${normalizedHost}`)
+}
+
+function splitHostPort(value: string): { host: string; port?: string } {
+  if (value.startsWith("[")) {
+    const close = value.indexOf("]")
+    if (close === -1) return { host: value }
+    return value[close + 1] === ":"
+      ? { host: value.slice(0, close + 1), port: value.slice(close + 2) }
+      : { host: value.slice(0, close + 1) }
+  }
+  const colon = value.lastIndexOf(":")
+  if (colon > 0 && /^\d+$/.test(value.slice(colon + 1))) {
+    return { host: value.slice(0, colon), port: value.slice(colon + 1) }
+  }
+  return { host: value }
+}
+
+function effectivePort(url: URL): string {
+  if (url.port) return url.port
+  return url.protocol === "https:" ? "443" : "80"
+}
+
+function splitBypass(value: string | undefined): string[] {
+  return value ? normalizeBypass(value.split(",")) : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,6 +20,17 @@ export interface SystemProxySettings {
   bypass: string[]
 }
 
+export interface StructuredProxyFields {
+  protocol: "http" | "https"
+  hostname: string
+  port: string
+  auth: boolean
+  username: string
+  password: string
+}
+
+export type StructuredProxyBuildResult = { url: string } | { error: string }
+
 export type ProxyPolicy =
   | { kind: "direct"; source: "cli" | "global" | "collection" }
   | {
@@ -206,6 +217,70 @@ export function validateProxyTemplate(template: string): string | null {
   }
 }
 
+export function parseStructuredProxyTemplate(
+  template: string,
+): StructuredProxyFields | null {
+  if (template !== template.trim()) return null
+  if (validateProxyTemplate(template) !== null) return null
+
+  const match = template.match(
+    /^(https?):\/\/(?:(\$\w+):(\$\w+)@)?(\[[^\]]+\]|[^:/?#@\s]+)(?::(\d+))?$/,
+  )
+  if (!match) return null
+
+  const [, protocol, username, password, rawHostname, port] = match
+  const hostname = rawHostname!.startsWith("[")
+    ? rawHostname.slice(1, -1)
+    : rawHostname!
+
+  return {
+    protocol: protocol as "http" | "https",
+    hostname,
+    port: port ?? "",
+    auth: username !== undefined,
+    username: username ?? "",
+    password: password ?? "",
+  }
+}
+
+export function buildStructuredProxyTemplate(
+  fields: StructuredProxyFields,
+): StructuredProxyBuildResult {
+  const hostname = fields.hostname.trim()
+  if (!hostname) return { error: "Proxy hostname is required" }
+  if (/[/?#@\s]/.test(hostname)) {
+    return { error: "Proxy hostname is invalid" }
+  }
+
+  const port = fields.port.trim()
+  if (port) {
+    const portNumber = Number(port)
+    if (!/^\d+$/.test(port) || portNumber < 1 || portNumber > 65535) {
+      return { error: "Proxy port must be between 1 and 65535" }
+    }
+  }
+
+  if (fields.auth) {
+    if (!isVariableReference(fields.username)) {
+      return { error: "Username must be a $VARNAME reference" }
+    }
+    if (!isVariableReference(fields.password)) {
+      return { error: "Password must be a $VARNAME reference" }
+    }
+  }
+
+  const host =
+    hostname.includes(":") && !hostname.startsWith("[")
+      ? `[${hostname}]`
+      : hostname
+  const credentials = fields.auth
+    ? `${fields.username}:${fields.password}@`
+    : ""
+  const url = `${fields.protocol}://${credentials}${host}${port ? `:${port}` : ""}`
+  const validationError = validateProxyTemplate(url)
+  return validationError ? { error: validationError } : { url }
+}
+
 function customProxy<T extends AppProxySettings | CollectionProxySettings>(
   url: string,
   bypass: string[],
@@ -275,4 +350,8 @@ function splitBypass(value: string | undefined): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isVariableReference(value: string): boolean {
+  return /^\$\w+$/.test(value)
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -105,6 +105,28 @@ export function takeSystemProxyFromEnv(
   return settings
 }
 
+export function createProxyFetcher(
+  policy: ProxyPolicy,
+  env?: Environment | null,
+  fetcher: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response> = globalThis.fetch,
+) {
+  return (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const target =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url
+    const route = proxyForUrl(policy, target, env ?? undefined)
+    const fetchInit: BunFetchRequestInit = { ...init }
+    if (route.kind === "proxy") fetchInit.proxy = route.url
+    return fetcher(input, fetchInit)
+  }
+}
+
 export function resolveProxyPolicy({
   noProxy = false,
   appProxy,
@@ -201,7 +223,10 @@ export function validateProxyTemplate(template: string): string | null {
   const value = template.trim()
   if (!value) return "Proxy URL is required"
   try {
-    const parsed = new URL(value.replace(VAR_RE, "proxy-variable"))
+    const parseable = value
+      .replace(/:\$\w+(?=[/?#]|$)/g, ":8080")
+      .replace(VAR_RE, "proxy-variable")
+    const parsed = new URL(parseable)
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return "Proxy URL must use http or https"
     }

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "../schema"
 import { send } from "./send"
 import { substitute } from "./substitute"
+import type { ProxyPolicy } from "../proxy"
 
 export interface RequestExecutor {
   send(
@@ -16,6 +17,7 @@ export interface RequestExecutor {
     collection?: Collection,
     requestPath?: string,
     onNetworkEvent?: (network: NetworkEvent[]) => void,
+    proxyPolicy?: ProxyPolicy,
   ): Promise<Response>
 }
 

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -16,6 +16,7 @@ import { mergeFolderOverrides } from "./mergeFolderOverrides"
 import { PATH_TOKEN_RE } from "./pathParams"
 import { withDefaultHttpsScheme } from "./url"
 import { expandUserPath } from "../userPath"
+import { proxyForUrl, redactProxyUrl, type ProxyPolicy } from "../proxy"
 
 export function interpolatePathParams(
   url: string,
@@ -68,6 +69,7 @@ export async function send(
   collection?: Collection,
   requestPath?: string,
   onNetworkEvent?: (network: NetworkEvent[]) => void,
+  proxyPolicy?: ProxyPolicy,
 ): Promise<Response> {
   const merged =
     collection && requestPath
@@ -155,6 +157,26 @@ export async function send(
   const followRedirects = req.followRedirects ?? true
 
   while (true) {
+    const proxyRoute = proxyPolicy
+      ? proxyForUrl(proxyPolicy, currentUrl, env)
+      : undefined
+    if (proxyRoute) {
+      recordNetworkEvent(
+        network,
+        start,
+        "proxy",
+        proxyRoute.kind === "proxy"
+          ? `Proxy: ${proxyRoute.source}`
+          : proxyRoute.reason === "bypass"
+            ? "Proxy: bypassed"
+            : proxyRoute.reason === "cli"
+              ? "Proxy: disabled by --noproxy"
+              : proxyRoute.reason === "off"
+                ? "Proxy: off"
+                : "Proxy: direct",
+        onNetworkEvent,
+      )
+    }
     recordNetworkEvent(
       network,
       start,
@@ -163,9 +185,18 @@ export async function send(
       onNetworkEvent,
     )
     try {
-      res = await fetch(currentUrl, currentInit)
+      const fetchInit: BunFetchRequestInit = { ...currentInit }
+      if (proxyRoute?.kind === "proxy") fetchInit.proxy = proxyRoute.url
+      res = await fetch(currentUrl, fetchInit)
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
+      const rawMessage = e instanceof Error ? e.message : String(e)
+      const msg =
+        proxyRoute?.kind === "proxy"
+          ? rawMessage.replaceAll(
+              proxyRoute.url,
+              redactProxyUrl(proxyRoute.url),
+            )
+          : rawMessage
       if (e instanceof DOMException && e.name === "AbortError") throw e
       throw networkFailure(
         `requests.send: fetch failed: ${msg}`,

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -89,7 +89,7 @@ export interface Response {
 }
 
 export type NetworkEventType =
-  "request" | "redirect" | "response" | "body" | "complete" | "error"
+  "request" | "redirect" | "response" | "body" | "complete" | "error" | "proxy"
 
 export interface NetworkEvent {
   timeMs: number
@@ -149,4 +149,17 @@ export interface TimelineBodyRef {
 
 export interface CollectionSettings {
   environment?: string
+  proxy?: CollectionProxySettings
 }
+
+export interface ProxySettings {
+  mode: "custom"
+  url: string
+  bypass?: string[]
+}
+
+export type AppProxySettings =
+  { mode: "system" } | { mode: "off" } | ProxySettings
+
+export type CollectionProxySettings =
+  { mode: "inherit" } | { mode: "off" } | ProxySettings

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -58,6 +58,8 @@ export function App({
   const [mode, setMode] = useState<CollectionMode>(initialMode)
   const [reloadKey, setReloadKey] = useState(0)
   const [settings, setSettings] = useState<CollectionSettings>(initialSettings)
+  const settingsRef = useRef(initialSettings)
+  const settingsSaveChainRef = useRef<Promise<void>>(Promise.resolve())
   const settingsEnv = settings.environment
   const [lastRequestId, setLastRequestId] = useState<string | undefined>(
     initialLastRequestId,
@@ -133,13 +135,18 @@ export function App({
   const handleCollectionProxyChange = useCallback(
     (proxy: CollectionProxySettings) => {
       if (mode !== "collection") return
-      const nextSettings = { ...settings, proxy }
+      const nextSettings = { ...settingsRef.current, proxy }
+      settingsRef.current = nextSettings
       setSettings(nextSettings)
-      saveSettings(activeCollectionDir, nextSettings).catch(() => {
+      const save = settingsSaveChainRef.current.then(() =>
+        saveSettings(activeCollectionDir, nextSettings),
+      )
+      settingsSaveChainRef.current = save.catch(() => {})
+      save.catch(() => {
         showToast("Failed to save proxy settings", "error")
       })
     },
-    [activeCollectionDir, mode, settings],
+    [activeCollectionDir, mode],
   )
 
   const handleEnvListChanged = useCallback(async () => {
@@ -154,13 +161,17 @@ export function App({
   const handleEnvChange = useCallback(
     (name: string | null) => {
       const envName = name ?? undefined
-      const nextSettings = { ...settings, environment: envName }
+      const nextSettings = { ...settingsRef.current, environment: envName }
+      settingsRef.current = nextSettings
       setSettings(nextSettings)
       if (mode === "collection") {
-        saveSettings(activeCollectionDir, nextSettings).catch(() => {})
+        const save = settingsSaveChainRef.current.then(() =>
+          saveSettings(activeCollectionDir, nextSettings),
+        )
+        settingsSaveChainRef.current = save.catch(() => {})
       }
     },
-    [activeCollectionDir, mode, settings],
+    [activeCollectionDir, mode],
   )
 
   const handleReloadCollection = useCallback(() => {
@@ -171,6 +182,7 @@ export function App({
     (bootstrappedDir: string) => {
       const resolved = resolve(bootstrappedDir)
       setMode("collection")
+      settingsRef.current = {}
       setSettings({})
       updateConfig((prev) => ({
         collections: upsertCollectionPath(prev.collections, resolved),
@@ -257,6 +269,7 @@ export function App({
 
         setEnvNames(nextEnvNames)
         setEnvColors(nextEnvColors)
+        settingsRef.current = nextSettings
         setSettings(nextSettings)
         setLastRequestId(nextLastRequestId)
         setInitialEnvNameState(undefined)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,6 +15,12 @@ import { loadLastRequest } from "./tabs/uiState"
 import type { Keybinds } from "./keybind"
 import type { CollectionMode } from "../app/main"
 import { classifyPath } from "../app/main"
+import type {
+  AppProxySettings,
+  CollectionProxySettings,
+  CollectionSettings,
+} from "../schema"
+import type { SystemProxySettings } from "../proxy"
 
 const CONFIG_DIR = `${process.env.HOME ?? "~"}/.config/noodle`
 
@@ -22,7 +28,9 @@ export function App({
   collectionDir,
   envList: initialEnvList,
   initialEnvName,
-  settingsEnv: initialSettingsEnv,
+  initialSettings = {},
+  noProxy = false,
+  systemProxy,
   keybinds: keybinds,
   lastRequestId: initialLastRequestId,
   shouldRegister = false,
@@ -31,7 +39,9 @@ export function App({
   collectionDir: string
   envList: string[]
   initialEnvName?: string
-  settingsEnv?: string
+  initialSettings?: CollectionSettings
+  noProxy?: boolean
+  systemProxy: SystemProxySettings
   keybinds: Keybinds
   lastRequestId?: string
   shouldRegister?: boolean
@@ -47,9 +57,8 @@ export function App({
     useState(initialCollectionDir)
   const [mode, setMode] = useState<CollectionMode>(initialMode)
   const [reloadKey, setReloadKey] = useState(0)
-  const [settingsEnv, setSettingsEnv] = useState<string | undefined>(
-    initialSettingsEnv,
-  )
+  const [settings, setSettings] = useState<CollectionSettings>(initialSettings)
+  const settingsEnv = settings.environment
   const [lastRequestId, setLastRequestId] = useState<string | undefined>(
     initialLastRequestId,
   )
@@ -114,6 +123,25 @@ export function App({
     [updateConfig],
   )
 
+  const handleAppProxyChange = useCallback(
+    (proxy: AppProxySettings) => {
+      updateConfig({ proxy }, { immediate: true })
+    },
+    [updateConfig],
+  )
+
+  const handleCollectionProxyChange = useCallback(
+    (proxy: CollectionProxySettings) => {
+      if (mode !== "collection") return
+      const nextSettings = { ...settings, proxy }
+      setSettings(nextSettings)
+      saveSettings(activeCollectionDir, nextSettings).catch(() => {
+        showToast("Failed to save proxy settings", "error")
+      })
+    },
+    [activeCollectionDir, mode, settings],
+  )
+
   const handleEnvListChanged = useCallback(async () => {
     if (mode !== "collection") return
     const items = await listEnvironmentsWithColors(activeEnvironmentsDir)
@@ -126,14 +154,13 @@ export function App({
   const handleEnvChange = useCallback(
     (name: string | null) => {
       const envName = name ?? undefined
-      setSettingsEnv(envName)
+      const nextSettings = { ...settings, environment: envName }
+      setSettings(nextSettings)
       if (mode === "collection") {
-        saveSettings(activeCollectionDir, { environment: envName }).catch(
-          () => {},
-        )
+        saveSettings(activeCollectionDir, nextSettings).catch(() => {})
       }
     },
-    [activeCollectionDir, mode],
+    [activeCollectionDir, mode, settings],
   )
 
   const handleReloadCollection = useCallback(() => {
@@ -144,6 +171,7 @@ export function App({
     (bootstrappedDir: string) => {
       const resolved = resolve(bootstrappedDir)
       setMode("collection")
+      setSettings({})
       updateConfig((prev) => ({
         collections: upsertCollectionPath(prev.collections, resolved),
       }))
@@ -209,12 +237,12 @@ export function App({
           }
         }
 
-        let nextSettingsEnv: string | undefined
+        let nextSettings: CollectionSettings = {}
         if (nextMode === "collection") {
           try {
-            nextSettingsEnv = (await loadSettings(normalized)).environment
+            nextSettings = await loadSettings(normalized)
           } catch {
-            nextSettingsEnv = undefined
+            nextSettings = {}
           }
         }
 
@@ -229,7 +257,7 @@ export function App({
 
         setEnvNames(nextEnvNames)
         setEnvColors(nextEnvColors)
-        setSettingsEnv(nextSettingsEnv)
+        setSettings(nextSettings)
         setLastRequestId(nextLastRequestId)
         setInitialEnvNameState(undefined)
         setActiveCollectionDir(normalized)
@@ -275,6 +303,12 @@ export function App({
         onEnvChange={handleEnvChange}
         onEnvListChanged={handleEnvListChanged}
         settingsEnv={settingsEnv}
+        appProxy={config.proxy}
+        collectionProxy={settings.proxy}
+        noProxy={noProxy}
+        systemProxy={systemProxy}
+        onAppProxyChange={handleAppProxyChange}
+        onCollectionProxyChange={handleCollectionProxyChange}
         initialLastRequestId={lastRequestId}
         collectionPaths={collectionPaths}
         onCollectionChange={handleCollectionChange}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -14,7 +14,13 @@ import {
 } from "./tree"
 import { useResponse } from "../hooks/useResponse"
 import type { SendCompleteResult } from "../hooks/useResponse"
-import type { Request as NoodleRequest, Method } from "../schema"
+import type {
+  AppProxySettings,
+  CollectionProxySettings,
+  Request as NoodleRequest,
+  Method,
+} from "../schema"
+import { resolveProxyPolicy, type SystemProxySettings } from "../proxy"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
 import { useFolderDraft } from "../hooks/useFolderDraft"
@@ -76,6 +82,7 @@ import {
   openEnvironmentPicker,
 } from "./commandActions"
 import { runCollectionExport } from "./collectionExport"
+import type { ProxySettingsValues } from "./overlays/ProxySettingsOverlay"
 import {
   runCollectionImport,
   type CollectionImportValues,
@@ -98,6 +105,12 @@ export function AppInner({
   onEnvChange,
   onEnvListChanged,
   settingsEnv,
+  appProxy,
+  collectionProxy,
+  noProxy,
+  systemProxy,
+  onAppProxyChange,
+  onCollectionProxyChange,
   initialLastRequestId,
   collectionPaths,
   onCollectionChange,
@@ -122,6 +135,12 @@ export function AppInner({
   onEnvChange: (name: string | null) => void
   onEnvListChanged: () => Promise<void>
   settingsEnv?: string
+  appProxy?: AppProxySettings
+  collectionProxy?: CollectionProxySettings
+  noProxy: boolean
+  systemProxy: SystemProxySettings
+  onAppProxyChange: (proxy: AppProxySettings) => void
+  onCollectionProxyChange: (proxy: CollectionProxySettings) => void
   initialLastRequestId?: string
   collectionPaths: string[]
   onCollectionChange: (collectionDir: string) => void
@@ -461,6 +480,17 @@ export function AppInner({
     )
   }
 
+  const proxyPolicy = useMemo(
+    () =>
+      resolveProxyPolicy({
+        noProxy,
+        appProxy,
+        collectionProxy,
+        systemProxy,
+      }),
+    [noProxy, appProxy, collectionProxy, systemProxy],
+  )
+
   const {
     state: responseState,
     trySend,
@@ -471,6 +501,7 @@ export function AppInner({
     onCompleteRef.current,
     collection ?? undefined,
     draft.draft?.id,
+    proxyPolicy,
   )
 
   const responseStateRef = useRef(responseState)
@@ -598,6 +629,9 @@ export function AppInner({
     newFolderVisible,
     setNewFolderVisible,
     newFolderRef,
+    proxySettingsVisible,
+    setProxySettingsVisible,
+    proxySettingsRef,
     folderDeletePending,
     setFolderDeletePending,
     undoAllPending,
@@ -931,6 +965,40 @@ export function AppInner({
     ],
   )
 
+  const handleProxySettingsConfirm = useCallback(
+    (values: ProxySettingsValues) => {
+      if (values.scope === "app") {
+        if (values.mode === "system" || values.mode === "off") {
+          onAppProxyChange({ mode: values.mode })
+        } else if (values.mode === "custom") {
+          onAppProxyChange(
+            values.bypass.length > 0
+              ? { mode: "custom", url: values.url, bypass: values.bypass }
+              : { mode: "custom", url: values.url },
+          )
+        }
+      } else if (isCollection) {
+        if (values.mode === "inherit" || values.mode === "off") {
+          onCollectionProxyChange({ mode: values.mode })
+        } else if (values.mode === "custom") {
+          onCollectionProxyChange(
+            values.bypass.length > 0
+              ? { mode: "custom", url: values.url, bypass: values.bypass }
+              : { mode: "custom", url: values.url },
+          )
+        }
+      }
+      setProxySettingsVisible(false)
+      showToast("Proxy settings saved", "success")
+    },
+    [
+      isCollection,
+      onAppProxyChange,
+      onCollectionProxyChange,
+      setProxySettingsVisible,
+    ],
+  )
+
   // ── Overlay intercepts ────────────────────────────────────────────
   const overlayActions = useOverlayIntercepts({
     activeOverlay,
@@ -1034,6 +1102,10 @@ export function AppInner({
     newFolderRef,
     setNewFolderVisible,
     onNewFolderConfirm: handleNewFolderConfirm,
+    proxySettingsVisible,
+    proxySettingsRef,
+    setProxySettingsVisible,
+    onProxySettingsConfirm: handleProxySettingsConfirm,
     folderDeletePending,
     setFolderDeletePending,
     onFolderDeleteConfirm: handleFolderDeleteConfirm,
@@ -1100,6 +1172,7 @@ export function AppInner({
         setNewRequestVisible,
         setImportCurlVisible,
         setNewFolderVisible,
+        setProxySettingsVisible,
         setCloneRequestVisible,
         setEditRequestVisible,
         setRequestDeletePending,
@@ -1127,6 +1200,7 @@ export function AppInner({
       confirmUndoAll,
       onLayoutChange,
       setCollectionSwitcherVisible,
+      setProxySettingsVisible,
       setImportCollectionVisible,
       requestReload,
       view,
@@ -1351,6 +1425,11 @@ export function AppInner({
           newFolderVisible={newFolderVisible}
           newFolderRef={newFolderRef}
           newFolderActions={overlayActions.newFolder}
+          proxySettingsVisible={proxySettingsVisible}
+          proxySettingsRef={proxySettingsRef}
+          proxySettingsActions={overlayActions.proxySettings}
+          appProxy={appProxy}
+          collectionProxy={collectionProxy}
           folderDeletePending={folderDeletePending}
           requestDeletePending={requestDeletePending}
           timelineDetailEntry={timelineDetailEntry}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -22,6 +22,7 @@ import type {
 } from "../schema"
 import {
   createProxyFetcher,
+  environmentForProxyPolicy,
   resolveProxyPolicy,
   type SystemProxySettings,
 } from "../proxy"
@@ -494,8 +495,11 @@ export function AppInner({
       }),
     [noProxy, appProxy, collectionProxy, systemProxy],
   )
-  const updateFetcher = useMemo(
-    () => createProxyFetcher(proxyPolicy, envState.activeEnv),
+  const updateDependencies = useMemo(
+    () => ({
+      fetcher: createProxyFetcher(proxyPolicy, envState.activeEnv),
+      env: environmentForProxyPolicy(proxyPolicy, envState.activeEnv),
+    }),
     [proxyPolicy, envState.activeEnv],
   )
 
@@ -603,7 +607,7 @@ export function AppInner({
     triggerUpdateCheck,
     confirmInstall: onConfirmInstall,
     cancelUpdate: onCancelUpdate,
-  } = useUpdateFlow(overlayActiveRef, updateFetcher)
+  } = useUpdateFlow(overlayActiveRef, updateDependencies)
   const {
     activeOverlay,
     helpVisible,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -20,7 +20,11 @@ import type {
   Request as NoodleRequest,
   Method,
 } from "../schema"
-import { resolveProxyPolicy, type SystemProxySettings } from "../proxy"
+import {
+  createProxyFetcher,
+  resolveProxyPolicy,
+  type SystemProxySettings,
+} from "../proxy"
 import { useRequestDraft } from "../hooks/useRequestDraft"
 import { useEditBrowse } from "../hooks/useEditBrowse"
 import { useFolderDraft } from "../hooks/useFolderDraft"
@@ -490,6 +494,10 @@ export function AppInner({
       }),
     [noProxy, appProxy, collectionProxy, systemProxy],
   )
+  const updateFetcher = useMemo(
+    () => createProxyFetcher(proxyPolicy, envState.activeEnv),
+    [proxyPolicy, envState.activeEnv],
+  )
 
   const {
     state: responseState,
@@ -595,7 +603,7 @@ export function AppInner({
     triggerUpdateCheck,
     confirmInstall: onConfirmInstall,
     cancelUpdate: onCancelUpdate,
-  } = useUpdateFlow(overlayActiveRef)
+  } = useUpdateFlow(overlayActiveRef, updateFetcher)
   const {
     activeOverlay,
     helpVisible,
@@ -987,6 +995,10 @@ export function AppInner({
               : { mode: "custom", url: values.url },
           )
         }
+      } else {
+        setProxySettingsVisible(false)
+        showToast("Collection proxy settings are read-only", "error")
+        return
       }
       setProxySettingsVisible(false)
       showToast("Proxy settings saved", "success")
@@ -1428,6 +1440,7 @@ export function AppInner({
           proxySettingsVisible={proxySettingsVisible}
           proxySettingsRef={proxySettingsRef}
           proxySettingsActions={overlayActions.proxySettings}
+          collectionProxyEditable={isCollection}
           appProxy={appProxy}
           collectionProxy={collectionProxy}
           folderDeletePending={folderDeletePending}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -40,6 +40,10 @@ import {
   ImportCollectionOverlay,
   type ImportCollectionOverlayHandle,
 } from "./overlays/ImportCollectionOverlay"
+import {
+  ProxySettingsOverlay,
+  type ProxySettingsOverlayHandle,
+} from "./overlays/ProxySettingsOverlay"
 import type {
   Collection,
   Environment,
@@ -146,6 +150,11 @@ interface AppOverlaysProps {
   newFolderVisible: boolean
   newFolderRef: RefObject<NewFolderOverlayHandle | null>
   newFolderActions: { confirm: () => void; cancel: () => void }
+  proxySettingsVisible: boolean
+  proxySettingsRef: RefObject<ProxySettingsOverlayHandle | null>
+  proxySettingsActions: { confirm: () => void; cancel: () => void }
+  appProxy?: import("../schema").AppProxySettings
+  collectionProxy?: import("../schema").CollectionProxySettings
   folderDeletePending: string | null
   requestDeletePending: string | null
   timelineDetailEntry: TimelineEntry | null
@@ -252,6 +261,11 @@ export function AppOverlays({
   newFolderVisible,
   newFolderRef,
   newFolderActions,
+  proxySettingsVisible,
+  proxySettingsRef,
+  proxySettingsActions,
+  appProxy,
+  collectionProxy,
   folderDeletePending,
   requestDeletePending,
   timelineDetailEntry,
@@ -497,6 +511,18 @@ export function AppOverlays({
           ref={newFolderRef}
           onConfirm={newFolderActions.confirm}
           onClose={newFolderActions.cancel}
+        />
+      )}
+      {proxySettingsVisible && (
+        <ProxySettingsOverlay
+          visible
+          ref={proxySettingsRef}
+          collectionAvailable={collection !== null}
+          appProxy={appProxy}
+          collectionProxy={collectionProxy}
+          activeEnv={activeEnv}
+          onConfirm={proxySettingsActions.confirm}
+          onClose={proxySettingsActions.cancel}
         />
       )}
       {activeOverlay === "delete-folder" && folderDeletePending !== null && (

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -153,6 +153,7 @@ interface AppOverlaysProps {
   proxySettingsVisible: boolean
   proxySettingsRef: RefObject<ProxySettingsOverlayHandle | null>
   proxySettingsActions: { confirm: () => void; cancel: () => void }
+  collectionProxyEditable: boolean
   appProxy?: import("../schema").AppProxySettings
   collectionProxy?: import("../schema").CollectionProxySettings
   folderDeletePending: string | null
@@ -264,6 +265,7 @@ export function AppOverlays({
   proxySettingsVisible,
   proxySettingsRef,
   proxySettingsActions,
+  collectionProxyEditable,
   appProxy,
   collectionProxy,
   folderDeletePending,
@@ -517,7 +519,7 @@ export function AppOverlays({
         <ProxySettingsOverlay
           visible
           ref={proxySettingsRef}
-          collectionAvailable={collection !== null}
+          collectionAvailable={collectionProxyEditable}
           appProxy={appProxy}
           collectionProxy={collectionProxy}
           activeEnv={activeEnv}

--- a/src/ui/NetworkTab.tsx
+++ b/src/ui/NetworkTab.tsx
@@ -9,6 +9,7 @@ function eventColor(event: NetworkEvent, theme: ReturnType<typeof useTheme>) {
   if (event.type === "response" || event.type === "complete")
     return theme.success
   if (event.type === "request") return theme.primary
+  if (event.type === "proxy") return theme.info
   return theme.textMuted
 }
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -85,6 +85,7 @@ export interface CommandBuilderContext {
   ) => void
   setImportCurlVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setNewFolderVisible: (v: boolean | ((prev: boolean) => boolean)) => void
+  setProxySettingsVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setCloneRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setEditRequestVisible: (v: boolean | ((prev: boolean) => boolean)) => void
   setRequestDeletePending: (
@@ -179,6 +180,7 @@ export function buildCommandPaletteCommands(
     setLayout,
     onLayoutChange,
     setNewFolderVisible,
+    setProxySettingsVisible,
     setExpanded,
     getKeymapFocus,
     getView,
@@ -536,6 +538,15 @@ export function buildCommandPaletteCommands(
       run: () => {
         setPreviewIndexProp(c.activeIndexRef.current)
         return openThemePicker()
+      },
+    },
+    {
+      id: "app.proxy-settings",
+      label: "Proxy Settings",
+      section: "System",
+      run: () => {
+        setProxySettingsVisible(true)
+        return true
       },
     },
     {

--- a/src/ui/intercepts/useFormOverlayIntercept.ts
+++ b/src/ui/intercepts/useFormOverlayIntercept.ts
@@ -8,6 +8,7 @@ export function useFormOverlayIntercept(opts: {
     cycleFocus?: (dir: 1 | -1) => void
     getFocus?: () => string
     commitField?: () => void
+    toggleFocused?: () => void
     confirm: () => unknown
   } | null>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,6 +58,12 @@ export function useFormOverlayIntercept(opts: {
             e.stopPropagation()
             handle.commitField?.()
           }
+          return
+        }
+        if (e.name === "space" && handle.getFocus?.() === "auth") {
+          e.preventDefault()
+          e.stopPropagation()
+          handle.toggleFocused?.()
           return
         }
         if (e.name === "s" && e.ctrl) {

--- a/src/ui/overlays/ProxySettingsOverlay.tsx
+++ b/src/ui/overlays/ProxySettingsOverlay.tsx
@@ -1,0 +1,333 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { MouseButton, type InputRenderable } from "@opentui/core"
+import type {
+  AppProxySettings,
+  CollectionProxySettings,
+  Environment,
+} from "../../schema"
+import { normalizeBypass, validateProxyTemplate } from "../../proxy"
+import { Select, type SelectItem } from "../Select"
+import { VarInput, type VarInputHandle } from "../VarInput"
+import { useTheme } from "../theme"
+import { EscapeClose } from "./EscapeClose"
+import { Overlay } from "./Overlay"
+
+export interface ProxySettingsValues {
+  scope: "app" | "collection"
+  mode: "system" | "inherit" | "custom" | "off"
+  url: string
+  bypass: string[]
+}
+
+export interface ProxySettingsOverlayHandle {
+  cycleFocus: (direction: 1 | -1) => void
+  commitField: () => void
+  confirm: () => ProxySettingsValues | null
+  getFocus: () => "scope" | "mode" | "proxy-url" | "bypass"
+  setError: (message: string) => void
+}
+
+interface ProxySettingsOverlayProps {
+  visible: boolean
+  collectionAvailable: boolean
+  appProxy?: AppProxySettings
+  collectionProxy?: CollectionProxySettings
+  activeEnv?: Environment | null
+  onConfirm?: () => void
+  onClose?: () => void
+}
+
+type Focus = "scope" | "mode" | "proxy-url" | "bypass"
+
+function valuesFor(
+  proxy: AppProxySettings | CollectionProxySettings | undefined,
+  fallback: "system" | "inherit",
+): {
+  mode: "system" | "inherit" | "custom" | "off"
+  url: string
+  bypass: string
+} {
+  if (!proxy || proxy.mode === "system" || proxy.mode === "inherit") {
+    return { mode: fallback, url: "", bypass: "" }
+  }
+  if (proxy.mode === "off") return { mode: "off", url: "", bypass: "" }
+  return {
+    mode: "custom",
+    url: proxy.url,
+    bypass: (proxy.bypass ?? []).join(", "),
+  }
+}
+
+export const ProxySettingsOverlay = forwardRef<
+  ProxySettingsOverlayHandle,
+  ProxySettingsOverlayProps
+>(function ProxySettingsOverlay(
+  {
+    visible,
+    collectionAvailable,
+    appProxy,
+    collectionProxy,
+    activeEnv,
+    onConfirm,
+    onClose,
+  },
+  ref,
+) {
+  const theme = useTheme()
+  const [scope, setScope] = useState<"app" | "collection">("app")
+  const [appValues, setAppValues] = useState(() =>
+    valuesFor(appProxy, "system"),
+  )
+  const [collectionValues, setCollectionValues] = useState(() =>
+    valuesFor(collectionProxy, "inherit"),
+  )
+  const [focus, setFocus] = useState<Focus>("scope")
+  const [errorText, setErrorText] = useState<string | null>(null)
+  const [selectOpen, setSelectOpen] = useState(false)
+  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
+    null,
+  )
+  const urlRef = useRef<VarInputHandle | null>(null)
+  const bypassRef = useRef<InputRenderable | null>(null)
+
+  const current = scope === "app" ? appValues : collectionValues
+  const updateCurrent = (patch: Partial<typeof current>) => {
+    const update = (values: typeof current) => ({ ...values, ...patch })
+    if (scope === "app") setAppValues(update)
+    else setCollectionValues(update)
+  }
+
+  const scopeItems = useMemo<SelectItem[]>(
+    () => [
+      { id: "app", label: "App-wide default" },
+      ...(collectionAvailable
+        ? [{ id: "collection", label: "Current collection" }]
+        : []),
+    ],
+    [collectionAvailable],
+  )
+  const modeItems = useMemo<SelectItem[]>(
+    () =>
+      scope === "app"
+        ? [
+            { id: "system", label: "Use system proxy" },
+            { id: "custom", label: "Custom proxy" },
+            { id: "off", label: "Off (direct connections)" },
+          ]
+        : [
+            { id: "inherit", label: "Inherit app default" },
+            { id: "custom", label: "Custom proxy" },
+            { id: "off", label: "Off (direct connections)" },
+          ],
+    [scope],
+  )
+  const focusOrder: Focus[] =
+    current.mode === "custom"
+      ? ["scope", "mode", "proxy-url", "bypass"]
+      : ["scope", "mode"]
+
+  useImperativeHandle(ref, () => ({
+    cycleFocus: (direction) => {
+      setErrorText(null)
+      setFocus((previous) => {
+        const index = focusOrder.indexOf(previous)
+        return focusOrder[
+          (index + direction + focusOrder.length) % focusOrder.length
+        ]!
+      })
+    },
+    commitField: () => {
+      const index = focusOrder.indexOf(focus)
+      setFocus(focusOrder[(index + 1) % focusOrder.length]!)
+    },
+    confirm: () => {
+      if (current.mode === "custom") {
+        const validationError = validateProxyTemplate(current.url)
+        if (validationError) {
+          setErrorText(validationError)
+          return null
+        }
+      }
+      setErrorText(null)
+      return {
+        scope,
+        mode: current.mode,
+        url: current.url.trim(),
+        bypass: normalizeBypass(current.bypass.split(",")),
+      }
+    },
+    getFocus: () => focus,
+    setError: setErrorText,
+  }))
+
+  useEffect(() => {
+    if (!visible) return
+    setScope("app")
+    setAppValues(valuesFor(appProxy, "system"))
+    setCollectionValues(valuesFor(collectionProxy, "inherit"))
+    setFocus("scope")
+    setErrorText(null)
+  }, [visible, appProxy, collectionProxy])
+
+  useEffect(() => {
+    if (focus === "proxy-url") urlRef.current?.focus()
+    else if (focus === "bypass") bypassRef.current?.focus()
+    else {
+      bypassRef.current?.blur()
+    }
+  }, [focus])
+
+  return (
+    <Overlay visible={visible} width={64} padding={1} gap={1}>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingBottom: 1,
+          paddingX: 2,
+        }}
+      >
+        <text fg={theme.text}>Proxy Settings</text>
+        <EscapeClose onClose={() => onClose?.()} />
+      </box>
+      <box
+        style={{
+          paddingX: 2,
+          flexDirection: "column",
+          gap: 1,
+          paddingBottom: 1,
+        }}
+      >
+        <box style={{ flexDirection: "column", zIndex: selectOpen ? 2 : 0 }}>
+          <text fg={theme.textMuted}>Scope</text>
+          <Select
+            items={scopeItems}
+            value={scope}
+            onChange={(next) => {
+              setScope(next as "app" | "collection")
+              setFocus("scope")
+            }}
+            focused={focus === "scope"}
+            onOpenChange={setSelectOpen}
+            onActivate={() => setFocus("scope")}
+            triggerPriority={110}
+          />
+        </box>
+        <box style={{ flexDirection: "column", zIndex: selectOpen ? 1 : 0 }}>
+          <text fg={theme.textMuted}>Mode</text>
+          <Select
+            items={modeItems}
+            value={current.mode}
+            onChange={(next) => {
+              updateCurrent({
+                mode: next as "system" | "inherit" | "custom" | "off",
+              })
+              setFocus("mode")
+            }}
+            focused={focus === "mode"}
+            onOpenChange={setSelectOpen}
+            onActivate={() => setFocus("mode")}
+            triggerPriority={110}
+          />
+        </box>
+        {current.mode === "custom" && (
+          <>
+            <box style={{ flexDirection: "column" }}>
+              <text fg={theme.textMuted}>Proxy URL</text>
+              <VarInput
+                ref={urlRef}
+                value={current.url}
+                env={activeEnv ?? null}
+                isEditing
+                isFocused={focus === "proxy-url"}
+                onChange={(url) => updateCurrent({ url })}
+                placeholder="http://$PROXY_USER:$PROXY_PASSWORD@proxy:8080"
+                backgroundColor={theme.backgroundElement}
+                focusedBackgroundColor={theme.borderSubtle}
+                onFocus={() => setFocus("proxy-url")}
+              />
+            </box>
+            <box style={{ flexDirection: "column" }}>
+              <text fg={theme.textMuted}>Bypass hosts</text>
+              <input
+                ref={bypassRef}
+                value={current.bypass}
+                placeholder="localhost, .internal.example, api.example:8443"
+                onInput={(bypass) => updateCurrent({ bypass })}
+                onMouseDown={(event) => {
+                  if (event.button === MouseButton.LEFT) setFocus("bypass")
+                }}
+                focused={focus === "bypass"}
+                backgroundColor={theme.backgroundElement}
+                focusedBackgroundColor={theme.borderSubtle}
+                textColor={theme.text}
+                cursorColor={theme.primary}
+                placeholderColor={theme.textMuted}
+              />
+              <text fg={theme.textMuted}>
+                Comma-separated. Supports *, hosts, .domains, IPs, and ports.
+              </text>
+            </box>
+          </>
+        )}
+        {errorText && <text fg={theme.error}>{errorText}</text>}
+      </box>
+      <box
+        style={{
+          flexDirection: "row",
+          justifyContent: "flex-end",
+          gap: 1,
+          paddingX: 2,
+        }}
+      >
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onConfirm?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("save")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "save" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>^S</text>
+          <text fg={theme.textMuted}> save</text>
+        </box>
+        <box
+          onMouseDown={(event) => {
+            if (event.button !== MouseButton.LEFT) return
+            onClose?.()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseOver={() => setHoveredAction("close")}
+          onMouseOut={() => setHoveredAction(null)}
+          style={{
+            flexDirection: "row",
+            paddingLeft: 1,
+            paddingRight: 1,
+            backgroundColor:
+              hoveredAction === "close" ? theme.backgroundElement : undefined,
+          }}
+        >
+          <text fg={theme.text}>esc</text>
+          <text fg={theme.textMuted}> close</text>
+        </box>
+      </box>
+    </Overlay>
+  )
+})

--- a/src/ui/overlays/ProxySettingsOverlay.tsx
+++ b/src/ui/overlays/ProxySettingsOverlay.tsx
@@ -12,7 +12,14 @@ import type {
   CollectionProxySettings,
   Environment,
 } from "../../schema"
-import { normalizeBypass, validateProxyTemplate } from "../../proxy"
+import {
+  buildStructuredProxyTemplate,
+  normalizeBypass,
+  parseStructuredProxyTemplate,
+  validateProxyTemplate,
+  type StructuredProxyFields,
+} from "../../proxy"
+import { Checkbox } from "../Checkbox"
 import { Select, type SelectItem } from "../Select"
 import { VarInput, type VarInputHandle } from "../VarInput"
 import { useTheme } from "../theme"
@@ -29,8 +36,9 @@ export interface ProxySettingsValues {
 export interface ProxySettingsOverlayHandle {
   cycleFocus: (direction: 1 | -1) => void
   commitField: () => void
+  toggleFocused: () => void
   confirm: () => ProxySettingsValues | null
-  getFocus: () => "scope" | "mode" | "proxy-url" | "bypass"
+  getFocus: () => Focus
   setError: (message: string) => void
 }
 
@@ -44,22 +52,65 @@ interface ProxySettingsOverlayProps {
   onClose?: () => void
 }
 
-type Focus = "scope" | "mode" | "proxy-url" | "bypass"
+type EditorMode = "fields" | "advanced"
+type ProxyMode = "system" | "inherit" | "custom" | "off"
+type Focus =
+  | "scope"
+  | "mode"
+  | "editor"
+  | "protocol"
+  | "hostname"
+  | "port"
+  | "auth"
+  | "username"
+  | "password"
+  | "proxy-url"
+  | "bypass"
+
+interface ProxyFormValues {
+  mode: ProxyMode
+  editor: EditorMode
+  fields: StructuredProxyFields
+  url: string
+  bypass: string
+}
+
+const EMPTY_FIELDS: StructuredProxyFields = {
+  protocol: "http",
+  hostname: "",
+  port: "",
+  auth: false,
+  username: "",
+  password: "",
+}
 
 function valuesFor(
   proxy: AppProxySettings | CollectionProxySettings | undefined,
   fallback: "system" | "inherit",
-): {
-  mode: "system" | "inherit" | "custom" | "off"
-  url: string
-  bypass: string
-} {
+): ProxyFormValues {
   if (!proxy || proxy.mode === "system" || proxy.mode === "inherit") {
-    return { mode: fallback, url: "", bypass: "" }
+    return {
+      mode: fallback,
+      editor: "fields",
+      fields: EMPTY_FIELDS,
+      url: "",
+      bypass: "",
+    }
   }
-  if (proxy.mode === "off") return { mode: "off", url: "", bypass: "" }
+  if (proxy.mode === "off") {
+    return {
+      mode: "off",
+      editor: "fields",
+      fields: EMPTY_FIELDS,
+      url: "",
+      bypass: "",
+    }
+  }
+  const fields = parseStructuredProxyTemplate(proxy.url)
   return {
     mode: "custom",
+    editor: fields ? "fields" : "advanced",
+    fields: fields ?? EMPTY_FIELDS,
     url: proxy.url,
     bypass: (proxy.bypass ?? []).join(", "),
   }
@@ -94,15 +145,21 @@ export const ProxySettingsOverlay = forwardRef<
   const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
     null,
   )
+  const hostnameRef = useRef<InputRenderable | null>(null)
+  const portRef = useRef<InputRenderable | null>(null)
+  const usernameRef = useRef<VarInputHandle | null>(null)
+  const passwordRef = useRef<VarInputHandle | null>(null)
   const urlRef = useRef<VarInputHandle | null>(null)
   const bypassRef = useRef<InputRenderable | null>(null)
 
   const current = scope === "app" ? appValues : collectionValues
-  const updateCurrent = (patch: Partial<typeof current>) => {
-    const update = (values: typeof current) => ({ ...values, ...patch })
+  const updateCurrent = (patch: Partial<ProxyFormValues>) => {
+    const update = (values: ProxyFormValues) => ({ ...values, ...patch })
     if (scope === "app") setAppValues(update)
     else setCollectionValues(update)
   }
+  const updateFields = (patch: Partial<StructuredProxyFields>) =>
+    updateCurrent({ fields: { ...current.fields, ...patch } })
 
   const scopeItems = useMemo<SelectItem[]>(
     () => [
@@ -128,10 +185,59 @@ export const ProxySettingsOverlay = forwardRef<
           ],
     [scope],
   )
+  const editorItems = useMemo<SelectItem[]>(
+    () => [
+      { id: "fields", label: "Fields" },
+      { id: "advanced", label: "Advanced URL" },
+    ],
+    [],
+  )
+  const protocolItems = useMemo<SelectItem[]>(
+    () => [
+      { id: "http", label: "HTTP" },
+      { id: "https", label: "HTTPS" },
+    ],
+    [],
+  )
   const focusOrder: Focus[] =
-    current.mode === "custom"
-      ? ["scope", "mode", "proxy-url", "bypass"]
-      : ["scope", "mode"]
+    current.mode !== "custom"
+      ? ["scope", "mode"]
+      : current.editor === "advanced"
+        ? ["scope", "mode", "editor", "proxy-url", "bypass"]
+        : [
+            "scope",
+            "mode",
+            "editor",
+            "protocol",
+            "hostname",
+            "port",
+            "auth",
+            ...(current.fields.auth ? (["username", "password"] as const) : []),
+            "bypass",
+          ]
+
+  const switchEditor = (editor: EditorMode) => {
+    if (editor === current.editor) return
+    if (editor === "fields") {
+      const fields = parseStructuredProxyTemplate(current.url)
+      if (!fields) {
+        setErrorText(
+          "This URL needs Advanced URL mode. Use an HTTP(S) host, optional port, and $VARNAME credentials only.",
+        )
+        return
+      }
+      updateCurrent({ editor, fields })
+    } else {
+      const result = buildStructuredProxyTemplate(current.fields)
+      if ("error" in result) {
+        setErrorText(result.error)
+        return
+      }
+      updateCurrent({ editor, url: result.url })
+    }
+    setErrorText(null)
+    setFocus("editor")
+  }
 
   useImperativeHandle(ref, () => ({
     cycleFocus: (direction) => {
@@ -147,19 +253,34 @@ export const ProxySettingsOverlay = forwardRef<
       const index = focusOrder.indexOf(focus)
       setFocus(focusOrder[(index + 1) % focusOrder.length]!)
     },
+    toggleFocused: () => {
+      if (focus !== "auth") return
+      updateFields({ auth: !current.fields.auth })
+      setErrorText(null)
+    },
     confirm: () => {
+      let url = current.url.trim()
       if (current.mode === "custom") {
-        const validationError = validateProxyTemplate(current.url)
-        if (validationError) {
-          setErrorText(validationError)
-          return null
+        if (current.editor === "fields") {
+          const result = buildStructuredProxyTemplate(current.fields)
+          if ("error" in result) {
+            setErrorText(result.error)
+            return null
+          }
+          url = result.url
+        } else {
+          const validationError = validateProxyTemplate(url)
+          if (validationError) {
+            setErrorText(validationError)
+            return null
+          }
         }
       }
       setErrorText(null)
       return {
         scope,
         mode: current.mode,
-        url: current.url.trim(),
+        url,
         bypass: normalizeBypass(current.bypass.split(",")),
       }
     },
@@ -177,11 +298,12 @@ export const ProxySettingsOverlay = forwardRef<
   }, [visible, appProxy, collectionProxy])
 
   useEffect(() => {
-    if (focus === "proxy-url") urlRef.current?.focus()
+    if (focus === "hostname") hostnameRef.current?.focus()
+    else if (focus === "port") portRef.current?.focus()
+    else if (focus === "username") usernameRef.current?.focus()
+    else if (focus === "password") passwordRef.current?.focus()
+    else if (focus === "proxy-url") urlRef.current?.focus()
     else if (focus === "bypass") bypassRef.current?.focus()
-    else {
-      bypassRef.current?.blur()
-    }
   }, [focus])
 
   return (
@@ -205,76 +327,145 @@ export const ProxySettingsOverlay = forwardRef<
           paddingBottom: 1,
         }}
       >
-        <box style={{ flexDirection: "column", zIndex: selectOpen ? 2 : 0 }}>
-          <text fg={theme.textMuted}>Scope</text>
-          <Select
-            items={scopeItems}
-            value={scope}
-            onChange={(next) => {
-              setScope(next as "app" | "collection")
-              setFocus("scope")
-            }}
-            focused={focus === "scope"}
-            onOpenChange={setSelectOpen}
-            onActivate={() => setFocus("scope")}
-            triggerPriority={110}
-          />
-        </box>
-        <box style={{ flexDirection: "column", zIndex: selectOpen ? 1 : 0 }}>
-          <text fg={theme.textMuted}>Mode</text>
-          <Select
-            items={modeItems}
-            value={current.mode}
-            onChange={(next) => {
-              updateCurrent({
-                mode: next as "system" | "inherit" | "custom" | "off",
-              })
-              setFocus("mode")
-            }}
-            focused={focus === "mode"}
-            onOpenChange={setSelectOpen}
-            onActivate={() => setFocus("mode")}
-            triggerPriority={110}
-          />
-        </box>
+        <SelectField
+          label="Scope"
+          items={scopeItems}
+          value={scope}
+          focused={focus === "scope"}
+          selectOpen={selectOpen}
+          onOpenChange={setSelectOpen}
+          onActivate={() => setFocus("scope")}
+          onChange={(next) => {
+            setScope(next as "app" | "collection")
+            setFocus("scope")
+          }}
+        />
+        <SelectField
+          label="Mode"
+          items={modeItems}
+          value={current.mode}
+          focused={focus === "mode"}
+          selectOpen={selectOpen}
+          onOpenChange={setSelectOpen}
+          onActivate={() => setFocus("mode")}
+          onChange={(next) => {
+            updateCurrent({ mode: next as ProxyMode })
+            setFocus("mode")
+          }}
+        />
         {current.mode === "custom" && (
           <>
-            <box style={{ flexDirection: "column" }}>
-              <text fg={theme.textMuted}>Proxy URL</text>
-              <VarInput
-                ref={urlRef}
+            <SelectField
+              label="Editor"
+              items={editorItems}
+              value={current.editor}
+              focused={focus === "editor"}
+              selectOpen={selectOpen}
+              onOpenChange={setSelectOpen}
+              onActivate={() => setFocus("editor")}
+              onChange={(next) => switchEditor(next as EditorMode)}
+            />
+            {current.editor === "fields" ? (
+              <>
+                <SelectField
+                  label="Protocol"
+                  items={protocolItems}
+                  value={current.fields.protocol}
+                  focused={focus === "protocol"}
+                  selectOpen={selectOpen}
+                  onOpenChange={setSelectOpen}
+                  onActivate={() => setFocus("protocol")}
+                  onChange={(protocol) => {
+                    updateFields({ protocol: protocol as "http" | "https" })
+                    setFocus("protocol")
+                  }}
+                />
+                <TextField
+                  label="Hostname"
+                  inputRef={hostnameRef}
+                  value={current.fields.hostname}
+                  placeholder="proxy.example or ::1"
+                  focused={focus === "hostname"}
+                  theme={theme}
+                  onFocus={() => setFocus("hostname")}
+                  onChange={(hostname) => updateFields({ hostname })}
+                />
+                <TextField
+                  label="Port"
+                  inputRef={portRef}
+                  value={current.fields.port}
+                  placeholder="optional"
+                  focused={focus === "port"}
+                  theme={theme}
+                  onFocus={() => setFocus("port")}
+                  onChange={(port) => updateFields({ port })}
+                />
+                <box
+                  onMouseDown={(event) => {
+                    if (event.button !== MouseButton.LEFT) return
+                    updateFields({ auth: !current.fields.auth })
+                    setFocus("auth")
+                    event.preventDefault()
+                    event.stopPropagation()
+                  }}
+                  style={{ flexDirection: "row" }}
+                >
+                  <Checkbox checked={current.fields.auth} theme={theme} />
+                  <text fg={focus === "auth" ? theme.text : theme.textMuted}>
+                    Proxy authentication
+                  </text>
+                </box>
+                {current.fields.auth && (
+                  <>
+                    <VariableField
+                      label="Username variable"
+                      inputRef={usernameRef}
+                      value={current.fields.username}
+                      placeholder="$PROXY_USER"
+                      focused={focus === "username"}
+                      env={activeEnv ?? null}
+                      theme={theme}
+                      onFocus={() => setFocus("username")}
+                      onChange={(username) => updateFields({ username })}
+                    />
+                    <VariableField
+                      label="Password variable"
+                      inputRef={passwordRef}
+                      value={current.fields.password}
+                      placeholder="$PROXY_PASSWORD"
+                      focused={focus === "password"}
+                      env={activeEnv ?? null}
+                      theme={theme}
+                      onFocus={() => setFocus("password")}
+                      onChange={(password) => updateFields({ password })}
+                    />
+                  </>
+                )}
+              </>
+            ) : (
+              <VariableField
+                label="Proxy URL"
+                inputRef={urlRef}
                 value={current.url}
-                env={activeEnv ?? null}
-                isEditing
-                isFocused={focus === "proxy-url"}
-                onChange={(url) => updateCurrent({ url })}
                 placeholder="http://$PROXY_USER:$PROXY_PASSWORD@proxy:8080"
-                backgroundColor={theme.backgroundElement}
-                focusedBackgroundColor={theme.borderSubtle}
+                focused={focus === "proxy-url"}
+                env={activeEnv ?? null}
+                theme={theme}
                 onFocus={() => setFocus("proxy-url")}
+                onChange={(url) => updateCurrent({ url })}
               />
-            </box>
-            <box style={{ flexDirection: "column" }}>
-              <text fg={theme.textMuted}>Bypass hosts</text>
-              <input
-                ref={bypassRef}
-                value={current.bypass}
-                placeholder="localhost, .internal.example, api.example:8443"
-                onInput={(bypass) => updateCurrent({ bypass })}
-                onMouseDown={(event) => {
-                  if (event.button === MouseButton.LEFT) setFocus("bypass")
-                }}
-                focused={focus === "bypass"}
-                backgroundColor={theme.backgroundElement}
-                focusedBackgroundColor={theme.borderSubtle}
-                textColor={theme.text}
-                cursorColor={theme.primary}
-                placeholderColor={theme.textMuted}
-              />
-              <text fg={theme.textMuted}>
-                Comma-separated. Supports *, hosts, .domains, IPs, and ports.
-              </text>
-            </box>
+            )}
+            <TextField
+              label="Bypass hosts"
+              inputRef={bypassRef}
+              value={current.bypass}
+              placeholder="localhost, .internal.example, api.example:8443"
+              focused={focus === "bypass"}
+              theme={theme}
+              onFocus={() => setFocus("bypass")}
+              onChange={(bypass) => updateCurrent({ bypass })}
+              hint="Comma-separated. Supports *, hosts, .domains, IPs, and ports."
+            />
           </>
         )}
         {errorText && <text fg={theme.error}>{errorText}</text>}
@@ -287,47 +478,185 @@ export const ProxySettingsOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <FooterAction
+          keyHint="^S"
+          label="save"
+          hovered={hoveredAction === "save"}
+          theme={theme}
+          onHover={() => setHoveredAction("save")}
+          onLeave={() => setHoveredAction(null)}
+          onClick={onConfirm}
+        />
+        <FooterAction
+          keyHint="esc"
+          label="close"
+          hovered={hoveredAction === "close"}
+          theme={theme}
+          onHover={() => setHoveredAction("close")}
+          onLeave={() => setHoveredAction(null)}
+          onClick={onClose}
+        />
       </box>
     </Overlay>
   )
 })
+
+function SelectField({
+  label,
+  items,
+  value,
+  focused,
+  selectOpen,
+  onOpenChange,
+  onActivate,
+  onChange,
+}: {
+  label: string
+  items: SelectItem[]
+  value: string
+  focused: boolean
+  selectOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onActivate: () => void
+  onChange: (value: string) => void
+}) {
+  const theme = useTheme()
+  return (
+    <box style={{ flexDirection: "column", zIndex: selectOpen ? 2 : 0 }}>
+      <text fg={theme.textMuted}>{label}</text>
+      <Select
+        items={items}
+        value={value}
+        onChange={onChange}
+        focused={focused}
+        onOpenChange={onOpenChange}
+        onActivate={onActivate}
+        triggerPriority={110}
+      />
+    </box>
+  )
+}
+
+function TextField({
+  label,
+  value,
+  placeholder,
+  focused,
+  theme,
+  onFocus,
+  onChange,
+  hint,
+  inputRef,
+}: {
+  label: string
+  value: string
+  placeholder: string
+  focused: boolean
+  theme: ReturnType<typeof useTheme>
+  onFocus: () => void
+  onChange: (value: string) => void
+  hint?: string
+  inputRef: { current: InputRenderable | null }
+}) {
+  return (
+    <box style={{ flexDirection: "column" }}>
+      <text fg={theme.textMuted}>{label}</text>
+      <input
+        ref={inputRef}
+        value={value}
+        placeholder={placeholder}
+        onInput={onChange}
+        onMouseDown={(event) => {
+          if (event.button === MouseButton.LEFT) onFocus()
+        }}
+        focused={focused}
+        backgroundColor={theme.backgroundElement}
+        focusedBackgroundColor={theme.borderSubtle}
+        textColor={theme.text}
+        cursorColor={theme.primary}
+        placeholderColor={theme.textMuted}
+      />
+      {hint && <text fg={theme.textMuted}>{hint}</text>}
+    </box>
+  )
+}
+
+function VariableField({
+  label,
+  value,
+  placeholder,
+  focused,
+  env,
+  theme,
+  onFocus,
+  onChange,
+  inputRef,
+}: {
+  label: string
+  value: string
+  placeholder: string
+  focused: boolean
+  env: Environment | null
+  theme: ReturnType<typeof useTheme>
+  onFocus: () => void
+  onChange: (value: string) => void
+  inputRef: { current: VarInputHandle | null }
+}) {
+  return (
+    <box style={{ flexDirection: "column" }}>
+      <text fg={theme.textMuted}>{label}</text>
+      <VarInput
+        ref={inputRef}
+        value={value}
+        env={env}
+        isEditing
+        isFocused={focused}
+        onChange={onChange}
+        placeholder={placeholder}
+        backgroundColor={theme.backgroundElement}
+        focusedBackgroundColor={theme.borderSubtle}
+        onFocus={onFocus}
+      />
+    </box>
+  )
+}
+
+function FooterAction({
+  keyHint,
+  label,
+  hovered,
+  theme,
+  onHover,
+  onLeave,
+  onClick,
+}: {
+  keyHint: string
+  label: string
+  hovered: boolean
+  theme: ReturnType<typeof useTheme>
+  onHover: () => void
+  onLeave: () => void
+  onClick?: () => void
+}) {
+  return (
+    <box
+      onMouseDown={(event) => {
+        if (event.button !== MouseButton.LEFT) return
+        onClick?.()
+        event.preventDefault()
+        event.stopPropagation()
+      }}
+      onMouseOver={onHover}
+      onMouseOut={onLeave}
+      style={{
+        flexDirection: "row",
+        paddingLeft: 1,
+        paddingRight: 1,
+        backgroundColor: hovered ? theme.backgroundElement : undefined,
+      }}
+    >
+      <text fg={theme.text}>{keyHint}</text>
+      <text fg={theme.textMuted}> {label}</text>
+    </box>
+  )
+}

--- a/src/ui/useModalKeyboardShield.ts
+++ b/src/ui/useModalKeyboardShield.ts
@@ -16,6 +16,7 @@ export const EDITABLE_OVERLAYS = new Set([
   "edit-request",
   "clone-request",
   "new-folder",
+  "proxy-settings",
 ])
 
 export const HARD_BLOCKING_OVERLAYS = new Set([

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -6,6 +6,10 @@ import type { EnvHeaderPaneHandle } from "./env-editor/EnvHeaderPane"
 import type { NewRequestOverlayHandle } from "./overlays/NewRequestOverlay"
 import type { CloneRequestOverlayHandle } from "./overlays/CloneRequestOverlay"
 import type { NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
+import type {
+  ProxySettingsOverlayHandle,
+  ProxySettingsValues,
+} from "./overlays/ProxySettingsOverlay"
 import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
 import type { ExportCollectionOverlayHandle } from "./overlays/ExportCollectionOverlay"
 import type { ImportCollectionOverlayHandle } from "./overlays/ImportCollectionOverlay"
@@ -111,6 +115,10 @@ export function useOverlayIntercepts(opts: {
   newFolderRef: RefObject<NewFolderOverlayHandle | null>
   setNewFolderVisible: (v: boolean) => void
   onNewFolderConfirm: (name: string) => void
+  proxySettingsVisible: boolean
+  proxySettingsRef: RefObject<ProxySettingsOverlayHandle | null>
+  setProxySettingsVisible: (v: boolean) => void
+  onProxySettingsConfirm: (values: ProxySettingsValues) => void
   folderDeletePending: string | null
   setFolderDeletePending: (s: string | null) => void
   onFolderDeleteConfirm: () => void
@@ -200,6 +208,14 @@ export function useOverlayIntercepts(opts: {
     onCancel: () => opts.setNewFolderVisible(false),
   })
 
+  const proxySettingsActions = useFormOverlayIntercept({
+    visible: opts.proxySettingsVisible,
+    handleRef: opts.proxySettingsRef,
+    onConfirm: opts.onProxySettingsConfirm,
+    onCancel: () => opts.setProxySettingsVisible(false),
+    passThroughFocuses: ["scope", "mode"],
+  })
+
   useEnvEditorIntercept(opts)
 
   return {
@@ -212,5 +228,6 @@ export function useOverlayIntercepts(opts: {
     editRequest: editRequestActions,
     cloneRequest: cloneRequestActions,
     newFolder: newFolderActions,
+    proxySettings: proxySettingsActions,
   }
 }

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -213,7 +213,7 @@ export function useOverlayIntercepts(opts: {
     handleRef: opts.proxySettingsRef,
     onConfirm: opts.onProxySettingsConfirm,
     onCancel: () => opts.setProxySettingsVisible(false),
-    passThroughFocuses: ["scope", "mode"],
+    passThroughFocuses: ["scope", "mode", "editor", "protocol"],
   })
 
   useEnvEditorIntercept(opts)

--- a/src/ui/useOverlayState.ts
+++ b/src/ui/useOverlayState.ts
@@ -9,6 +9,7 @@ import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
 import type { NewEnvironmentOverlayHandle } from "./overlays/NewEnvironmentOverlay"
 import type { ExportCollectionOverlayHandle } from "./overlays/ExportCollectionOverlay"
 import type { ImportCollectionOverlayHandle } from "./overlays/ImportCollectionOverlay"
+import type { ProxySettingsOverlayHandle } from "./overlays/ProxySettingsOverlay"
 
 export interface ImportedCollectionPending {
   path: string
@@ -39,6 +40,7 @@ export type ActiveOverlay =
   | "edit-request"
   | "clone-request"
   | "new-folder"
+  | "proxy-settings"
   | "delete-folder"
   | "request-delete"
   | "update-confirm"
@@ -84,6 +86,8 @@ export function useOverlayState({
   >(null)
   const [newFolderVisible, setNewFolderVisible] = useState(false)
   const newFolderRef = useRef<NewFolderOverlayHandle>(null)
+  const [proxySettingsVisible, setProxySettingsVisible] = useState(false)
+  const proxySettingsRef = useRef<ProxySettingsOverlayHandle>(null)
   const [folderDeletePending, setFolderDeletePending] = useState<string | null>(
     null,
   )
@@ -130,6 +134,7 @@ export function useOverlayState({
     if (editRequestVisible) return "edit-request"
     if (cloneRequestVisible) return "clone-request"
     if (newFolderVisible) return "new-folder"
+    if (proxySettingsVisible) return "proxy-settings"
     if (folderDeletePending !== null) return "delete-folder"
     if (requestDeletePending !== null) return "request-delete"
     if (updatePhase === "confirm") return "update-confirm"
@@ -159,6 +164,7 @@ export function useOverlayState({
     editRequestVisible,
     cloneRequestVisible,
     newFolderVisible,
+    proxySettingsVisible,
     folderDeletePending,
     requestDeletePending,
     updatePhase,
@@ -198,6 +204,9 @@ export function useOverlayState({
     newFolderVisible,
     setNewFolderVisible,
     newFolderRef,
+    proxySettingsVisible,
+    setProxySettingsVisible,
+    proxySettingsRef,
     folderDeletePending,
     setFolderDeletePending,
     undoAllPending,

--- a/src/ui/useUpdateFlow.ts
+++ b/src/ui/useUpdateFlow.ts
@@ -4,6 +4,7 @@ import {
   checkForUpdates,
   installBinaryUpdate,
   installBrewUpdate,
+  type UpdateDependencies,
 } from "../app/commands/update"
 import { showToast } from "./Toast"
 import type { UpdateFlowState } from "./appState"
@@ -12,7 +13,10 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
+export function useUpdateFlow(
+  overlayActiveRef: RefObject<boolean>,
+  fetcher: UpdateDependencies["fetcher"] = globalThis.fetch,
+) {
   const [checkToken, setCheckToken] = useState(0)
   const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>({
     phase: "idle",
@@ -21,6 +25,8 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null)
   const updateFlowRef = useRef(updateFlow)
   updateFlowRef.current = updateFlow
+  const fetcherRef = useRef(fetcher)
+  fetcherRef.current = fetcher
   const installTokenRef = useRef(0)
 
   const triggerUpdateCheck = useCallback(
@@ -31,7 +37,7 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
   useEffect(() => {
     if (checkToken === 0 || updateFlowRef.current.phase === "installing") return
     let cancelled = false
-    checkForUpdates(true)
+    checkForUpdates(true, { fetcher: fetcherRef.current })
       .then((status) => {
         if (cancelled || overlayActiveRef.current) return
         if (status.kind === "up_to_date") {
@@ -102,6 +108,7 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
         update.version,
         update.assetUrl,
         update.expectedSha256,
+        { fetcher: fetcherRef.current },
       )
         .then((result) => {
           if (token !== installTokenRef.current) return
@@ -131,7 +138,7 @@ export function useUpdateFlow(overlayActiveRef: RefObject<boolean>) {
 
   useEffect(() => {
     let cancelled = false
-    checkForUpdates()
+    checkForUpdates(false, { fetcher: fetcherRef.current })
       .then((status) => {
         if (!cancelled && status.kind === "update_available") {
           setUpdateAvailable(status.latestVersion)

--- a/src/ui/useUpdateFlow.ts
+++ b/src/ui/useUpdateFlow.ts
@@ -15,7 +15,10 @@ function getErrorMessage(error: unknown): string {
 
 export function useUpdateFlow(
   overlayActiveRef: RefObject<boolean>,
-  fetcher: UpdateDependencies["fetcher"] = globalThis.fetch,
+  dependencies: Pick<UpdateDependencies, "fetcher" | "env"> = {
+    fetcher: globalThis.fetch,
+    env: process.env,
+  },
 ) {
   const [checkToken, setCheckToken] = useState(0)
   const [updateFlow, setUpdateFlow] = useState<UpdateFlowState>({
@@ -25,9 +28,12 @@ export function useUpdateFlow(
   const [updateAvailable, setUpdateAvailable] = useState<string | null>(null)
   const updateFlowRef = useRef(updateFlow)
   updateFlowRef.current = updateFlow
-  const fetcherRef = useRef(fetcher)
-  fetcherRef.current = fetcher
+  const dependenciesRef = useRef(dependencies)
   const installTokenRef = useRef(0)
+
+  useEffect(() => {
+    dependenciesRef.current = dependencies
+  }, [dependencies])
 
   const triggerUpdateCheck = useCallback(
     () => setCheckToken((token) => token + 1),
@@ -37,7 +43,7 @@ export function useUpdateFlow(
   useEffect(() => {
     if (checkToken === 0 || updateFlowRef.current.phase === "installing") return
     let cancelled = false
-    checkForUpdates(true, { fetcher: fetcherRef.current })
+    checkForUpdates(true, dependenciesRef.current)
       .then((status) => {
         if (cancelled || overlayActiveRef.current) return
         if (status.kind === "up_to_date") {
@@ -72,7 +78,7 @@ export function useUpdateFlow(
     const update = updateFlow
     const token = ++installTokenRef.current
     if (update.installType === "brew") {
-      installBrewUpdate()
+      installBrewUpdate(dependenciesRef.current)
         .then((result) => {
           if (token !== installTokenRef.current) return
           if (result.data.status === "homebrew_updated") {
@@ -108,7 +114,7 @@ export function useUpdateFlow(
         update.version,
         update.assetUrl,
         update.expectedSha256,
-        { fetcher: fetcherRef.current },
+        dependenciesRef.current,
       )
         .then((result) => {
           if (token !== installTokenRef.current) return
@@ -138,7 +144,7 @@ export function useUpdateFlow(
 
   useEffect(() => {
     let cancelled = false
-    checkForUpdates(false, { fetcher: fetcherRef.current })
+    checkForUpdates(false, dependenciesRef.current)
       .then((status) => {
         if (!cancelled && status.kind === "update_available") {
           setUpdateAvailable(status.latestVersion)

--- a/tests/bootstrap.test.ts
+++ b/tests/bootstrap.test.ts
@@ -50,4 +50,47 @@ describe("bootstrap", () => {
     exitSpy.mockRestore()
     stderrSpy.mockRestore()
   })
+
+  it("clears ambient proxy variables when --noproxy is used", async () => {
+    const proxyKeys = [
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "NO_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "no_proxy",
+    ] as const
+    const original = new Map(proxyKeys.map((key) => [key, process.env[key]]))
+    process.env.HTTP_PROXY = "http://proxy.test:8080"
+    const exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called")
+    }) as never)
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(
+      () => true,
+    )
+
+    try {
+      try {
+        await bootstrapInvalidPath({ noProxy: true })
+      } catch (error) {
+        expect((error as Error).message).toBe("process.exit called")
+      }
+      for (const key of proxyKeys) expect(process.env[key]).toBeUndefined()
+    } finally {
+      for (const [key, value] of original) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      exitSpy.mockRestore()
+      stderrSpy.mockRestore()
+    }
+  })
+
+  async function bootstrapInvalidPath(options: { noProxy: boolean }) {
+    const { bootstrap } = await import("../src/app/main")
+    return bootstrap({
+      collectionDir: join(tempDir(), "missing"),
+      ...options,
+    })
+  }
 })

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -522,6 +522,21 @@ describe("filestore.loadSettings", () => {
     const result = await loadSettings(dir)
     expect(result).toEqual({ environment: "dev" })
   })
+
+  it("reads a collection proxy override", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "proxy:\n  mode: custom\n  url: http://$PROXY@proxy.test:8080\n  bypass:\n    - localhost\n",
+      "utf8",
+    )
+    expect(await loadSettings(dir)).toEqual({
+      proxy: {
+        mode: "custom",
+        url: "http://$PROXY@proxy.test:8080",
+        bypass: ["localhost"],
+      },
+    })
+  })
 })
 
 describe("filestore.saveSettings", () => {
@@ -535,6 +550,13 @@ describe("filestore.saveSettings", () => {
     await saveSettings(dir, { environment: "staging" })
     const result = await loadSettings(dir)
     expect(result).toEqual({ environment: "staging" })
+  })
+
+  it("round-trips a collection proxy override", async () => {
+    await saveSettings(dir, {
+      proxy: { mode: "off" },
+    })
+    expect(await loadSettings(dir)).toEqual({ proxy: { mode: "off" } })
   })
 
   it("writes minimal file when environment is undefined", async () => {

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -292,6 +292,46 @@ describe("automation services", () => {
     }
   })
 
+  it("passes collection proxy policy and --noproxy to the executor", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "proxy:\n  mode: custom\n  url: http://proxy.test:8080\n",
+    )
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\n",
+    )
+    const send = executor.send
+    const policies: unknown[] = []
+    executor.send = async (...args) => {
+      policies.push(args[6])
+      return { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 1 }
+    }
+    try {
+      await collectionRun(dir, undefined, undefined, false, {
+        http: "http://system.test:8080",
+        https: "http://system.test:8080",
+        bypass: [],
+      })
+      await collectionRun(dir, undefined, undefined, true, {
+        http: "http://system.test:8080",
+        https: "http://system.test:8080",
+        bypass: [],
+      })
+      expect(policies).toEqual([
+        {
+          kind: "custom",
+          source: "collection",
+          url: "http://proxy.test:8080",
+          bypass: [],
+        },
+        { kind: "direct", source: "cli" },
+      ])
+    } finally {
+      executor.send = send
+    }
+  })
+
   it("does not audit nested settings files as collection settings", async () => {
     await mkdir(join(dir, "folder"))
     await writeFile(join(dir, "settings.yml"), "{}\n")

--- a/tests/unit/ProxySettingsOverlay.test.tsx
+++ b/tests/unit/ProxySettingsOverlay.test.tsx
@@ -53,6 +53,21 @@ describe("ProxySettingsOverlay", () => {
     cleanup()
   })
 
+  it("hides collection scope when it is not editable", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsOverlay visible collectionAvailable={false} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).not.toContain("Current collection")
+    cleanup()
+  })
+
   it("starts with the app system policy and cycles focus", async () => {
     const { keymap, cleanup } = setupKeymap()
     const ref = createRef<ProxySettingsOverlayHandle>()

--- a/tests/unit/ProxySettingsOverlay.test.tsx
+++ b/tests/unit/ProxySettingsOverlay.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test"
+import { act, createRef } from "react"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import {
+  registerDefaultKeys,
+  registerEnabledFields,
+} from "@opentui/keymap/addons"
+import { KeymapProvider } from "@opentui/keymap/react"
+import type { KeymapProviderProps } from "@opentui/keymap/react"
+import { createTestRender } from "../testRender"
+import { ThemeProvider } from "../../src/ui/theme"
+import {
+  ProxySettingsOverlay,
+  type ProxySettingsOverlayHandle,
+  type ProxySettingsValues,
+} from "../../src/ui/overlays/ProxySettingsOverlay"
+
+const testRender = createTestRender()
+
+function setupKeymap() {
+  const { keymap, cleanup: hostCleanup } = createTestKeymap()
+  const disposeEnabled = registerEnabledFields(keymap)
+  const disposeKeys = registerDefaultKeys(keymap)
+  return {
+    keymap: keymap as unknown as KeymapProviderProps["keymap"],
+    cleanup: () => {
+      disposeEnabled()
+      disposeKeys()
+      hostCleanup()
+    },
+  }
+}
+
+describe("ProxySettingsOverlay", () => {
+  it("renders app and collection scope controls", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsOverlay visible collectionAvailable />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Proxy Settings")
+    expect(frame).toContain("Scope")
+    expect(frame).toContain("App-wide default")
+    expect(frame).toContain("Mode")
+    expect(frame).toContain("Use system proxy")
+    cleanup()
+  })
+
+  it("starts with the app system policy and cycles focus", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ProxySettingsOverlayHandle>()
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsOverlay visible collectionAvailable ref={ref} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    const values: Array<ProxySettingsValues | null> = []
+    await act(async () => {
+      values.push(ref.current?.confirm() ?? null)
+    })
+    expect(values[0]).toEqual({
+      scope: "app",
+      mode: "system",
+      url: "",
+      bypass: [],
+    })
+    expect(ref.current?.getFocus()).toBe("scope")
+    await act(async () => ref.current?.cycleFocus(1))
+    expect(ref.current?.getFocus()).toBe("mode")
+    cleanup()
+  })
+})

--- a/tests/unit/ProxySettingsOverlay.test.tsx
+++ b/tests/unit/ProxySettingsOverlay.test.tsx
@@ -18,11 +18,12 @@ import {
 const testRender = createTestRender()
 
 function setupKeymap() {
-  const { keymap, cleanup: hostCleanup } = createTestKeymap()
+  const { keymap, host, cleanup: hostCleanup } = createTestKeymap()
   const disposeEnabled = registerEnabledFields(keymap)
   const disposeKeys = registerDefaultKeys(keymap)
   return {
     keymap: keymap as unknown as KeymapProviderProps["keymap"],
+    host,
     cleanup: () => {
       disposeEnabled()
       disposeKeys()
@@ -77,6 +78,99 @@ describe("ProxySettingsOverlay", () => {
     expect(ref.current?.getFocus()).toBe("scope")
     await act(async () => ref.current?.cycleFocus(1))
     expect(ref.current?.getFocus()).toBe("mode")
+    cleanup()
+  })
+
+  it("opens canonical custom proxies in Fields mode and saves the same URL", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ProxySettingsOverlayHandle>()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsOverlay
+            visible
+            collectionAvailable
+            ref={ref}
+            appProxy={{
+              mode: "custom",
+              url: "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
+              bypass: ["localhost"],
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 36 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("Fields")
+    expect(frame).toContain("Protocol")
+    expect(frame).toContain("Hostname")
+    expect(frame).toContain("Port")
+    expect(frame).toContain("Proxy authentication")
+    expect(frame).toContain("Username variable")
+    expect(frame).toContain("Password variable")
+    let saved: ProxySettingsValues | null | undefined
+    await act(async () => {
+      saved = ref.current?.confirm()
+    })
+    expect(saved).toEqual({
+      scope: "app",
+      mode: "custom",
+      url: "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
+      bypass: ["localhost"],
+    })
+
+    const focusOrder = [
+      "scope",
+      "mode",
+      "editor",
+      "protocol",
+      "hostname",
+      "port",
+      "auth",
+      "username",
+      "password",
+      "bypass",
+    ] as const
+    for (const expected of focusOrder.slice(1)) {
+      await act(async () => ref.current?.cycleFocus(1))
+      expect(ref.current?.getFocus()).toBe(expected)
+    }
+    cleanup()
+  })
+
+  it("opens non-lossless URLs in Advanced URL mode", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<ProxySettingsOverlayHandle>()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsOverlay
+            visible
+            collectionAvailable
+            ref={ref}
+            appProxy={{ mode: "custom", url: "http://proxy.test/path" }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 36 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Advanced URL")
+    expect(captureCharFrame()).toContain("Proxy URL")
+    let saved: ProxySettingsValues | null | undefined
+    await act(async () => {
+      saved = ref.current?.confirm()
+    })
+    expect(saved).toEqual({
+      scope: "app",
+      mode: "custom",
+      url: "http://proxy.test/path",
+      bypass: [],
+    })
+
+    expect(captureCharFrame()).not.toContain("Hostname")
     cleanup()
   })
 })

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -51,6 +51,7 @@ function minimalContext(): CommandBuilderContext {
     setNewRequestVisible: () => {},
     setImportCurlVisible: () => {},
     setNewFolderVisible: () => {},
+    setProxySettingsVisible: () => {},
     setCloneRequestVisible: () => {},
     setEditRequestVisible: () => {},
     setRequestDeletePending: () => {},

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import {
   buildStructuredProxyTemplate,
+  createProxyFetcher,
   parseAppProxy,
   parseCollectionProxy,
   parseStructuredProxyTemplate,
@@ -73,6 +74,22 @@ describe("proxy policy", () => {
       bypass: ["localhost"],
     })
     expect(env).toEqual({})
+  })
+
+  it("applies captured proxy settings to fetches explicitly", async () => {
+    let init: RequestInit | undefined
+    const fetcher = createProxyFetcher(
+      resolveProxyPolicy({ systemProxy: system }),
+      undefined,
+      async (_input, options) => {
+        init = options
+        return new Response()
+      },
+    )
+
+    await fetcher("https://example.com")
+
+    expect((init as BunFetchRequestInit).proxy).toBe("http://system-https:8080")
   })
 
   it("bypasses wildcard, domain, port, and IPv6 entries", () => {
@@ -211,6 +228,17 @@ describe("proxy validation", () => {
         vars: { PROXY_USER: "alice", PROXY_PASSWORD: "secret" },
       }),
     ).toBe("http://alice:secret@proxy.test:8080")
+  })
+
+  it("validates and resolves a variable proxy port", () => {
+    const template = "http://proxy.test:$PROXY_PORT"
+    expect(validateProxyTemplate(template)).toBeNull()
+    expect(
+      resolveProxyUrl(template, {
+        name: "dev",
+        vars: { PROXY_PORT: "8080" },
+      }),
+    ).toBe("http://proxy.test:8080")
   })
 
   it("fails clearly for an unresolved proxy variable", () => {

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test"
+import {
+  parseAppProxy,
+  parseCollectionProxy,
+  proxyForUrl,
+  redactProxyUrl,
+  resolveProxyPolicy,
+  resolveProxyUrl,
+  systemProxyFromEnv,
+  takeSystemProxyFromEnv,
+  validateProxyTemplate,
+} from "../../src/proxy"
+
+describe("proxy policy", () => {
+  const system = systemProxyFromEnv({
+    HTTP_PROXY: "http://system-http:8080",
+    HTTPS_PROXY: "http://system-https:8080",
+    NO_PROXY: "localhost, .internal.test",
+  })
+
+  it("prefers --noproxy over collection, app, and system settings", () => {
+    const policy = resolveProxyPolicy({
+      noProxy: true,
+      appProxy: { mode: "custom", url: "http://app:8080" },
+      collectionProxy: { mode: "custom", url: "http://collection:8080" },
+      systemProxy: system,
+    })
+
+    expect(proxyForUrl(policy, "https://example.com")).toEqual({
+      kind: "direct",
+      reason: "cli",
+    })
+  })
+
+  it("uses a collection custom proxy ahead of app and system settings", () => {
+    const policy = resolveProxyPolicy({
+      appProxy: { mode: "custom", url: "http://app:8080" },
+      collectionProxy: { mode: "custom", url: "http://collection:8080" },
+      systemProxy: system,
+    })
+
+    expect(proxyForUrl(policy, "https://example.com")).toEqual({
+      kind: "proxy",
+      source: "collection",
+      url: "http://collection:8080",
+    })
+  })
+
+  it("falls back to system HTTP and HTTPS proxies", () => {
+    const policy = resolveProxyPolicy({ systemProxy: system })
+
+    expect(proxyForUrl(policy, "http://example.com")).toMatchObject({
+      kind: "proxy",
+      url: "http://system-http:8080",
+    })
+    expect(proxyForUrl(policy, "https://example.com")).toMatchObject({
+      kind: "proxy",
+      url: "http://system-https:8080",
+    })
+  })
+
+  it("captures then clears ambient proxy variables for explicit routing", () => {
+    const env: Record<string, string | undefined> = {
+      HTTP_PROXY: "http://system-http:8080",
+      HTTPS_PROXY: "http://system-https:8080",
+      NO_PROXY: "localhost",
+    }
+    expect(takeSystemProxyFromEnv(env)).toEqual({
+      http: "http://system-http:8080",
+      https: "http://system-https:8080",
+      bypass: ["localhost"],
+    })
+    expect(env).toEqual({})
+  })
+
+  it("bypasses wildcard, domain, port, and IPv6 entries", () => {
+    const policy = resolveProxyPolicy({
+      appProxy: {
+        mode: "custom",
+        url: "http://proxy:8080",
+        bypass: [".internal.test", "api.example.com:8443", "[::1]"],
+      },
+      systemProxy: system,
+    })
+
+    expect(proxyForUrl(policy, "https://service.internal.test/path")).toEqual({
+      kind: "direct",
+      reason: "bypass",
+    })
+    expect(proxyForUrl(policy, "https://api.example.com:8443")).toEqual({
+      kind: "direct",
+      reason: "bypass",
+    })
+    expect(proxyForUrl(policy, "https://api.example.com:443")).toMatchObject({
+      kind: "proxy",
+    })
+    expect(proxyForUrl(policy, "http://[::1]/")).toEqual({
+      kind: "direct",
+      reason: "bypass",
+    })
+  })
+})
+
+describe("proxy validation", () => {
+  it("resolves credentials from the active environment", () => {
+    expect(
+      resolveProxyUrl("http://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8080", {
+        name: "dev",
+        vars: { PROXY_USER: "alice", PROXY_PASSWORD: "secret" },
+      }),
+    ).toBe("http://alice:secret@proxy.test:8080")
+  })
+
+  it("fails clearly for an unresolved proxy variable", () => {
+    expect(() =>
+      resolveProxyUrl("http://$PROXY@proxy.test", { name: "dev", vars: {} }),
+    ).toThrow('proxy: unresolved variable "PROXY" in proxy.url')
+  })
+
+  it("rejects literal stored credentials and invalid protocols", () => {
+    expect(validateProxyTemplate("http://alice:secret@proxy.test")).toBe(
+      "Use $VARNAME for proxy credentials",
+    )
+    expect(validateProxyTemplate("socks5://proxy.test")).toBe(
+      "Proxy URL must use http or https",
+    )
+    expect(
+      parseAppProxy({ mode: "custom", url: "http://alice@proxy.test" }),
+    ).toBeUndefined()
+    expect(
+      parseCollectionProxy({ mode: "custom", url: "socks5://proxy.test" }),
+    ).toBeUndefined()
+  })
+
+  it("redacts credentials before presentation", () => {
+    expect(redactProxyUrl("http://alice:secret@proxy.test:8080")).toBe(
+      "http://***:***@proxy.test:8080/",
+    )
+  })
+})

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test"
 import {
+  buildStructuredProxyTemplate,
   parseAppProxy,
   parseCollectionProxy,
+  parseStructuredProxyTemplate,
   proxyForUrl,
   redactProxyUrl,
   resolveProxyPolicy,
@@ -102,6 +104,106 @@ describe("proxy policy", () => {
 })
 
 describe("proxy validation", () => {
+  it("builds a structured proxy URL with variable credentials", () => {
+    expect(
+      buildStructuredProxyTemplate({
+        protocol: "https",
+        hostname: "proxy.test",
+        port: "8443",
+        auth: true,
+        username: "$PROXY_USER",
+        password: "$PROXY_PASSWORD",
+      }),
+    ).toEqual({
+      url: "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
+    })
+  })
+
+  it("parses HTTP, HTTPS, omitted ports, and IPv4 hosts losslessly", () => {
+    expect(parseStructuredProxyTemplate("http://192.168.1.20")).toEqual({
+      protocol: "http",
+      hostname: "192.168.1.20",
+      port: "",
+      auth: false,
+      username: "",
+      password: "",
+    })
+    expect(
+      parseStructuredProxyTemplate(
+        "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
+      ),
+    ).toEqual({
+      protocol: "https",
+      hostname: "proxy.test",
+      port: "8443",
+      auth: true,
+      username: "$PROXY_USER",
+      password: "$PROXY_PASSWORD",
+    })
+  })
+
+  it("builds IPv6 proxy URLs and parses them back losslessly", () => {
+    const fields = {
+      protocol: "http" as const,
+      hostname: "::1",
+      port: "",
+      auth: false,
+      username: "",
+      password: "",
+    }
+    expect(buildStructuredProxyTemplate(fields)).toEqual({
+      url: "http://[::1]",
+    })
+    expect(parseStructuredProxyTemplate("http://[::1]")).toEqual(fields)
+  })
+
+  it("keeps variable-heavy and non-proxy URL forms in advanced mode", () => {
+    expect(parseStructuredProxyTemplate("http://proxy.test/path")).toBeNull()
+    expect(parseStructuredProxyTemplate("http://$PROXY@proxy.test")).toBeNull()
+    expect(
+      parseStructuredProxyTemplate("http://proxy.test?debug=true"),
+    ).toBeNull()
+  })
+
+  it("rejects invalid structured fields", () => {
+    const fields = {
+      protocol: "http" as const,
+      hostname: "",
+      port: "not-a-port",
+      auth: true,
+      username: "literal-user",
+      password: "",
+    }
+    expect(buildStructuredProxyTemplate(fields)).toEqual({
+      error: "Proxy hostname is required",
+    })
+    expect(
+      buildStructuredProxyTemplate({ ...fields, hostname: "proxy.test" }),
+    ).toEqual({ error: "Proxy port must be between 1 and 65535" })
+    expect(
+      buildStructuredProxyTemplate({
+        ...fields,
+        hostname: "proxy.test",
+        port: "65536",
+      }),
+    ).toEqual({ error: "Proxy port must be between 1 and 65535" })
+    expect(
+      buildStructuredProxyTemplate({
+        ...fields,
+        hostname: "proxy.test",
+        port: "8080",
+      }),
+    ).toEqual({ error: "Username must be a $VARNAME reference" })
+    expect(
+      buildStructuredProxyTemplate({
+        ...fields,
+        hostname: "proxy.test",
+        port: "8080",
+        username: "$PROXY_USER",
+      }),
+    ).toEqual({ error: "Password must be a $VARNAME reference" })
+  })
+
   it("resolves credentials from the active environment", () => {
     expect(
       resolveProxyUrl("http://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8080", {

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import {
   buildStructuredProxyTemplate,
   createProxyFetcher,
+  environmentForProxyPolicy,
   parseAppProxy,
   parseCollectionProxy,
   parseStructuredProxyTemplate,
@@ -90,6 +91,42 @@ describe("proxy policy", () => {
     await fetcher("https://example.com")
 
     expect((init as BunFetchRequestInit).proxy).toBe("http://system-https:8080")
+  })
+
+  it("removes a caller proxy from direct fetches", async () => {
+    let init: RequestInit | undefined
+    const fetcher = createProxyFetcher(
+      resolveProxyPolicy({ noProxy: true, systemProxy: system }),
+      undefined,
+      async (_input, options) => {
+        init = options
+        return new Response()
+      },
+    )
+
+    await fetcher("https://example.com", {
+      proxy: "http://caller-proxy:8080",
+    } as BunFetchRequestInit)
+
+    expect("proxy" in (init as BunFetchRequestInit)).toBe(false)
+  })
+
+  it("restores resolved proxy settings for subprocesses", () => {
+    const env = environmentForProxyPolicy(
+      resolveProxyPolicy({ systemProxy: system }),
+      undefined,
+      { PATH: "/usr/bin", HTTPS_PROXY: "http://ambient:8080" },
+    )
+
+    expect(env).toEqual({
+      PATH: "/usr/bin",
+      HTTP_PROXY: "http://system-http:8080",
+      http_proxy: "http://system-http:8080",
+      HTTPS_PROXY: "http://system-https:8080",
+      https_proxy: "http://system-https:8080",
+      NO_PROXY: "localhost,.internal.test",
+      no_proxy: "localhost,.internal.test",
+    })
   })
 
   it("bypasses wildcard, domain, port, and IPv6 entries", () => {

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -137,6 +137,86 @@ describe("send — param deduplication", () => {
 })
 
 describe("send — network trace", () => {
+  it("passes the resolved proxy to fetch and reports the selected route", async () => {
+    const originalFetch = globalThis.fetch
+    let proxy: string | undefined
+    globalThis.fetch = mock(async (_url, init) => {
+      const selected = (init as BunFetchRequestInit).proxy
+      proxy = typeof selected === "string" ? selected : selected?.url
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(
+        makeReq(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          kind: "custom",
+          source: "global",
+          url: "http://proxy.test:8080",
+          bypass: [],
+        },
+      )
+      expect(proxy).toBe("http://proxy.test:8080")
+      expect(response.network?.map((event) => event.type)).toEqual([
+        "proxy",
+        "request",
+        "response",
+        "body",
+        "complete",
+      ])
+      expect(response.network?.[0]?.message).toBe("Proxy: global")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("re-evaluates bypass rules for every redirect hop", async () => {
+    const originalFetch = globalThis.fetch
+    const proxies: Array<string | undefined> = []
+    let calls = 0
+    globalThis.fetch = mock(async (_url, init) => {
+      const selected = (init as BunFetchRequestInit).proxy
+      proxies.push(typeof selected === "string" ? selected : selected?.url)
+      calls++
+      return calls === 1
+        ? new Response(null, {
+            status: 302,
+            headers: { location: "https://internal.test/next" },
+          })
+        : new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(
+        makeReq({ url: "https://public.test/start" }),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          kind: "custom",
+          source: "global",
+          url: "http://proxy.test:8080",
+          bypass: ["internal.test"],
+        },
+      )
+      expect(proxies).toEqual(["http://proxy.test:8080", undefined])
+      expect(
+        response.network
+          ?.filter((event) => event.type === "proxy")
+          .map((event) => event.message),
+      ).toEqual(["Proxy: global", "Proxy: bypassed"])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it("records request, response, body, and completion", async () => {
     const originalFetch = globalThis.fetch
     globalThis.fetch = mock(

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -746,15 +746,18 @@ describe("checkForUpdates", () => {
     let receivedArgs: string[] | undefined
     let captured: boolean | undefined
     let signal: AbortSignal | undefined
+    let receivedEnv: Record<string, string | undefined> | undefined
+    const env = { HTTPS_PROXY: "http://proxy.test:8080" }
     const status = await checkForUpdates(false, {
       execPath: "/opt/homebrew/bin/noodle",
       platform: "darwin",
       arch: "arm64",
-      env: {},
+      env,
       runProcess: async (args, capture, options) => {
         receivedArgs = args
         captured = capture
         signal = options?.signal
+        receivedEnv = options?.env
         return {
           exitCode: 0,
           stdout: JSON.stringify({
@@ -771,6 +774,7 @@ describe("checkForUpdates", () => {
     expect(receivedArgs).toEqual(["brew", "info", "--json=v2", "noodle"])
     expect(captured).toBe(true)
     expect(signal).toBeInstanceOf(AbortSignal)
+    expect(receivedEnv).toBe(env)
   })
 
   it("returns update_available for brew when outdated finds newer", async () => {
@@ -1156,13 +1160,16 @@ describe("installBinaryUpdate", () => {
 describe("installBrewUpdate", () => {
   it("runs brew upgrade and returns success", async () => {
     let receivedArgs: string[] | undefined
+    let receivedEnv: Record<string, string | undefined> | undefined
+    const env = { HTTPS_PROXY: "http://proxy.test:8080" }
     const result = await installBrewUpdate({
       execPath: "/opt/homebrew/bin/noodle",
       platform: "darwin",
       arch: "arm64",
-      env: {},
-      runProcess: async (args, capture) => {
+      env,
+      runProcess: async (args, capture, options) => {
         receivedArgs = args
+        receivedEnv = options?.env
         void capture
         return { exitCode: 0 }
       },
@@ -1171,6 +1178,7 @@ describe("installBrewUpdate", () => {
       data: { status: "homebrew_updated", command: "brew upgrade noodle" },
     })
     expect(receivedArgs).toEqual(["brew", "upgrade", "noodle"])
+    expect(receivedEnv).toBe(env)
   })
 
   it("reports brew upgrade failure", async () => {

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -114,6 +114,19 @@ describe("loadConfig", () => {
     const result = loadConfig(dir)
     expect(result.collections).toHaveLength(1)
   })
+
+  it("reads a custom app proxy", () => {
+    writeFileSync(
+      join(dir, CONFIG_FILE_NAME),
+      "proxy:\n  mode: custom\n  url: http://$PROXY@proxy.test:8080\n  bypass:\n    - localhost\n",
+      "utf8",
+    )
+    expect(loadConfig(dir).proxy).toEqual({
+      mode: "custom",
+      url: "http://$PROXY@proxy.test:8080",
+      bypass: ["localhost"],
+    })
+  })
 })
 
 describe("appendCollectionPath", () => {
@@ -168,6 +181,15 @@ describe("saveConfig", () => {
     saveConfig(dir, input)
     const result = loadConfig(dir)
     expect(result).toEqual(input)
+  })
+
+  it("round-trips app proxy settings", () => {
+    const input: NoodleConfig = {
+      ...DEFAULTS,
+      proxy: { mode: "off" },
+    }
+    saveConfig(dir, input)
+    expect(loadConfig(dir)).toEqual(input)
   })
 
   it("writes and reads back null lastEnv", () => {


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement

### What does this PR do?

- Preserve request/response fold state through layout and expand changes (request/response panes are now hidden via `visible` instead of unmounted, so fold state and editor instances survive layout changes)
- Add mouse support for completion popups (variable, path, and code editor completions can be clicked to select)
- Simplify toast messages to static text instead of leaking raw error/path details
- Simplify the Postman target availability check in collection export
- Add unit tests covering the new behavior

### How did you verify your code works?

- `bun test` passes (2235 tests, 0 fail)
- `bun run lint` passes
- `bun run typecheck` passes
- New unit tests cover fold persistence, mouse-based completion selection, and Postman target error handling

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable proxy routing at application and collection levels.
  - Supports system, custom, inherited, disabled, and bypassed connections.
  - Added proxy settings with structured or advanced URL configuration, authentication variables, bypass patterns, and validation.
  - Added `--noproxy` for direct connections.
  - Network traces now show proxy activity and routing decisions, including redirects.

- **Documentation**
  - Added guidance for proxy configuration and command-line usage.

- **Bug Fixes**
  - Proxy credentials are redacted from displayed network errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->