### PR TITLE
feat(settings): collection metadata, timeline retention, and settings UX polish

### DIFF
--- a/.agents/skills/noodle-dev/architecture.md
+++ b/.agents/skills/noodle-dev/architecture.md
@@ -83,6 +83,9 @@ Folder overrides are resolved in `requests/mergeFolderOverrides.ts` — walks an
 Collection-level settings at the root, loaded by `filestore/loadSettings()`:
 
 ```yaml
+name: Payments API # Optional display name
+description: Requests for the payments platform. # Optional notes
+timeline_max_entries: 50 # Per-request history retention; 0 disables
 environment: development # Last active environment name
 ```
 
@@ -99,7 +102,7 @@ display and completion.
 
 ### Timeline (`.timeline/`)
 
-Per-request response history stored as YAML arrays of `TimelineEntry` objects. Max 50 entries per request (FIFO — `unshift` + truncate). Files mirror the request ID structure: `.timeline/auth/login.yml` for request `auth/login`. Bodies over 10 KB are gzip-compressed into a sibling `.yml.bodies/` directory; the entry stores a `bodyRef` with its filename, encoding, and byte size. Eviction and timeline clearing remove associated sidecars. Entries contain substituted request data, so timeline files and sidecars can contain resolved secrets. The detail view masks configured bearer, basic, and header API-key auth for display, but does not redact storage.
+Per-request response history stored as YAML arrays of `TimelineEntry` objects. Retention defaults to 50 entries per request and is configurable through `timeline_max_entries` (FIFO — `unshift` + truncate); `0` disables history. Files mirror the request ID structure: `.timeline/auth/login.yml` for request `auth/login`. Bodies over 10 KB are gzip-compressed into a sibling `.yml.bodies/` directory; the entry stores a `bodyRef` with its filename, encoding, and byte size. Eviction and timeline clearing remove associated sidecars. Entries contain substituted request data, so timeline files and sidecars can contain resolved secrets. The detail view masks configured bearer, basic, and header API-key auth for display, but does not redact storage.
 
 ### File write conventions
 

--- a/.agents/skills/noodle-use/SKILL.md
+++ b/.agents/skills/noodle-use/SKILL.md
@@ -59,7 +59,9 @@ auth:
 `meta` is optional. `meta.seq` controls sort order (lower = first, undefined = last). `meta.name` overrides display name (defaults to directory name).
 
 ### Collection settings
-`settings.yml` at collection root: `environment: <name>` sets the default active environment. Single field only.
+`settings.yml` at collection root supports optional `name`, multiline
+`description`, `timeline_max_entries`, `environment`, and `proxy` fields.
+Timeline retention defaults to 50 responses per request; `0` disables history.
 
 ### Path safety
 When creating/deleting files, only operate within the collection directory. Never create files outside the collection root. IDs must not contain `..`, leading `/`, backslashes, empty path segments, or hidden path segments.

--- a/.agents/skills/noodle-use/schema.md
+++ b/.agents/skills/noodle-use/schema.md
@@ -186,9 +186,17 @@ api_key=sk-abc123
 
 Single file at collection root:
 ```yaml
+name: Payments API
+description: |-
+  Requests for the payments platform.
+timeline_max_entries: 50
 environment: development
 ```
-Sets the default active environment name. Must match an env file in `.environments/`.
+
+- `name`: optional display name; falls back to the collection directory name
+- `description`: optional multiline collection notes
+- `timeline_max_entries`: optional non-negative integer; defaults to 50, and `0` disables history
+- `environment`: default active environment name; must match an env file in `.environments/`
 
 ## Variable substitution rules
 
@@ -200,7 +208,7 @@ Sets the default active environment name. Must match an env file in `.environmen
 
 ## Timeline file (`.timeline/<request-id>.yml`)
 
-Response history for each request. Stored in `<collection>/.timeline/`, one file per request. Max 50 entries, newest first (prepended on save). Bodies larger than 10 KB are stored without truncation as gzip sidecars in `<request-id>.yml.bodies/`; their YAML field is replaced by a `bodyRef`. Treat timeline YAML and sidecars as generated, sensitive data. YAML array:
+Response history for each request. Stored in `<collection>/.timeline/`, one file per request. Retention is controlled by `settings.yml` and defaults to 50 entries, newest first (prepended on save). Bodies larger than 10 KB are stored without truncation as gzip sidecars in `<request-id>.yml.bodies/`; their YAML field is replaced by a `bodyRef`. Treat timeline YAML and sidecars as generated, sensitive data. YAML array:
 
 ```yaml
 - timestamp: 1783374564216

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ drafts
 AWS API Gateway.yaml
 api-docs.json
 openapi.yml
+.codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,3 +334,16 @@ Active pane gets cyan border + `▸` prefix. Global keys work regardless of focu
 - `bun test` runs all tests. No external services needed.
 - Pure helpers in `tests/unit/`, integration tests in `tests/integration/`.
 - Tests use real filesystem I/O for filestore, lang, and env modules (write to temp dirs with `mkdtemp`).
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # <img src="assets/logo.png" data-canonical-src="/logo.png" width="32" height="32" /> noodle
 
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
+
 ## Readable requests. Versioned workflows. No lock-in.
 
 Noodle is a terminal HTTP client that keeps requests as readable YAML files in
@@ -124,6 +126,18 @@ are rejected. Bypass entries are comma-separated and support `*`, hosts,
 
 Use `--noproxy` with the TUI, `collection run`, or `request run` to force
 direct connections for that invocation.
+
+Collection metadata and response-history retention also live in
+`settings.yml`. `timeline_max_entries` defaults to 50 per request; lowering it
+prunes older entries, and `0` disables timeline recording.
+
+```yaml
+name: Payments API
+description: |-
+  Requests for the payments platform.
+timeline_max_entries: 50
+environment: development
+```
 
 ### Bring in and run existing work
 

--- a/collections/settings.yml
+++ b/collections/settings.yml
@@ -1,3 +1,5 @@
+name: Noodle Collection
+description: This is a sample collection designed to help Noodle developers.
 environment: development
 proxy:
   mode: inherit

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -32,6 +32,7 @@ import {
 import type {
   Collection,
   CollectionItem,
+  CollectionSettings,
   Environment,
   Request,
 } from "../schema"
@@ -98,7 +99,7 @@ export interface CollectionInspectResult {
   requestCount: number
   folderCount: number
   environments: string[]
-  settings: { environment?: string }
+  settings: CollectionSettings
   tree: CollectionTreeItem[]
 }
 export function collectionTree(items: CollectionItem[]): CollectionTreeItem[] {
@@ -367,24 +368,48 @@ async function auditFile(
   try {
     if (name === "settings.yml") {
       const raw = yaml.load(content)
-      const settings = raw as { environment?: unknown; proxy?: unknown }
+      const settings = raw as {
+        name?: unknown
+        description?: unknown
+        timeline_max_entries?: unknown
+        environment?: unknown
+        proxy?: unknown
+      }
       const proxy = parseCollectionProxy(settings?.proxy)
       if (
         !raw ||
         typeof raw !== "object" ||
         Array.isArray(raw) ||
         Object.keys(raw as object).some(
-          (key) => key !== "environment" && key !== "proxy",
+          (key) =>
+            ![
+              "name",
+              "description",
+              "timeline_max_entries",
+              "environment",
+              "proxy",
+            ].includes(key),
         ) ||
+        (settings.name !== undefined && typeof settings.name !== "string") ||
+        (settings.description !== undefined &&
+          typeof settings.description !== "string") ||
+        (settings.timeline_max_entries !== undefined &&
+          (typeof settings.timeline_max_entries !== "number" ||
+            !Number.isSafeInteger(settings.timeline_max_entries) ||
+            settings.timeline_max_entries < 0)) ||
         (settings.environment !== undefined &&
           typeof settings.environment !== "string") ||
         (settings.proxy !== undefined && proxy === undefined)
       )
         throw new Error(
-          "expected settings mapping with optional string environment and valid proxy",
+          "expected settings mapping with optional string metadata, non-negative integer timeline_max_entries, string environment, and valid proxy",
         )
       if (fix) {
         await saveSettings(root, {
+          name: settings.name as string | undefined,
+          description: settings.description as string | undefined,
+          timelineMaxEntries: settings.timeline_max_entries as
+            number | undefined,
           environment: settings.environment as string | undefined,
           proxy,
         })

--- a/src/filestore/index.ts
+++ b/src/filestore/index.ts
@@ -20,6 +20,8 @@ import {
   exportTimelineEntry,
   getDownloadsDir,
   saveTimelineEntry,
+  pruneTimeline,
+  DEFAULT_TIMELINE_MAX_ENTRIES,
   clearTimelineForRequest,
   clearAllTimeline,
 } from "./timeline"
@@ -39,6 +41,8 @@ export {
   exportTimelineEntry,
   getDownloadsDir,
   saveTimelineEntry,
+  pruneTimeline,
+  DEFAULT_TIMELINE_MAX_ENTRIES,
   clearTimelineForRequest,
   clearAllTimeline,
 }

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -325,6 +325,19 @@ export async function loadSettings(dir: string): Promise<CollectionSettings> {
     if (!data || typeof data !== "object") return {}
     const obj = data as Record<string, unknown>
     const settings: CollectionSettings = {}
+    if (typeof obj.name === "string" && obj.name.trim()) {
+      settings.name = obj.name.trim()
+    }
+    if (typeof obj.description === "string" && obj.description.trim()) {
+      settings.description = obj.description.trim()
+    }
+    if (
+      typeof obj.timeline_max_entries === "number" &&
+      Number.isSafeInteger(obj.timeline_max_entries) &&
+      obj.timeline_max_entries >= 0
+    ) {
+      settings.timelineMaxEntries = obj.timeline_max_entries
+    }
     if (typeof obj.environment === "string") {
       settings.environment = obj.environment
     }

--- a/src/filestore/save.ts
+++ b/src/filestore/save.ts
@@ -104,6 +104,15 @@ export async function saveSettings(
   dir: string,
   settings: CollectionSettings,
 ): Promise<void> {
+  if (
+    settings.timelineMaxEntries !== undefined &&
+    (!Number.isSafeInteger(settings.timelineMaxEntries) ||
+      settings.timelineMaxEntries < 0)
+  ) {
+    throw new Error(
+      "filestore.saveSettings: timeline max entries must be a non-negative integer",
+    )
+  }
   try {
     await mkdir(dir, { recursive: true })
   } catch (e) {
@@ -112,6 +121,13 @@ export async function saveSettings(
   }
 
   const data: Record<string, unknown> = {}
+  const name = settings.name?.trim()
+  if (name) data.name = name
+  const description = settings.description?.trim()
+  if (description) data.description = description
+  if (settings.timelineMaxEntries !== undefined) {
+    data.timeline_max_entries = settings.timelineMaxEntries
+  }
   if (settings.environment !== undefined) {
     data.environment = settings.environment
   }

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -18,6 +18,23 @@ export const DEFAULT_TIMELINE_MAX_ENTRIES = 50
 const INLINE_BODY_LIMIT = 10_000
 const gzipAsync = promisify(gzip)
 const gunzipAsync = promisify(gunzip)
+const timelineLocks = new Map<string, Promise<void>>()
+
+function withTimelineLock<T>(
+  colDir: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = timelineLocks.get(colDir) ?? Promise.resolve()
+  const current = previous.then(operation)
+  const tail = current.then(
+    () => {},
+    () => {},
+  )
+  timelineLocks.set(colDir, tail)
+  return current.finally(() => {
+    if (timelineLocks.get(colDir) === tail) timelineLocks.delete(colDir)
+  })
+}
 
 export async function getDownloadsDir(): Promise<string> {
   if (process.env.NOODLE_DOWNLOADS_DIR) {
@@ -295,27 +312,31 @@ export async function saveTimelineEntry(
   entry: TimelineEntry,
   maxEntries = DEFAULT_TIMELINE_MAX_ENTRIES,
 ): Promise<TimelineEntry> {
-  const filePath = timelinePath(colDir, reqId)
-  await mkdir(dirname(filePath), { recursive: true })
-  const { entry: persisted, refs } = await persistBodies(colDir, reqId, entry)
-  const current = await readTimelineEntries(colDir, reqId)
-  const next = [persisted, ...current]
-  const evicted = next.splice(maxEntries)
+  return withTimelineLock(colDir, async () => {
+    const filePath = timelinePath(colDir, reqId)
+    await mkdir(dirname(filePath), { recursive: true })
+    const { entry: persisted, refs } = await persistBodies(colDir, reqId, entry)
+    const current = await readTimelineEntries(colDir, reqId)
+    const next = [persisted, ...current]
+    const evicted = next.splice(maxEntries)
 
-  try {
-    await writeFile(filePath, yaml.dump(next), "utf8")
-  } catch (e) {
-    await Promise.all(refs.map((ref) => removeBody(colDir, reqId, ref)))
-    throw new Error(
-      "filestore.saveTimelineEntry: failed to save timeline entry",
-      {
-        cause: e,
-      },
+    try {
+      await writeFile(filePath, yaml.dump(next), "utf8")
+    } catch (e) {
+      await Promise.all(refs.map((ref) => removeBody(colDir, reqId, ref)))
+      throw new Error(
+        "filestore.saveTimelineEntry: failed to save timeline entry",
+        {
+          cause: e,
+        },
+      )
+    }
+
+    await Promise.all(
+      evicted.map((old) => removeEntryBodies(colDir, reqId, old)),
     )
-  }
-
-  await Promise.all(evicted.map((old) => removeEntryBodies(colDir, reqId, old)))
-  return persisted
+    return persisted
+  })
 }
 
 async function collectTimelineFiles(dir: string): Promise<string[]> {
@@ -349,28 +370,34 @@ export async function pruneTimeline(
       "filestore.pruneTimeline: max entries must be a non-negative integer",
     )
   }
-  const dir = timelineDir(colDir)
-  try {
-    if (maxEntries === 0) {
-      await rm(dir, { recursive: true, force: true })
-      await mkdir(dir, { recursive: true })
-      return
+  return withTimelineLock(colDir, async () => {
+    const dir = timelineDir(colDir)
+    try {
+      if (maxEntries === 0) {
+        await rm(dir, { recursive: true, force: true })
+        await mkdir(dir, { recursive: true })
+        return
+      }
+      for (const filePath of await collectTimelineFiles(dir)) {
+        const reqId = relative(dir, filePath).slice(0, -".yml".length)
+        const current = await readTimelineEntries(colDir, reqId)
+        const evicted = current.slice(maxEntries)
+        if (evicted.length === 0) continue
+        await writeFile(
+          filePath,
+          yaml.dump(current.slice(0, maxEntries)),
+          "utf8",
+        )
+        await Promise.all(
+          evicted.map((entry) => removeEntryBodies(colDir, reqId, entry)),
+        )
+      }
+    } catch (e) {
+      throw new Error("filestore.pruneTimeline: failed to prune timeline", {
+        cause: e,
+      })
     }
-    for (const filePath of await collectTimelineFiles(dir)) {
-      const reqId = relative(dir, filePath).slice(0, -".yml".length)
-      const current = await readTimelineEntries(colDir, reqId)
-      const evicted = current.slice(maxEntries)
-      if (evicted.length === 0) continue
-      await writeFile(filePath, yaml.dump(current.slice(0, maxEntries)), "utf8")
-      await Promise.all(
-        evicted.map((entry) => removeEntryBodies(colDir, reqId, entry)),
-      )
-    }
-  } catch (e) {
-    throw new Error("filestore.pruneTimeline: failed to prune timeline", {
-      cause: e,
-    })
-  }
+  })
 }
 
 export async function clearTimelineForRequest(

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -2,12 +2,19 @@ import { homedir } from "node:os"
 import { randomUUID } from "node:crypto"
 import { gzip, gunzip } from "node:zlib"
 import { promisify } from "node:util"
-import { mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises"
-import { basename, dirname, join } from "node:path"
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises"
+import { basename, dirname, join, relative } from "node:path"
 import * as yaml from "js-yaml"
 import type { ParamEntry, TimelineBodyRef, TimelineEntry } from "../schema"
 
-const DEFAULT_MAX_ENTRIES = 50
+export const DEFAULT_TIMELINE_MAX_ENTRIES = 50
 const INLINE_BODY_LIMIT = 10_000
 const gzipAsync = promisify(gzip)
 const gunzipAsync = promisify(gunzip)
@@ -286,7 +293,7 @@ export async function saveTimelineEntry(
   colDir: string,
   reqId: string,
   entry: TimelineEntry,
-  maxEntries = DEFAULT_MAX_ENTRIES,
+  maxEntries = DEFAULT_TIMELINE_MAX_ENTRIES,
 ): Promise<TimelineEntry> {
   const filePath = timelinePath(colDir, reqId)
   await mkdir(dirname(filePath), { recursive: true })
@@ -309,6 +316,61 @@ export async function saveTimelineEntry(
 
   await Promise.all(evicted.map((old) => removeEntryBodies(colDir, reqId, old)))
   return persisted
+}
+
+async function collectTimelineFiles(dir: string): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw e
+  }
+  const nested = await Promise.all(
+    entries.map((entry) => {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory() && !entry.name.endsWith(".yml.bodies")) {
+        return collectTimelineFiles(path)
+      }
+      return Promise.resolve(
+        entry.isFile() && entry.name.endsWith(".yml") ? [path] : [],
+      )
+    }),
+  )
+  return nested.flat()
+}
+
+export async function pruneTimeline(
+  colDir: string,
+  maxEntries: number,
+): Promise<void> {
+  if (!Number.isSafeInteger(maxEntries) || maxEntries < 0) {
+    throw new Error(
+      "filestore.pruneTimeline: max entries must be a non-negative integer",
+    )
+  }
+  const dir = timelineDir(colDir)
+  try {
+    if (maxEntries === 0) {
+      await rm(dir, { recursive: true, force: true })
+      await mkdir(dir, { recursive: true })
+      return
+    }
+    for (const filePath of await collectTimelineFiles(dir)) {
+      const reqId = relative(dir, filePath).slice(0, -".yml".length)
+      const current = await readTimelineEntries(colDir, reqId)
+      const evicted = current.slice(maxEntries)
+      if (evicted.length === 0) continue
+      await writeFile(filePath, yaml.dump(current.slice(0, maxEntries)), "utf8")
+      await Promise.all(
+        evicted.map((entry) => removeEntryBodies(colDir, reqId, entry)),
+      )
+    }
+  } catch (e) {
+    throw new Error("filestore.pruneTimeline: failed to prune timeline", {
+      cause: e,
+    })
+  }
 }
 
 export async function clearTimelineForRequest(

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -148,6 +148,9 @@ export interface TimelineBodyRef {
 }
 
 export interface CollectionSettings {
+  name?: string
+  description?: string
+  timelineMaxEntries?: number
   environment?: string
   proxy?: CollectionProxySettings
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,7 +6,12 @@ import { listEnvironmentsWithColors } from "../env/listWithColors"
 import { ThemeProvider, THEMES, DEFAULT_THEME_INDEX } from "./theme"
 import { stat } from "node:fs/promises"
 import { Toast, showToast } from "./Toast"
-import { loadSettings, saveSettings } from "../filestore"
+import {
+  DEFAULT_TIMELINE_MAX_ENTRIES,
+  loadSettings,
+  pruneTimeline,
+  saveSettings,
+} from "../filestore"
 import { loadLastRequest } from "./tabs/uiState"
 import type { Keybinds } from "./keybind"
 import type { KeybindName } from "./keybind"
@@ -52,6 +57,7 @@ export function App({
   mode?: CollectionMode
 }) {
   const { config, updateConfig } = useConfig(CONFIG_DIR)
+  const collectionPaths = config.collections
   const [liveKeybinds, setLiveKeybinds] = useState(keybinds)
   const switchingRef = useRef(false)
   const initialCollectionDir = useMemo(
@@ -63,6 +69,8 @@ export function App({
   const [mode, setMode] = useState<CollectionMode>(initialMode)
   const [reloadKey, setReloadKey] = useState(0)
   const [settings, setSettings] = useState<CollectionSettings>(initialSettings)
+  const [registeredCollectionSettings, setRegisteredCollectionSettings] =
+    useState<Record<string, CollectionSettings>>({})
   const settingsRef = useRef(initialSettings)
   const persistedSettingsRef = useRef(initialSettings)
   const activeCollectionDirRef = useRef(initialCollectionDir)
@@ -115,6 +123,37 @@ export function App({
       }))
     }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all(
+      collectionPaths.map(async (path) => {
+        try {
+          return [path, await loadSettings(path)] as const
+        } catch {
+          return [path, {}] as const
+        }
+      }),
+    ).then((entries) => {
+      if (!cancelled)
+        setRegisteredCollectionSettings(Object.fromEntries(entries))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [collectionPaths])
+
+  useEffect(() => {
+    if (mode !== "collection") return
+    const limit = persistedSettingsRef.current.timelineMaxEntries
+    if (limit === undefined) return
+    pruneTimeline(activeCollectionDir, limit).catch(() =>
+      showToast(
+        "Timeline limit loaded, but existing history could not be pruned",
+        "error",
+      ),
+    )
+  }, [activeCollectionDir, mode])
 
   const updateGlobalConfig = useCallback(
     (patch: Parameters<typeof updateConfig>[0], errorMessage: string) => {
@@ -228,6 +267,45 @@ export function App({
         saveSettings,
         setSettings,
         () => showToast("Failed to save proxy settings", "error"),
+      )
+      return true
+    },
+    [activeCollectionDir, mode, settingsPersistence],
+  )
+
+  const handleCollectionSettingsChange = useCallback(
+    (
+      patch: Pick<
+        CollectionSettings,
+        "name" | "description" | "timelineMaxEntries"
+      >,
+    ) => {
+      if (mode !== "collection") return false
+      const previous = settingsRef.current
+      const nextSettings = { ...previous, ...patch }
+      const previousLimit =
+        previous.timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES
+      const nextLimit =
+        nextSettings.timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES
+      settingsRef.current = nextSettings
+      setSettings(nextSettings)
+      queueCollectionSettingsSave(
+        settingsPersistence,
+        activeCollectionDir,
+        nextSettings,
+        saveSettings,
+        setSettings,
+        () => showToast("Failed to save collection settings", "error"),
+        nextLimit < previousLimit
+          ? () => {
+              pruneTimeline(activeCollectionDir, nextLimit).catch(() =>
+                showToast(
+                  "Timeline limit saved, but existing history could not be pruned",
+                  "error",
+                ),
+              )
+            }
+          : undefined,
       )
       return true
     },
@@ -379,7 +457,13 @@ export function App({
     [activeCollectionDir, updateConfig],
   )
 
-  const collectionPaths = config.collections
+  const collectionSettingsByPath = useMemo(
+    () => ({
+      ...registeredCollectionSettings,
+      [activeCollectionDir]: settings,
+    }),
+    [activeCollectionDir, registeredCollectionSettings, settings],
+  )
 
   return (
     <ThemeProvider activeIndex={activeIndex} previewIndex={previewIndex}>
@@ -412,12 +496,17 @@ export function App({
         settingsEnv={settingsEnv}
         appProxy={config.proxy}
         collectionProxy={settings.proxy}
+        collectionName={settings.name}
+        collectionDescription={settings.description}
+        timelineMaxEntries={settings.timelineMaxEntries}
         noProxy={noProxy}
         systemProxy={systemProxy}
         onAppProxyChange={handleAppProxyChange}
         onCollectionProxyChange={handleCollectionProxyChange}
+        onCollectionSettingsChange={handleCollectionSettingsChange}
         initialLastRequestId={lastRequestId}
         collectionPaths={collectionPaths}
+        collectionSettingsByPath={collectionSettingsByPath}
         activeCollectionDir={activeCollectionDir}
         onCollectionsChange={handleCollectionsChange}
         onRegisterCollection={handleRegisterCollection}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -296,16 +296,20 @@ export function App({
         saveSettings,
         setSettings,
         () => showToast("Failed to save collection settings", "error"),
-        nextLimit < previousLimit
-          ? () => {
-              pruneTimeline(activeCollectionDir, nextLimit).catch(() =>
-                showToast(
-                  "Timeline limit saved, but existing history could not be pruned",
-                  "error",
-                ),
-              )
-            }
-          : undefined,
+        () => {
+          setRegisteredCollectionSettings((current) => ({
+            ...current,
+            [activeCollectionDir]: nextSettings,
+          }))
+          if (nextLimit < previousLimit) {
+            pruneTimeline(activeCollectionDir, nextLimit).catch(() =>
+              showToast(
+                "Timeline limit saved, but existing history could not be pruned",
+                "error",
+              ),
+            )
+          }
+        },
       )
       return true
     },

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -24,6 +24,7 @@ import type { SendCompleteResult } from "../hooks/useResponse"
 import type {
   AppProxySettings,
   CollectionProxySettings,
+  CollectionSettings,
   Request as NoodleRequest,
   Method,
 } from "../schema"
@@ -94,7 +95,10 @@ import {
   openEnvironmentPicker,
 } from "./commandActions"
 import { runCollectionExport } from "./collectionExport"
-import { unregisterCollection } from "./settings/collectionRegistry"
+import {
+  collectionDisplayName,
+  unregisterCollection,
+} from "./settings/collectionRegistry"
 import {
   runCollectionImport,
   type CollectionImportValues,
@@ -127,12 +131,17 @@ export function AppInner({
   settingsEnv,
   appProxy,
   collectionProxy,
+  collectionName,
+  collectionDescription,
+  timelineMaxEntries,
   noProxy,
   systemProxy,
   onAppProxyChange,
   onCollectionProxyChange,
+  onCollectionSettingsChange,
   initialLastRequestId,
   collectionPaths,
+  collectionSettingsByPath,
   activeCollectionDir,
   onCollectionsChange,
   onRegisterCollection,
@@ -170,12 +179,22 @@ export function AppInner({
   settingsEnv?: string
   appProxy?: AppProxySettings
   collectionProxy?: CollectionProxySettings
+  collectionName?: string
+  collectionDescription?: string
+  timelineMaxEntries?: number
   noProxy: boolean
   systemProxy: SystemProxySettings
   onAppProxyChange: (proxy: AppProxySettings) => boolean
   onCollectionProxyChange: (proxy: CollectionProxySettings) => boolean
+  onCollectionSettingsChange: (
+    patch: Pick<
+      CollectionSettings,
+      "name" | "description" | "timelineMaxEntries"
+    >,
+  ) => boolean
   initialLastRequestId?: string
   collectionPaths: string[]
+  collectionSettingsByPath: Record<string, CollectionSettings>
   activeCollectionDir: string
   onCollectionsChange: (collections: string[]) => boolean
   onRegisterCollection: (path: string) => string | null
@@ -457,6 +476,7 @@ export function AppInner({
   const timeline = useTimeline(
     isCollection ? collectionDir : undefined,
     selectedRequest?.id,
+    timelineMaxEntries,
   )
   const timelineAppendRef = useRef(timeline.appendEntry)
   timelineAppendRef.current = timeline.appendEntry
@@ -1298,7 +1318,9 @@ export function AppInner({
       }}
     >
       <Header
-        collectionLabel={basename(collectionDir) || collectionDir}
+        collectionLabel={collectionDisplayName(collectionDir, {
+          name: collectionName,
+        })}
         envLabel={envState.indicatorLabel}
         envStatus={envState.status}
         envColor={envState.activeEnv?.color}
@@ -1427,6 +1449,9 @@ export function AppInner({
             confirmUndoAll={confirmUndoAll}
             appProxy={appProxy}
             collectionProxy={collectionProxy}
+            collectionName={collectionName}
+            collectionDescription={collectionDescription}
+            timelineMaxEntries={timelineMaxEntries}
             noProxy={noProxy}
             activeEnv={envState.activeEnv}
             envNames={envState.names}
@@ -1451,6 +1476,7 @@ export function AppInner({
             onConfirmUndoAllChange={onConfirmUndoAllChange}
             onAppProxyChange={onAppProxyChange}
             onCollectionProxyChange={onCollectionProxyChange}
+            onCollectionSettingsChange={onCollectionSettingsChange}
             onEnvironmentChange={envState.select}
             onKeybindChange={onKeybindChange}
             onCollectionsChange={onCollectionsChange}
@@ -1499,6 +1525,7 @@ export function AppInner({
           setRequestFinderVisible={setRequestFinderVisible}
           collectionSwitcherVisible={collectionSwitcherVisible}
           collectionPaths={collectionPaths}
+          collectionSettingsByPath={collectionSettingsByPath}
           collectionDir={collectionDir}
           requestCollectionSwitch={requestCollectionSwitch}
           setCollectionSwitcherVisible={setCollectionSwitcherVisible}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -40,7 +40,7 @@ import { useFolderDraft } from "../hooks/useFolderDraft"
 import { useFolderEditBrowse } from "../hooks/useFolderEditBrowse"
 import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
-import { type Focus, type UrlBarSubFocus } from "./focus"
+import { settingsReturnFocus, type Focus, type UrlBarSubFocus } from "./focus"
 import {
   buildCommandPaletteCommands,
   type CommandPaletteTarget,
@@ -217,6 +217,7 @@ export function AppInner({
   const [view, setView] = useState<AppView>("main")
   const viewRef = useRef(view)
   viewRef.current = view
+  const settingsReturnFocusRef = useRef<Focus>("sidebar")
   const [layout, setLayout] = useState<"stacked" | "side-by-side">(
     initialLayout,
   )
@@ -909,6 +910,12 @@ export function AppInner({
       scope?: SettingsScope,
       category?: GlobalSettingsCategory | CollectionSettingsCategory,
     ) => {
+      if (viewRef.current !== "settings") {
+        settingsReturnFocusRef.current = settingsReturnFocus(
+          viewRef.current,
+          focusRef.current,
+        )
+      }
       envEditor.closeEditor()
       if (scope) onSettingsScopeChange(scope)
       if (scope === "global" && category) {
@@ -1464,7 +1471,7 @@ export function AppInner({
             onPaneFocus={focusPane}
             onClose={() => {
               setView("main")
-              setFocus("sidebar")
+              setFocus(settingsReturnFocusRef.current)
               setJumpMode(false)
             }}
             onThemeChange={onThemeChange}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -42,6 +42,7 @@ import {
 } from "./overlays/ImportCollectionOverlay"
 import type {
   Collection,
+  CollectionSettings,
   Environment,
   Request as NoodleRequest,
   TimelineEntry,
@@ -56,6 +57,7 @@ import type { SaveState } from "./saveState"
 import { initialYamlEditorState, type YamlEditorState } from "./appState"
 import type { ActiveOverlay } from "./useOverlayState"
 import { buildDisplayUrl } from "./urlParams"
+import { collectionDisplayName } from "./settings/collectionRegistry"
 
 interface FolderPathOption {
   id: string
@@ -92,6 +94,7 @@ interface AppOverlaysProps {
   setRequestFinderVisible: (visible: boolean) => void
   collectionSwitcherVisible: boolean
   collectionPaths: string[]
+  collectionSettingsByPath: Record<string, CollectionSettings>
   collectionDir: string
   requestCollectionSwitch: (nextDir: string) => void
   setCollectionSwitcherVisible: (visible: boolean) => void
@@ -199,6 +202,7 @@ export function AppOverlays({
   setRequestFinderVisible,
   collectionSwitcherVisible,
   collectionPaths,
+  collectionSettingsByPath,
   collectionDir,
   requestCollectionSwitch,
   setCollectionSwitcherVisible,
@@ -289,7 +293,10 @@ export function AppOverlays({
         collectionUnregisterPending !== null && (
           <ConfirmOverlay
             visible
-            message={`Unregister collection "${collectionUnregisterPending}"? Files will not be changed.`}
+            message={`Unregister collection "${collectionDisplayName(
+              collectionUnregisterPending,
+              collectionSettingsByPath[collectionUnregisterPending],
+            )}"? Files will not be changed.`}
             onConfirm={onConfirmDialog}
             onCancel={onCancelDialog}
           />
@@ -367,6 +374,7 @@ export function AppOverlays({
         <CollectionSwitcherOverlay
           visible
           collections={collectionPaths}
+          collectionSettingsByPath={collectionSettingsByPath}
           activeCollectionDir={collectionDir}
           onSelect={requestCollectionSwitch}
           onClose={() => setCollectionSwitcherVisible(false)}

--- a/src/ui/focus.ts
+++ b/src/ui/focus.ts
@@ -26,6 +26,10 @@ const MAIN_FOCUS_ORDER: Focus[] = ["sidebar", "urlbar", "request", "response"]
 const ENV_FOCUS_ORDER: Focus[] = ["env-sidebar", "env-header", "env-vars"]
 const SETTINGS_FOCUS_ORDER: Focus[] = ["settings-sidebar", "settings-content"]
 
+export function settingsReturnFocus(view: string, focus: Focus): Focus {
+  return view === "main" ? focus : "sidebar"
+}
+
 export function cycleFocus(
   current: Focus,
   delta: 1 | -1,

--- a/src/ui/keybindingHints.ts
+++ b/src/ui/keybindingHints.ts
@@ -109,7 +109,7 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
     if (ctx.focus === "settings-sidebar") {
       return [
         { key: "↑/↓", word: "categories" },
-        { key: "Tab", word: "edit" },
+        { key: "←/→", word: "scope" },
         close,
       ]
     }
@@ -122,7 +122,7 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
     }
     if (ctx.settingsCategory === "collections") {
       return [
-        { key: "Enter", word: "add" },
+        { key: "↑/↓", word: "select" },
         { key: "Ctrl+↑/↓", word: "reorder" },
         { key: "Del", word: "unregister" },
       ]
@@ -134,15 +134,15 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
         close,
       ]
     }
-    if (
-      ctx.settingsCategory === "appearance" ||
-      ctx.settingsCategory === "general"
-    ) {
+    if (ctx.settingsCategory === "appearance") {
       return [
         { key: "Enter", word: "choose" },
         { key: "Tab", word: "next" },
         close,
       ]
+    }
+    if (ctx.settingsCategory === "general") {
+      return [{ key: "Tab", word: "next" }, close]
     }
     return [{ key: "Tab", word: "next" }, close]
   }

--- a/src/ui/overlays/CollectionSwitcherOverlay.tsx
+++ b/src/ui/overlays/CollectionSwitcherOverlay.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { basename } from "node:path"
 import { TextAttributes } from "@opentui/core"
 import { PickerOverlay } from "./PickerOverlay"
 import { useTheme } from "../theme"
+import type { CollectionSettings } from "../../schema"
+import { collectionDisplayName } from "../settings/collectionRegistry"
 
 export interface CollectionSwitcherOverlayProps {
   visible: boolean
   collections: string[]
+  collectionSettingsByPath?: Record<string, CollectionSettings>
   activeCollectionDir: string
   onSelect: (collectionDir: string) => void
   onClose: () => void
@@ -20,6 +22,7 @@ interface CollectionItem {
 export function CollectionSwitcherOverlay({
   visible,
   collections,
+  collectionSettingsByPath = {},
   activeCollectionDir,
   onSelect,
   onClose,
@@ -36,9 +39,9 @@ export function CollectionSwitcherOverlay({
     () =>
       collections.map((path) => ({
         path,
-        label: basename(path) || path,
+        label: collectionDisplayName(path, collectionSettingsByPath[path]),
       })),
-    [collections],
+    [collectionSettingsByPath, collections],
   )
 
   const activeItem = useMemo(

--- a/src/ui/settings/ProxySettingsForm.tsx
+++ b/src/ui/settings/ProxySettingsForm.tsx
@@ -229,16 +229,20 @@ export function ProxySettingsForm({
       if (editor === "fields") {
         const fields = parseStructuredProxyTemplate(values.url)
         if (!fields) {
-          setError(
-            "This URL needs Advanced mode. Use an HTTP(S) host, optional port, and $VARNAME credentials only.",
-          )
-          return
-        }
-        update({ editor, fields })
+          if (values.url.trim()) {
+            setError(
+              "This URL needs Advanced mode. Use an HTTP(S) host, optional port, and $VARNAME credentials only.",
+            )
+            return
+          }
+          update({ editor }, false)
+          setError(null)
+        } else update({ editor, fields })
       } else {
         const result = buildStructuredProxyTemplate(values.fields)
         if ("error" in result) {
-          setError(result.error)
+          update({ editor }, false)
+          setError(null)
           return
         }
         update({ editor, url: result.url })

--- a/src/ui/settings/ProxySettingsForm.tsx
+++ b/src/ui/settings/ProxySettingsForm.tsx
@@ -408,6 +408,7 @@ export function ProxySettingsForm({
               placeholder="http://$PROXY_USER:$PROXY_PASSWORD@proxy:8080"
               focused={focused && field === "proxy-url"}
               env={activeEnv ?? null}
+              hint="Include $VARNAME credentials directly in the URL."
               onFocus={() => setField("proxy-url")}
               onChange={(url) => update({ url }, false)}
             />
@@ -423,48 +424,54 @@ export function ProxySettingsForm({
             onChange={(bypass) => update({ bypass })}
             hint="Comma-separated. Supports *, hosts, .domains, IPs, and ports."
           />
-          <box
-            id="settings-proxy-auth"
-            onMouseDown={(event) => {
-              if (event.button !== MouseButton.LEFT) return
-              setField("auth")
-              updateFields({ auth: !values.fields.auth })
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            style={{ flexDirection: "row" }}
-          >
-            <Checkbox checked={values.fields.auth} theme={theme} />
-            <text
-              fg={focused && field === "auth" ? theme.text : theme.textMuted}
-            >
-              Proxy authentication
-            </text>
-          </box>
-          {values.fields.auth && (
+          {values.editor === "fields" && (
             <>
-              <VariableField
-                id="settings-proxy-username"
-                label="Username variable"
-                inputRef={usernameRef}
-                value={values.fields.username}
-                placeholder="$PROXY_USER"
-                focused={focused && field === "username"}
-                env={activeEnv ?? null}
-                onFocus={() => setField("username")}
-                onChange={(username) => updateFields({ username })}
-              />
-              <VariableField
-                id="settings-proxy-password"
-                label="Password variable"
-                inputRef={passwordRef}
-                value={values.fields.password}
-                placeholder="$PROXY_PASSWORD"
-                focused={focused && field === "password"}
-                env={activeEnv ?? null}
-                onFocus={() => setField("password")}
-                onChange={(password) => updateFields({ password })}
-              />
+              <box
+                id="settings-proxy-auth"
+                onMouseDown={(event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  setField("auth")
+                  updateFields({ auth: !values.fields.auth })
+                  event.preventDefault()
+                  event.stopPropagation()
+                }}
+                style={{ flexDirection: "row" }}
+              >
+                <Checkbox checked={values.fields.auth} theme={theme} />
+                <text
+                  fg={
+                    focused && field === "auth" ? theme.text : theme.textMuted
+                  }
+                >
+                  Proxy authentication
+                </text>
+              </box>
+              {values.fields.auth && (
+                <>
+                  <VariableField
+                    id="settings-proxy-username"
+                    label="Username variable"
+                    inputRef={usernameRef}
+                    value={values.fields.username}
+                    placeholder="$PROXY_USER"
+                    focused={focused && field === "username"}
+                    env={activeEnv ?? null}
+                    onFocus={() => setField("username")}
+                    onChange={(username) => updateFields({ username })}
+                  />
+                  <VariableField
+                    id="settings-proxy-password"
+                    label="Password variable"
+                    inputRef={passwordRef}
+                    value={values.fields.password}
+                    placeholder="$PROXY_PASSWORD"
+                    focused={focused && field === "password"}
+                    env={activeEnv ?? null}
+                    onFocus={() => setField("password")}
+                    onChange={(password) => updateFields({ password })}
+                  />
+                </>
+              )}
             </>
           )}
         </>
@@ -577,6 +584,7 @@ function VariableField({
   onFocus,
   onChange,
   inputRef,
+  hint,
 }: {
   id: string
   label: string
@@ -587,6 +595,7 @@ function VariableField({
   onFocus: () => void
   onChange: (value: string) => void
   inputRef: { current: VarInputHandle | null }
+  hint?: string
 }) {
   const theme = useTheme()
   return (
@@ -606,6 +615,11 @@ function VariableField({
           onFocus={onFocus}
         />
       </box>
+      {hint && (
+        <text fg={theme.textMuted} wrapMode="word">
+          {hint}
+        </text>
+      )}
     </box>
   )
 }

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -1,4 +1,10 @@
-import { MouseButton, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import {
+  MouseButton,
+  ScrollBoxRenderable,
+  TextAttributes,
+  type InputRenderable,
+  type TextareaRenderable,
+} from "@opentui/core"
 import { useKeymap } from "@opentui/keymap/react"
 import {
   useCallback,
@@ -11,8 +17,10 @@ import {
 import type {
   AppProxySettings,
   CollectionProxySettings,
+  CollectionSettings,
   Environment,
 } from "../../schema"
+import { DEFAULT_TIMELINE_MAX_ENTRIES } from "../../filestore"
 import type { Focus } from "../focus"
 import {
   Definitions,
@@ -69,6 +77,22 @@ const KEYBIND_CATEGORIES: readonly KeybindCategory[] = [
   "System",
 ]
 
+export function parseTimelineMaxEntries(
+  rawValue: string,
+): { value: number | undefined } | { error: string } {
+  const raw = rawValue.trim()
+  if (raw !== "" && !/^\d+$/.test(raw)) {
+    return {
+      error:
+        "Timeline entries must be a non-negative integer, or blank for 50.",
+    }
+  }
+  const value = raw === "" ? undefined : Number(raw)
+  return value === undefined || Number.isSafeInteger(value)
+    ? { value }
+    : { error: "Timeline entries must be a non-negative safe integer." }
+}
+
 export function SettingsView({
   scope,
   category,
@@ -80,6 +104,9 @@ export function SettingsView({
   confirmUndoAll,
   appProxy,
   collectionProxy,
+  collectionName,
+  collectionDescription,
+  timelineMaxEntries,
   noProxy,
   activeEnv,
   envNames,
@@ -96,6 +123,7 @@ export function SettingsView({
   onConfirmUndoAllChange,
   onAppProxyChange,
   onCollectionProxyChange,
+  onCollectionSettingsChange,
   onEnvironmentChange,
   onKeybindChange,
   onCollectionsChange,
@@ -112,6 +140,9 @@ export function SettingsView({
   confirmUndoAll: boolean
   appProxy?: AppProxySettings
   collectionProxy?: CollectionProxySettings
+  collectionName?: string
+  collectionDescription?: string
+  timelineMaxEntries?: number
   noProxy: boolean
   activeEnv: Environment | null
   envNames: string[]
@@ -128,6 +159,12 @@ export function SettingsView({
   onConfirmUndoAllChange: (value: boolean) => void
   onAppProxyChange: (proxy: AppProxySettings) => boolean
   onCollectionProxyChange: (proxy: CollectionProxySettings) => boolean
+  onCollectionSettingsChange: (
+    patch: Pick<
+      CollectionSettings,
+      "name" | "description" | "timelineMaxEntries"
+    >,
+  ) => boolean
   onEnvironmentChange: (name: string) => void
   onKeybindChange: (name: KeybindName, key: string) => boolean
   onCollectionsChange: (collections: string[]) => boolean
@@ -138,6 +175,9 @@ export function SettingsView({
   const keymap = useKeymap()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
   const pathInputRef = useRef<VarInputHandle | null>(null)
+  const collectionNameRef = useRef<InputRenderable | null>(null)
+  const collectionDescriptionRef = useRef<TextareaRenderable | null>(null)
+  const timelineMaxEntriesRef = useRef<InputRenderable | null>(null)
   const [contentIndex, setContentIndex] = useState(0)
   const [selectOpen, setSelectOpen] = useState(false)
   const [captureName, setCaptureName] = useState<KeybindName | null>(null)
@@ -146,6 +186,18 @@ export function SettingsView({
     kind: "success" | "error"
   } | null>(null)
   const [pathInput, setPathInput] = useState("")
+  const [collectionNameDraft, setCollectionNameDraft] = useState(
+    collectionName ?? "",
+  )
+  const [collectionDescriptionDraft, setCollectionDescriptionDraft] = useState(
+    collectionDescription ?? "",
+  )
+  const [timelineMaxEntriesDraft, setTimelineMaxEntriesDraft] = useState(
+    String(timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES),
+  )
+  const [collectionGeneralError, setCollectionGeneralError] = useState<
+    string | null
+  >(null)
   const [proxyTextInput, setProxyTextInput] = useState(false)
   const [hoveredCollectionIndex, setHoveredCollectionIndex] = useState<
     number | null
@@ -184,10 +236,96 @@ export function SettingsView({
   }, [])
 
   useEffect(() => {
+    setCollectionNameDraft(collectionName ?? "")
+    setCollectionDescriptionDraft(collectionDescription ?? "")
+    setTimelineMaxEntriesDraft(
+      String(timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES),
+    )
+    setCollectionGeneralError(null)
+  }, [
+    activeCollectionDir,
+    collectionDescription,
+    collectionName,
+    timelineMaxEntries,
+  ])
+
+  const commitCollectionGeneralField = useCallback(
+    (index: number): boolean => {
+      setCollectionGeneralError(null)
+      if (index === 0) {
+        const name = collectionNameDraft.trim() || undefined
+        if (name === collectionName) return true
+        if (!onCollectionSettingsChange({ name })) return false
+        setCollectionNameDraft(name ?? "")
+        return true
+      }
+      if (index === 1) {
+        const description =
+          (
+            collectionDescriptionRef.current?.plainText ??
+            collectionDescriptionDraft
+          ).trim() || undefined
+        if (description === collectionDescription) return true
+        if (!onCollectionSettingsChange({ description })) return false
+        setCollectionDescriptionDraft(description ?? "")
+        return true
+      }
+      if (index !== 2) return true
+
+      const parsed = parseTimelineMaxEntries(timelineMaxEntriesDraft)
+      if ("error" in parsed) {
+        setCollectionGeneralError(parsed.error)
+        return false
+      }
+      const { value } = parsed
+      if (value !== timelineMaxEntries) {
+        if (!onCollectionSettingsChange({ timelineMaxEntries: value })) {
+          return false
+        }
+      }
+      setTimelineMaxEntriesDraft(String(value ?? DEFAULT_TIMELINE_MAX_ENTRIES))
+      return true
+    },
+    [
+      collectionDescription,
+      collectionDescriptionDraft,
+      collectionName,
+      collectionNameDraft,
+      onCollectionSettingsChange,
+      timelineMaxEntries,
+      timelineMaxEntriesDraft,
+    ],
+  )
+
+  const activateCollectionGeneralField = useCallback(
+    (index: number) => {
+      if (
+        contentIndex === index ||
+        commitCollectionGeneralField(contentIndex)
+      ) {
+        setContentIndex(index)
+        onPaneFocus("settings-content")
+      }
+    },
+    [commitCollectionGeneralField, contentIndex, onPaneFocus],
+  )
+
+  const commitCurrentCollectionGeneralField = useCallback(
+    () =>
+      scope !== "collection" ||
+      category !== "general" ||
+      commitCollectionGeneralField(contentIndex),
+    [category, commitCollectionGeneralField, contentIndex, scope],
+  )
+
+  useEffect(() => {
     const textInputActive =
       focus === "settings-content" &&
       ((category === "collections" &&
         contentIndex === collectionRegisterIndex) ||
+        (scope === "collection" &&
+          category === "general" &&
+          contentIndex < 3) ||
         (category === "network" && proxyTextInput))
     keymap.setData("app.text-input", textInputActive)
     return () => keymap.setData("app.text-input", false)
@@ -198,6 +336,7 @@ export function SettingsView({
     focus,
     keymap,
     proxyTextInput,
+    scope,
   ])
 
   useEffect(() => {
@@ -212,12 +351,21 @@ export function SettingsView({
   useEffect(() => {
     if (
       focus === "settings-content" &&
+      scope === "collection" &&
+      category === "general"
+    ) {
+      if (contentIndex === 0) collectionNameRef.current?.focus()
+      else if (contentIndex === 1) collectionDescriptionRef.current?.focus()
+      else if (contentIndex === 2) timelineMaxEntriesRef.current?.focus()
+    }
+    if (
+      focus === "settings-content" &&
       category === "collections" &&
       contentIndex === collectionRegisterIndex
     ) {
       pathInputRef.current?.focus()
     }
-  }, [category, collectionRegisterIndex, contentIndex, focus])
+  }, [category, collectionRegisterIndex, contentIndex, focus, scope])
 
   useEffect(() => {
     if (focus !== "settings-content") return
@@ -230,8 +378,16 @@ export function SettingsView({
           ? `settings-collection-${contentIndex}`
           : "settings-collection-register",
       )
+    } else if (scope === "collection" && category === "general") {
+      const id = [
+        "settings-collection-name",
+        "settings-collection-description",
+        "settings-timeline-max-entries",
+        "settings-active-environment",
+      ][contentIndex]
+      if (id) scrollRef.current?.scrollChildIntoView(id)
     }
-  }, [category, contentIndex, collections, focus, keybindNames, message])
+  }, [category, contentIndex, collections, focus, keybindNames, message, scope])
 
   useEffect(() => {
     if (!captureName) return
@@ -281,6 +437,7 @@ export function SettingsView({
         if (event.name === "escape") {
           event.preventDefault()
           event.stopPropagation()
+          if (!commitCurrentCollectionGeneralField()) return
           onClose()
           return
         }
@@ -288,6 +445,7 @@ export function SettingsView({
           if (event.name === "left" || event.name === "right") {
             event.preventDefault()
             event.stopPropagation()
+            if (!commitCurrentCollectionGeneralField()) return
             if (scope === "global" && collectionAvailable) {
               onScopeChange("collection")
             } else if (scope === "collection") {
@@ -298,6 +456,7 @@ export function SettingsView({
           if (["up", "down", "home", "end"].includes(event.name)) {
             event.preventDefault()
             event.stopPropagation()
+            if (!commitCurrentCollectionGeneralField()) return
             const next =
               event.name === "home"
                 ? 0
@@ -312,6 +471,29 @@ export function SettingsView({
           return
         }
         if (focus !== "settings-content") return
+
+        if (scope === "collection" && category === "general") {
+          if (event.name === "tab") {
+            event.preventDefault()
+            event.stopPropagation()
+            if (!commitCollectionGeneralField(contentIndex)) return
+            const next = contentIndex + (event.shift ? -1 : 1)
+            if (next < 0 || next >= 4) onPaneFocus("settings-sidebar")
+            else setContentIndex(next)
+          } else if (
+            event.name === "return" &&
+            (contentIndex === 0 || contentIndex === 2)
+          ) {
+            event.preventDefault()
+            event.stopPropagation()
+            commitCollectionGeneralField(contentIndex)
+          } else if (event.name === "return" && contentIndex === 1) {
+            event.preventDefault()
+            event.stopPropagation()
+            collectionDescriptionRef.current?.insertText("\n")
+          }
+          return
+        }
 
         if (category === "keyboard") {
           if (event.name === "up" || event.name === "down") {
@@ -427,6 +609,8 @@ export function SettingsView({
     collectionAvailable,
     collectionRegisterIndex,
     collections,
+    commitCollectionGeneralField,
+    commitCurrentCollectionGeneralField,
     confirmUndoAll,
     contentIndex,
     focus,
@@ -465,7 +649,11 @@ export function SettingsView({
         borderColor={
           focus === "settings-sidebar" ? theme.primary : theme.borderSubtle
         }
-        onPaneFocus={() => onPaneFocus("settings-sidebar")}
+        onPaneFocus={() => {
+          if (commitCurrentCollectionGeneralField()) {
+            onPaneFocus("settings-sidebar")
+          }
+        }}
       >
         {jumpMode && <JumpBadge letter="s" style={JUMP_BADGE_TOP_INDENT} />}
         <box style={{ flexDirection: "row", gap: 0 }}>
@@ -473,7 +661,11 @@ export function SettingsView({
             id="settings-scope-global"
             label="Global"
             selected={scope === "global"}
-            onSelect={() => onScopeChange("global")}
+            onSelect={() => {
+              if (commitCurrentCollectionGeneralField()) {
+                onScopeChange("global")
+              }
+            }}
           />
           <ScopeButton
             id="settings-scope-collection"
@@ -481,7 +673,12 @@ export function SettingsView({
             selected={scope === "collection"}
             disabled={!collectionAvailable}
             onSelect={() => {
-              if (collectionAvailable) onScopeChange("collection")
+              if (
+                collectionAvailable &&
+                commitCurrentCollectionGeneralField()
+              ) {
+                onScopeChange("collection")
+              }
             }}
           />
         </box>
@@ -510,6 +707,7 @@ export function SettingsView({
                 borderColor={selected ? theme.primary : theme.backgroundPanel}
                 onMouseDown={(event) => {
                   if (event.button !== MouseButton.LEFT) return
+                  if (!commitCurrentCollectionGeneralField()) return
                   onCategoryChange(item.id)
                   onPaneFocus("settings-sidebar")
                   event.stopPropagation()
@@ -775,29 +973,117 @@ export function SettingsView({
               <>
                 <SettingsSectionHeader
                   title="General"
-                  description="Choose the environment used by this collection."
+                  description="Describe this collection and control its local history."
                 />
-                <SettingLabel
-                  title="Active environment"
-                  description="Used for variable substitution when sending requests."
-                >
-                  <Select
-                    items={envNames.map((name) => ({
-                      id: name,
-                      label: name,
-                    }))}
-                    value={activeEnvName ?? undefined}
-                    placeholder={
-                      envNames.length === 0
-                        ? "No environments"
-                        : "Select environment"
-                    }
-                    interactive={envNames.length > 0}
-                    focused={focus === "settings-content"}
-                    onOpenChange={setSelectOpen}
-                    onChange={onEnvironmentChange}
-                  />
-                </SettingLabel>
+                <box id="settings-collection-name">
+                  <SettingLabel
+                    title="Name"
+                    description="Display name used in collection menus. The directory name is used when blank."
+                  >
+                    <input
+                      ref={collectionNameRef}
+                      value={collectionNameDraft}
+                      placeholder="Collection name"
+                      onInput={setCollectionNameDraft}
+                      onMouseDown={() => activateCollectionGeneralField(0)}
+                      focused={
+                        focus === "settings-content" && contentIndex === 0
+                      }
+                      backgroundColor={theme.backgroundElement}
+                      focusedBackgroundColor={theme.borderSubtle}
+                      textColor={theme.text}
+                      cursorColor={theme.primary}
+                      placeholderColor={theme.textMuted}
+                      paddingX={1}
+                    />
+                  </SettingLabel>
+                </box>
+                <box id="settings-collection-description">
+                  <SettingLabel
+                    title="Description"
+                    description="Optional notes stored with this collection."
+                  >
+                    <textarea
+                      key={`${activeCollectionDir}:${collectionDescription ?? ""}`}
+                      ref={collectionDescriptionRef}
+                      initialValue={collectionDescription ?? ""}
+                      placeholder="What is this collection for?"
+                      onContentChange={() =>
+                        setCollectionDescriptionDraft(
+                          collectionDescriptionRef.current?.plainText ?? "",
+                        )
+                      }
+                      onMouseDown={() => activateCollectionGeneralField(1)}
+                      focused={
+                        focus === "settings-content" && contentIndex === 1
+                      }
+                      backgroundColor={theme.backgroundElement}
+                      focusedBackgroundColor={theme.borderSubtle}
+                      textColor={theme.text}
+                      cursorColor={theme.primary}
+                      placeholderColor={theme.textMuted}
+                      height={4}
+                      paddingX={1}
+                    />
+                  </SettingLabel>
+                </box>
+                <box id="settings-timeline-max-entries">
+                  <SettingLabel
+                    title="Timeline entries"
+                    description="Maximum saved responses per request. Use 0 to disable history; blank resets to 50."
+                  >
+                    <input
+                      ref={timelineMaxEntriesRef}
+                      value={timelineMaxEntriesDraft}
+                      placeholder={String(DEFAULT_TIMELINE_MAX_ENTRIES)}
+                      onInput={(value) => {
+                        setTimelineMaxEntriesDraft(value)
+                        setCollectionGeneralError(null)
+                      }}
+                      onMouseDown={() => activateCollectionGeneralField(2)}
+                      focused={
+                        focus === "settings-content" && contentIndex === 2
+                      }
+                      backgroundColor={theme.backgroundElement}
+                      focusedBackgroundColor={theme.borderSubtle}
+                      textColor={theme.text}
+                      cursorColor={theme.primary}
+                      placeholderColor={theme.textMuted}
+                      paddingX={1}
+                    />
+                    {collectionGeneralError && (
+                      <text fg={theme.error} wrapMode="word">
+                        {collectionGeneralError}
+                      </text>
+                    )}
+                  </SettingLabel>
+                </box>
+                <box id="settings-active-environment">
+                  <SettingLabel
+                    title="Active environment"
+                    description="Used for variable substitution when sending requests."
+                  >
+                    <Select
+                      items={envNames.map((name) => ({
+                        id: name,
+                        label: name,
+                      }))}
+                      value={activeEnvName ?? undefined}
+                      placeholder={
+                        envNames.length === 0
+                          ? "No environments"
+                          : "Select environment"
+                      }
+                      interactive={envNames.length > 0}
+                      focused={
+                        focus === "settings-content" && contentIndex === 3
+                      }
+                      onActivate={() => activateCollectionGeneralField(3)}
+                      onOpenChange={setSelectOpen}
+                      onChange={onEnvironmentChange}
+                    />
+                  </SettingLabel>
+                </box>
               </>
             )}
             {message && category !== "keyboard" && (

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -39,9 +39,9 @@ import { Checkbox } from "../Checkbox"
 import { Select } from "../Select"
 import { VarInput, type VarInputHandle } from "../VarInput"
 import { JumpBadge, JUMP_BADGE_TOP_INDENT } from "../JumpBadge"
+import { SIDEBAR_WIDTH } from "../Sidebar"
 import { ProxySettingsForm } from "./ProxySettingsForm"
 import { moveRegisteredCollection } from "./collectionRegistry"
-import { SIDEBAR_WIDTH } from "../Sidebar"
 
 export type SettingsScope = "global" | "collection"
 export type GlobalSettingsCategory =
@@ -959,6 +959,7 @@ export function SettingsView({
                 <KeyboardRows
                   names={keybindNames}
                   selectedIndex={contentIndex}
+                  active={focus === "settings-content"}
                   captureName={captureName}
                   message={message}
                   keybinds={keybinds}
@@ -1179,7 +1180,10 @@ function SettingsSectionHeader({
 }) {
   const theme = useTheme()
   return (
-    <box style={{ flexDirection: "column", gap: 0 }}>
+    <box
+      id="settings-section-header"
+      style={{ flexDirection: "column", gap: 0 }}
+    >
       <text fg={theme.text}>{title}</text>
       <text fg={theme.textMuted} wrapMode="word">
         {description}
@@ -1191,6 +1195,7 @@ function SettingsSectionHeader({
 function KeyboardRows({
   names,
   selectedIndex,
+  active,
   captureName,
   message,
   keybinds,
@@ -1198,6 +1203,7 @@ function KeyboardRows({
 }: {
   names: KeybindName[]
   selectedIndex: number
+  active: boolean
   captureName: KeybindName | null
   message: { text: string; kind: "success" | "error" } | null
   keybinds: Keybinds
@@ -1211,7 +1217,7 @@ function KeyboardRows({
         const definition = Definitions[name]
         const showCategory = definition.category !== previousCategory
         previousCategory = definition.category
-        const selected = index === selectedIndex
+        const selected = active && index === selectedIndex
         const conflict = findKeybindConflict(name, keybinds[name], keybinds)
         return (
           <box
@@ -1228,6 +1234,7 @@ function KeyboardRows({
               </text>
             )}
             <box
+              id={`settings-key-${name}-row`}
               style={{
                 flexDirection: "row",
                 justifyContent: "space-between",

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -437,7 +437,14 @@ export function SettingsView({
         if (event.name === "escape") {
           event.preventDefault()
           event.stopPropagation()
-          if (!commitCurrentCollectionGeneralField()) return
+          if (!commitCurrentCollectionGeneralField()) {
+            setCollectionNameDraft(collectionName ?? "")
+            setCollectionDescriptionDraft(collectionDescription ?? "")
+            setTimelineMaxEntriesDraft(
+              String(timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES),
+            )
+            setCollectionGeneralError(null)
+          }
           onClose()
           return
         }

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -56,7 +56,7 @@ const GLOBAL_CATEGORIES: readonly {
 }[] = [
   { id: "appearance", label: "Appearance" },
   { id: "behavior", label: "Behavior" },
-  { id: "network", label: "Network" },
+  { id: "network", label: "Proxy" },
   { id: "collections", label: "Collections" },
   { id: "keyboard", label: "Keyboard" },
 ]
@@ -66,7 +66,7 @@ const COLLECTION_CATEGORIES: readonly {
   label: string
 }[] = [
   { id: "general", label: "General" },
-  { id: "network", label: "Network" },
+  { id: "network", label: "Proxy" },
 ]
 
 const KEYBIND_CATEGORIES: readonly KeybindCategory[] = [
@@ -826,7 +826,7 @@ export function SettingsView({
             {category === "network" && (
               <>
                 <SettingsSectionHeader
-                  title="Network"
+                  title="Proxy"
                   description={
                     scope === "global"
                       ? "Configure proxy behavior for Noodle requests."

--- a/src/ui/settings/collectionRegistry.ts
+++ b/src/ui/settings/collectionRegistry.ts
@@ -1,10 +1,18 @@
 import { homedir } from "node:os"
-import { resolve } from "node:path"
+import { basename, resolve } from "node:path"
 import { classifyPath } from "../../collectionPath"
+import type { CollectionSettings } from "../../schema"
 import { expandUserPath } from "../../userPath"
 
 export type CollectionRegistrationResult =
   { ok: true; path: string } | { ok: false; error: string }
+
+export function collectionDisplayName(
+  path: string,
+  settings?: Pick<CollectionSettings, "name">,
+): string {
+  return settings?.name?.trim() || basename(path) || path
+}
 
 export function resolveCollectionRegistration(
   rawPath: string,

--- a/src/ui/settings/settingsPersistence.ts
+++ b/src/ui/settings/settingsPersistence.ts
@@ -25,7 +25,9 @@ export function queueCollectionSettingsSave(
       if (persistence.activeCollectionDir.current === collectionDir) {
         persistence.persistedSettings.current = settings
       }
-      onSaved?.()
+      if (persistence.currentSettings.current === settings) {
+        onSaved?.()
+      }
     },
     () => {
       if (

--- a/src/ui/settings/settingsPersistence.ts
+++ b/src/ui/settings/settingsPersistence.ts
@@ -14,6 +14,7 @@ export function queueCollectionSettingsSave(
   saveSettings: (dir: string, settings: CollectionSettings) => Promise<void>,
   setSettings: (settings: CollectionSettings) => void,
   onError: () => void,
+  onSaved?: () => void,
 ): void {
   const save = persistence.saveChain.current.then(() =>
     saveSettings(collectionDir, settings),
@@ -24,6 +25,7 @@ export function queueCollectionSettingsSave(
       if (persistence.activeCollectionDir.current === collectionDir) {
         persistence.persistedSettings.current = settings
       }
+      onSaved?.()
     },
     () => {
       if (

--- a/src/ui/timeline/useTimeline.ts
+++ b/src/ui/timeline/useTimeline.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { TimelineEntry } from "../../schema"
-import { loadTimeline, saveTimelineEntry } from "../../filestore"
+import {
+  DEFAULT_TIMELINE_MAX_ENTRIES,
+  loadTimeline,
+  saveTimelineEntry,
+} from "../../filestore"
 
 export interface UseTimelineResult {
   entries: TimelineEntry[]
@@ -12,7 +16,7 @@ export interface UseTimelineResult {
 export function useTimeline(
   collectionDir: string | undefined,
   requestId: string | undefined,
-  maxEntries = 50,
+  maxEntries = DEFAULT_TIMELINE_MAX_ENTRIES,
 ): UseTimelineResult {
   const [entries, setEntries] = useState<TimelineEntry[]>([])
   const [loading, setLoading] = useState(false)
@@ -36,26 +40,27 @@ export function useTimeline(
     try {
       const loaded = await loadTimeline(collectionDir, requestId)
       if (mountedRef.current) {
-        setEntries(loaded)
+        setEntries(loaded.slice(0, maxEntries))
       }
     } catch {
       if (mountedRef.current) setEntries([])
     } finally {
       if (mountedRef.current) setLoading(false)
     }
-  }, [collectionDir, requestId])
+  }, [collectionDir, requestId, maxEntries])
 
   useEffect(() => {
-    const key = `${collectionDir ?? ""}||${requestId ?? ""}`
+    const key = `${collectionDir ?? ""}||${requestId ?? ""}||${maxEntries}`
     if (key !== lastKeyRef.current) {
       lastKeyRef.current = key
       doLoad()
     }
-  }, [collectionDir, requestId, doLoad])
+  }, [collectionDir, requestId, maxEntries, doLoad])
 
   const appendEntry = useCallback(
     async (entry: TimelineEntry) => {
       if (!collectionDir || !requestId) return
+      if (maxEntries === 0) return
       const save = saveChainRef.current.then(() =>
         saveTimelineEntry(collectionDir, requestId, entry, maxEntries),
       )

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -495,6 +495,28 @@ describe("filestore.loadSettings", () => {
     expect(result).toEqual({ environment: "staging" })
   })
 
+  it("reads collection metadata and timeline retention", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "name: Payments API\ndescription: |-\n  First line.\n  Second line.\ntimeline_max_entries: 25\n",
+      "utf8",
+    )
+    expect(await loadSettings(dir)).toEqual({
+      name: "Payments API",
+      description: "First line.\nSecond line.",
+      timelineMaxEntries: 25,
+    })
+  })
+
+  it("ignores invalid collection metadata and timeline retention", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "name: '   '\ndescription: 42\ntimeline_max_entries: -1\nenvironment: dev\n",
+      "utf8",
+    )
+    expect(await loadSettings(dir)).toEqual({ environment: "dev" })
+  })
+
   it("returns empty for invalid YAML in settings.yml", async () => {
     await writeFile(join(dir, "settings.yml"), "{ broken: : : ", "utf8")
     const result = await loadSettings(dir)
@@ -550,6 +572,27 @@ describe("filestore.saveSettings", () => {
     await saveSettings(dir, { environment: "staging" })
     const result = await loadSettings(dir)
     expect(result).toEqual({ environment: "staging" })
+  })
+
+  it("round-trips collection metadata and timeline retention", async () => {
+    await saveSettings(dir, {
+      name: " Payments API ",
+      description: "First line.\nSecond line.\n",
+      timelineMaxEntries: 0,
+    })
+    expect(await loadSettings(dir)).toEqual({
+      name: "Payments API",
+      description: "First line.\nSecond line.",
+      timelineMaxEntries: 0,
+    })
+    const content = await readFile(join(dir, "settings.yml"), "utf8")
+    expect(content).toContain("timeline_max_entries: 0")
+  })
+
+  it("rejects invalid timeline retention", async () => {
+    await expect(saveSettings(dir, { timelineMaxEntries: -1 })).rejects.toThrow(
+      "timeline max entries must be a non-negative integer",
+    )
   })
 
   it("round-trips a collection proxy override", async () => {

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -351,6 +351,34 @@ describe("automation services", () => {
     expect(await readFile(join(dir, "settings.yml"), "utf8")).toBe("{}\n")
   })
 
+  it("audits and canonicalizes collection metadata and timeline retention", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "description: |-\n  First line.\n  Second line.\nname: Payments API\ntimeline_max_entries: 0\nenvironment: development\n",
+    )
+
+    const result = await collectionAudit(dir, true)
+
+    expect(result.valid).toBe(true)
+    expect(await collectionInspect(dir)).toMatchObject({
+      settings: {
+        name: "Payments API",
+        description: "First line.\nSecond line.",
+        timelineMaxEntries: 0,
+        environment: "development",
+      },
+    })
+  })
+
+  it("rejects invalid timeline retention during collection audit", async () => {
+    await writeFile(join(dir, "settings.yml"), "timeline_max_entries: -1\n")
+    const result = await collectionAudit(dir, false)
+    expect(result.valid).toBe(false)
+    expect(result.issues[0]?.message).toContain(
+      "non-negative integer timeline_max_entries",
+    )
+  })
+
   it("reports invalid registered collections without changing config", async () => {
     const configDir = join(dir, "config")
     const missing = join(dir, "missing")

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -6,6 +6,7 @@ import {
   loadTimeline,
   loadTimelineBody,
   saveTimelineEntry,
+  pruneTimeline,
   clearTimelineForRequest,
   clearAllTimeline,
 } from "../src/filestore/timeline"
@@ -286,6 +287,59 @@ describe("saveTimelineEntry", () => {
     expect(a[0].timestamp).toBe(1)
     expect(b).toHaveLength(1)
     expect(b[0].timestamp).toBe(2)
+  })
+})
+
+describe("pruneTimeline", () => {
+  it("prunes nested request histories and removes evicted sidecars", async () => {
+    const body = "x".repeat(12_000)
+    const evicted = await saveTimelineEntry(
+      dir,
+      "folder/request",
+      makeEntry({
+        timestamp: 1,
+        request: { ...makeEntry().request, body },
+      }),
+      10,
+    )
+    await saveTimelineEntry(
+      dir,
+      "folder/request",
+      makeEntry({ timestamp: 2 }),
+      10,
+    )
+
+    await pruneTimeline(dir, 1)
+
+    expect(
+      (await loadTimeline(dir, "folder/request")).map(
+        (entry) => entry.timestamp,
+      ),
+    ).toEqual([2])
+    await expect(
+      loadTimelineBody(dir, "folder/request", evicted.request.bodyRef!),
+    ).rejects.toThrow()
+  })
+
+  it("clears all history when retention is zero", async () => {
+    await saveTimelineEntry(dir, "one", makeEntry({ timestamp: 1 }))
+    await saveTimelineEntry(dir, "folder/two", makeEntry({ timestamp: 2 }))
+
+    await pruneTimeline(dir, 0)
+
+    expect(await loadTimeline(dir, "one")).toEqual([])
+    expect(await loadTimeline(dir, "folder/two")).toEqual([])
+  })
+
+  it("does nothing when the timeline directory does not exist", async () => {
+    await pruneTimeline(dir, 5)
+    expect(await loadTimeline(dir, "missing")).toEqual([])
+  })
+
+  it("rejects invalid retention limits", async () => {
+    await expect(pruneTimeline(dir, -1)).rejects.toThrow(
+      "max entries must be a non-negative integer",
+    )
   })
 })
 

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -211,6 +211,32 @@ describe("saveTimelineEntry", () => {
     expect(result[49].timestamp).toBe(10)
   })
 
+  it("serializes saves with retention pruning", async () => {
+    await saveTimelineEntry(dir, "racing", makeEntry({ timestamp: 1 }), 10)
+    await saveTimelineEntry(dir, "racing", makeEntry({ timestamp: 2 }), 10)
+    const completedBody = "completed-".repeat(2_000)
+
+    await Promise.all([
+      saveTimelineEntry(
+        dir,
+        "racing",
+        makeEntry({
+          timestamp: 3,
+          request: { ...makeEntry().request, body: completedBody },
+        }),
+        10,
+      ),
+      pruneTimeline(dir, 1),
+    ])
+
+    const result = await loadTimeline(dir, "racing")
+    expect(result.map((entry) => entry.timestamp)).toEqual([3])
+    expect(result[0]?.request.bodyRef).toBeDefined()
+    await expect(
+      loadTimelineBody(dir, "racing", result[0]!.request.bodyRef!),
+    ).resolves.toBe(completedBody)
+  })
+
   it("persists full entry data including response and error", async () => {
     const entry = makeEntry({
       timestamp: 500,

--- a/tests/unit/CollectionSwitcherOverlay.test.tsx
+++ b/tests/unit/CollectionSwitcherOverlay.test.tsx
@@ -62,6 +62,34 @@ describe("CollectionSwitcherOverlay", () => {
     cleanup()
   })
 
+  it("uses collection metadata names and keeps paths searchable", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionSwitcherOverlay
+            visible
+            collections={collections}
+            collectionSettingsByPath={{
+              [collections[0]!]: { name: "Payments API" },
+            }}
+            activeCollectionDir={collections[0]!}
+            onSelect={() => {}}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 24 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Payments API")
+
+    await act(async () => mockInput.typeText("/projects/api"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Payments API")
+    cleanup()
+  })
+
   it("filters collections by search text", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame, mockInput } = await testRender(

--- a/tests/unit/ProxySettingsForm.test.tsx
+++ b/tests/unit/ProxySettingsForm.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { act } from "react"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerDefaultKeys,
@@ -13,11 +14,12 @@ import { ProxySettingsForm } from "../../src/ui/settings/ProxySettingsForm"
 const testRender = createTestRender()
 
 function setupKeymap() {
-  const { keymap, cleanup: hostCleanup } = createTestKeymap()
+  const { keymap, host, cleanup: hostCleanup } = createTestKeymap()
   const disposeEnabled = registerEnabledFields(keymap)
   const disposeKeys = registerDefaultKeys(keymap)
   return {
     keymap: keymap as unknown as KeymapProviderProps["keymap"],
+    host,
     cleanup: () => {
       disposeEnabled()
       disposeKeys()
@@ -27,6 +29,45 @@ function setupKeymap() {
 }
 
 describe("ProxySettingsForm", () => {
+  it("switches between Fields and Advanced URL before either is filled", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsForm
+            scope="app"
+            focused
+            proxy={{ mode: "system" }}
+            activeEnv={null}
+            onChange={() => true}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 18 },
+    )
+    await renderOnce()
+
+    await act(async () => host.press("return"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    await act(async () => host.press("tab"))
+    await act(async () => host.press("return"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("Proxy URL")
+
+    await act(async () => host.press("return"))
+    await act(async () => host.press("up"))
+    await act(async () => host.press("return"))
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("Hostname")
+    expect(captureCharFrame()).not.toContain("Proxy URL")
+    cleanup()
+  })
+
   it("renders canonical custom proxies as structured fields", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(

--- a/tests/unit/ProxySettingsForm.test.tsx
+++ b/tests/unit/ProxySettingsForm.test.tsx
@@ -125,6 +125,10 @@ describe("ProxySettingsForm", () => {
     expect(frame).toContain("Advanced URL")
     expect(frame).toContain("Proxy URL")
     expect(frame).not.toContain("Hostname")
+    expect(frame).not.toContain("Proxy authentication")
+    expect(frame).not.toContain("Username variable")
+    expect(frame).not.toContain("Password variable")
+    expect(frame).toContain("credentials directly in the URL")
     cleanup()
   })
 

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { act, useState } from "react"
-import type { InputRenderable } from "@opentui/core"
+import { type BoxRenderable, type InputRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -20,6 +20,7 @@ import {
   type SettingsCategory,
   type SettingsScope,
 } from "../../src/ui/settings/SettingsView"
+import { SIDEBAR_WIDTH } from "../../src/ui/Sidebar"
 
 const testRender = createTestRender()
 
@@ -50,6 +51,7 @@ function Harness({
   onCollectionUnregister = () => {},
   onKeybindChange = () => true,
   onCollectionSettingsChange = () => true,
+  onThemeChange = () => {},
   appProxy = { mode: "system" },
   initialCollectionSettings = {},
 }: {
@@ -68,6 +70,7 @@ function Harness({
       "name" | "description" | "timelineMaxEntries"
     >,
   ) => boolean
+  onThemeChange?: (index: number) => void
   appProxy?: AppProxySettings
   initialCollectionSettings?: CollectionSettings
 }) {
@@ -108,7 +111,7 @@ function Harness({
       }}
       onPaneFocus={setFocus}
       onClose={onClose}
-      onThemeChange={() => {}}
+      onThemeChange={onThemeChange}
       onLayoutChange={() => true}
       onConfirmUndoAllChange={() => {}}
       onAppProxyChange={() => true}
@@ -151,6 +154,8 @@ describe("SettingsView", () => {
       expect(frame).toContain("Proxy")
       expect(frame).not.toContain("Network")
       expect(frame).toContain("Theme")
+      expect(frame).not.toContain("Settings")
+      expect(frame).not.toContain("Auto-save")
       expect(frame).toContain("Choose how Noodle")
       if (size.width === 110) {
         const lines = frame.split("\n")
@@ -170,6 +175,55 @@ describe("SettingsView", () => {
       }
       cleanup()
     }
+  })
+
+  it("uses the shared sidebar width and keeps core controls visible", async () => {
+    for (const size of [
+      { width: 64, height: 16 },
+      { width: 80, height: 24 },
+      { width: 110, height: 30 },
+    ]) {
+      const { keymap, cleanup } = setupKeymap()
+      const { renderOnce, captureCharFrame, renderer } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <Harness />
+          </ThemeProvider>
+        </KeymapProvider>,
+        size,
+      )
+      await renderOnce()
+
+      const scope = renderer.root.findDescendantById("settings-scope-global")!
+      const section = renderer.root.findDescendantById(
+        "settings-section-header",
+      )!
+      expect(section.screenX - scope.screenX).toBe(SIDEBAR_WIDTH + 1)
+      expect(captureCharFrame()).toContain("Theme")
+      cleanup()
+    }
+  })
+
+  it("uses the shared theme select behavior", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const selected: number[] = []
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness
+            initialFocus="settings-content"
+            onThemeChange={(index) => selected.push(index)}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 24 },
+    )
+    await renderOnce()
+    await act(async () => host.press("return"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    expect(selected).toEqual([1])
+    cleanup()
   })
 
   it("keeps Collection disabled in browse/empty modes", async () => {
@@ -220,7 +274,7 @@ describe("SettingsView", () => {
     await act(async () => host.press("right"))
     expect(captureCharFrame()).toContain("Active environment")
     expect(captureCharFrame()).toContain("Describe this collection")
-    expect(captureCharFrame()).toContain("local history")
+    expect(captureCharFrame()).toContain("history.")
     cleanup()
   })
 
@@ -291,7 +345,7 @@ describe("SettingsView", () => {
 
     expect(patches).toEqual([])
     expect(captureCharFrame()).toContain("non-negative")
-    expect(captureCharFrame()).toContain("integer, or blank")
+    expect(captureCharFrame()).toContain("blank for 50")
     cleanup()
   })
 
@@ -501,6 +555,45 @@ describe("SettingsView", () => {
     expect(create.screenY - find.screenY).toBe(1)
     expect(environment.screenY - create.screenY).toBeGreaterThan(1)
     cleanup()
+  })
+
+  it("only highlights a keyboard row while the content pane is active", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, renderer } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness initialCategory="keyboard" />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 24 },
+    )
+    await renderOnce()
+
+    const firstRow = () =>
+      renderer.root.findDescendantById(
+        "settings-key-jump_mode-row",
+      ) as BoxRenderable
+    expect(firstRow().backgroundColor.a).toBe(0)
+    cleanup()
+
+    const activeKeymap = setupKeymap()
+    const activeRender = await testRender(
+      <KeymapProvider keymap={activeKeymap.keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness initialCategory="keyboard" initialFocus="settings-content" />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 24 },
+    )
+    await activeRender.renderOnce()
+    expect(
+      (
+        activeRender.renderer.root.findDescendantById(
+          "settings-key-jump_mode-row",
+        ) as BoxRenderable
+      ).backgroundColor.a,
+    ).toBeGreaterThan(0)
+    activeKeymap.cleanup()
   })
 
   it("keeps the focused proxy field visible in a compact terminal", async () => {

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -349,6 +349,40 @@ describe("SettingsView", () => {
     cleanup()
   })
 
+  it("closes with Escape and discards an invalid timeline retention", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let closed = false
+    const patches: Array<Partial<CollectionSettings>> = []
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness
+            initialScope="collection"
+            initialCategory="general"
+            initialFocus="settings-content"
+            onClose={() => (closed = true)}
+            onCollectionSettingsChange={(patch) => {
+              patches.push(patch)
+              return true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 26 },
+    )
+    await renderOnce()
+    await act(async () => host.press("tab"))
+    await act(async () => host.press("tab"))
+    await act(async () => host.press("backspace"))
+    await act(async () => host.press("backspace"))
+    await act(async () => mockInput.typeText("-1"))
+    await act(async () => host.press("escape"))
+
+    expect(closed).toBe(true)
+    expect(patches).toEqual([])
+    cleanup()
+  })
+
   it("parses blank timeline retention as the default and accepts zero", () => {
     expect(parseTimelineMaxEntries("  ")).toEqual({ value: undefined })
     expect(parseTimelineMaxEntries("0")).toEqual({ value: 0 })

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -148,6 +148,8 @@ describe("SettingsView", () => {
       expect(frame).toContain("Collection")
       expect(frame).toContain("Appearance")
       expect(frame).toContain("Keyboard")
+      expect(frame).toContain("Proxy")
+      expect(frame).not.toContain("Network")
       expect(frame).toContain("Theme")
       expect(frame).toContain("Choose how Noodle")
       if (size.width === 110) {

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -13,9 +13,10 @@ import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { bindingDefaults } from "../../src/ui/keybind"
 import type { Focus } from "../../src/ui/focus"
-import type { AppProxySettings } from "../../src/schema"
+import type { AppProxySettings, CollectionSettings } from "../../src/schema"
 import {
   SettingsView,
+  parseTimelineMaxEntries,
   type SettingsCategory,
   type SettingsScope,
 } from "../../src/ui/settings/SettingsView"
@@ -42,26 +43,40 @@ function Harness({
   collectionAvailable = true,
   onClose = () => {},
   initialCategory = "appearance",
+  initialScope = "global",
   initialFocus = "settings-sidebar",
   onCategoryVisited = () => {},
   onCollectionsChange = () => true,
   onCollectionUnregister = () => {},
   onKeybindChange = () => true,
+  onCollectionSettingsChange = () => true,
   appProxy = { mode: "system" },
+  initialCollectionSettings = {},
 }: {
   collectionAvailable?: boolean
   onClose?: () => void
   initialCategory?: SettingsCategory
+  initialScope?: SettingsScope
   initialFocus?: Focus
   onCategoryVisited?: (category: SettingsCategory) => void
   onCollectionsChange?: (collections: string[]) => boolean
   onCollectionUnregister?: (path: string) => void
   onKeybindChange?: (name: string, key: string) => boolean
+  onCollectionSettingsChange?: (
+    patch: Pick<
+      CollectionSettings,
+      "name" | "description" | "timelineMaxEntries"
+    >,
+  ) => boolean
   appProxy?: AppProxySettings
+  initialCollectionSettings?: CollectionSettings
 }) {
-  const [scope, setScope] = useState<SettingsScope>("global")
+  const [scope, setScope] = useState<SettingsScope>(initialScope)
   const [category, setCategory] = useState<SettingsCategory>(initialCategory)
   const [focus, setFocus] = useState<Focus>(initialFocus)
+  const [collectionSettings, setCollectionSettings] = useState(
+    initialCollectionSettings,
+  )
   return (
     <SettingsView
       scope={scope}
@@ -73,6 +88,9 @@ function Harness({
       confirmUndoAll
       appProxy={appProxy}
       collectionProxy={{ mode: "inherit" }}
+      collectionName={collectionSettings.name}
+      collectionDescription={collectionSettings.description}
+      timelineMaxEntries={collectionSettings.timelineMaxEntries}
       noProxy={false}
       activeEnv={{ name: "development", vars: {} }}
       envNames={["development", "production"]}
@@ -95,6 +113,11 @@ function Harness({
       onConfirmUndoAllChange={() => {}}
       onAppProxyChange={() => true}
       onCollectionProxyChange={() => true}
+      onCollectionSettingsChange={(patch) => {
+        if (!onCollectionSettingsChange(patch)) return false
+        setCollectionSettings((current) => ({ ...current, ...patch }))
+        return true
+      }}
       onEnvironmentChange={() => {}}
       onKeybindChange={onKeybindChange}
       onCollectionsChange={onCollectionsChange}
@@ -189,13 +212,91 @@ describe("SettingsView", () => {
           <Harness />
         </ThemeProvider>
       </KeymapProvider>,
-      { width: 90, height: 22 },
+      { width: 90, height: 32 },
     )
     await renderOnce()
     await act(async () => host.press("right"))
     expect(captureCharFrame()).toContain("Active environment")
-    expect(captureCharFrame()).toContain("Choose the environment used")
+    expect(captureCharFrame()).toContain("Describe this collection")
+    expect(captureCharFrame()).toContain("local history")
     cleanup()
+  })
+
+  it("commits collection name and multiline description when tabbing", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const patches: Array<Partial<CollectionSettings>> = []
+    const { renderOnce, mockInput, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness
+            initialScope="collection"
+            initialCategory="general"
+            initialFocus="settings-content"
+            onCollectionSettingsChange={(patch) => {
+              patches.push(patch)
+              return true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 26 },
+    )
+    await renderOnce()
+
+    await act(async () => mockInput.typeText("Payments API"))
+    await act(async () => host.press("tab"))
+    await act(async () => mockInput.typeText("First line"))
+    await act(async () => host.press("return"))
+    await act(async () => mockInput.typeText("Second line"))
+    await act(async () => host.press("tab"))
+    await renderOnce()
+
+    expect(patches).toEqual([
+      { name: "Payments API" },
+      { description: "First line\nSecond line" },
+    ])
+    expect(captureCharFrame()).toContain("Timeline entries")
+    cleanup()
+  })
+
+  it("keeps invalid timeline retention unsaved with an inline error", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const patches: Array<Partial<CollectionSettings>> = []
+    const { renderOnce, mockInput, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness
+            initialScope="collection"
+            initialCategory="general"
+            initialFocus="settings-content"
+            onCollectionSettingsChange={(patch) => {
+              patches.push(patch)
+              return true
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 26 },
+    )
+    await renderOnce()
+    await act(async () => host.press("tab"))
+    await act(async () => host.press("tab"))
+    await act(async () => host.press("backspace"))
+    await act(async () => host.press("backspace"))
+    await act(async () => mockInput.typeText("-1"))
+    await act(async () => host.press("tab"))
+    await renderOnce()
+
+    expect(patches).toEqual([])
+    expect(captureCharFrame()).toContain("non-negative")
+    expect(captureCharFrame()).toContain("integer, or blank")
+    cleanup()
+  })
+
+  it("parses blank timeline retention as the default and accepts zero", () => {
+    expect(parseTimelineMaxEntries("  ")).toEqual({ value: undefined })
+    expect(parseTimelineMaxEntries("0")).toEqual({ value: 0 })
+    expect(parseTimelineMaxEntries("-1")).toHaveProperty("error")
   })
 
   it("keeps registered collection rows compact", async () => {

--- a/tests/unit/collectionRegistry.test.ts
+++ b/tests/unit/collectionRegistry.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
+  collectionDisplayName,
   moveRegisteredCollection,
   resolveCollectionRegistration,
   unregisterCollection,
@@ -26,6 +27,15 @@ afterEach(() => {
 })
 
 describe("collection registry settings", () => {
+  it("uses collection metadata names with a path fallback", () => {
+    expect(
+      collectionDisplayName("/tmp/payments", { name: " Payments API " }),
+    ).toBe("Payments API")
+    expect(collectionDisplayName("/tmp/payments", { name: " " })).toBe(
+      "payments",
+    )
+  })
+
   it("normalizes relative and @/ paths to initialized collections", () => {
     const root = workspace()
     const relative = join(root, "relative")

--- a/tests/unit/focus.test.ts
+++ b/tests/unit/focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { cycleFocus } from "../../src/ui/focus"
+import { cycleFocus, settingsReturnFocus } from "../../src/ui/focus"
 
 describe("cycleFocus", () => {
   it("moves forward from UrlBar to request pane", () => {
@@ -25,5 +25,24 @@ describe("cycleFocus", () => {
     expect(cycleFocus("settings-content", 1, "settings")).toBe(
       "settings-sidebar",
     )
+  })
+})
+
+describe("settingsReturnFocus", () => {
+  it("restores the pane that opened settings from the main view", () => {
+    for (const focus of [
+      "sidebar",
+      "urlbar",
+      "request",
+      "response",
+      "folder",
+    ] as const) {
+      expect(settingsReturnFocus("main", focus)).toBe(focus)
+    }
+  })
+
+  it("falls back to the main sidebar outside the main view", () => {
+    expect(settingsReturnFocus("env-editor", "env-vars")).toBe("sidebar")
+    expect(settingsReturnFocus("settings", "settings-content")).toBe("sidebar")
   })
 })

--- a/tests/unit/keybindingHints.test.ts
+++ b/tests/unit/keybindingHints.test.ts
@@ -59,7 +59,7 @@ describe("getKeybindingHints footer", () => {
         .footer,
     ).toEqual([
       seg("↑/↓", "categories"),
-      seg("Tab", "edit"),
+      seg("←/→", "scope"),
       seg("Esc", "close settings"),
     ])
 
@@ -86,10 +86,20 @@ describe("getKeybindingHints footer", () => {
         }),
       ).footer,
     ).toEqual([
-      seg("Enter", "add"),
+      seg("↑/↓", "select"),
       seg("Ctrl+↑/↓", "reorder"),
       seg("Del", "unregister"),
     ])
+
+    expect(
+      getKeybindingHints(
+        ctx({
+          view: "settings",
+          focus: "settings-content",
+          settingsCategory: "general",
+        }),
+      ).footer,
+    ).toEqual([seg("Tab", "next"), seg("Esc", "close settings")])
   })
 
   it("uses the active request browse commands", () => {

--- a/tests/unit/settingsPersistence.test.ts
+++ b/tests/unit/settingsPersistence.test.ts
@@ -4,13 +4,16 @@ import { queueCollectionSettingsSave } from "../../src/ui/settings/settingsPersi
 
 function deferred(): {
   promise: Promise<void>
+  resolve: () => void
   reject: (error: Error) => void
 } {
+  let resolve!: () => void
   let reject!: (error: Error) => void
-  const promise = new Promise<void>((_, rejectPromise) => {
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
     reject = rejectPromise
   })
-  return { promise, reject }
+  return { promise, resolve, reject }
 }
 
 async function flush(): Promise<void> {
@@ -97,5 +100,46 @@ describe("queueCollectionSettingsSave", () => {
 
     expect(persistence.currentSettings.current).toEqual(persisted)
     expect(renderedSettings).toEqual(persisted)
+  })
+
+  it("skips the success callback for superseded settings", async () => {
+    const first = deferred()
+    const persistedSettings: CollectionSettings = { timelineMaxEntries: 50 }
+    const oldSettings: CollectionSettings = { timelineMaxEntries: 10 }
+    const currentSettings: CollectionSettings = { timelineMaxEntries: 50 }
+    const persistence = {
+      activeCollectionDir: { current: "/collection" },
+      currentSettings: { current: oldSettings },
+      persistedSettings: { current: persistedSettings },
+      saveChain: { current: Promise.resolve() },
+    }
+    let saved = 0
+
+    queueCollectionSettingsSave(
+      persistence,
+      "/collection",
+      oldSettings,
+      async () => first.promise,
+      () => {},
+      () => {},
+      () => {
+        saved++
+      },
+    )
+    persistence.currentSettings.current = currentSettings
+    queueCollectionSettingsSave(
+      persistence,
+      "/collection",
+      currentSettings,
+      async () => {},
+      () => {},
+      () => {},
+    )
+
+    first.resolve()
+    await persistence.saveChain.current
+    await flush()
+
+    expect(saved).toBe(0)
   })
 })

--- a/tests/unit/settingsPersistence.test.ts
+++ b/tests/unit/settingsPersistence.test.ts
@@ -19,6 +19,33 @@ async function flush(): Promise<void> {
 }
 
 describe("queueCollectionSettingsSave", () => {
+  it("runs the success callback only after settings persist", async () => {
+    const persisted: CollectionSettings = { timelineMaxEntries: 10 }
+    const persistence = {
+      activeCollectionDir: { current: "/collection" },
+      currentSettings: { current: persisted },
+      persistedSettings: { current: {} },
+      saveChain: { current: Promise.resolve() },
+    }
+    let saved = false
+
+    queueCollectionSettingsSave(
+      persistence,
+      "/collection",
+      persisted,
+      async () => {},
+      () => {},
+      () => {},
+      () => {
+        saved = true
+      },
+    )
+    expect(saved).toBe(false)
+    await persistence.saveChain.current
+    await flush()
+    expect(saved).toBe(true)
+  })
+
   it("restores persisted settings when superseded proxy and environment saves fail", async () => {
     const persisted: CollectionSettings = { environment: "development" }
     const proxySettings: CollectionSettings = {


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds collection-level settings for name, description, and configurable timeline retention (max saved responses per request), persisted in `settings.yml`. The settings view gains a new General section for these fields, timeline persistence honors the limit, and proxy settings are simplified (renamed Network → Proxy, auth fields merged into the URL).

Includes a follow-up refactor improving settings focus restoration and keybinding hints.

### How did you verify your code works?

- Unit tests updated/added for `SettingsView`, `ProxySettingsForm`, `settingsPersistence`, `collectionRegistry`, and `CollectionSwitcherOverlay`
- `filestore` tests for loading/saving the new `settings.yml` fields
- Timeline retention covered in `timeline-filestore.test.ts` and integration tests
- `bun test`, `bun run lint`, and `bun run typecheck` pass

### Screenshots / recordings

N/A (terminal UI)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collection settings for display name, description, environment, proxy, and timeline retention.
  * Timeline history defaults to 50 entries, supports custom limits, and can be disabled with zero.
  * Collection metadata appears throughout the interface.
* **Bug Fixes**
  * Improved proxy mode switching, validation, and credential guidance.
  * Timeline history is pruned when retention limits decrease.
  * Settings navigation restores the previously focused view.
* **Documentation**
  * Updated README and settings documentation with supported options and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->