### PR TITLE
feat(secrets): store environment secrets in the OS keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ Use `$variables` from an environment file, keep required URL segments in
 supports headers, query parameters, JSON, form, multipart, and binary bodies,
 plus bearer, basic, and API-key authentication.
 
+Mark sensitive environment values as secrets in the environment editor, or
+declare them directly with a blank placeholder:
+
+```dotenv
+# @secret API_TOKEN
+API_TOKEN=
+```
+
+The value is stored in macOS Keychain, Linux Secret Service, or Windows
+Credential Manager instead of the `.env` file. A nonempty process environment
+value takes precedence, which keeps CI setup simple. Secret values remain
+masked in the editor and are excluded from persisted request history, code
+generation, request search, and exports.
+
 For multipart file entries and binary `file_path` values, use a quoted `@/`
 path such as `'@/Documents/report.pdf'` to start from the current user's home
 directory. Noodle completes the shorthand in the TUI and expands it only when
@@ -166,12 +180,16 @@ Collection metadata and response-history retention also live in
 prunes older entries, and `0` disables timeline recording.
 
 ```yaml
+collection_id: 123e4567-e89b-42d3-a456-426614174000
 name: Payments API
 description: |-
   Requests for the payments platform.
 timeline_max_entries: 50
 environment: development
 ```
+
+Noodle creates and maintains `collection_id`; it is public metadata used only
+to keep credential-store entries stable when a collection moves.
 
 `settings.yml` is validated strictly whenever a collection is opened, audited,
 or run. Unknown keys, invalid field types, malformed proxy/TLS blocks, and YAML
@@ -253,6 +271,10 @@ are non-interactive and support `--json`, which emits one
 | `noodle request create <id> --url <url> --collection <dir>`            | Create a minimal request.                                |
 | `noodle request run <id> --collection <dir>`                           | Run one request.                                         |
 | `noodle environment set <key> <value> --env <name> --collection <dir>` | Set an environment value.                                |
+| `noodle secret set <key> --env <name> --collection <dir>`              | Prompt for and securely store a secret.                  |
+| `noodle secret set <key> --env <name> --stdin`                         | Read a secret from stdin for automation.                 |
+| `noodle secret list --env <name> --collection <dir>`                   | List secret names and their active source.               |
+| `noodle secret delete <key> --env <name> --collection <dir>`           | Remove only the locally stored secret value.             |
 
 Run commands accept `--env <name>` when you want to override the collection's
 default environment. Request IDs are collection-relative paths without `.yml`,

--- a/collections/.environments/development.env
+++ b/collections/.environments/development.env
@@ -1,6 +1,6 @@
 _color=success
 base_url=https://jsonplaceholder.typicode.com
-post_id=1
-user_id=1
-api_token=sdf7f7s8fdfs0d8fs0f
-x_api_key=s98df7s98f7sf7sfs87sdf
+# @secret api_token
+api_token=
+# @secret x_api_key
+x_api_key=

--- a/collections/settings.yml
+++ b/collections/settings.yml
@@ -1,3 +1,4 @@
+collection_id: de92de2f-f40b-48ab-bdbc-64d58f72e9d9
 name: Noodle Collection
 description: This is a sample collection designed to help Noodle developers.
 environment: development

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -11,6 +11,7 @@ import {
   collection,
   request,
   environment,
+  secret,
 } from "./commands/automation"
 
 const rawArgs = process.argv.slice(2)
@@ -27,6 +28,7 @@ const KNOWN_SUBCOMMANDS = new Set([
   "collection",
   "request",
   "environment",
+  "secret",
 ])
 
 const userArgsStart = getUserArgsStart(process.argv)
@@ -73,6 +75,7 @@ const main = defineCommand({
     collection,
     request,
     environment,
+    secret,
   },
   default: "noodle",
 })

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -10,6 +10,9 @@ import {
   formatCollectionList,
   formatCollectionRun,
   formatEnvironmentSet,
+  formatSecretDelete,
+  formatSecretList,
+  formatSecretSet,
   formatRequestCreate,
   formatRequestRun,
   formatWorkspaceAudit,
@@ -24,6 +27,9 @@ import {
   collectionList,
   collectionRun,
   environmentSet,
+  secretDelete,
+  secretList,
+  secretSet,
   requestCreate,
   requestRun,
   workspaceAudit,
@@ -51,6 +57,58 @@ const methods: Method[] = [
   "HEAD",
   "OPTIONS",
 ]
+
+async function readSecretInput(fromStdin: boolean): Promise<string> {
+  if (fromStdin) {
+    const value = await Bun.stdin.text()
+    return value.replace(/\r?\n$/, "")
+  }
+  if (!process.stdin.isTTY || !process.stderr.isTTY) {
+    throw new Error("secret input requires a TTY; use --stdin for automation")
+  }
+  process.stderr.write("Secret value: ")
+  return new Promise((resolve, reject) => {
+    const input = process.stdin
+    const wasRaw = input.isRaw
+    let value = ""
+    const cleanup = () => {
+      input.off("data", onData)
+      input.setRawMode?.(Boolean(wasRaw))
+      input.pause()
+    }
+    const onData = (chunk: Buffer | string) => {
+      const text = chunk.toString()
+      for (const char of text) {
+        if (char === "\u0003") {
+          cleanup()
+          process.stderr.write("\n")
+          reject(new Error("secret input cancelled"))
+          return
+        }
+        if (char === "\r" || char === "\n") {
+          cleanup()
+          process.stderr.write("\n")
+          resolve(value)
+          return
+        }
+        if (char === "\u007f" || char === "\b") {
+          if (value) {
+            value = [...value].slice(0, -1).join("")
+            process.stderr.write("\b \b")
+          }
+          continue
+        }
+        if (char >= " ") {
+          value += char
+          process.stderr.write("•")
+        }
+      }
+    }
+    input.setRawMode?.(true)
+    input.resume()
+    input.on("data", onData)
+  })
+}
 
 const workspace = defineCommand({
   meta: { name: "workspace", description: "Manage registered collections" },
@@ -301,4 +359,67 @@ const environment = defineCommand({
     }),
   },
 })
-export { workspace, collection, request, environment }
+const secret = defineCommand({
+  meta: { name: "secret", description: "Manage secure environment values" },
+  subCommands: {
+    set: defineCommand({
+      meta: { name: "set", description: "Store or replace a secret value" },
+      args: {
+        key: { type: "positional", required: true },
+        env: { type: "string", required: true },
+        collection: collectionArg,
+        stdin: {
+          type: "boolean",
+          default: false,
+          description: "Read the secret value from stdin",
+        },
+        json: jsonArg,
+      },
+      run: ({ args }) =>
+        emitCommand(
+          args.json,
+          async () => ({
+            data: await secretSet(
+              args.key,
+              await readSecretInput(args.stdin),
+              args.env,
+              args.collection,
+            ),
+          }),
+          formatSecretSet,
+        ),
+    }),
+    list: defineCommand({
+      meta: { name: "list", description: "List secret names and status" },
+      args: {
+        env: { type: "string", required: true },
+        collection: collectionArg,
+        json: jsonArg,
+      },
+      run: ({ args }) =>
+        emitCommand(
+          args.json,
+          async () => ({ data: await secretList(args.env, args.collection) }),
+          formatSecretList,
+        ),
+    }),
+    delete: defineCommand({
+      meta: { name: "delete", description: "Remove a local secret value" },
+      args: {
+        key: { type: "positional", required: true },
+        env: { type: "string", required: true },
+        collection: collectionArg,
+        json: jsonArg,
+      },
+      run: ({ args }) =>
+        emitCommand(
+          args.json,
+          async () => ({
+            data: await secretDelete(args.key, args.env, args.collection),
+          }),
+          formatSecretDelete,
+        ),
+    }),
+  },
+})
+export { workspace, collection, request, environment, secret }

--- a/src/app/export.ts
+++ b/src/app/export.ts
@@ -38,7 +38,9 @@ async function exportEnvironments(
   const environments = await Promise.all(
     names.map(async (name) => {
       try {
-        return await env.loadEnvironment(directory, name)
+        return await env.loadEnvironment(directory, name, {
+          resolveSecrets: false,
+        })
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         throw new Error(

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -170,6 +170,39 @@ export function formatEnvironmentSet(data: {
   return `${color("✓", "green")} Set ${data.key} in ${data.environment}`
 }
 
+export function formatSecretSet(data: {
+  environment: string
+  key: string
+}): string {
+  return `${color("✓", "green")} Stored ${data.key} securely for ${data.environment}`
+}
+
+export function formatSecretList(data: {
+  environment: string
+  secrets: { key: string; enabled: boolean; status: string }[]
+}): string {
+  if (data.secrets.length === 0) {
+    return `No secrets declared in ${data.environment}.`
+  }
+  return [
+    `Secrets in ${data.environment}`,
+    ...data.secrets.map(
+      (secret) =>
+        `  ${secret.enabled ? "●" : "○"} ${secret.key}  ${color(secret.status, secret.status === "missing" ? "yellow" : "dim")}`,
+    ),
+  ].join("\n")
+}
+
+export function formatSecretDelete(data: {
+  environment: string
+  key: string
+  deleted: boolean
+}): string {
+  return data.deleted
+    ? `${color("✓", "green")} Removed the local value for ${data.key} in ${data.environment}`
+    : `No local value was stored for ${data.key} in ${data.environment}`
+}
+
 export function formatImport(data: {
   path: string
   name: string

--- a/src/app/import.ts
+++ b/src/app/import.ts
@@ -9,7 +9,12 @@ import {
   supportedFormats,
   type ImportResult,
 } from "../converters/index"
-import { saveRequest, saveFolder, saveSettings } from "../filestore"
+import {
+  loadSettings,
+  saveRequest,
+  saveFolder,
+  saveSettings,
+} from "../filestore"
 import { formatJson } from "../lang/formatJson"
 import type {
   Collection,
@@ -290,6 +295,7 @@ export async function runImport(
   }
 
   let removePartialImport = false
+  const initializeCollectionId = options.destination?.kind !== "current"
   try {
     if (options.destination?.kind === "new") {
       await mkdir(collDir)
@@ -315,8 +321,12 @@ export async function runImport(
       }
     }
 
-    if (removePartialImport) {
-      await saveSettings(collDir, { collectionId: randomUUID() })
+    if (initializeCollectionId) {
+      const settings = await loadSettings(collDir)
+      await saveSettings(collDir, {
+        ...settings,
+        collectionId: settings.collectionId ?? randomUUID(),
+      })
     }
   } catch (e) {
     if (removePartialImport) {

--- a/src/app/import.ts
+++ b/src/app/import.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join, posix, relative, resolve, sep } from "node:path"
+import { randomUUID } from "node:crypto"
 import {
   getImporter,
   detectFormat,
@@ -315,7 +316,7 @@ export async function runImport(
     }
 
     if (removePartialImport) {
-      await saveSettings(collDir, {})
+      await saveSettings(collDir, { collectionId: randomUUID() })
     }
   } catch (e) {
     if (removePartialImport) {

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -8,6 +8,7 @@ import {
   writeFile,
 } from "node:fs/promises"
 import { basename, join, relative, resolve } from "node:path"
+import { randomUUID } from "node:crypto"
 import { load as yamlLoad } from "js-yaml"
 import { loadConfig, saveConfig, upsertCollectionPath } from "../config"
 import { env } from "../env"
@@ -18,6 +19,7 @@ import {
   saveRequest,
   saveSettings,
   ensureCollectionBootstrapped,
+  redactTimelineSecrets,
 } from "../filestore"
 import { formatJson } from "../lang/formatJson"
 import { lang } from "../lang"
@@ -37,6 +39,13 @@ import type {
   Environment,
   Request,
 } from "../schema"
+import {
+  deleteStoredSecret,
+  ensureCollectionId,
+  getStoredSecret,
+  setStoredSecret,
+} from "../secrets"
+import { environmentSecretValues, redactKnownSecrets } from "../secrets/redact"
 
 const CONFIG_DIR = join(process.env.HOME ?? "~", ".config/noodle")
 const SKIP_DIRS = new Set([".noodle", ".timeline", ".git", "node_modules"])
@@ -205,7 +214,10 @@ export async function collectionCreate(
   const path = resolve(output, name)
   if (existsSync(path)) throw new Error(`collection already exists: ${path}`)
   await mkdir(join(path, ".environments"), { recursive: true })
-  await saveSettings(path, { environment: "development" })
+  await saveSettings(path, {
+    collectionId: randomUUID(),
+    environment: "development",
+  })
   await env.saveEnvironment(join(path, ".environments"), {
     name: "development",
     vars: {},
@@ -412,8 +424,12 @@ async function auditFile(
       const parsed = await env.loadEnvironment(
         join(path, ".."),
         name.slice(0, -4),
+        { resolveSecrets: false },
       )
       if (fix) {
+        if (Object.keys(parsed.secretVars ?? {}).length > 0) {
+          await ensureCollectionId(root)
+        }
         await env.saveEnvironment(join(path, ".."), parsed)
         issues.push({
           path: rel,
@@ -520,6 +536,8 @@ async function runRequest(
   proxyPolicy?: ProxyPolicy,
   tlsPolicy?: TlsPolicy,
 ): Promise<RequestRunResult> {
+  const secretValues = environmentSecretValues(environment)
+  const redact = (value: string) => redactKnownSecrets(value, secretValues)
   try {
     const response = await executor.send(request, {
       environment,
@@ -532,12 +550,17 @@ async function runRequest(
     return {
       id: request.id,
       method: request.method,
-      url: effective.url,
+      url: redact(effective.url),
       response: {
         status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-        body: response.body,
+        statusText: redact(response.statusText),
+        headers: Object.fromEntries(
+          Object.entries(response.headers).map(([key, value]) => [
+            redact(key),
+            redact(value),
+          ]),
+        ),
+        body: redact(response.body),
         timeMs: response.timeMs,
       },
       ok: response.status < 400,
@@ -546,8 +569,8 @@ async function runRequest(
     return {
       id: request.id,
       method: request.method,
-      url: request.url,
-      error: errorMessage(error),
+      url: redact(request.url),
+      error: redact(errorMessage(error)),
       ok: false,
     }
   }
@@ -663,7 +686,14 @@ export async function environmentSet(
     throw new Error(`invalid environment key "${key}"`)
   const collectionRoot = await requireCollectionRoot(collectionDir)
   const dir = join(collectionRoot, ".environments")
-  const current = await env.loadEnvironment(dir, name)
+  const current = await env.loadEnvironment(dir, name, {
+    resolveSecrets: false,
+  })
+  if (current.secretVars?.[key]) {
+    throw new Error(
+      `"${key}" is a secret; use "noodle secret set ${key} --env ${name}"`,
+    )
+  }
   const disabled = { ...(current.disabledVars ?? {}) }
   delete disabled[key]
   await env.saveEnvironment(dir, {
@@ -672,4 +702,101 @@ export async function environmentSet(
     disabledVars: Object.keys(disabled).length ? disabled : undefined,
   })
   return { environment: name, key }
+}
+
+export interface SecretListItem {
+  key: string
+  enabled: boolean
+  status: "process" | "keychain" | "missing" | "disabled"
+}
+
+function validateSecretKey(key: string): void {
+  if (!/^\w+$/.test(key)) {
+    throw new Error(
+      `invalid secret key "${key}"; expected letters, numbers, or _`,
+    )
+  }
+}
+
+export async function secretSet(
+  key: string,
+  value: string,
+  name: string,
+  collectionDir: string,
+): Promise<{ environment: string; key: string; status: "stored" }> {
+  validateSecretKey(key)
+  if (!value) throw new Error("secret value must not be empty")
+  const collectionRoot = await requireCollectionRoot(collectionDir)
+  const directory = join(collectionRoot, ".environments")
+  const current = await env.loadEnvironment(directory, name, {
+    resolveSecrets: false,
+  })
+  const oldPlaintext = current.vars[key] ?? current.disabledVars?.[key]
+  if (oldPlaintext) await redactTimelineSecrets(collectionRoot, [oldPlaintext])
+
+  const previous = await getStoredSecret(collectionRoot, name, key)
+  await setStoredSecret(collectionRoot, name, key, value)
+  const wasDisabled =
+    current.secretVars?.[key] === "disabled" ||
+    Object.hasOwn(current.disabledVars ?? {}, key)
+  const vars = { ...current.vars }
+  const disabledVars = { ...(current.disabledVars ?? {}) }
+  delete vars[key]
+  delete disabledVars[key]
+  try {
+    await env.saveEnvironment(directory, {
+      ...current,
+      vars,
+      disabledVars: Object.keys(disabledVars).length ? disabledVars : undefined,
+      secretVars: {
+        ...(current.secretVars ?? {}),
+        [key]: wasDisabled ? "disabled" : "keychain",
+      },
+    })
+  } catch (error) {
+    if (previous) await setStoredSecret(collectionRoot, name, key, previous)
+    else await deleteStoredSecret(collectionRoot, name, key).catch(() => false)
+    throw error
+  }
+  return { environment: name, key, status: "stored" }
+}
+
+export async function secretList(
+  name: string,
+  collectionDir: string,
+): Promise<{ environment: string; secrets: SecretListItem[] }> {
+  const collectionRoot = await requireCollectionRoot(collectionDir)
+  const current = await env.loadEnvironment(
+    join(collectionRoot, ".environments"),
+    name,
+  )
+  return {
+    environment: name,
+    secrets: Object.entries(current.secretVars ?? {})
+      .map(([key, status]) => ({
+        key,
+        enabled: status !== "disabled",
+        status,
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key)),
+  }
+}
+
+export async function secretDelete(
+  key: string,
+  name: string,
+  collectionDir: string,
+): Promise<{ environment: string; key: string; deleted: boolean }> {
+  validateSecretKey(key)
+  const collectionRoot = await requireCollectionRoot(collectionDir)
+  const current = await env.loadEnvironment(
+    join(collectionRoot, ".environments"),
+    name,
+    { resolveSecrets: false },
+  )
+  if (!current.secretVars?.[key]) {
+    throw new Error(`secret "${key}" is not declared in ${name}`)
+  }
+  const deleted = await deleteStoredSecret(collectionRoot, name, key)
+  return { environment: name, key, deleted }
 }

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -553,14 +553,9 @@ async function runRequest(
       url: redact(effective.url),
       response: {
         status: response.status,
-        statusText: redact(response.statusText),
-        headers: Object.fromEntries(
-          Object.entries(response.headers).map(([key, value]) => [
-            redact(key),
-            redact(value),
-          ]),
-        ),
-        body: redact(response.body),
+        statusText: response.statusText,
+        headers: response.headers,
+        body: response.body,
         timeMs: response.timeMs,
       },
       ok: response.status < 400,

--- a/src/codegen/buildHar.ts
+++ b/src/codegen/buildHar.ts
@@ -77,6 +77,7 @@ export function buildHar(
 function interpolateRequest(req: Request, env: Environment): Request {
   const resolveVar = (s: string): string => {
     return s.replace(VAR_RE, (_, name) => {
+      if (Object.hasOwn(env.secretVars ?? {}, name)) return `$${name}`
       if (Object.hasOwn(env.vars, name)) return env.vars[name]
       return `$${name}`
     })

--- a/src/converters/postman/export.ts
+++ b/src/converters/postman/export.ts
@@ -225,19 +225,32 @@ export function exportPostman(collection: Collection): PostmanExportResult {
 export function exportPostmanEnvironment(
   environment: Environment,
 ): PostmanObject {
+  const secretKeys = new Set(Object.keys(environment.secretVars ?? {}))
   const values = [
     ...Object.entries(environment.vars).map(([key]) => ({
       key,
       value: "",
-      type: "default",
+      type: secretKeys.has(key) ? "secret" : "default",
       enabled: true,
     })),
     ...Object.entries(environment.disabledVars ?? {}).map(([key]) => ({
       key,
       value: "",
-      type: "default",
+      type: secretKeys.has(key) ? "secret" : "default",
       enabled: false,
     })),
+    ...Object.entries(environment.secretVars ?? {})
+      .filter(
+        ([key]) =>
+          !Object.hasOwn(environment.vars, key) &&
+          !Object.hasOwn(environment.disabledVars ?? {}, key),
+      )
+      .map(([key, status]) => ({
+        key,
+        value: "",
+        type: "secret",
+        enabled: status !== "disabled",
+      })),
   ].sort(
     (a, b) =>
       a.key.localeCompare(b.key) || Number(b.enabled) - Number(a.enabled),

--- a/src/env/clone.ts
+++ b/src/env/clone.ts
@@ -14,11 +14,14 @@ export async function cloneEnvironment(
     throw new Error("env.clone: invalid target name")
   }
 
-  const source = await loadEnvironment(dir, sourceName)
+  const source = await loadEnvironment(dir, sourceName, {
+    resolveSecrets: false,
+  })
   await saveEnvironment(dir, {
     name: targetName,
     vars: source.vars,
     color: source.color,
     disabledVars: source.disabledVars,
+    secretVars: source.secretVars,
   })
 }

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -1,4 +1,4 @@
-import { loadEnvironment } from "./load"
+import { loadEnvironment, type LoadEnvironmentOptions } from "./load"
 import { listEnvironments } from "./list"
 import { saveEnvironment } from "./save"
 import { deleteEnvironment } from "./delete"
@@ -6,7 +6,11 @@ import { cloneEnvironment } from "./clone"
 import type { Environment } from "../schema"
 
 export interface Env {
-  loadEnvironment(dir: string, name: string): Promise<Environment>
+  loadEnvironment(
+    dir: string,
+    name: string,
+    options?: LoadEnvironmentOptions,
+  ): Promise<Environment>
   listEnvironments(dir: string): Promise<string[]>
   saveEnvironment(dir: string, env: Environment): Promise<void>
   deleteEnvironment(dir: string, name: string): Promise<void>

--- a/src/env/load.ts
+++ b/src/env/load.ts
@@ -1,11 +1,17 @@
 import { readFile } from "node:fs/promises"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import type { Environment } from "../schema"
 import { VALID_COLORS } from "./constants"
+import { resolveStoredSecret } from "../secrets"
+
+export interface LoadEnvironmentOptions {
+  resolveSecrets?: boolean
+}
 
 export async function loadEnvironment(
   dir: string,
   name: string,
+  options: LoadEnvironmentOptions = {},
 ): Promise<Environment> {
   if (name.includes("..") || name.includes("/") || name.includes("\\")) {
     throw new Error("env.load: invalid environment name")
@@ -26,20 +32,78 @@ export async function loadEnvironment(
 
   const vars: Record<string, string> = {}
   const disabledVars: Record<string, string> = {}
+  const secretVars: NonNullable<Environment["secretVars"]> = {}
+  const declarations = new Map<string, boolean>()
   let color: string | undefined
   const lines = content.split("\n")
+  let pendingSecret: string | undefined
 
   for (const raw of lines) {
     const trimmed = raw.trim()
-    if (trimmed === "") continue
+    if (trimmed === "") {
+      if (pendingSecret) {
+        throw new Error(
+          `env.load: dangling secret marker for "${pendingSecret}"`,
+        )
+      }
+      continue
+    }
+    if (/^# @secret(?:\s|$)/.test(trimmed)) {
+      if (pendingSecret) {
+        throw new Error(
+          `env.load: dangling secret marker for "${pendingSecret}"`,
+        )
+      }
+      const marker = trimmed.match(/^# @secret\s+(\w+)$/)
+      const key = marker?.[1]
+      if (!key) {
+        throw new Error(`env.load: invalid secret marker "${trimmed}"`)
+      }
+      if (declarations.has(key)) {
+        throw new Error(`env.load: duplicate secret marker for "${key}"`)
+      }
+      if (Object.hasOwn(vars, key) || Object.hasOwn(disabledVars, key)) {
+        throw new Error(`env.load: secret "${key}" is declared more than once`)
+      }
+      pendingSecret = key
+      continue
+    }
     if (trimmed.startsWith("#")) {
       const afterHash = trimmed.slice(1).trimStart()
       const eq = afterHash.indexOf("=")
-      if (eq === -1) continue
+      if (eq === -1) {
+        if (pendingSecret) {
+          throw new Error(
+            `env.load: secret marker for "${pendingSecret}" must be followed by a blank placeholder`,
+          )
+        }
+        continue
+      }
       const key = afterHash.slice(0, eq).trimEnd()
       if (key === "") continue
       if (key === "_color") continue
-      disabledVars[key] = afterHash.slice(eq + 1)
+      const value = afterHash.slice(eq + 1)
+      if (pendingSecret) {
+        if (key !== pendingSecret) {
+          throw new Error(
+            `env.load: secret marker for "${pendingSecret}" does not match "${key}"`,
+          )
+        }
+        if (value !== "") {
+          throw new Error(`env.load: secret "${key}" must have a blank value`)
+        }
+        declarations.set(key, false)
+        secretVars[key] = "disabled"
+        disabledVars[key] = ""
+        pendingSecret = undefined
+      } else {
+        if (declarations.has(key)) {
+          throw new Error(
+            `env.load: secret "${key}" is declared more than once`,
+          )
+        }
+        disabledVars[key] = value
+      }
       continue
     }
     const eq = trimmed.indexOf("=")
@@ -54,6 +118,11 @@ export async function loadEnvironment(
       throw new Error("env.load: var name must not be empty")
     }
     if (key === "_color") {
+      if (pendingSecret) {
+        throw new Error(
+          `env.load: secret marker for "${pendingSecret}" does not match "_color"`,
+        )
+      }
       if (!VALID_COLORS.has(value)) {
         throw new Error(
           `env.load: unknown _color "${value}", expected one of ${[...VALID_COLORS].join("|")}`,
@@ -62,7 +131,38 @@ export async function loadEnvironment(
       color = value
       continue
     }
-    vars[key] = value
+    if (pendingSecret) {
+      if (key !== pendingSecret) {
+        throw new Error(
+          `env.load: secret marker for "${pendingSecret}" does not match "${key}"`,
+        )
+      }
+      if (value !== "") {
+        throw new Error(`env.load: secret "${key}" must have a blank value`)
+      }
+      declarations.set(key, true)
+      pendingSecret = undefined
+    } else {
+      if (declarations.has(key)) {
+        throw new Error(`env.load: secret "${key}" is declared more than once`)
+      }
+      vars[key] = value
+    }
+  }
+
+  if (pendingSecret) {
+    throw new Error(`env.load: dangling secret marker for "${pendingSecret}"`)
+  }
+
+  for (const [key, enabled] of declarations) {
+    if (!enabled) continue
+    if (options.resolveSecrets === false) {
+      secretVars[key] = "missing"
+      continue
+    }
+    const resolved = await resolveStoredSecret(dirname(dir), name, key)
+    secretVars[key] = resolved.status
+    if (resolved.value !== undefined) vars[key] = resolved.value
   }
 
   return {
@@ -71,5 +171,6 @@ export async function loadEnvironment(
     color,
     disabledVars:
       Object.keys(disabledVars).length > 0 ? disabledVars : undefined,
+    secretVars: Object.keys(secretVars).length > 0 ? secretVars : undefined,
   }
 }

--- a/src/env/save.ts
+++ b/src/env/save.ts
@@ -29,15 +29,27 @@ export async function saveEnvironment(
     lines.push(`_color=${env.color}`)
   }
 
+  const secretKeys = new Set(Object.keys(env.secretVars ?? {}))
+
   for (const [key, value] of Object.entries(env.vars)) {
     if (key === "") continue
+    if (secretKeys.has(key)) continue
     lines.push(`${key}=${value}`)
   }
 
   const disabledVars = env.disabledVars ?? {}
   for (const [key, value] of Object.entries(disabledVars)) {
     if (key === "") continue
+    if (secretKeys.has(key)) continue
     lines.push(`# ${key}=${value}`)
+  }
+
+  for (const [key, status] of Object.entries(env.secretVars ?? {})) {
+    if (!/^\w+$/.test(key)) {
+      throw new Error(`env.save: invalid secret key "${key}"`)
+    }
+    lines.push(`# @secret ${key}`)
+    lines.push(status === "disabled" ? `# ${key}=` : `${key}=`)
   }
 
   lines.push("")

--- a/src/env/save.ts
+++ b/src/env/save.ts
@@ -45,7 +45,7 @@ export async function saveEnvironment(
   }
 
   for (const [key, status] of Object.entries(env.secretVars ?? {})) {
-    if (!/^\w+$/.test(key)) {
+    if (key === "_color" || !/^\w+$/.test(key)) {
       throw new Error(`env.save: invalid secret key "${key}"`)
     }
     lines.push(`# @secret ${key}`)

--- a/src/filestore/bootstrap.ts
+++ b/src/filestore/bootstrap.ts
@@ -1,0 +1,22 @@
+import { existsSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
+import { randomUUID } from "node:crypto"
+import { join } from "node:path"
+import { env } from "../env"
+import { saveSettings } from "./save"
+
+export async function ensureCollectionBootstrapped(dir: string): Promise<void> {
+  const envDir = join(dir, ".environments")
+  const settingsPath = join(dir, "settings.yml")
+
+  if (!existsSync(settingsPath)) {
+    await saveSettings(dir, {
+      collectionId: randomUUID(),
+      environment: "development",
+    })
+  }
+  if (!existsSync(envDir)) {
+    await mkdir(envDir, { recursive: true })
+    await env.saveEnvironment(envDir, { name: "development", vars: {} })
+  }
+}

--- a/src/filestore/index.ts
+++ b/src/filestore/index.ts
@@ -12,8 +12,8 @@ import {
   deleteRequest,
   saveFolder,
   deleteFolder,
-  ensureCollectionBootstrapped,
 } from "./save"
+import { ensureCollectionBootstrapped } from "./bootstrap"
 import {
   loadTimeline,
   loadTimelineBody,
@@ -25,6 +25,7 @@ import {
   DEFAULT_TIMELINE_MAX_ENTRIES,
   clearTimelineForRequest,
   clearAllTimeline,
+  redactTimelineSecrets,
 } from "./timeline"
 
 export {
@@ -47,6 +48,7 @@ export {
   DEFAULT_TIMELINE_MAX_ENTRIES,
   clearTimelineForRequest,
   clearAllTimeline,
+  redactTimelineSecrets,
 }
 export type { CollectionSettings }
 

--- a/src/filestore/load.ts
+++ b/src/filestore/load.ts
@@ -342,6 +342,7 @@ export function parseCollectionSettings(value: unknown): CollectionSettings {
   }
   const obj = value as Record<string, unknown>
   const allowed = new Set([
+    "collection_id",
     "name",
     "description",
     "timeline_max_entries",
@@ -355,6 +356,17 @@ export function parseCollectionSettings(value: unknown): CollectionSettings {
   }
 
   const settings: CollectionSettings = {}
+  if (obj.collection_id !== undefined) {
+    if (
+      typeof obj.collection_id !== "string" ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        obj.collection_id,
+      )
+    ) {
+      throw new Error("settings.yml: collection_id must be a UUID")
+    }
+    settings.collectionId = obj.collection_id
+  }
   if (obj.name !== undefined) {
     if (typeof obj.name !== "string") {
       throw new Error("settings.yml: name must be a string")

--- a/src/filestore/save.ts
+++ b/src/filestore/save.ts
@@ -1,13 +1,11 @@
 import { mkdir, writeFile, unlink, rm, rename } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
-import { existsSync } from "node:fs"
 import { dirname, join } from "node:path"
 import * as yaml from "js-yaml"
 import { lang } from "../lang"
 import type { CollectionSettings, Folder, Request } from "../schema"
 import { collectionTlsToYaml } from "../tls"
 import { parseCollectionProxyStrict } from "../proxy"
-import { env } from "../env"
 
 function validatePathId(id: string | undefined): void {
   if (!id) {
@@ -124,6 +122,16 @@ export async function saveSettings(
   }
 
   const data: Record<string, unknown> = {}
+  if (settings.collectionId !== undefined) {
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        settings.collectionId,
+      )
+    ) {
+      throw new Error("filestore.saveSettings: collection id must be a UUID")
+    }
+    data.collection_id = settings.collectionId
+  }
   const name = settings.name?.trim()
   if (name) data.name = name
   const description = settings.description?.trim()
@@ -151,18 +159,5 @@ export async function saveSettings(
     await unlink(temporaryPath).catch(() => {})
     const msg = e instanceof Error ? e.message : String(e)
     throw new Error(`filestore.saveSettings: ${msg}`, { cause: e })
-  }
-}
-
-export async function ensureCollectionBootstrapped(dir: string): Promise<void> {
-  const envDir = join(dir, ".environments")
-  const settingsPath = join(dir, "settings.yml")
-
-  if (!existsSync(settingsPath)) {
-    await saveSettings(dir, { environment: "development" })
-  }
-  if (!existsSync(envDir)) {
-    await mkdir(envDir, { recursive: true })
-    await env.saveEnvironment(envDir, { name: "development", vars: {} })
   }
 }

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -442,6 +442,17 @@ function redactValue(value: unknown, secrets: string[]): unknown {
   return value
 }
 
+function redactTimelineEntry(value: unknown, secrets: string[]): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value
+  const entry = value as Record<string, unknown>
+  return {
+    ...entry,
+    request: redactValue(entry.request, secrets),
+    network: redactValue(entry.network, secrets),
+    error: redactValue(entry.error, secrets),
+  }
+}
+
 async function atomicWrite(
   path: string,
   data: string | Uint8Array,
@@ -487,9 +498,13 @@ export async function redactTimelineSecrets(
         if (path.endsWith(".yml")) {
           const raw = await readFile(path, "utf8")
           const parsed = yaml.load(raw)
-          const redacted = yaml.dump(redactValue(parsed, secrets))
+          const redacted = yaml.dump(
+            Array.isArray(parsed)
+              ? parsed.map((entry) => redactTimelineEntry(entry, secrets))
+              : parsed,
+          )
           if (redacted !== raw) await atomicWrite(path, redacted)
-        } else if (path.endsWith(".gz")) {
+        } else if (path.endsWith(".gz") && !/-response\.gz$/i.test(path)) {
           const raw = await gunzipAsync(await readFile(path))
           const redacted = redactKnownSecrets(raw.toString("utf8"), secrets)
           if (redacted !== raw.toString("utf8")) {

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  rename,
   rm,
   unlink,
   writeFile,
@@ -13,6 +14,7 @@ import {
 import { basename, dirname, join, relative } from "node:path"
 import * as yaml from "js-yaml"
 import type { ParamEntry, TimelineBodyRef, TimelineEntry } from "../schema"
+import { redactKnownSecrets } from "../secrets/redact"
 
 export const DEFAULT_TIMELINE_MAX_ENTRIES = 50
 const INLINE_BODY_LIMIT = 10_000
@@ -423,4 +425,82 @@ export async function clearAllTimeline(colDir: string): Promise<void> {
   } catch {
     // ignore
   }
+}
+
+function redactValue(value: unknown, secrets: string[]): unknown {
+  if (typeof value === "string") return redactKnownSecrets(value, secrets)
+  if (Array.isArray(value))
+    return value.map((item) => redactValue(item, secrets))
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        redactKnownSecrets(key, secrets),
+        redactValue(item, secrets),
+      ]),
+    )
+  }
+  return value
+}
+
+async function atomicWrite(
+  path: string,
+  data: string | Uint8Array,
+): Promise<void> {
+  const temporary = `${path}.${randomUUID()}.tmp`
+  await writeFile(temporary, data)
+  try {
+    await rename(temporary, path)
+  } catch (error) {
+    await unlink(temporary).catch(() => {})
+    throw error
+  }
+}
+
+async function collectAllTimelineFiles(dir: string): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw error
+  }
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name)
+      return entry.isDirectory() ? collectAllTimelineFiles(path) : [path]
+    }),
+  )
+  return files.flat()
+}
+
+export async function redactTimelineSecrets(
+  colDir: string,
+  values: string[],
+): Promise<void> {
+  const secrets = [...new Set(values.filter(Boolean))].sort(
+    (a, b) => b.length - a.length,
+  )
+  if (secrets.length === 0) return
+  return withTimelineLock(colDir, async () => {
+    try {
+      for (const path of await collectAllTimelineFiles(timelineDir(colDir))) {
+        if (path.endsWith(".yml")) {
+          const raw = await readFile(path, "utf8")
+          const parsed = yaml.load(raw)
+          const redacted = yaml.dump(redactValue(parsed, secrets))
+          if (redacted !== raw) await atomicWrite(path, redacted)
+        } else if (path.endsWith(".gz")) {
+          const raw = await gunzipAsync(await readFile(path))
+          const redacted = redactKnownSecrets(raw.toString("utf8"), secrets)
+          if (redacted !== raw.toString("utf8")) {
+            await atomicWrite(path, await gzipAsync(Buffer.from(redacted)))
+          }
+        }
+      }
+    } catch (error) {
+      throw new Error("filestore.redactTimelineSecrets: redaction failed", {
+        cause: error,
+      })
+    }
+  })
 }

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -96,7 +96,6 @@ export interface UseEnvironmentEditorResult {
   toggleSecret: (index: number) => void
   toggleReveal: (index: number) => void
   revealedRowId: number | null
-  secretConfirmRowId: number | null
   clonePrompt: { source: string; target: string } | null
   confirmClone: (copySecrets: boolean) => Promise<void>
   remaskSecrets: () => void
@@ -131,6 +130,7 @@ function envToVarRows(environment: Environment): VarRow[] {
       value: vars[key] ?? "",
       enabled: status !== "disabled",
       secret: true,
+      originSecret: true,
       secretStatus: status,
     })
   }
@@ -225,9 +225,6 @@ export function useEnvironmentEditor({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [revealedRowId, setRevealedRowId] = useState<number | null>(null)
-  const [secretConfirmRowId, setSecretConfirmRowId] = useState<number | null>(
-    null,
-  )
   const [clonePrompt, setClonePrompt] = useState<{
     source: string
     target: string
@@ -289,7 +286,6 @@ export function useEnvironmentEditor({
         setEditValue("")
         setError(null)
         setRevealedRowId(null)
-        setSecretConfirmRowId(null)
         return true
       } catch (e: unknown) {
         if (generation !== loadGenerationRef.current) return false
@@ -340,7 +336,6 @@ export function useEnvironmentEditor({
     setError(null)
     setSaving(false)
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
   }, [])
 
   const selectEnv = useCallback(
@@ -405,7 +400,6 @@ export function useEnvironmentEditor({
 
   const browseUp = useCallback(() => {
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       if (prev.addingRow) {
@@ -419,7 +413,6 @@ export function useEnvironmentEditor({
 
   const browseDown = useCallback(() => {
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       const rows = draftRef.current?.varRows.length ?? 0
@@ -433,7 +426,6 @@ export function useEnvironmentEditor({
 
   const browseFirst = useCallback(() => {
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       const rows = draftRef.current?.varRows.length ?? 0
@@ -446,7 +438,6 @@ export function useEnvironmentEditor({
 
   const browseLast = useCallback(() => {
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       return { ...prev, row: -1, addingRow: true }
@@ -462,8 +453,9 @@ export function useEnvironmentEditor({
       setEditValue("")
     } else {
       const row = currentDraft?.varRows[state.row]
+      if (row?.secret && row.secretStatus === "process") return
       setEditKey(row?.key ?? "")
-      setEditValue(row?.secret || row?.originSecret ? "" : (row?.value ?? ""))
+      setEditValue(row?.value ?? "")
     }
     setEditState({
       mode: "editing",
@@ -496,14 +488,17 @@ export function useEnvironmentEditor({
       } else {
         rows = rows.map((r, i) => {
           if (i !== state.editingRow) return r
-          if ((r.secret || r.originSecret) && value === "") {
-            return { ...r, key }
-          }
+          const tracksSecretValue = r.secret || r.originSecret
+          const originalRow = originalRef.current?.varRows.find(
+            (candidate) => candidate.id === r.id,
+          )
           return {
             ...r,
             key,
             value,
-            valueChanged: r.secret || r.originSecret ? true : r.valueChanged,
+            valueChanged: tracksSecretValue
+              ? value !== (originalRow?.value ?? r.value) || undefined
+              : r.valueChanged,
           }
         })
       }
@@ -537,14 +532,10 @@ export function useEnvironmentEditor({
       const currentRow = addingRow
         ? undefined
         : draftRef.current?.varRows[resolvedRow]
+      if (currentRow?.secret && currentRow.secretStatus === "process") return
       setEditKey(currentRow?.key ?? "")
-      setEditValue(
-        currentRow?.secret || currentRow?.originSecret
-          ? ""
-          : (currentRow?.value ?? ""),
-      )
+      setEditValue(currentRow?.value ?? "")
       setRevealedRowId(null)
-      setSecretConfirmRowId(null)
       setEditState({
         mode: "editing",
         row: resolvedRow,
@@ -600,51 +591,40 @@ export function useEnvironmentEditor({
     setDraft(next)
   }, [])
 
-  const toggleSecret = useCallback(
-    (index: number) => {
-      const prev = draftRef.current
-      const row = prev?.varRows[index]
-      if (!prev || !row || !row.key) return
-      if (row.secret && secretConfirmRowId !== row.id) {
-        setSecretConfirmRowId(row.id)
-        setRevealedRowId(null)
-        return
-      }
-      const rows = prev.varRows.map((item, i) =>
-        i === index
-          ? {
-              ...item,
-              secret: !item.secret,
-              originSecret: item.secret ? true : false,
-              secretStatus: item.secret
+  const toggleSecret = useCallback((index: number) => {
+    const prev = draftRef.current
+    const row = prev?.varRows[index]
+    if (!prev || !row || !row.key) return
+    const rows = prev.varRows.map((item, i) =>
+      i === index
+        ? {
+            ...item,
+            secret: !item.secret,
+            originSecret: item.secret ? item.originSecret : false,
+            secretStatus: item.secret
+              ? item.secretStatus
+              : item.originSecret && item.secretStatus
                 ? item.secretStatus
-                : item.originSecret && item.secretStatus
-                  ? item.secretStatus
-                  : item.enabled
-                    ? ("missing" as const)
-                    : ("disabled" as const),
-            }
-          : item,
-      )
-      const next = { ...prev, varRows: rows }
-      draftRef.current = next
-      setDraft(next)
-      setSecretConfirmRowId(null)
-      setRevealedRowId(null)
-    },
-    [secretConfirmRowId],
-  )
+                : item.enabled
+                  ? ("missing" as const)
+                  : ("disabled" as const),
+          }
+        : item,
+    )
+    const next = { ...prev, varRows: rows }
+    draftRef.current = next
+    setDraft(next)
+    setRevealedRowId(null)
+  }, [])
 
   const toggleReveal = useCallback((index: number) => {
     const row = draftRef.current?.varRows[index]
     if (!row?.secret || !row.value) return
     setRevealedRowId((current) => (current === row.id ? null : row.id))
-    setSecretConfirmRowId(null)
   }, [])
 
   const remaskSecrets = useCallback(() => {
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
   }, [])
 
   const revertVar = useCallback((index: number) => {
@@ -778,7 +758,9 @@ export function useEnvironmentEditor({
               })
             }
           } else if (before?.secret) {
-            if (!row.valueChanged) {
+            const canReuseStoredValue =
+              before.secretStatus === "keychain" && row.value !== ""
+            if (!row.valueChanged && !canReuseStoredValue) {
               throw new Error(
                 `Enter a plaintext value before unmarking "${row.key}"`,
               )
@@ -826,7 +808,7 @@ export function useEnvironmentEditor({
 
         const savedRows = curDraft.varRows.map((row) => ({
           ...row,
-          originSecret: false,
+          originSecret: row.secret,
           secretStatus: row.secret ? row.secretStatus : undefined,
           valueChanged: false,
         }))
@@ -883,7 +865,6 @@ export function useEnvironmentEditor({
         onEnvDataChangedRef.current?.()
       }
       setRevealedRowId(null)
-      setSecretConfirmRowId(null)
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       setError(msg)
@@ -1104,7 +1085,6 @@ export function useEnvironmentEditor({
     setEditValue("")
     setError(null)
     setRevealedRowId(null)
-    setSecretConfirmRowId(null)
     setClonePrompt(null)
   }, [])
 
@@ -1149,7 +1129,6 @@ export function useEnvironmentEditor({
     toggleSecret,
     toggleReveal,
     revealedRowId,
-    secretConfirmRowId,
     clonePrompt,
     confirmClone,
     remaskSecrets,

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -1,5 +1,13 @@
 import { useCallback, useRef, useState } from "react"
 import { env } from "../env"
+import { dirname } from "node:path"
+import type { Environment, SecretStatus } from "../schema"
+import {
+  deleteStoredSecret,
+  getStoredSecret,
+  setStoredSecret,
+} from "../secrets"
+import { redactTimelineSecrets } from "../filestore"
 
 let nextVarId = 1
 
@@ -8,6 +16,10 @@ export interface VarRow {
   key: string
   value: string
   enabled: boolean
+  secret?: boolean
+  originSecret?: boolean
+  secretStatus?: SecretStatus
+  valueChanged?: boolean
 }
 
 export interface EnvDraft {
@@ -33,6 +45,8 @@ interface OriginalEnv {
   color: string | undefined
   vars: Record<string, string>
   disabledVars: Record<string, string>
+  secretVars: Record<string, SecretStatus>
+  varRows: VarRow[]
 }
 
 export interface UseEnvironmentEditorProps {
@@ -79,6 +93,13 @@ export interface UseEnvironmentEditorResult {
   cancelEdit: () => void
   browseTab: () => void
   toggleVar: (index: number) => void
+  toggleSecret: (index: number) => void
+  toggleReveal: (index: number) => void
+  revealedRowId: number | null
+  secretConfirmRowId: number | null
+  clonePrompt: { source: string; target: string } | null
+  confirmClone: (copySecrets: boolean) => Promise<void>
+  remaskSecrets: () => void
   revertVar: (index: number) => void
   save: () => Promise<void>
   createEnv: (values: {
@@ -90,16 +111,28 @@ export interface UseEnvironmentEditorResult {
   revertDraft: () => void
 }
 
-function envToVarRows(
-  vars: Record<string, string>,
-  disabledVars: Record<string, string>,
-): VarRow[] {
+function envToVarRows(environment: Environment): VarRow[] {
+  const vars = environment.vars
+  const disabledVars = environment.disabledVars ?? {}
+  const secretVars = environment.secretVars ?? {}
   const rows: VarRow[] = []
   for (const [key, value] of Object.entries(vars)) {
-    rows.push({ id: nextVarId++, key, value, enabled: true })
+    if (secretVars[key]) continue
+    rows.push({ id: nextVarId++, key, value, enabled: true, secret: false })
   }
   for (const [key, value] of Object.entries(disabledVars)) {
-    rows.push({ id: nextVarId++, key, value, enabled: false })
+    if (secretVars[key]) continue
+    rows.push({ id: nextVarId++, key, value, enabled: false, secret: false })
+  }
+  for (const [key, status] of Object.entries(secretVars)) {
+    rows.push({
+      id: nextVarId++,
+      key,
+      value: vars[key] ?? "",
+      enabled: status !== "disabled",
+      secret: true,
+      secretStatus: status,
+    })
   }
   return rows
 }
@@ -107,18 +140,26 @@ function envToVarRows(
 function varRowsToEnv(rows: VarRow[]): {
   vars: Record<string, string>
   disabledVars: Record<string, string>
+  secretVars: Record<string, SecretStatus>
 } {
   const vars: Record<string, string> = {}
   const disabledVars: Record<string, string> = {}
+  const secretVars: Record<string, SecretStatus> = {}
   for (const row of rows) {
     if (row.key === "") continue
+    if (row.secret) {
+      secretVars[row.key] = row.enabled
+        ? (row.secretStatus ?? "missing")
+        : "disabled"
+      continue
+    }
     if (row.enabled) {
       vars[row.key] = row.value
     } else {
       disabledVars[row.key] = row.value
     }
   }
-  return { vars, disabledVars }
+  return { vars, disabledVars, secretVars }
 }
 
 function dirtyChanged(
@@ -131,16 +172,30 @@ function dirtyChanged(
   if (name !== original.name) return true
   if (color !== original.color) return true
 
-  const { vars, disabledVars } = varRowsToEnv(rows)
+  const { vars, disabledVars, secretVars } = varRowsToEnv(rows)
   const allKeys = new Set([
     ...Object.keys(original.vars),
     ...Object.keys(original.disabledVars),
     ...Object.keys(vars),
     ...Object.keys(disabledVars),
+    ...Object.keys(original.secretVars),
+    ...Object.keys(secretVars),
   ])
   for (const key of allKeys) {
     const origEnabled = key in original.vars
     const nowEnabled = key in vars
+    const wasSecret = key in original.secretVars
+    const isSecret = key in secretVars
+    if (wasSecret !== isSecret) return true
+    if (key in secretVars) {
+      const originallyDisabled = original.secretVars[key] === "disabled"
+      const nowDisabled = secretVars[key] === "disabled"
+      if (originallyDisabled !== nowDisabled) return true
+      const originalRow = original.varRows.find((row) => row.key === key)
+      const nextRow = rows.find((row) => row.key === key)
+      if (originalRow?.id !== nextRow?.id || nextRow?.valueChanged) return true
+      continue
+    }
     if (origEnabled !== nowEnabled) return true
     const origVal = origEnabled
       ? original.vars[key]
@@ -169,6 +224,14 @@ export function useEnvironmentEditor({
   const [editValue, setEditValue] = useState("")
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [revealedRowId, setRevealedRowId] = useState<number | null>(null)
+  const [secretConfirmRowId, setSecretConfirmRowId] = useState<number | null>(
+    null,
+  )
+  const [clonePrompt, setClonePrompt] = useState<{
+    source: string
+    target: string
+  } | null>(null)
 
   const draftRef = useRef(draft)
   draftRef.current = draft
@@ -200,7 +263,7 @@ export function useEnvironmentEditor({
       try {
         const loaded = await env.loadEnvironment(environmentsDir, name)
         if (generation !== loadGenerationRef.current) return false
-        const rows = envToVarRows(loaded.vars, loaded.disabledVars ?? {})
+        const rows = envToVarRows(loaded)
         const nextDraft = {
           name: loaded.name,
           color: loaded.color,
@@ -211,6 +274,8 @@ export function useEnvironmentEditor({
           color: loaded.color,
           vars: { ...loaded.vars },
           disabledVars: { ...(loaded.disabledVars ?? {}) },
+          secretVars: { ...(loaded.secretVars ?? {}) },
+          varRows: rows.map((row) => ({ ...row })),
         }
         draftRef.current = nextDraft
         setDraft(nextDraft)
@@ -223,6 +288,8 @@ export function useEnvironmentEditor({
         setEditKey("")
         setEditValue("")
         setError(null)
+        setRevealedRowId(null)
+        setSecretConfirmRowId(null)
         return true
       } catch (e: unknown) {
         if (generation !== loadGenerationRef.current) return false
@@ -272,6 +339,8 @@ export function useEnvironmentEditor({
     setEditValue("")
     setError(null)
     setSaving(false)
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
   }, [])
 
   const selectEnv = useCallback(
@@ -335,6 +404,8 @@ export function useEnvironmentEditor({
   }, [])
 
   const browseUp = useCallback(() => {
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       if (prev.addingRow) {
@@ -347,6 +418,8 @@ export function useEnvironmentEditor({
   }, [])
 
   const browseDown = useCallback(() => {
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       const rows = draftRef.current?.varRows.length ?? 0
@@ -359,6 +432,8 @@ export function useEnvironmentEditor({
   }, [])
 
   const browseFirst = useCallback(() => {
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       const rows = draftRef.current?.varRows.length ?? 0
@@ -370,6 +445,8 @@ export function useEnvironmentEditor({
   }, [])
 
   const browseLast = useCallback(() => {
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
       return { ...prev, row: -1, addingRow: true }
@@ -386,7 +463,7 @@ export function useEnvironmentEditor({
     } else {
       const row = currentDraft?.varRows[state.row]
       setEditKey(row?.key ?? "")
-      setEditValue(row?.value ?? "")
+      setEditValue(row?.secret || row?.originSecret ? "" : (row?.value ?? ""))
     }
     setEditState({
       mode: "editing",
@@ -408,15 +485,27 @@ export function useEnvironmentEditor({
 
     if (state.addingRow) {
       if (key !== "") {
-        rows = [...rows, { id: nextVarId++, key, value, enabled: true }]
+        rows = [
+          ...rows,
+          { id: nextVarId++, key, value, enabled: true, secret: false },
+        ]
       }
     } else {
       if (key === "") {
         rows = rows.filter((_, i) => i !== state.editingRow)
       } else {
-        rows = rows.map((r, i) =>
-          i === state.editingRow ? { ...r, key, value } : r,
-        )
+        rows = rows.map((r, i) => {
+          if (i !== state.editingRow) return r
+          if ((r.secret || r.originSecret) && value === "") {
+            return { ...r, key }
+          }
+          return {
+            ...r,
+            key,
+            value,
+            valueChanged: r.secret || r.originSecret ? true : r.valueChanged,
+          }
+        })
       }
     }
 
@@ -449,7 +538,13 @@ export function useEnvironmentEditor({
         ? undefined
         : draftRef.current?.varRows[resolvedRow]
       setEditKey(currentRow?.key ?? "")
-      setEditValue(currentRow?.value ?? "")
+      setEditValue(
+        currentRow?.secret || currentRow?.originSecret
+          ? ""
+          : (currentRow?.value ?? ""),
+      )
+      setRevealedRowId(null)
+      setSecretConfirmRowId(null)
       setEditState({
         mode: "editing",
         row: resolvedRow,
@@ -489,10 +584,67 @@ export function useEnvironmentEditor({
     const rows = [...prev.varRows]
     if (index >= 0 && index < rows.length) {
       rows[index] = { ...rows[index]!, enabled: !rows[index]!.enabled }
+      if (rows[index]!.secret) {
+        rows[index] = {
+          ...rows[index]!,
+          secretStatus: rows[index]!.enabled
+            ? rows[index]!.secretStatus === "disabled"
+              ? "missing"
+              : rows[index]!.secretStatus
+            : "disabled",
+        }
+      }
     }
     const next = { ...prev, varRows: rows }
     draftRef.current = next
     setDraft(next)
+  }, [])
+
+  const toggleSecret = useCallback(
+    (index: number) => {
+      const prev = draftRef.current
+      const row = prev?.varRows[index]
+      if (!prev || !row || !row.key) return
+      if (row.secret && secretConfirmRowId !== row.id) {
+        setSecretConfirmRowId(row.id)
+        setRevealedRowId(null)
+        return
+      }
+      const rows = prev.varRows.map((item, i) =>
+        i === index
+          ? {
+              ...item,
+              secret: !item.secret,
+              originSecret: item.secret ? true : false,
+              secretStatus: item.secret
+                ? item.secretStatus
+                : item.originSecret && item.secretStatus
+                  ? item.secretStatus
+                  : item.enabled
+                    ? ("missing" as const)
+                    : ("disabled" as const),
+            }
+          : item,
+      )
+      const next = { ...prev, varRows: rows }
+      draftRef.current = next
+      setDraft(next)
+      setSecretConfirmRowId(null)
+      setRevealedRowId(null)
+    },
+    [secretConfirmRowId],
+  )
+
+  const toggleReveal = useCallback((index: number) => {
+    const row = draftRef.current?.varRows[index]
+    if (!row?.secret || !row.value) return
+    setRevealedRowId((current) => (current === row.id ? null : row.id))
+    setSecretConfirmRowId(null)
+  }, [])
+
+  const remaskSecrets = useCallback(() => {
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
   }, [])
 
   const revertVar = useCallback((index: number) => {
@@ -539,31 +691,178 @@ export function useEnvironmentEditor({
     setError(null)
 
     try {
-      const { vars, disabledVars } = varRowsToEnv(curDraft.varRows)
+      const collectionDir = dirname(environmentsDir)
+      const duplicate = curDraft.varRows.find(
+        (row, index) =>
+          row.key &&
+          curDraft.varRows.findIndex(
+            (candidate) => candidate.key === row.key,
+          ) !== index,
+      )
+      if (duplicate) throw new Error(`Duplicate variable "${duplicate.key}"`)
 
-      await env.saveEnvironment(environmentsDir, {
-        name: curDraft.name,
-        vars,
-        color: curDraft.color,
-        disabledVars,
-      })
-
-      if (oldName) {
-        try {
-          await env.deleteEnvironment(environmentsDir, oldName)
-        } catch {
-          // old file may already be gone
+      const originalById = new Map(
+        (curOriginal?.varRows ?? []).map((row) => [row.id, row]),
+      )
+      const plaintextToRedact: string[] = []
+      for (const row of curDraft.varRows) {
+        const before = originalById.get(row.id)
+        if (row.secret && !before?.secret && before?.value) {
+          plaintextToRedact.push(before.value)
         }
       }
+      await redactTimelineSecrets(collectionDir, plaintextToRedact)
 
-      const nextOriginal = {
-        name: curDraft.name,
-        color: curDraft.color,
-        vars,
-        disabledVars,
+      const written: {
+        environment: string
+        key: string
+        previous: string | null
+      }[] = []
+      const cleanup: { environment: string; key: string }[] = []
+      try {
+        for (const row of curDraft.varRows) {
+          const before = originalById.get(row.id)
+          if (row.secret) {
+            const destinationChanged =
+              !before?.secret ||
+              before.key !== row.key ||
+              curOriginal?.name !== curDraft.name
+            if (
+              destinationChanged &&
+              before?.secretStatus === "process" &&
+              !row.valueChanged
+            ) {
+              throw new Error(
+                `Enter a replacement value before renaming process-sourced secret "${before.key}"`,
+              )
+            }
+            let value: string | undefined
+            if (row.valueChanged || !before?.secret) value = row.value
+            else if (destinationChanged && before.secretStatus === "keychain") {
+              value = before.value
+            }
+            if (value) {
+              const previous = await getStoredSecret(
+                collectionDir,
+                curDraft.name,
+                row.key,
+              )
+              await setStoredSecret(
+                collectionDir,
+                curDraft.name,
+                row.key,
+                value,
+              )
+              written.push({
+                environment: curDraft.name,
+                key: row.key,
+                previous,
+              })
+              row.secretStatus = row.enabled
+                ? process.env[row.key]
+                  ? "process"
+                  : "keychain"
+                : "disabled"
+            } else if (process.env[row.key]) {
+              row.secretStatus = row.enabled ? "process" : "disabled"
+            } else if (!before?.secret || row.valueChanged) {
+              throw new Error(`Secret "${row.key}" must not be empty`)
+            }
+            if (
+              before?.secret &&
+              (before.key !== row.key || curOriginal?.name !== curDraft.name)
+            ) {
+              cleanup.push({
+                environment: curOriginal!.name,
+                key: before.key,
+              })
+            }
+          } else if (before?.secret) {
+            if (!row.valueChanged) {
+              throw new Error(
+                `Enter a plaintext value before unmarking "${row.key}"`,
+              )
+            }
+            cleanup.push({ environment: curOriginal!.name, key: before.key })
+          }
+        }
+
+        for (const before of curOriginal?.varRows ?? []) {
+          if (
+            before.secret &&
+            !curDraft.varRows.some((row) => row.id === before.id)
+          ) {
+            cleanup.push({ environment: curOriginal!.name, key: before.key })
+          }
+        }
+
+        const { vars, disabledVars, secretVars } = varRowsToEnv(
+          curDraft.varRows,
+        )
+
+        await env.saveEnvironment(environmentsDir, {
+          name: curDraft.name,
+          vars,
+          color: curDraft.color,
+          disabledVars,
+          secretVars,
+        })
+
+        for (const target of cleanup) {
+          await deleteStoredSecret(
+            collectionDir,
+            target.environment,
+            target.key,
+          ).catch(() => false)
+        }
+
+        if (oldName) {
+          try {
+            await env.deleteEnvironment(environmentsDir, oldName)
+          } catch {
+            // old file may already be gone
+          }
+        }
+
+        const savedRows = curDraft.varRows.map((row) => ({
+          ...row,
+          originSecret: false,
+          secretStatus: row.secret ? row.secretStatus : undefined,
+          valueChanged: false,
+        }))
+        const nextOriginal = {
+          name: curDraft.name,
+          color: curDraft.color,
+          vars,
+          disabledVars,
+          secretVars,
+          varRows: savedRows.map((row) => ({ ...row })),
+        }
+        const nextDraft = { ...curDraft, varRows: savedRows }
+        draftRef.current = nextDraft
+        setDraft(nextDraft)
+        originalRef.current = nextOriginal
+        setOriginal(nextOriginal)
+      } catch (error) {
+        for (const item of written.reverse()) {
+          if (item.previous) {
+            await setStoredSecret(
+              collectionDir,
+              item.environment,
+              item.key,
+              item.previous,
+            ).catch(() => {})
+          } else {
+            await deleteStoredSecret(
+              collectionDir,
+              item.environment,
+              item.key,
+            ).catch(() => false)
+          }
+        }
+        throw error
       }
-      originalRef.current = nextOriginal
-      setOriginal(nextOriginal)
+
       setSelectedEnvName(curDraft.name)
       loadedEnvNameRef.current = curDraft.name
       if (oldName) {
@@ -583,6 +882,8 @@ export function useEnvironmentEditor({
         onActiveEnvChangedRef.current?.(curDraft.name)
         onEnvDataChangedRef.current?.()
       }
+      setRevealedRowId(null)
+      setSecretConfirmRowId(null)
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       setError(msg)
@@ -624,6 +925,8 @@ export function useEnvironmentEditor({
             color,
             vars: {},
             disabledVars: {},
+            secretVars: {},
+            varRows: [],
           }
           const nextNames = [...localNamesRef.current, trimmedName]
           draftRef.current = nextDraft
@@ -664,7 +967,17 @@ export function useEnvironmentEditor({
     setSaving(true)
     setError(null)
     try {
+      const current = await env.loadEnvironment(environmentsDir, name, {
+        resolveSecrets: false,
+      })
       await env.deleteEnvironment(environmentsDir, name)
+      await Promise.all(
+        Object.keys(current.secretVars ?? {}).map((key) =>
+          deleteStoredSecret(dirname(environmentsDir), name, key).catch(
+            () => false,
+          ),
+        ),
+      )
       if (activeEnvName === name) {
         const remaining = localNames.filter((n) => n !== name)
         onActiveEnvChangedRef.current?.(remaining[0] ?? "")
@@ -690,6 +1003,13 @@ export function useEnvironmentEditor({
     async (targetName: string) => {
       const name = selectedEnvNameRef.current
       if (!name) return
+      const source = await env.loadEnvironment(environmentsDir, name, {
+        resolveSecrets: false,
+      })
+      if (Object.keys(source.secretVars ?? {}).length > 0) {
+        setClonePrompt({ source: name, target: targetName })
+        return
+      }
       setSaving(true)
       setError(null)
       try {
@@ -709,6 +1029,69 @@ export function useEnvironmentEditor({
     [environmentsDir, localNames, loadEnv],
   )
 
+  const confirmClone = useCallback(
+    async (copySecrets: boolean) => {
+      const pending = clonePrompt
+      if (!pending) return
+      setClonePrompt(null)
+      setSaving(true)
+      setError(null)
+      const copied: string[] = []
+      try {
+        const source = await env.loadEnvironment(
+          environmentsDir,
+          pending.source,
+          { resolveSecrets: false },
+        )
+        await env.cloneEnvironment(
+          environmentsDir,
+          pending.source,
+          pending.target,
+        )
+        if (copySecrets) {
+          for (const key of Object.keys(source.secretVars ?? {})) {
+            if (process.env[key]) continue
+            const value = await getStoredSecret(
+              dirname(environmentsDir),
+              pending.source,
+              key,
+            )
+            if (!value) continue
+            await setStoredSecret(
+              dirname(environmentsDir),
+              pending.target,
+              key,
+              value,
+            )
+            copied.push(key)
+          }
+        }
+        const updatedNames = [...localNamesRef.current, pending.target]
+        setLocalNames(updatedNames)
+        onEnvsChangedRef.current?.()
+        setSelectedEnvName(pending.target)
+        await loadEnv(pending.target)
+      } catch (e: unknown) {
+        await Promise.all(
+          copied.map((key) =>
+            deleteStoredSecret(
+              dirname(environmentsDir),
+              pending.target,
+              key,
+            ).catch(() => false),
+          ),
+        )
+        await env
+          .deleteEnvironment(environmentsDir, pending.target)
+          .catch(() => {})
+        setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        setSaving(false)
+      }
+    },
+    [clonePrompt, environmentsDir, loadEnv],
+  )
+
   const revertDraft = useCallback(() => {
     draftRef.current = null
     originalRef.current = null
@@ -720,6 +1103,9 @@ export function useEnvironmentEditor({
     setEditKey("")
     setEditValue("")
     setError(null)
+    setRevealedRowId(null)
+    setSecretConfirmRowId(null)
+    setClonePrompt(null)
   }, [])
 
   const dirty = dirtyChanged(
@@ -760,6 +1146,13 @@ export function useEnvironmentEditor({
     cancelEdit,
     browseTab,
     toggleVar,
+    toggleSecret,
+    toggleReveal,
+    revealedRowId,
+    secretConfirmRowId,
+    clonePrompt,
+    confirmClone,
+    remaskSecrets,
     revertVar,
     save,
     createEnv,

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -698,6 +698,11 @@ export function useEnvironmentEditor({
         key: string
         previous: string | null
       }[] = []
+      const deleted: {
+        environment: string
+        key: string
+        previous: string
+      }[] = []
       const cleanup: { environment: string; key: string }[] = []
       try {
         for (const row of curDraft.varRows) {
@@ -739,11 +744,11 @@ export function useEnvironmentEditor({
                 previous,
               })
               row.secretStatus = row.enabled
-                ? process.env[row.key]
+                ? process.env[row.key] !== undefined
                   ? "process"
                   : "keychain"
                 : "disabled"
-            } else if (process.env[row.key]) {
+            } else if (process.env[row.key] !== undefined) {
               row.secretStatus = row.enabled ? "process" : "disabled"
             } else if (!before?.secret || row.valueChanged) {
               throw new Error(`Secret "${row.key}" must not be empty`)
@@ -782,6 +787,22 @@ export function useEnvironmentEditor({
           curDraft.varRows,
         )
 
+        for (const target of cleanup) {
+          const previous = await getStoredSecret(
+            collectionDir,
+            target.environment,
+            target.key,
+          )
+          const removed = await deleteStoredSecret(
+            collectionDir,
+            target.environment,
+            target.key,
+          )
+          if (removed && previous !== null) {
+            deleted.push({ ...target, previous })
+          }
+        }
+
         await env.saveEnvironment(environmentsDir, {
           name: curDraft.name,
           vars,
@@ -789,14 +810,6 @@ export function useEnvironmentEditor({
           disabledVars,
           secretVars,
         })
-
-        for (const target of cleanup) {
-          await deleteStoredSecret(
-            collectionDir,
-            target.environment,
-            target.key,
-          ).catch(() => false)
-        }
 
         if (oldName) {
           try {
@@ -826,6 +839,14 @@ export function useEnvironmentEditor({
         originalRef.current = nextOriginal
         setOriginal(nextOriginal)
       } catch (error) {
+        for (const item of deleted.reverse()) {
+          await setStoredSecret(
+            collectionDir,
+            item.environment,
+            item.key,
+            item.previous,
+          ).catch(() => {})
+        }
         for (const item of written.reverse()) {
           if (item.previous) {
             await setStoredSecret(
@@ -947,18 +968,25 @@ export function useEnvironmentEditor({
     if (!name) return
     setSaving(true)
     setError(null)
+    const deleted: { key: string; previous: string }[] = []
     try {
       const current = await env.loadEnvironment(environmentsDir, name, {
         resolveSecrets: false,
       })
+      for (const key of Object.keys(current.secretVars ?? {})) {
+        const previous = await getStoredSecret(
+          dirname(environmentsDir),
+          name,
+          key,
+        )
+        const removed = await deleteStoredSecret(
+          dirname(environmentsDir),
+          name,
+          key,
+        )
+        if (removed && previous !== null) deleted.push({ key, previous })
+      }
       await env.deleteEnvironment(environmentsDir, name)
-      await Promise.all(
-        Object.keys(current.secretVars ?? {}).map((key) =>
-          deleteStoredSecret(dirname(environmentsDir), name, key).catch(
-            () => false,
-          ),
-        ),
-      )
       if (activeEnvName === name) {
         const remaining = localNames.filter((n) => n !== name)
         onActiveEnvChangedRef.current?.(remaining[0] ?? "")
@@ -967,6 +995,14 @@ export function useEnvironmentEditor({
       onEnvsChangedRef.current?.()
       closeEditor()
     } catch (e: unknown) {
+      for (const item of deleted.reverse()) {
+        await setStoredSecret(
+          dirname(environmentsDir),
+          name,
+          item.key,
+          item.previous,
+        ).catch(() => {})
+      }
       const msg = e instanceof Error ? e.message : String(e)
       setError(msg)
     } finally {
@@ -984,16 +1020,16 @@ export function useEnvironmentEditor({
     async (targetName: string) => {
       const name = selectedEnvNameRef.current
       if (!name) return
-      const source = await env.loadEnvironment(environmentsDir, name, {
-        resolveSecrets: false,
-      })
-      if (Object.keys(source.secretVars ?? {}).length > 0) {
-        setClonePrompt({ source: name, target: targetName })
-        return
-      }
       setSaving(true)
       setError(null)
       try {
+        const source = await env.loadEnvironment(environmentsDir, name, {
+          resolveSecrets: false,
+        })
+        if (Object.keys(source.secretVars ?? {}).length > 0) {
+          setClonePrompt({ source: name, target: targetName })
+          return
+        }
         await env.cloneEnvironment(environmentsDir, name, targetName)
         const updatedNames = [...localNames, targetName]
         setLocalNames(updatedNames)
@@ -1031,7 +1067,7 @@ export function useEnvironmentEditor({
         )
         if (copySecrets) {
           for (const key of Object.keys(source.secretVars ?? {})) {
-            if (process.env[key]) continue
+            if (process.env[key] !== undefined) continue
             const value = await getStoredSecret(
               dirname(environmentsDir),
               pending.source,

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -40,6 +40,31 @@ function initialEditState(): EnvEditState {
   return { mode: "inactive", row: -1, addingRow: false, editingRow: -1 }
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function attemptRollback(
+  failures: unknown[],
+  operation: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await operation()
+  } catch (error) {
+    failures.push(error)
+  }
+}
+
+function withRollbackFailures(original: unknown, failures: unknown[]): Error {
+  if (failures.length === 0) {
+    return original instanceof Error ? original : new Error(String(original))
+  }
+  return new Error(
+    `${errorMessage(original)}; rollback failed: ${failures.map(errorMessage).join("; ")}`,
+    { cause: original },
+  )
+}
+
 interface OriginalEnv {
   name: string
   color: string | undefined
@@ -839,31 +864,35 @@ export function useEnvironmentEditor({
         originalRef.current = nextOriginal
         setOriginal(nextOriginal)
       } catch (error) {
+        const rollbackFailures: unknown[] = []
         for (const item of deleted.reverse()) {
-          await setStoredSecret(
-            collectionDir,
-            item.environment,
-            item.key,
-            item.previous,
-          ).catch(() => {})
-        }
-        for (const item of written.reverse()) {
-          if (item.previous) {
-            await setStoredSecret(
+          await attemptRollback(rollbackFailures, () =>
+            setStoredSecret(
               collectionDir,
               item.environment,
               item.key,
               item.previous,
-            ).catch(() => {})
+            ),
+          )
+        }
+        for (const item of written.reverse()) {
+          const previous = item.previous
+          if (previous !== null) {
+            await attemptRollback(rollbackFailures, () =>
+              setStoredSecret(
+                collectionDir,
+                item.environment,
+                item.key,
+                previous,
+              ),
+            )
           } else {
-            await deleteStoredSecret(
-              collectionDir,
-              item.environment,
-              item.key,
-            ).catch(() => false)
+            await attemptRollback(rollbackFailures, () =>
+              deleteStoredSecret(collectionDir, item.environment, item.key),
+            )
           }
         }
-        throw error
+        throw withRollbackFailures(error, rollbackFailures)
       }
 
       setSelectedEnvName(curDraft.name)
@@ -995,16 +1024,18 @@ export function useEnvironmentEditor({
       onEnvsChangedRef.current?.()
       closeEditor()
     } catch (e: unknown) {
+      const rollbackFailures: unknown[] = []
       for (const item of deleted.reverse()) {
-        await setStoredSecret(
-          dirname(environmentsDir),
-          name,
-          item.key,
-          item.previous,
-        ).catch(() => {})
+        await attemptRollback(rollbackFailures, () =>
+          setStoredSecret(
+            dirname(environmentsDir),
+            name,
+            item.key,
+            item.previous,
+          ),
+        )
       }
-      const msg = e instanceof Error ? e.message : String(e)
-      setError(msg)
+      setError(withRollbackFailures(e, rollbackFailures).message)
     } finally {
       setSaving(false)
     }
@@ -1054,6 +1085,7 @@ export function useEnvironmentEditor({
       setSaving(true)
       setError(null)
       const copied: string[] = []
+      let cloned = false
       try {
         const source = await env.loadEnvironment(
           environmentsDir,
@@ -1065,6 +1097,7 @@ export function useEnvironmentEditor({
           pending.source,
           pending.target,
         )
+        cloned = true
         if (copySecrets) {
           for (const key of Object.keys(source.secretVars ?? {})) {
             if (process.env[key] !== undefined) continue
@@ -1089,19 +1122,18 @@ export function useEnvironmentEditor({
         setSelectedEnvName(pending.target)
         await loadEnv(pending.target)
       } catch (e: unknown) {
-        await Promise.all(
-          copied.map((key) =>
-            deleteStoredSecret(
-              dirname(environmentsDir),
-              pending.target,
-              key,
-            ).catch(() => false),
-          ),
-        )
-        await env
-          .deleteEnvironment(environmentsDir, pending.target)
-          .catch(() => {})
-        setError(e instanceof Error ? e.message : String(e))
+        const rollbackFailures: unknown[] = []
+        for (const key of copied.reverse()) {
+          await attemptRollback(rollbackFailures, () =>
+            deleteStoredSecret(dirname(environmentsDir), pending.target, key),
+          )
+        }
+        if (cloned) {
+          await attemptRollback(rollbackFailures, () =>
+            env.deleteEnvironment(environmentsDir, pending.target),
+          )
+        }
+        setError(withRollbackFailures(e, rollbackFailures).message)
       } finally {
         setSaving(false)
       }

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -114,7 +114,10 @@ export interface Environment {
   vars: Record<string, string>
   color?: string
   disabledVars?: Record<string, string>
+  secretVars?: Record<string, SecretStatus>
 }
+
+export type SecretStatus = "process" | "keychain" | "missing" | "disabled"
 
 export interface TimelineEntry {
   id?: string
@@ -156,6 +159,7 @@ export interface TimelineBodyRef {
 }
 
 export interface CollectionSettings {
+  collectionId?: string
   name?: string
   description?: string
   timelineMaxEntries?: number

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -1,4 +1,6 @@
 import { createHash, randomUUID } from "node:crypto"
+import { link, mkdir, readFile, unlink, writeFile } from "node:fs/promises"
+import { join } from "node:path"
 import { loadSettings } from "../filestore/load"
 import { saveSettings } from "../filestore/save"
 import type { SecretStatus } from "../schema"
@@ -58,14 +60,33 @@ export function secretAccount(
   return `${collectionId}:${digest}`
 }
 
+async function reserveCollectionId(collectionDir: string): Promise<string> {
+  const stateDir = join(collectionDir, ".noodle")
+  const reservationPath = join(stateDir, "collection-id")
+  const candidate = randomUUID()
+  const candidatePath = `${reservationPath}.${candidate}.tmp`
+  await mkdir(stateDir, { recursive: true })
+  await writeFile(candidatePath, candidate, "utf8")
+  try {
+    await link(candidatePath, reservationPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+  } finally {
+    await unlink(candidatePath).catch(() => {})
+  }
+  return (await readFile(reservationPath, "utf8")).trim()
+}
+
 export async function ensureCollectionId(
   collectionDir: string,
 ): Promise<string> {
   const settings = await loadSettings(collectionDir)
   if (settings.collectionId) return settings.collectionId
-  const collectionId = randomUUID()
-  await saveSettings(collectionDir, { ...settings, collectionId })
-  return collectionId
+  const reservedId = await reserveCollectionId(collectionDir)
+  const current = await loadSettings(collectionDir)
+  if (current.collectionId) return current.collectionId
+  await saveSettings(collectionDir, { ...current, collectionId: reservedId })
+  return reservedId
 }
 
 export async function getStoredSecret(
@@ -126,7 +147,9 @@ export async function resolveStoredSecret(
   key: string,
 ): Promise<{ value?: string; status: SecretStatus }> {
   const processValue = process.env[key]
-  if (processValue) return { value: processValue, status: "process" }
+  if (processValue !== undefined) {
+    return { value: processValue, status: "process" }
+  }
   const stored = await getStoredSecret(collectionDir, environment, key)
   return stored ? { value: stored, status: "keychain" } : { status: "missing" }
 }

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -1,0 +1,132 @@
+import { createHash, randomUUID } from "node:crypto"
+import { loadSettings } from "../filestore/load"
+import { saveSettings } from "../filestore/save"
+import type { SecretStatus } from "../schema"
+
+export const SECRET_SERVICE = "dev.noodlerest.noodle"
+
+export interface SecretBackend {
+  get(options: { service: string; name: string }): Promise<string | null>
+  set(options: {
+    service: string
+    name: string
+    value: string
+    allowUnrestrictedAccess?: boolean
+  }): Promise<void>
+  delete(options: { service: string; name: string }): Promise<boolean>
+}
+
+let testBackend: SecretBackend | undefined
+
+export function setSecretBackendForTests(
+  backend: SecretBackend | undefined,
+): void {
+  testBackend = backend
+}
+
+function backend(): SecretBackend {
+  const candidate = testBackend ?? Bun.secrets
+  if (!candidate) {
+    throw new Error(
+      "secure credential storage is unavailable in this Bun runtime",
+    )
+  }
+  return candidate
+}
+
+function storageError(action: string, error: unknown): Error {
+  const platformHint =
+    process.platform === "linux"
+      ? " Ensure a Secret Service provider such as GNOME Keyring or KWallet is running."
+      : " Ensure the operating system credential manager is available."
+  const message = error instanceof Error ? error.message : String(error)
+  return new Error(`secret ${action} failed: ${message}.${platformHint}`, {
+    cause: error,
+  })
+}
+
+export function secretAccount(
+  collectionId: string,
+  environment: string,
+  key: string,
+): string {
+  const digest = createHash("sha256")
+    .update(environment)
+    .update("\0")
+    .update(key)
+    .digest("hex")
+  return `${collectionId}:${digest}`
+}
+
+export async function ensureCollectionId(
+  collectionDir: string,
+): Promise<string> {
+  const settings = await loadSettings(collectionDir)
+  if (settings.collectionId) return settings.collectionId
+  const collectionId = randomUUID()
+  await saveSettings(collectionDir, { ...settings, collectionId })
+  return collectionId
+}
+
+export async function getStoredSecret(
+  collectionDir: string,
+  environment: string,
+  key: string,
+): Promise<string | null> {
+  const collectionId = await ensureCollectionId(collectionDir)
+  try {
+    return await backend().get({
+      service: SECRET_SERVICE,
+      name: secretAccount(collectionId, environment, key),
+    })
+  } catch (error) {
+    throw storageError("read", error)
+  }
+}
+
+export async function setStoredSecret(
+  collectionDir: string,
+  environment: string,
+  key: string,
+  value: string,
+): Promise<void> {
+  if (value.length === 0) throw new Error("secret value must not be empty")
+  const collectionId = await ensureCollectionId(collectionDir)
+  try {
+    await backend().set({
+      service: SECRET_SERVICE,
+      name: secretAccount(collectionId, environment, key),
+      value,
+      allowUnrestrictedAccess: false,
+    })
+  } catch (error) {
+    throw storageError("write", error)
+  }
+}
+
+export async function deleteStoredSecret(
+  collectionDir: string,
+  environment: string,
+  key: string,
+): Promise<boolean> {
+  const collectionId = await ensureCollectionId(collectionDir)
+  try {
+    return await backend().delete({
+      service: SECRET_SERVICE,
+      name: secretAccount(collectionId, environment, key),
+    })
+  } catch (error) {
+    throw storageError("delete", error)
+  }
+}
+
+export async function resolveStoredSecret(
+  collectionDir: string,
+  environment: string,
+  key: string,
+): Promise<{ value?: string; status: SecretStatus }> {
+  const processValue = process.env[key]
+  if (processValue) return { value: processValue, status: "process" }
+  const stored = await getStoredSecret(collectionDir, environment, key)
+  return stored ? { value: stored, status: "keychain" } : { status: "missing" }
+}

--- a/src/secrets/redact.ts
+++ b/src/secrets/redact.ts
@@ -1,0 +1,40 @@
+import type { Environment } from "../schema"
+
+export const REDACTED = "[REDACTED]"
+
+export function environmentSecretValues(
+  environment: Environment | null | undefined,
+): string[] {
+  if (!environment?.secretVars) return []
+  return [
+    ...new Set(
+      Object.keys(environment.secretVars)
+        .map((key) => environment.vars[key])
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ].sort((a, b) => b.length - a.length)
+}
+
+export function redactKnownSecrets(input: string, values: string[]): string {
+  let output = input
+  for (const value of [...new Set(values.filter(Boolean))].sort(
+    (a, b) => b.length - a.length,
+  )) {
+    output = output.split(value).join(REDACTED)
+  }
+  return output
+}
+
+export function isSensitiveHeader(name: string): boolean {
+  const normalized = name.toLowerCase().replace(/[_\s]/g, "-")
+  return (
+    normalized === "authorization" ||
+    normalized === "proxy-authorization" ||
+    normalized === "cookie" ||
+    normalized === "set-cookie" ||
+    normalized.includes("api-key") ||
+    normalized.includes("apikey") ||
+    normalized.includes("token") ||
+    normalized.includes("secret")
+  )
+}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -67,9 +67,6 @@ import { useOverlayIntercepts } from "./useOverlayIntercepts"
 import { useCollectionFileActions } from "./useCollectionFileActions"
 import { useTimeline } from "./timeline/useTimeline"
 import { buildTimelineEntry } from "./timeline/formatTimeline"
-import { substitute } from "../requests"
-import type { SubstitutedRequest } from "../requests/substitute"
-import { interpolatePathParams } from "../requests/send"
 import { flattenRequests, getRequestIds, findFolderByPath } from "./tree"
 import { useUIState } from "./tabs/useUIState"
 import type { FieldKind } from "./editMode"
@@ -492,55 +489,13 @@ export function AppInner({
     (_req: NoodleRequest, _result: SendCompleteResult) => {},
   )
   onCompleteRef.current = (req: NoodleRequest, result: SendCompleteResult) => {
-    let substituted: SubstitutedRequest | undefined
-    const activeEnv = envStateRef.current.activeEnv
-    if (activeEnv) {
-      try {
-        substituted = substitute(req, activeEnv)
-        const pathParams = substituted.pathParams ?? []
-        if (pathParams.length > 0) {
-          try {
-            substituted = {
-              ...substituted,
-              url: interpolatePathParams(substituted.url, pathParams),
-            }
-          } catch {
-            // keep unresolved URL
-          }
-        }
-      } catch {
-        substituted = undefined
-      }
-    } else {
-      const rawPathParams = req.pathParams ?? []
-      if (rawPathParams.length > 0) {
-        try {
-          const headers: Record<string, string> = {}
-          for (const [k, v] of Object.entries(req.headers)) {
-            if (v.enabled) headers[k] = v.value
-          }
-          substituted = {
-            id: req.id,
-            name: req.name,
-            method: req.method,
-            url: interpolatePathParams(req.url, rawPathParams),
-            timeout: req.timeout,
-            headers,
-            params: [...req.params],
-            pathParams: rawPathParams.map((p) => ({ ...p })),
-            body: req.body,
-            bodyType: req.bodyType,
-            formData: req.formData,
-            filePath: req.filePath,
-            auth: req.auth,
-          }
-        } catch {
-          // keep undefined — timeline stores template URL
-        }
-      }
-    }
     timelineAppendRef.current(
-      buildTimelineEntry(req, result, envNameRef.current, substituted),
+      buildTimelineEntry(
+        req,
+        result,
+        envNameRef.current,
+        envStateRef.current.activeEnv,
+      ),
     )
   }
 

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -59,6 +59,7 @@ export interface VarInputProps {
   pathCompletion?: PathCompletionOptions
   stopMousePropagation?: boolean
   onFocus?: () => void
+  masked?: boolean
 }
 
 export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
@@ -81,6 +82,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       pathCompletion,
       stopMousePropagation = false,
       onFocus,
+      masked = false,
     },
     ref,
   ) {
@@ -98,9 +100,15 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       return editable && !editable.isDestroyed ? editable : null
     }, [])
     const suggestionNames = useMemo(() => {
+      if (masked) return []
       if (variableNames != null) return [...variableNames]
-      return Object.keys(env?.vars ?? {})
-    }, [variableNames, env?.vars])
+      return [
+        ...new Set([
+          ...Object.keys(env?.vars ?? {}),
+          ...Object.keys(env?.secretVars ?? {}),
+        ]),
+      ]
+    }, [masked, variableNames, env?.vars])
 
     const inputFocused = isFocused ?? true
 
@@ -149,13 +157,25 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       applyHighlights()
     }, [applyHighlights, onChange, value])
 
+    const displayValue = masked ? "•".repeat([...value].length) : value
+
     const handleInput = useCallback(
       (nextValue: string) => {
-        onChange?.(nextValue)
+        if (masked) {
+          const previousLength = [...displayValue].length
+          const nextLength = [...nextValue].length
+          if (nextLength < previousLength) {
+            onChange?.([...value].slice(0, nextLength).join(""))
+          } else if (nextLength > previousLength) {
+            onChange?.(value + [...nextValue].slice(previousLength).join(""))
+          }
+        } else {
+          onChange?.(nextValue)
+        }
         setCompletionDismissed(false)
         applyHighlights()
       },
-      [applyHighlights, onChange],
+      [applyHighlights, displayValue, masked, onChange, value],
     )
 
     useEffect(() => {
@@ -339,7 +359,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         >
           <input
             ref={inputRef}
-            value={value}
+            value={displayValue}
             placeholder={placeholder}
             onInput={handleInput}
             focused={inputFocused}
@@ -357,7 +377,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     }
 
     const displayColor = value ? defaultColor : theme.textMuted
-    const displayText = value ? value : (placeholder ?? "")
+    const displayText = value ? displayValue : (placeholder ?? "")
 
     return (
       <box

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -59,7 +59,6 @@ export interface VarInputProps {
   pathCompletion?: PathCompletionOptions
   stopMousePropagation?: boolean
   onFocus?: () => void
-  masked?: boolean
 }
 
 export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
@@ -82,7 +81,6 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       pathCompletion,
       stopMousePropagation = false,
       onFocus,
-      masked = false,
     },
     ref,
   ) {
@@ -100,7 +98,6 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       return editable && !editable.isDestroyed ? editable : null
     }, [])
     const suggestionNames = useMemo(() => {
-      if (masked) return []
       if (variableNames != null) return [...variableNames]
       return [
         ...new Set([
@@ -108,7 +105,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
           ...Object.keys(env?.secretVars ?? {}),
         ]),
       ]
-    }, [masked, variableNames, env?.vars])
+    }, [variableNames, env?.vars, env?.secretVars])
 
     const inputFocused = isFocused ?? true
 
@@ -157,25 +154,13 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       applyHighlights()
     }, [applyHighlights, onChange, value])
 
-    const displayValue = masked ? "•".repeat([...value].length) : value
-
     const handleInput = useCallback(
       (nextValue: string) => {
-        if (masked) {
-          const previousLength = [...displayValue].length
-          const nextLength = [...nextValue].length
-          if (nextLength < previousLength) {
-            onChange?.([...value].slice(0, nextLength).join(""))
-          } else if (nextLength > previousLength) {
-            onChange?.(value + [...nextValue].slice(previousLength).join(""))
-          }
-        } else {
-          onChange?.(nextValue)
-        }
+        onChange?.(nextValue)
         setCompletionDismissed(false)
         applyHighlights()
       },
-      [applyHighlights, displayValue, masked, onChange, value],
+      [applyHighlights, onChange],
     )
 
     useEffect(() => {
@@ -359,7 +344,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         >
           <input
             ref={inputRef}
-            value={displayValue}
+            value={value}
             placeholder={placeholder}
             onInput={handleInput}
             focused={inputFocused}
@@ -377,7 +362,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
     }
 
     const displayColor = value ? defaultColor : theme.textMuted
-    const displayText = value ? displayValue : (placeholder ?? "")
+    const displayText = value || (placeholder ?? "")
 
     return (
       <box

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -28,7 +28,6 @@ export function EnvEditorPane({
   onToggleSecret,
   onRevealSecret,
   revealedRowId,
-  secretConfirmRowId,
   clonePrompt,
 }: {
   draft: EnvDraft | null
@@ -52,7 +51,6 @@ export function EnvEditorPane({
   onToggleSecret?: (row: number) => void
   onRevealSecret?: (row: number) => void
   revealedRowId?: number | null
-  secretConfirmRowId?: number | null
   clonePrompt?: { source: string; target: string } | null
 }) {
   const theme = useTheme()
@@ -175,14 +173,20 @@ export function EnvEditorPane({
           const cursorOnThisRow =
             inBrowse && !editState.addingRow && editState.row === i
           const dimmed = (inEdit && !isEditingThisRow) || !row.enabled
-          const canHoverRow =
-            !isEditingThisRow &&
-            (onActivateRow !== undefined || onToggleRow !== undefined)
+          const processManaged = row.secret && row.secretStatus === "process"
+          const missingSecret = row.secret && row.secretStatus === "missing"
           const canActivateRow =
-            !isEditingThisRow && onActivateRow !== undefined
+            !isEditingThisRow && !processManaged && onActivateRow !== undefined
+          const canHoverRow =
+            !isEditingThisRow && (canActivateRow || onToggleRow !== undefined)
 
-          const keyBaseColor = dimmed ? theme.textMuted : theme.primary
-          const valueBaseColor = dimmed ? theme.textMuted : theme.text
+          const keyBaseColor = missingSecret
+            ? theme.error
+            : dimmed || processManaged
+              ? theme.textMuted
+              : theme.primary
+          const valueBaseColor =
+            dimmed || processManaged ? theme.textMuted : theme.text
           const revealed = revealedRowId === row.id
           const displayValue =
             row.secret || row.originSecret
@@ -236,22 +240,6 @@ export function EnvEditorPane({
                 <Checkbox checked={row.enabled} theme={theme} />
               </box>
               <box
-                style={{ width: 3, justifyContent: "center" }}
-                onMouseDown={
-                  onToggleSecret
-                    ? (event) => {
-                        if (event.button !== MouseButton.LEFT) return
-                        onToggleSecret(i)
-                        event.stopPropagation()
-                      }
-                    : undefined
-                }
-              >
-                <text fg={row.secret ? theme.warning : theme.textMuted}>
-                  {row.secret ? "🔒" : "·"}
-                </text>
-              </box>
-              <box
                 onMouseDown={
                   canActivateRow
                     ? (event) => {
@@ -294,17 +282,10 @@ export function EnvEditorPane({
               >
                 <VarInput
                   value={isEditingThisRow ? editValue : displayValue}
-                  placeholder={
-                    row.secret && row.secretStatus === "missing"
-                      ? "(missing)"
-                      : "Value..."
-                  }
+                  placeholder="Value..."
                   env={draftEnv}
                   isEditing={isEditingThisRow}
                   onChange={setEditValue}
-                  masked={Boolean(
-                    (row.secret || row.originSecret) && isEditingThisRow,
-                  )}
                   isFocused={isEditingThisRow && editState.subfield === "value"}
                   baseColor={valueBaseColor}
                   backgroundColor={
@@ -316,30 +297,36 @@ export function EnvEditorPane({
                   variableNames={variableNames}
                 />
               </box>
-              {row.secret && (
-                <box
-                  style={{ width: 12, justifyContent: "flex-end" }}
-                  onMouseDown={
-                    onRevealSecret
-                      ? (event) => {
-                          if (event.button !== MouseButton.LEFT) return
-                          onRevealSecret(i)
-                          event.stopPropagation()
-                        }
-                      : undefined
-                  }
-                >
-                  <text
-                    fg={
-                      row.secretStatus === "missing"
-                        ? theme.error
-                        : theme.textMuted
-                    }
-                  >
-                    {revealed ? "hide" : (row.secretStatus ?? "secret")}
-                  </text>
-                </box>
-              )}
+              <box
+                style={{ width: 12, justifyContent: "flex-end" }}
+                onMouseDown={
+                  processManaged && onRevealSecret
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onRevealSecret(i)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
+              >
+                {processManaged && <text fg={theme.textMuted}>process</text>}
+              </box>
+              <box
+                style={{ width: 10, justifyContent: "flex-end" }}
+                onMouseDown={
+                  onToggleSecret
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onToggleSecret(i)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
+              >
+                <text fg={row.secret ? theme.warning : theme.textMuted}>
+                  {row.secret ? "[secret]" : "[plain]"}
+                </text>
+              </box>
             </box>
           )
         })}
@@ -449,16 +436,13 @@ export function EnvEditorPane({
                   variableNames={variableNames}
                 />
               </box>
+              <box style={{ width: 12 }} />
+              <box style={{ width: 10 }} />
             </box>
           )
         })()}
       </scrollbox>
       {error && <text fg={theme.error}>Error: {error}</text>}
-      {secretConfirmRowId !== null && (
-        <text fg={theme.warning}>
-          Press s again to confirm storing this value as plaintext
-        </text>
-      )}
       {clonePrompt && (
         <text fg={theme.warning}>
           Copy stored secrets to {clonePrompt.target}? y copy · n declarations

--- a/src/ui/env-editor/EnvEditorPane.tsx
+++ b/src/ui/env-editor/EnvEditorPane.tsx
@@ -25,6 +25,11 @@ export function EnvEditorPane({
   onInteraction,
   onActivateRow,
   onToggleRow,
+  onToggleSecret,
+  onRevealSecret,
+  revealedRowId,
+  secretConfirmRowId,
+  clonePrompt,
 }: {
   draft: EnvDraft | null
   editState: EnvEditState
@@ -44,6 +49,11 @@ export function EnvEditorPane({
     subfield?: "key" | "value",
   ) => void
   onToggleRow?: (row: number) => void
+  onToggleSecret?: (row: number) => void
+  onRevealSecret?: (row: number) => void
+  revealedRowId?: number | null
+  secretConfirmRowId?: number | null
+  clonePrompt?: { source: string; target: string } | null
 }) {
   const theme = useTheme()
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
@@ -173,6 +183,15 @@ export function EnvEditorPane({
 
           const keyBaseColor = dimmed ? theme.textMuted : theme.primary
           const valueBaseColor = dimmed ? theme.textMuted : theme.text
+          const revealed = revealedRowId === row.id
+          const displayValue =
+            row.secret || row.originSecret
+              ? revealed
+                ? row.value
+                : row.value
+                  ? "••••••••"
+                  : ""
+              : row.value
           const rowBg =
             cursorOnThisRow || isEditingThisRow
               ? theme.backgroundElement
@@ -217,6 +236,22 @@ export function EnvEditorPane({
                 <Checkbox checked={row.enabled} theme={theme} />
               </box>
               <box
+                style={{ width: 3, justifyContent: "center" }}
+                onMouseDown={
+                  onToggleSecret
+                    ? (event) => {
+                        if (event.button !== MouseButton.LEFT) return
+                        onToggleSecret(i)
+                        event.stopPropagation()
+                      }
+                    : undefined
+                }
+              >
+                <text fg={row.secret ? theme.warning : theme.textMuted}>
+                  {row.secret ? "🔒" : "·"}
+                </text>
+              </box>
+              <box
                 onMouseDown={
                   canActivateRow
                     ? (event) => {
@@ -258,11 +293,18 @@ export function EnvEditorPane({
                 style={{ flexGrow: 6, flexShrink: 1, flexBasis: 0 }}
               >
                 <VarInput
-                  value={isEditingThisRow ? editValue : row.value}
-                  placeholder="Value..."
+                  value={isEditingThisRow ? editValue : displayValue}
+                  placeholder={
+                    row.secret && row.secretStatus === "missing"
+                      ? "(missing)"
+                      : "Value..."
+                  }
                   env={draftEnv}
                   isEditing={isEditingThisRow}
                   onChange={setEditValue}
+                  masked={Boolean(
+                    (row.secret || row.originSecret) && isEditingThisRow,
+                  )}
                   isFocused={isEditingThisRow && editState.subfield === "value"}
                   baseColor={valueBaseColor}
                   backgroundColor={
@@ -274,6 +316,30 @@ export function EnvEditorPane({
                   variableNames={variableNames}
                 />
               </box>
+              {row.secret && (
+                <box
+                  style={{ width: 12, justifyContent: "flex-end" }}
+                  onMouseDown={
+                    onRevealSecret
+                      ? (event) => {
+                          if (event.button !== MouseButton.LEFT) return
+                          onRevealSecret(i)
+                          event.stopPropagation()
+                        }
+                      : undefined
+                  }
+                >
+                  <text
+                    fg={
+                      row.secretStatus === "missing"
+                        ? theme.error
+                        : theme.textMuted
+                    }
+                  >
+                    {revealed ? "hide" : (row.secretStatus ?? "secret")}
+                  </text>
+                </box>
+              )}
             </box>
           )
         })}
@@ -388,6 +454,17 @@ export function EnvEditorPane({
         })()}
       </scrollbox>
       {error && <text fg={theme.error}>Error: {error}</text>}
+      {secretConfirmRowId !== null && (
+        <text fg={theme.warning}>
+          Press s again to confirm storing this value as plaintext
+        </text>
+      )}
+      {clonePrompt && (
+        <text fg={theme.warning}>
+          Copy stored secrets to {clonePrompt.target}? y copy · n declarations
+          only
+        </text>
+      )}
       {saving && <text fg={theme.info}>Saving...</text>}
     </Frame>
   )

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -119,7 +119,6 @@ export function EnvironmentEditorView({
           }}
           onRevealSecret={envEditor.toggleReveal}
           revealedRowId={envEditor.revealedRowId}
-          secretConfirmRowId={envEditor.secretConfirmRowId}
           clonePrompt={envEditor.clonePrompt}
         />
       </box>

--- a/src/ui/env-editor/EnvironmentEditorView.tsx
+++ b/src/ui/env-editor/EnvironmentEditorView.tsx
@@ -1,7 +1,7 @@
 import { EnvSidebar } from "./EnvSidebar"
 import { EnvHeaderPane, type EnvHeaderPaneHandle } from "./EnvHeaderPane"
 import { EnvEditorPane } from "./EnvEditorPane"
-import type { RefObject } from "react"
+import { useEffect, type RefObject } from "react"
 import type { UseEnvironmentEditorResult } from "../../hooks/useEnvironmentEditor"
 import type { Environment } from "../../schema"
 import type { Focus } from "../focus"
@@ -31,6 +31,11 @@ export function EnvironmentEditorView({
   onEnvironmentContextMenu,
   setEnvDeletePending,
 }: EnvironmentEditorViewProps) {
+  const remaskSecrets = envEditor.remaskSecrets
+  useEffect(() => {
+    if (focus !== "env-vars") remaskSecrets()
+  }, [focus, remaskSecrets])
+
   return (
     <box style={{ flexDirection: "row", flexGrow: 1, gap: 1, minHeight: 0 }}>
       <EnvSidebar
@@ -57,7 +62,10 @@ export function EnvironmentEditorView({
         }}
         focused={focus === "env-sidebar"}
         jumpMode={jumpMode}
-        onPaneFocus={() => onPaneFocus("env-sidebar")}
+        onPaneFocus={() => {
+          envEditor.remaskSecrets()
+          onPaneFocus("env-sidebar")
+        }}
         onEnvironmentContextMenu={onEnvironmentContextMenu}
       />
       <box
@@ -77,7 +85,10 @@ export function EnvironmentEditorView({
           focused={focus === "env-header"}
           jumpMode={jumpMode}
           onColorFocus={() => onHeaderFieldFocus?.("color")}
-          onPaneFocus={() => onPaneFocus("env-header")}
+          onPaneFocus={() => {
+            envEditor.remaskSecrets()
+            onPaneFocus("env-header")
+          }}
         />
         <EnvEditorPane
           draft={envEditor.draft}
@@ -101,6 +112,15 @@ export function EnvironmentEditorView({
             envEditor.commitEdit()
             envEditor.toggleVar(row)
           }}
+          onToggleSecret={(row) => {
+            onPaneFocus("env-vars")
+            envEditor.commitEdit()
+            envEditor.toggleSecret(row)
+          }}
+          onRevealSecret={envEditor.toggleReveal}
+          revealedRowId={envEditor.revealedRowId}
+          secretConfirmRowId={envEditor.secretConfirmRowId}
+          clonePrompt={envEditor.clonePrompt}
         />
       </box>
     </box>

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -208,10 +208,10 @@ export const Definitions = {
     "env-browse",
     "env-edit",
   ]),
-  env_secret: keybind("s", "Toggle environment secret", true, "Environment", [
+  env_secret: keybind("s", "Toggle environment secret", false, "Environment", [
     "env-browse",
   ]),
-  env_reveal: keybind("r", "Reveal environment secret", true, "Environment", [
+  env_reveal: keybind("r", "Reveal environment secret", false, "Environment", [
     "env-browse",
   ]),
   env_new: keybind("ctrl+n", "Create new environment", false, "Environment", [

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -208,6 +208,12 @@ export const Definitions = {
     "env-browse",
     "env-edit",
   ]),
+  env_secret: keybind("s", "Toggle environment secret", true, "Environment", [
+    "env-browse",
+  ]),
+  env_reveal: keybind("r", "Reveal environment secret", true, "Environment", [
+    "env-browse",
+  ]),
   env_new: keybind("ctrl+n", "Create new environment", false, "Environment", [
     "env-editor",
   ]),
@@ -260,6 +266,8 @@ export const CommandMap = {
   edit_commit: "edit.commit",
   edit_cancel: "edit.cancel",
   env_save: "env.save",
+  env_secret: "env-browse.secret",
+  env_reveal: "env-browse.reveal",
   env_new: "env.new",
   env_clone: "env.clone",
   env_delete: "env.delete",

--- a/src/ui/keybindingHints.ts
+++ b/src/ui/keybindingHints.ts
@@ -88,14 +88,22 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
     if (ctx.focus === "env-vars" && ctx.paneMode === "browse") {
       return [
         { key: "Space", word: "toggle", command: "env-browse.toggle" },
-        { key: "s", word: "secret", command: "env-browse.secret" },
-        { key: "r", word: "reveal", command: "env-browse.reveal" },
+        {
+          key: displayKey(kb.env_secret),
+          word: "secret",
+          command: "env-browse.secret",
+        },
+        { key: displayKey(kb.env_save), word: "save", command: "env.save" },
+        {
+          key: displayKey(kb.env_reveal),
+          word: "reveal",
+          command: "env-browse.reveal",
+        },
         {
           key: displayKey(kb.browse_delete),
           word: "revert",
           command: "env-browse.revert",
         },
-        { key: displayKey(kb.env_save), word: "save", command: "env.save" },
       ]
     }
     if (ctx.focus === "env-vars" && ctx.paneMode === "edit") {

--- a/src/ui/keybindingHints.ts
+++ b/src/ui/keybindingHints.ts
@@ -88,6 +88,8 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
     if (ctx.focus === "env-vars" && ctx.paneMode === "browse") {
       return [
         { key: "Space", word: "toggle", command: "env-browse.toggle" },
+        { key: "s", word: "secret", command: "env-browse.secret" },
+        { key: "r", word: "reveal", command: "env-browse.reveal" },
         {
           key: displayKey(kb.browse_delete),
           word: "revert",

--- a/src/ui/keymap/environmentLayers.ts
+++ b/src/ui/keymap/environmentLayers.ts
@@ -52,12 +52,28 @@ export function createEnvironmentLayers(
           if (target) environment.setEnvDeletePending(target.envName)
         },
       },
+      {
+        name: "env.clone.copy-secrets",
+        enabled: () => environment.envEditorRef.current.clonePrompt !== null,
+        run: () => {
+          void environment.envEditorRef.current.confirmClone(true)
+        },
+      },
+      {
+        name: "env.clone.declarations-only",
+        enabled: () => environment.envEditorRef.current.clonePrompt !== null,
+        run: () => {
+          void environment.envEditorRef.current.confirmClone(false)
+        },
+      },
     ],
     bindings: [
       { key: keybinds.env_save, cmd: "env.save" },
       { key: keybinds.env_new, cmd: "env.new" },
       { key: keybinds.env_clone, cmd: "env.clone" },
       { key: keybinds.env_delete, cmd: "env.delete" },
+      { key: "y", cmd: "env.clone.copy-secrets" },
+      { key: "n", cmd: "env.clone.declarations-only" },
     ],
   }
 
@@ -113,6 +129,25 @@ export function createEnvironmentLayers(
         },
       },
       {
+        name: "env-browse.secret",
+        enabled: canEdit,
+        run: () => {
+          const state = environment.envEditorRef.current.editState
+          if (!state.addingRow && state.row >= 0) {
+            environment.envEditorRef.current.toggleSecret(state.row)
+          }
+        },
+      },
+      {
+        name: "env-browse.reveal",
+        run: () => {
+          const state = environment.envEditorRef.current.editState
+          if (!state.addingRow && state.row >= 0) {
+            environment.envEditorRef.current.toggleReveal(state.row)
+          }
+        },
+      },
+      {
         name: "env.save",
         enabled: canEdit,
         run: () => {
@@ -129,6 +164,8 @@ export function createEnvironmentLayers(
       { key: "escape", cmd: "env-browse.escape" },
       { key: "space", cmd: "env-browse.toggle" },
       { key: keybinds.browse_delete, cmd: "env-browse.revert" },
+      { key: "s", cmd: "env-browse.secret" },
+      { key: "r", cmd: "env-browse.reveal" },
       { key: keybinds.env_save, cmd: "env.save" },
     ],
   }

--- a/src/ui/keymap/environmentLayers.ts
+++ b/src/ui/keymap/environmentLayers.ts
@@ -164,8 +164,8 @@ export function createEnvironmentLayers(
       { key: "escape", cmd: "env-browse.escape" },
       { key: "space", cmd: "env-browse.toggle" },
       { key: keybinds.browse_delete, cmd: "env-browse.revert" },
-      { key: "s", cmd: "env-browse.secret" },
-      { key: "r", cmd: "env-browse.reveal" },
+      { key: keybinds.env_secret, cmd: "env-browse.secret" },
+      { key: keybinds.env_reveal, cmd: "env-browse.reveal" },
       { key: keybinds.env_save, cmd: "env.save" },
     ],
   }

--- a/src/ui/requestFinder.ts
+++ b/src/ui/requestFinder.ts
@@ -28,9 +28,10 @@ export function resolveFinderUrl(
   activeEnv: Environment | null,
 ): string {
   if (activeEnv === null) return url
-  return url.replace(VAR_RE, (match, name: string) =>
-    Object.hasOwn(activeEnv.vars, name) ? activeEnv.vars[name]! : match,
-  )
+  return url.replace(VAR_RE, (match, name: string) => {
+    if (Object.hasOwn(activeEnv.secretVars ?? {}, name)) return match
+    return Object.hasOwn(activeEnv.vars, name) ? activeEnv.vars[name]! : match
+  })
 }
 
 function fuzzyMatch(value: string, token: string): boolean {

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -3,6 +3,7 @@ import type { NetworkError } from "../../schema"
 import type { Request } from "../../schema"
 import type { SendCompleteResult } from "../../hooks/useResponse"
 import { randomUUID } from "node:crypto"
+import { interpolatePathParams } from "../../requests/send"
 import {
   environmentSecretValues,
   isSensitiveHeader,
@@ -22,13 +23,27 @@ export function buildTimelineEntry(
 ): TimelineEntry {
   const secretValues = environmentSecretValues(environment)
   const redact = (value: string) => redactKnownSecrets(value, secretValues)
-  const redactHeaders = (headers: Record<string, string>) =>
-    Object.fromEntries(
-      Object.entries(headers).map(([key, value]) => [
-        key,
-        isSensitiveHeader(key) ? REDACTED : redact(value),
-      ]),
+  const resolvePublicVars = (value: string) =>
+    environment
+      ? value.replace(/\$(\w+)/g, (token, key: string) =>
+          !environment.secretVars?.[key] && Object.hasOwn(environment.vars, key)
+            ? environment.vars[key]!
+            : token,
+        )
+      : value
+  let url = req.url
+  try {
+    url = interpolatePathParams(
+      resolvePublicVars(req.url),
+      (req.pathParams ?? []).map((param) => ({
+        ...param,
+        name: resolvePublicVars(param.name),
+        value: resolvePublicVars(param.value),
+      })),
     )
+  } catch {
+    // Preserve the template when substitution fails, matching send errors.
+  }
   const requestHeaders = Object.fromEntries(
     Object.entries(req.headers).map(([key, value]) => [
       key,
@@ -77,7 +92,7 @@ export function buildTimelineEntry(
       id: req.id,
       name: req.name,
       method: req.method,
-      url: redact(req.url),
+      url: redact(url),
       headers: requestHeaders,
       params: req.params.map((param) => ({
         ...param,
@@ -97,8 +112,8 @@ export function buildTimelineEntry(
         ? {
             status: result.response.status,
             statusText: result.response.statusText,
-            headers: redactHeaders(result.response.headers),
-            body: redact(result.response.body),
+            headers: result.response.headers,
+            body: result.response.body,
             timeMs: result.response.timeMs,
             size: responseSize(result.response.body),
           }

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -1,9 +1,14 @@
-import type { TimelineEntry, Method } from "../../schema"
+import type { Environment, TimelineEntry, Method } from "../../schema"
 import type { NetworkError } from "../../schema"
 import type { Request } from "../../schema"
 import type { SendCompleteResult } from "../../hooks/useResponse"
-import type { SubstitutedRequest } from "../../requests/substitute"
 import { randomUUID } from "node:crypto"
+import {
+  environmentSecretValues,
+  isSensitiveHeader,
+  redactKnownSecrets,
+  REDACTED,
+} from "../../secrets/redact"
 
 function responseSize(body: string): number {
   return new TextEncoder().encode(body).length
@@ -13,53 +18,95 @@ export function buildTimelineEntry(
   req: Request,
   result: SendCompleteResult,
   envName?: string,
-  substituted?: SubstitutedRequest,
+  environment?: Environment | null,
 ): TimelineEntry {
+  const secretValues = environmentSecretValues(environment)
+  const redact = (value: string) => redactKnownSecrets(value, secretValues)
+  const redactHeaders = (headers: Record<string, string>) =>
+    Object.fromEntries(
+      Object.entries(headers).map(([key, value]) => [
+        key,
+        isSensitiveHeader(key) ? REDACTED : redact(value),
+      ]),
+    )
+  const requestHeaders = Object.fromEntries(
+    Object.entries(req.headers).map(([key, value]) => [
+      key,
+      {
+        ...value,
+        value: isSensitiveHeader(key) ? REDACTED : redact(value.value),
+      },
+    ]),
+  )
+  const redactAuth = (auth: Request["auth"]): Request["auth"] => {
+    if (!auth || auth.type === "none" || auth.type === "inherit") return auth
+    if (auth.type === "bearer") {
+      return {
+        type: "bearer",
+        token: auth.token.includes("$") ? redact(auth.token) : REDACTED,
+      }
+    }
+    if (auth.type === "basic") {
+      return {
+        type: "basic",
+        user: redact(auth.user),
+        pass: auth.pass.includes("$") ? redact(auth.pass) : REDACTED,
+      }
+    }
+    return {
+      ...auth,
+      key: redact(auth.key),
+      value: auth.value.includes("$") ? redact(auth.value) : REDACTED,
+    }
+  }
   return {
     id: randomUUID(),
     timestamp: Date.now(),
     envName,
     network:
       result.status === "done"
-        ? result.response.network?.map((event) => ({ ...event }))
+        ? result.response.network?.map((event) => ({
+            ...event,
+            message: redact(event.message),
+          }))
         : (result.error as NetworkError).network?.map((event) => ({
             ...event,
+            message: redact(event.message),
           })),
     request: {
       id: req.id,
       name: req.name,
       method: req.method,
-      url: substituted?.url ?? req.url,
-      headers: substituted
-        ? Object.fromEntries(
-            Object.entries(substituted.headers).map(([k, v]) => [
-              k,
-              { value: v, enabled: true },
-            ]),
-          )
-        : { ...req.headers },
-      params: substituted
-        ? substituted.params.map((p) => ({ ...p }))
-        : [...req.params],
-      pathParams: substituted
-        ? (substituted.pathParams ?? []).map((p) => ({ ...p }))
-        : [...(req.pathParams ?? [])],
-      body: substituted?.body ?? req.body,
-      auth: substituted?.auth ?? (req.auth ? { ...req.auth } : undefined),
+      url: redact(req.url),
+      headers: requestHeaders,
+      params: req.params.map((param) => ({
+        ...param,
+        name: redact(param.name),
+        value: redact(param.value),
+      })),
+      pathParams: (req.pathParams ?? []).map((param) => ({
+        ...param,
+        name: redact(param.name),
+        value: redact(param.value),
+      })),
+      body: req.body === undefined ? undefined : redact(req.body),
+      auth: redactAuth(req.auth),
     },
     response:
       result.status === "done"
         ? {
             status: result.response.status,
             statusText: result.response.statusText,
-            headers: { ...result.response.headers },
-            body: result.response.body,
+            headers: redactHeaders(result.response.headers),
+            body: redact(result.response.body),
             timeMs: result.response.timeMs,
             size: responseSize(result.response.body),
           }
         : undefined,
     error:
-      result.status === "error" ? { message: result.error.message } : undefined,
+      result.status === "error"
+        ? { message: redact(result.error.message) }
+        : undefined,
   }
 }
 

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -49,7 +49,11 @@ export function buildTimelineEntry(
       key,
       {
         ...value,
-        value: isSensitiveHeader(key) ? REDACTED : redact(value.value),
+        value: isSensitiveHeader(key)
+          ? REDACTED
+          : redact(
+              value.enabled ? resolvePublicVars(value.value) : value.value,
+            ),
       },
     ]),
   )
@@ -58,20 +62,26 @@ export function buildTimelineEntry(
     if (auth.type === "bearer") {
       return {
         type: "bearer",
-        token: auth.token.includes("$") ? redact(auth.token) : REDACTED,
+        token: auth.token.includes("$")
+          ? redact(resolvePublicVars(auth.token))
+          : REDACTED,
       }
     }
     if (auth.type === "basic") {
       return {
         type: "basic",
-        user: redact(auth.user),
-        pass: auth.pass.includes("$") ? redact(auth.pass) : REDACTED,
+        user: redact(resolvePublicVars(auth.user)),
+        pass: auth.pass.includes("$")
+          ? redact(resolvePublicVars(auth.pass))
+          : REDACTED,
       }
     }
     return {
       ...auth,
-      key: redact(auth.key),
-      value: auth.value.includes("$") ? redact(auth.value) : REDACTED,
+      key: redact(resolvePublicVars(auth.key)),
+      value: auth.value.includes("$")
+        ? redact(resolvePublicVars(auth.value))
+        : REDACTED,
     }
   }
   return {
@@ -96,15 +106,22 @@ export function buildTimelineEntry(
       headers: requestHeaders,
       params: req.params.map((param) => ({
         ...param,
-        name: redact(param.name),
-        value: redact(param.value),
+        name: redact(
+          param.enabled ? resolvePublicVars(param.name) : param.name,
+        ),
+        value: redact(
+          param.enabled ? resolvePublicVars(param.value) : param.value,
+        ),
       })),
       pathParams: (req.pathParams ?? []).map((param) => ({
         ...param,
-        name: redact(param.name),
-        value: redact(param.value),
+        name: redact(resolvePublicVars(param.name)),
+        value: redact(resolvePublicVars(param.value)),
       })),
-      body: req.body === undefined ? undefined : redact(req.body),
+      body:
+        req.body === undefined
+          ? undefined
+          : redact(resolvePublicVars(req.body)),
       auth: redactAuth(req.auth),
     },
     response:

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -389,6 +389,53 @@ describe("CLI integration", () => {
     expect(out).toContain("collection")
   })
 
+  it("lists secret status without printing a process-provided value", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-cli-secret-"))
+    try {
+      await mkdir(join(dir, ".environments"))
+      await writeFile(
+        join(dir, "settings.yml"),
+        "collection_id: 123e4567-e89b-42d3-a456-426614174000\n",
+      )
+      await writeFile(
+        join(dir, ".environments", "dev.env"),
+        "# @secret CLI_SECRET_TEST\nCLI_SECRET_TEST=\n",
+      )
+      const proc = Bun.spawnSync(
+        [
+          "bun",
+          CLI,
+          "secret",
+          "list",
+          "--env",
+          "dev",
+          "--collection",
+          dir,
+          "--json",
+        ],
+        { env: { ...process.env, CLI_SECRET_TEST: "never-print-this" } },
+      )
+      expect(proc.exitCode).toBe(0)
+      expect(proc.stdout.toString()).not.toContain("never-print-this")
+      expect(JSON.parse(proc.stdout.toString())).toEqual({
+        status: "success",
+        data: {
+          environment: "dev",
+          secrets: [
+            {
+              key: "CLI_SECRET_TEST",
+              enabled: true,
+              status: "process",
+            },
+          ],
+        },
+        errors: [],
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it("accepts --env with -e alias", () => {
     const proc = Bun.spawnSync([
       "bun",

--- a/tests/converters/postman-export.test.ts
+++ b/tests/converters/postman-export.test.ts
@@ -483,4 +483,17 @@ describe("Postman export", () => {
       _postman_variable_scope: "environment",
     })
   })
+
+  it("marks declared environment secrets for Postman", () => {
+    const exported = exportPostmanEnvironment({
+      name: "production",
+      vars: {},
+      secretVars: { TOKEN: "missing" },
+    }) as {
+      values: { key: string; value: string; type: string; enabled: boolean }[]
+    }
+    expect(exported.values).toEqual([
+      { key: "TOKEN", value: "", type: "secret", enabled: true },
+    ])
+  })
 })

--- a/tests/env-clone.test.ts
+++ b/tests/env-clone.test.ts
@@ -33,6 +33,20 @@ describe("cloneEnvironment", () => {
     expect(loaded.disabledVars).toEqual({ old_key: "old_val" })
   })
 
+  it("clones secret declarations without copying values", async () => {
+    await env.saveEnvironment(dir, {
+      name: "with-secret",
+      vars: { TOKEN: "must-not-persist" },
+      secretVars: { TOKEN: "keychain" },
+    })
+    await env.cloneEnvironment(dir, "with-secret", "secret-copy")
+    const loaded = await env.loadEnvironment(dir, "secret-copy", {
+      resolveSecrets: false,
+    })
+    expect(loaded.vars).toEqual({})
+    expect(loaded.secretVars).toEqual({ TOKEN: "missing" })
+  })
+
   it("rejects invalid target name", async () => {
     await expect(
       env.cloneEnvironment(dir, "original", "../bad"),

--- a/tests/env-save.test.ts
+++ b/tests/env-save.test.ts
@@ -63,4 +63,14 @@ describe("saveEnvironment", () => {
       }),
     ).rejects.toThrow('env.save: unknown color "nonexistent"')
   })
+
+  it("rejects the reserved _color secret key", async () => {
+    await expect(
+      env.saveEnvironment(dir, {
+        name: "test",
+        vars: {},
+        secretVars: { _color: "missing" },
+      }),
+    ).rejects.toThrow('env.save: invalid secret key "_color"')
+  })
 })

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -595,6 +595,15 @@ describe("filestore.loadSettings", () => {
 })
 
 describe("filestore.saveSettings", () => {
+  it("round-trips a collection credential namespace id", async () => {
+    const collectionId = "123e4567-e89b-42d3-a456-426614174000"
+    await saveSettings(dir, { collectionId })
+    expect(await loadSettings(dir)).toEqual({ collectionId })
+    expect(await readFile(join(dir, "settings.yml"), "utf8")).toContain(
+      `collection_id: ${collectionId}`,
+    )
+  })
+
   it("writes environment to settings.yml", async () => {
     await saveSettings(dir, { environment: "production" })
     const content = await readFile(join(dir, "settings.yml"), "utf8")

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -284,7 +284,7 @@ describe("automation services", () => {
     }
   })
 
-  it("redacts secrets from automation response fields", async () => {
+  it("keeps server response fields intact in automation output", async () => {
     const key = "NOODLE_AUTOMATION_RESPONSE_SECRET"
     process.env[key] = "response-secret"
     await writeFile(join(dir, "settings.yml"), "environment: development\n")
@@ -308,9 +308,9 @@ describe("automation services", () => {
     try {
       const result = await collectionRun(dir)
       expect(result.results[0]!.response).toMatchObject({
-        statusText: "[REDACTED]",
-        headers: { "x-echo": "[REDACTED]" },
-        body: "echo:[REDACTED]",
+        statusText: "response-secret",
+        headers: { "x-echo": "response-secret" },
+        body: "echo:response-secret",
       })
     } finally {
       executor.send = send

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -286,26 +286,27 @@ describe("automation services", () => {
 
   it("keeps server response fields intact in automation output", async () => {
     const key = "NOODLE_AUTOMATION_RESPONSE_SECRET"
-    process.env[key] = "response-secret"
-    await writeFile(join(dir, "settings.yml"), "environment: development\n")
-    await env.saveEnvironment(join(dir, ".environments"), {
-      name: "development",
-      vars: {},
-      secretVars: { [key]: "process" },
-    })
-    await writeFile(
-      join(dir, "request.yml"),
-      "name: Request\nmethod: GET\nurl: https://example.com\n",
-    )
+    const originalValue = process.env[key]
     const send = executor.send
-    executor.send = async () => ({
-      status: 200,
-      statusText: "response-secret",
-      headers: { "x-echo": "response-secret" },
-      body: "echo:response-secret",
-      timeMs: 1,
-    })
     try {
+      process.env[key] = "response-secret"
+      await writeFile(join(dir, "settings.yml"), "environment: development\n")
+      await env.saveEnvironment(join(dir, ".environments"), {
+        name: "development",
+        vars: {},
+        secretVars: { [key]: "process" },
+      })
+      await writeFile(
+        join(dir, "request.yml"),
+        "name: Request\nmethod: GET\nurl: https://example.com\n",
+      )
+      executor.send = async () => ({
+        status: 200,
+        statusText: "response-secret",
+        headers: { "x-echo": "response-secret" },
+        body: "echo:response-secret",
+        timeMs: 1,
+      })
       const result = await collectionRun(dir)
       expect(result.results[0]!.response).toMatchObject({
         statusText: "response-secret",
@@ -314,7 +315,8 @@ describe("automation services", () => {
       })
     } finally {
       executor.send = send
-      delete process.env[key]
+      if (originalValue === undefined) delete process.env[key]
+      else process.env[key] = originalValue
     }
   })
 

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -284,6 +284,40 @@ describe("automation services", () => {
     }
   })
 
+  it("redacts secrets from automation response fields", async () => {
+    const key = "NOODLE_AUTOMATION_RESPONSE_SECRET"
+    process.env[key] = "response-secret"
+    await writeFile(join(dir, "settings.yml"), "environment: development\n")
+    await env.saveEnvironment(join(dir, ".environments"), {
+      name: "development",
+      vars: {},
+      secretVars: { [key]: "process" },
+    })
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\n",
+    )
+    const send = executor.send
+    executor.send = async () => ({
+      status: 200,
+      statusText: "response-secret",
+      headers: { "x-echo": "response-secret" },
+      body: "echo:response-secret",
+      timeMs: 1,
+    })
+    try {
+      const result = await collectionRun(dir)
+      expect(result.results[0]!.response).toMatchObject({
+        statusText: "[REDACTED]",
+        headers: { "x-echo": "[REDACTED]" },
+        body: "echo:[REDACTED]",
+      })
+    } finally {
+      executor.send = send
+      delete process.env[key]
+    }
+  })
+
   it("reports run progress before and after each collection request", async () => {
     await writeFile(join(dir, "settings.yml"), "{}\n")
     await writeFile(

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -67,7 +67,7 @@ describe("import — integration", () => {
     const collDir = join(outDir, "test-api")
     expect(existsSync(collDir)).toBe(true)
     expect(readFileSync(join(collDir, "settings.yml"), "utf8")).toMatch(
-      /collection_id: [0-9a-f-]{36}/,
+      /^collection_id: [0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\s*$/im,
     )
 
     const listUsersYml = readFileSync(

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -66,6 +66,9 @@ describe("import — integration", () => {
 
     const collDir = join(outDir, "test-api")
     expect(existsSync(collDir)).toBe(true)
+    expect(readFileSync(join(collDir, "settings.yml"), "utf8")).toMatch(
+      /collection_id: [0-9a-f-]{36}/,
+    )
 
     const listUsersYml = readFileSync(
       join(collDir, "users", "get-users.yml"),

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
@@ -37,9 +37,17 @@ function memoryBackend(): SecretBackend & { values: Map<string, string> } {
   }
 }
 
+let originalSecretTest: string | undefined
+
+beforeEach(() => {
+  originalSecretTest = process.env.NOODLE_SECRET_TEST
+  delete process.env.NOODLE_SECRET_TEST
+})
+
 afterEach(() => {
   setSecretBackendForTests(undefined)
-  delete process.env.NOODLE_SECRET_TEST
+  if (originalSecretTest === undefined) delete process.env.NOODLE_SECRET_TEST
+  else process.env.NOODLE_SECRET_TEST = originalSecretTest
 })
 
 describe("secret storage", () => {
@@ -66,6 +74,11 @@ describe("secret storage", () => {
     loaded = await env.loadEnvironment(directory, "dev")
     expect(loaded.vars.NOODLE_SECRET_TEST).toBe("process")
     expect(loaded.secretVars?.NOODLE_SECRET_TEST).toBe("process")
+
+    process.env.NOODLE_SECRET_TEST = ""
+    loaded = await env.loadEnvironment(directory, "dev")
+    expect(loaded.vars.NOODLE_SECRET_TEST).toBe("")
+    expect(loaded.secretVars?.NOODLE_SECRET_TEST).toBe("process")
     expect(
       backend.values.has(
         `${SECRET_SERVICE}:${secretAccount(
@@ -86,6 +99,30 @@ describe("secret storage", () => {
     await deleteStoredSecret(root, "dev", "TOKEN")
     expect((await loadSettings(root)).collectionId).toBe(first)
     expect(first).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it("uses one collection id when secret operations initialize concurrently", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-race-"))
+    await saveSettings(root, { environment: "dev" })
+    const collectionIds = new Set<string>()
+    const backend = memoryBackend()
+    setSecretBackendForTests({
+      ...backend,
+      async set(options) {
+        collectionIds.add(options.name.split(":", 1)[0]!)
+        await backend.set(options)
+      },
+    })
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        setStoredSecret(root, "dev", `TOKEN_${index}`, `value-${index}`),
+      ),
+    )
+
+    const savedId = (await loadSettings(root)).collectionId
+    expect(savedId).toBeDefined()
+    expect(collectionIds).toEqual(new Set([savedId!]))
   })
 
   it("rejects empty values", async () => {

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { env } from "../src/env"
+import { loadSettings, saveSettings } from "../src/filestore"
+import { saveRequest } from "../src/filestore"
+import {
+  environmentSet,
+  secretDelete,
+  secretList,
+  secretSet,
+} from "../src/app/services"
+import {
+  SECRET_SERVICE,
+  deleteStoredSecret,
+  secretAccount,
+  setSecretBackendForTests,
+  setStoredSecret,
+  type SecretBackend,
+} from "../src/secrets"
+
+function memoryBackend(): SecretBackend & { values: Map<string, string> } {
+  const values = new Map<string, string>()
+  return {
+    values,
+    async get({ service, name }) {
+      return values.get(`${service}:${name}`) ?? null
+    },
+    async set({ service, name, value, allowUnrestrictedAccess }) {
+      expect(allowUnrestrictedAccess).toBe(false)
+      values.set(`${service}:${name}`, value)
+    },
+    async delete({ service, name }) {
+      return values.delete(`${service}:${name}`)
+    },
+  }
+}
+
+afterEach(() => {
+  setSecretBackendForTests(undefined)
+  delete process.env.NOODLE_SECRET_TEST
+})
+
+describe("secret storage", () => {
+  it("namespaces credentials and resolves process values before the keychain", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-"))
+    const directory = join(root, ".environments")
+    await mkdir(directory)
+    await saveSettings(root, {
+      collectionId: "123e4567-e89b-42d3-a456-426614174000",
+    })
+    await writeFile(
+      join(directory, "dev.env"),
+      "# @secret NOODLE_SECRET_TEST\nNOODLE_SECRET_TEST=\n",
+    )
+    const backend = memoryBackend()
+    setSecretBackendForTests(backend)
+    await setStoredSecret(root, "dev", "NOODLE_SECRET_TEST", "stored")
+
+    let loaded = await env.loadEnvironment(directory, "dev")
+    expect(loaded.vars.NOODLE_SECRET_TEST).toBe("stored")
+    expect(loaded.secretVars?.NOODLE_SECRET_TEST).toBe("keychain")
+
+    process.env.NOODLE_SECRET_TEST = "process"
+    loaded = await env.loadEnvironment(directory, "dev")
+    expect(loaded.vars.NOODLE_SECRET_TEST).toBe("process")
+    expect(loaded.secretVars?.NOODLE_SECRET_TEST).toBe("process")
+    expect(
+      backend.values.has(
+        `${SECRET_SERVICE}:${secretAccount(
+          "123e4567-e89b-42d3-a456-426614174000",
+          "dev",
+          "NOODLE_SECRET_TEST",
+        )}`,
+      ),
+    ).toBe(true)
+  })
+
+  it("creates a stable collection id on the first secret operation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-id-"))
+    await saveSettings(root, { environment: "dev" })
+    setSecretBackendForTests(memoryBackend())
+    await setStoredSecret(root, "dev", "TOKEN", "value")
+    const first = (await loadSettings(root)).collectionId
+    await deleteStoredSecret(root, "dev", "TOKEN")
+    expect((await loadSettings(root)).collectionId).toBe(first)
+    expect(first).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it("rejects empty values", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-empty-"))
+    setSecretBackendForTests(memoryBackend())
+    await expect(setStoredSecret(root, "dev", "TOKEN", "")).rejects.toThrow(
+      "must not be empty",
+    )
+  })
+
+  it("reports missing values and actionable credential backend failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-errors-"))
+    const directory = join(root, ".environments")
+    await mkdir(directory)
+    await writeFile(join(directory, "dev.env"), "# @secret TOKEN\nTOKEN=\n")
+    setSecretBackendForTests(memoryBackend())
+    const missing = await env.loadEnvironment(directory, "dev")
+    expect(missing.vars.TOKEN).toBeUndefined()
+    expect(missing.secretVars?.TOKEN).toBe("missing")
+
+    setSecretBackendForTests({
+      async get() {
+        throw new Error("backend unavailable")
+      },
+      async set() {
+        throw new Error("backend unavailable")
+      },
+      async delete() {
+        throw new Error("backend unavailable")
+      },
+    })
+    await expect(env.loadEnvironment(directory, "dev")).rejects.toThrow(
+      /secret read failed: backend unavailable.*credential|secret read failed: backend unavailable.*Secret Service/,
+    )
+  })
+})
+
+describe("secret environment declarations", () => {
+  it("round-trips enabled and disabled declarations without plaintext", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-env-"))
+    const directory = join(root, ".environments")
+    setSecretBackendForTests(memoryBackend())
+    await env.saveEnvironment(directory, {
+      name: "dev",
+      vars: { URL: "https://example.com", TOKEN: "must-not-persist" },
+      disabledVars: { OLD_TOKEN: "must-not-persist" },
+      secretVars: { TOKEN: "keychain", OLD_TOKEN: "disabled" },
+    })
+    const raw = await readFile(join(directory, "dev.env"), "utf8")
+    expect(raw).toContain("# @secret TOKEN\nTOKEN=")
+    expect(raw).toContain("# @secret OLD_TOKEN\n# OLD_TOKEN=")
+    expect(raw).not.toContain("must-not-persist")
+
+    const loaded = await env.loadEnvironment(directory, "dev", {
+      resolveSecrets: false,
+    })
+    expect(loaded.secretVars).toEqual({
+      TOKEN: "missing",
+      OLD_TOKEN: "disabled",
+    })
+  })
+
+  it("rejects malformed declarations and plaintext secret placeholders", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-invalid-"))
+    const directory = join(root, ".environments")
+    await mkdir(directory)
+    await writeFile(
+      join(directory, "dev.env"),
+      "# @secret TOKEN\nTOKEN=plaintext\n",
+    )
+    await expect(
+      env.loadEnvironment(directory, "dev", { resolveSecrets: false }),
+    ).rejects.toThrow("must have a blank value")
+  })
+
+  it("rejects malformed, duplicate, mismatched, and dangling declarations", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-strict-"))
+    const directory = join(root, ".environments")
+    await mkdir(directory)
+    const cases = [
+      ["# @secret\nTOKEN=\n", "invalid secret marker"],
+      ["# @secret TOKEN\n", "dangling secret marker"],
+      [
+        "# @secret TOKEN\nOTHER=\n",
+        'secret marker for "TOKEN" does not match "OTHER"',
+      ],
+      [
+        "# @secret TOKEN\nTOKEN=\n# @secret TOKEN\nTOKEN=\n",
+        "duplicate secret marker",
+      ],
+      ["# @secret TOKEN\n\nTOKEN=\n", 'dangling secret marker for "TOKEN"'],
+    ] as const
+
+    for (const [content, message] of cases) {
+      await writeFile(join(directory, "dev.env"), content)
+      await expect(
+        env.loadEnvironment(directory, "dev", { resolveSecrets: false }),
+      ).rejects.toThrow(message)
+    }
+  })
+})
+
+describe("secret automation services", () => {
+  it("migrates plaintext, lists status, and deletes only the local value", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-secret-service-"))
+    const directory = join(root, ".environments")
+    await saveSettings(root, {
+      collectionId: "123e4567-e89b-42d3-a456-426614174000",
+      environment: "dev",
+    })
+    await env.saveEnvironment(directory, {
+      name: "dev",
+      vars: { TOKEN: "old-plaintext" },
+    })
+    await saveRequest(root, {
+      id: "example",
+      name: "Example",
+      method: "GET",
+      url: "https://example.com/$TOKEN",
+      timeout: 30_000,
+      headers: {},
+      params: [],
+    })
+    setSecretBackendForTests(memoryBackend())
+
+    await secretSet("TOKEN", "new-secret", "dev", root)
+    const raw = await readFile(join(directory, "dev.env"), "utf8")
+    expect(raw).toContain("# @secret TOKEN\nTOKEN=")
+    expect(raw).not.toContain("old-plaintext")
+    expect(await secretList("dev", root)).toEqual({
+      environment: "dev",
+      secrets: [{ key: "TOKEN", enabled: true, status: "keychain" }],
+    })
+    await expect(
+      environmentSet("TOKEN", "plaintext", "dev", root),
+    ).rejects.toThrow("noodle secret set")
+
+    expect((await secretDelete("TOKEN", "dev", root)).deleted).toBe(true)
+    const metadata = await env.loadEnvironment(directory, "dev", {
+      resolveSecrets: false,
+    })
+    expect(metadata.secretVars?.TOKEN).toBe("missing")
+  })
+})

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -9,6 +9,7 @@ import {
   pruneTimeline,
   clearTimelineForRequest,
   clearAllTimeline,
+  redactTimelineSecrets,
 } from "../src/filestore/timeline"
 import type { TimelineEntry } from "../src/schema"
 
@@ -16,6 +17,42 @@ let dir: string
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "noodle-tl-"))
+})
+
+describe("redactTimelineSecrets", () => {
+  it("redacts inline and compressed bodies in place", async () => {
+    const secret = "super-secret-value"
+    await saveTimelineEntry(
+      dir,
+      "redact",
+      makeEntry({
+        request: {
+          ...makeEntry().request,
+          url: `https://example.com?token=${secret}`,
+        },
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: { "x-result": secret },
+          body: `${"x".repeat(10_100)}${secret}`,
+          timeMs: 1,
+          size: 10_100 + secret.length,
+        },
+      }),
+    )
+
+    await redactTimelineSecrets(dir, [secret])
+    const [entry] = await loadTimeline(dir, "redact")
+    expect(entry!.request.url).toContain("[REDACTED]")
+    expect(entry!.response!.headers["x-result"]).toBe("[REDACTED]")
+    const body = await loadTimelineBody(
+      dir,
+      "redact",
+      entry!.response!.bodyRef!,
+    )
+    expect(body).not.toContain(secret)
+    expect(body).toContain("[REDACTED]")
+  })
 })
 
 afterEach(async () => {

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -20,7 +20,7 @@ beforeEach(async () => {
 })
 
 describe("redactTimelineSecrets", () => {
-  it("redacts inline and compressed bodies in place", async () => {
+  it("redacts request history without rewriting compressed response bodies", async () => {
     const secret = "super-secret-value"
     await saveTimelineEntry(
       dir,
@@ -44,14 +44,14 @@ describe("redactTimelineSecrets", () => {
     await redactTimelineSecrets(dir, [secret])
     const [entry] = await loadTimeline(dir, "redact")
     expect(entry!.request.url).toContain("[REDACTED]")
-    expect(entry!.response!.headers["x-result"]).toBe("[REDACTED]")
+    expect(entry!.response!.headers["x-result"]).toBe(secret)
     const body = await loadTimelineBody(
       dir,
       "redact",
       entry!.response!.bodyRef!,
     )
-    expect(body).not.toContain(secret)
-    expect(body).toContain("[REDACTED]")
+    expect(body).toContain(secret)
+    expect(body).not.toContain("[REDACTED]")
   })
 })
 

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -533,7 +533,7 @@ describe("buildTimelineEntry", () => {
     expect(entry.envName).toBe("dev")
   })
 
-  it("redacts known values and sensitive headers only in the timeline entry", () => {
+  it("redacts request credentials without altering the server response", () => {
     const secret = "timeline-secret"
     const req = {
       id: "req-secret",
@@ -549,7 +549,7 @@ describe("buildTimelineEntry", () => {
     }
     const response = {
       status: 200,
-      statusText: "OK",
+      statusText: secret,
       headers: { "set-cookie": secret, "x-echo": secret },
       body: `echo:${secret}`,
       timeMs: 1,
@@ -561,9 +561,10 @@ describe("buildTimelineEntry", () => {
     })
     expect(entry.request.url).toBe("https://api.example.com/$TOKEN")
     expect(entry.request.headers.Authorization!.value).toBe("[REDACTED]")
-    expect(entry.response?.headers["set-cookie"]).toBe("[REDACTED]")
-    expect(entry.response?.headers["x-echo"]).toBe("[REDACTED]")
-    expect(entry.response?.body).toBe("echo:[REDACTED]")
+    expect(entry.response?.statusText).toBe(secret)
+    expect(entry.response?.headers["set-cookie"]).toBe(secret)
+    expect(entry.response?.headers["x-echo"]).toBe(secret)
+    expect(entry.response?.body).toBe(`echo:${secret}`)
     expect(response.body).toBe(`echo:${secret}`)
   })
 
@@ -619,14 +620,15 @@ describe("buildTimelineEntry", () => {
     expect(entry.network).toEqual(error.network)
   })
 
-  it("persists the template URL instead of a resolved URL", () => {
+  it("resolves public variables and path params while preserving secret placeholders", () => {
     const req = {
       id: "req-3",
       name: "Env",
       method: "GET" as const,
-      url: "https://api.example.com/$base/path",
+      url: "$base_url/comments/:commentId/$TOKEN",
       headers: {},
       params: [],
+      pathParams: [{ name: "commentId", value: "$comment_id", enabled: true }],
       body: undefined,
       auth: undefined,
       timeout: 0,
@@ -643,8 +645,16 @@ describe("buildTimelineEntry", () => {
       request: req,
       envName: "dev",
     }
-    const entry = buildTimelineEntry(req, result, "dev")
-    expect(entry.request.url).toBe("https://api.example.com/$base/path")
+    const entry = buildTimelineEntry(req, result, "dev", {
+      name: "dev",
+      vars: {
+        base_url: "https://api.example.com",
+        comment_id: "42",
+        TOKEN: "top-secret",
+      },
+      secretVars: { TOKEN: "keychain" },
+    })
+    expect(entry.request.url).toBe("https://api.example.com/comments/42/$TOKEN")
   })
 
   it("builds error entry", () => {

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -533,6 +533,40 @@ describe("buildTimelineEntry", () => {
     expect(entry.envName).toBe("dev")
   })
 
+  it("redacts known values and sensitive headers only in the timeline entry", () => {
+    const secret = "timeline-secret"
+    const req = {
+      id: "req-secret",
+      name: "Secret",
+      method: "POST" as const,
+      url: "https://api.example.com/$TOKEN",
+      headers: {
+        Authorization: { value: "Bearer $TOKEN", enabled: true },
+      },
+      params: [],
+      body: '{"token":"$TOKEN"}',
+      timeout: 0,
+    }
+    const response = {
+      status: 200,
+      statusText: "OK",
+      headers: { "set-cookie": secret, "x-echo": secret },
+      body: `echo:${secret}`,
+      timeMs: 1,
+    }
+    const entry = buildTimelineEntry(req, { status: "done", response }, "dev", {
+      name: "dev",
+      vars: { TOKEN: secret },
+      secretVars: { TOKEN: "keychain" },
+    })
+    expect(entry.request.url).toBe("https://api.example.com/$TOKEN")
+    expect(entry.request.headers.Authorization!.value).toBe("[REDACTED]")
+    expect(entry.response?.headers["set-cookie"]).toBe("[REDACTED]")
+    expect(entry.response?.headers["x-echo"]).toBe("[REDACTED]")
+    expect(entry.response?.body).toBe("echo:[REDACTED]")
+    expect(response.body).toBe(`echo:${secret}`)
+  })
+
   it("copies network activity into the saved entry", () => {
     const req = {
       id: "req-network",
@@ -585,7 +619,7 @@ describe("buildTimelineEntry", () => {
     expect(entry.network).toEqual(error.network)
   })
 
-  it("uses resolvedUrl when provided", () => {
+  it("persists the template URL instead of a resolved URL", () => {
     const req = {
       id: "req-3",
       name: "Env",
@@ -609,16 +643,8 @@ describe("buildTimelineEntry", () => {
       request: req,
       envName: "dev",
     }
-    const entry = buildTimelineEntry(req, result, "dev", {
-      id: req.id,
-      name: req.name,
-      method: req.method,
-      url: "https://api.example.com/v1/path",
-      timeout: req.timeout,
-      headers: {},
-      params: [],
-    })
-    expect(entry.request.url).toBe("https://api.example.com/v1/path")
+    const entry = buildTimelineEntry(req, result, "dev")
+    expect(entry.request.url).toBe("https://api.example.com/$base/path")
   })
 
   it("builds error entry", () => {

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -626,11 +626,18 @@ describe("buildTimelineEntry", () => {
       name: "Env",
       method: "GET" as const,
       url: "$base_url/comments/:commentId/$TOKEN",
-      headers: {},
-      params: [],
+      headers: {
+        "X-Comment": { value: "$comment_id", enabled: true },
+        "X-Disabled": { value: "$comment_id", enabled: false },
+        Authorization: { value: "Bearer $TOKEN", enabled: true },
+      },
+      params: [
+        { name: "$comment_name", value: "$comment_id", enabled: true },
+        { name: "disabled", value: "$comment_id", enabled: false },
+      ],
       pathParams: [{ name: "commentId", value: "$comment_id", enabled: true }],
-      body: undefined,
-      auth: undefined,
+      body: '{"id":"$comment_id","token":"$TOKEN"}',
+      auth: { type: "basic" as const, user: "$comment_id", pass: "$TOKEN" },
       timeout: 0,
     }
     const result = {
@@ -650,11 +657,30 @@ describe("buildTimelineEntry", () => {
       vars: {
         base_url: "https://api.example.com",
         comment_id: "42",
+        comment_name: "comment",
         TOKEN: "top-secret",
       },
       secretVars: { TOKEN: "keychain" },
     })
     expect(entry.request.url).toBe("https://api.example.com/comments/42/$TOKEN")
+    expect(entry.request.headers).toEqual({
+      "X-Comment": { value: "42", enabled: true },
+      "X-Disabled": { value: "$comment_id", enabled: false },
+      Authorization: { value: "[REDACTED]", enabled: true },
+    })
+    expect(entry.request.params).toEqual([
+      { name: "comment", value: "42", enabled: true },
+      { name: "disabled", value: "$comment_id", enabled: false },
+    ])
+    expect(entry.request.pathParams).toEqual([
+      { name: "commentId", value: "42", enabled: true },
+    ])
+    expect(entry.request.body).toBe('{"id":"42","token":"$TOKEN"}')
+    expect(entry.request.auth).toEqual({
+      type: "basic",
+      user: "42",
+      pass: "$TOKEN",
+    })
   })
 
   it("builds error entry", () => {

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test"
+import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestRender } from "../testRender"
 import { act } from "react"
-import { ThemeProvider } from "../../src/ui/theme"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { EnvEditorPane } from "../../src/ui/env-editor/EnvEditorPane"
 
 const testRender = createTestRender()
@@ -15,10 +16,10 @@ const inactive = {
 }
 
 describe("EnvEditorPane", () => {
-  it("masks secret values and shows their source status", async () => {
-    const { renderOnce, captureCharFrame } = await testRender(
+  it("masks secrets, shows only process, and colors missing keys", async () => {
+    const { renderOnce, captureCharFrame, captureSpans } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
-        <box width={80} height={8}>
+        <box width={80} height={12}>
           <EnvEditorPane
             draft={{
               name: "development",
@@ -37,9 +38,25 @@ describe("EnvEditorPane", () => {
                   key: "PROCESS_TOKEN",
                   value: "process-value-must-stay-masked",
                   enabled: true,
-                  secret: false,
+                  secret: true,
                   originSecret: true,
                   secretStatus: "process",
+                },
+                {
+                  id: 3,
+                  key: "MISSING_TOKEN",
+                  value: "",
+                  enabled: true,
+                  secret: true,
+                  secretStatus: "missing",
+                },
+                {
+                  id: 4,
+                  key: "DISABLED_TOKEN",
+                  value: "",
+                  enabled: false,
+                  secret: true,
+                  secretStatus: "disabled",
                 },
               ],
             }}
@@ -54,14 +71,128 @@ describe("EnvEditorPane", () => {
           />
         </box>
       </ThemeProvider>,
-      { width: 80, height: 8 },
+      { width: 80, height: 12 },
     )
     await renderOnce()
     const frame = captureCharFrame()
     expect(frame).not.toContain("do-not-render")
     expect(frame).not.toContain("process-value-must-stay-masked")
     expect(frame).toContain("••••••••")
-    expect(frame).toContain("keychain")
+    expect(frame).not.toContain("keychain")
+    expect(frame).not.toContain("missing")
+    expect(frame).not.toContain("disabled")
+    expect(frame).not.toContain("hide")
+    const processLine = frame
+      .split("\n")
+      .find((line) => line.includes("PROCESS_TOKEN"))!
+    expect(processLine).toContain("process")
+    expect(processLine.indexOf("[secret]")).toBeGreaterThan(
+      processLine.indexOf("process"),
+    )
+
+    const missingKeySpan = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("MISSING_TOKEN"))
+    expect(missingKeySpan).toBeDefined()
+    expect(missingKeySpan!.fg.equals(RGBA.fromHex(THEMES[0]!.error))).toBe(true)
+  })
+
+  it("reveals a secret value while editing it", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={8}>
+          <EnvEditorPane
+            draft={{
+              name: "development",
+              color: undefined,
+              varRows: [
+                {
+                  id: 1,
+                  key: "TOKEN",
+                  value: "keychain-value",
+                  enabled: true,
+                  secret: true,
+                  originSecret: true,
+                  secretStatus: "keychain",
+                },
+              ],
+            }}
+            editState={{
+              mode: "editing",
+              row: 0,
+              addingRow: false,
+              subfield: "value",
+              editingRow: 0,
+            }}
+            editKey="TOKEN"
+            editValue="keychain-value"
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+
+    const frame = captureCharFrame()
+    expect(frame).toContain("keychain-value")
+    expect(frame).not.toContain("••••••••")
+  })
+
+  it("aligns value columns for plain, secret, and new variables", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={100} height={9}>
+          <EnvEditorPane
+            draft={{
+              name: "development",
+              color: undefined,
+              varRows: [
+                {
+                  id: 1,
+                  key: "BASE_URL",
+                  value: "plain-value",
+                  enabled: true,
+                },
+                {
+                  id: 2,
+                  key: "TOKEN",
+                  value: "secret-value",
+                  enabled: true,
+                  secret: true,
+                  originSecret: true,
+                  secretStatus: "keychain",
+                },
+              ],
+            }}
+            editState={inactive}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 100, height: 9 },
+    )
+    await renderOnce()
+
+    const lines = captureCharFrame().split("\n")
+    const plainLine = lines.find((line) => line.includes("BASE_URL"))!
+    const secretLine = lines.find((line) => line.includes("TOKEN"))!
+    const addLine = lines.find((line) => line.includes("Key..."))!
+
+    expect(plainLine.indexOf("plain-value")).toBe(
+      secretLine.indexOf("••••••••"),
+    )
+    expect(addLine.indexOf("Value...")).toBe(secretLine.indexOf("••••••••"))
   })
 
   it("commits when clicking pane background but not the active input", async () => {
@@ -147,7 +278,8 @@ describe("EnvEditorPane", () => {
     const activations: Array<[number, boolean, "key" | "value" | undefined]> =
       []
     const toggles: number[] = []
-    const { renderOnce, mockMouse } = await testRender(
+    const secretToggles: number[] = []
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>
         <box width={80} height={8}>
           <EnvEditorPane
@@ -175,18 +307,23 @@ describe("EnvEditorPane", () => {
               activations.push([row, addingRow, subfield])
             }
             onToggleRow={(row) => toggles.push(row)}
+            onToggleSecret={(row) => secretToggles.push(row)}
           />
         </box>
       </ThemeProvider>,
       { width: 80, height: 8 },
     )
     await renderOnce()
+    const lines = captureCharFrame().split("\n")
+    const variableRow = lines.findIndex((line) => line.includes("BASE_URL"))
+    const valueColumn = lines[variableRow]!.indexOf("https://api.test")
 
     await act(async () => {
-      await mockMouse.click(10, 2, MouseButtons.LEFT)
-      await mockMouse.click(60, 2, MouseButtons.LEFT)
-      await mockMouse.click(2, 2, MouseButtons.LEFT)
-      await mockMouse.click(10, 3, MouseButtons.LEFT)
+      await mockMouse.click(10, variableRow, MouseButtons.LEFT)
+      await mockMouse.click(valueColumn, variableRow, MouseButtons.LEFT)
+      await mockMouse.click(2, variableRow, MouseButtons.LEFT)
+      await mockMouse.click(77, variableRow, MouseButtons.LEFT)
+      await mockMouse.click(10, variableRow + 1, MouseButtons.LEFT)
     })
 
     expect(activations).toEqual([
@@ -195,5 +332,59 @@ describe("EnvEditorPane", () => {
       [-1, true, "key"],
     ])
     expect(toggles).toEqual([0])
+    expect(secretToggles).toEqual([0])
+  })
+
+  it("does not activate process-sourced secret fields", async () => {
+    const activations: number[] = []
+    const reveals: number[] = []
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={8}>
+          <EnvEditorPane
+            draft={{
+              name: "development",
+              color: undefined,
+              varRows: [
+                {
+                  id: 1,
+                  key: "PROCESS_TOKEN",
+                  value: "process-value",
+                  enabled: true,
+                  secret: true,
+                  originSecret: true,
+                  secretStatus: "process",
+                },
+              ],
+            }}
+            editState={inactive}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused
+            onActivateRow={(row) => activations.push(row)}
+            onRevealSecret={(row) => reveals.push(row)}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+
+    const lines = captureCharFrame().split("\n")
+    const row = lines.findIndex((line) => line.includes("PROCESS_TOKEN"))
+    if (row < 0) throw new Error("process secret row was not rendered")
+
+    await act(async () => {
+      await mockMouse.click(lines[row]!.indexOf("PROCESS_TOKEN"), row)
+      await mockMouse.click(45, row)
+      await mockMouse.click(60, row)
+    })
+
+    expect(activations).toEqual([])
+    expect(reveals).toEqual([0])
   })
 })

--- a/tests/unit/EnvEditorPane.test.tsx
+++ b/tests/unit/EnvEditorPane.test.tsx
@@ -15,6 +15,55 @@ const inactive = {
 }
 
 describe("EnvEditorPane", () => {
+  it("masks secret values and shows their source status", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box width={80} height={8}>
+          <EnvEditorPane
+            draft={{
+              name: "development",
+              color: undefined,
+              varRows: [
+                {
+                  id: 1,
+                  key: "TOKEN",
+                  value: "do-not-render",
+                  enabled: true,
+                  secret: true,
+                  secretStatus: "keychain",
+                },
+                {
+                  id: 2,
+                  key: "PROCESS_TOKEN",
+                  value: "process-value-must-stay-masked",
+                  enabled: true,
+                  secret: false,
+                  originSecret: true,
+                  secretStatus: "process",
+                },
+              ],
+            }}
+            editState={inactive}
+            editKey=""
+            editValue=""
+            setEditKey={() => {}}
+            setEditValue={() => {}}
+            saving={false}
+            error={null}
+            focused
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 80, height: 8 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).not.toContain("do-not-render")
+    expect(frame).not.toContain("process-value-must-stay-masked")
+    expect(frame).toContain("••••••••")
+    expect(frame).toContain("keychain")
+  })
+
   it("commits when clicking pane background but not the active input", async () => {
     let interactions = 0
     const { renderOnce, captureCharFrame, mockMouse } = await testRender(

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -160,8 +160,8 @@ describe("Select", () => {
 
     await act(async () => {
       await mockMouse.click(1, 0, MouseButtons.LEFT)
-      await renderOnce()
     })
+    await renderOnce()
 
     expect(activated).toBe(0)
     expect(open).toBe(false)

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -264,6 +264,22 @@ describe("buildHar", () => {
 })
 
 describe("generateCode", () => {
+  it("does not interpolate declared secrets", () => {
+    const generated = generateCode(
+      makeRequest({ url: "https://example.com/$TOKEN/$PUBLIC" }),
+      CODE_TARGETS[0]!,
+      undefined,
+      {
+        name: "dev",
+        vars: { TOKEN: "secret", PUBLIC: "visible" },
+        secretVars: { TOKEN: "keychain" },
+      },
+      true,
+    )
+    expect(generated.code).toContain("$TOKEN")
+    expect(generated.code).not.toContain("secret")
+    expect(generated.code).toContain("visible")
+  })
   it("generates a cURL snippet", () => {
     const result = generateCode(makeRequest(), curlTarget())
     expect(result.code).toContain("curl")

--- a/tests/unit/getContextualSegments.test.ts
+++ b/tests/unit/getContextualSegments.test.ts
@@ -425,6 +425,8 @@ describe("getContextualSegments", () => {
     })
     expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
+      seg("s", "secret"),
+      seg("r", "reveal"),
       seg("^d", "revert"),
       seg("^s", "save"),
     ])

--- a/tests/unit/getContextualSegments.test.ts
+++ b/tests/unit/getContextualSegments.test.ts
@@ -426,9 +426,9 @@ describe("getContextualSegments", () => {
     expect(r.footer).toMatchObject([
       seg("Space", "toggle"),
       seg("s", "secret"),
+      seg("^s", "save"),
       seg("r", "reveal"),
       seg("^d", "revert"),
-      seg("^s", "save"),
     ])
   })
 

--- a/tests/unit/keybind.test.ts
+++ b/tests/unit/keybind.test.ts
@@ -31,9 +31,13 @@ describe("parseOverrides", () => {
     const result = parseOverrides({
       env_picker: "ctrl+e",
       env_editor: "shift+e",
+      env_secret: "x",
+      env_reveal: "v",
     })
     expect(result.env_picker).toBe("ctrl+e")
     expect(result.env_editor).toBe("shift+e")
+    expect(result.env_secret).toBe("x")
+    expect(result.env_reveal).toBe("v")
   })
 
   it("ignores fixed key overrides (uses default)", () => {

--- a/tests/unit/keybind.test.ts
+++ b/tests/unit/keybind.test.ts
@@ -127,6 +127,10 @@ describe("shortcut editing", () => {
     expect(findKeybindConflict("request_save", "f4", keybinds)).toBe(
       "settings_open",
     )
+    expect(findKeybindConflict("env_save", "s", keybinds)).toBe("env_secret")
+    expect(findKeybindConflict("browse_delete", "r", keybinds)).toBe(
+      "env_reveal",
+    )
   })
 
   it("serializes only non-default, non-fixed overrides", () => {

--- a/tests/unit/keybindingHints.test.ts
+++ b/tests/unit/keybindingHints.test.ts
@@ -142,6 +142,8 @@ describe("getKeybindingHints footer", () => {
       ).footer,
     ).toEqual([
       seg("Space", "toggle", "env-browse.toggle"),
+      seg("s", "secret", "env-browse.secret"),
+      seg("r", "reveal", "env-browse.reveal"),
       seg("^d", "revert", "env-browse.revert"),
       seg("^s", "save", "env.save"),
     ])

--- a/tests/unit/keybindingHints.test.ts
+++ b/tests/unit/keybindingHints.test.ts
@@ -143,9 +143,9 @@ describe("getKeybindingHints footer", () => {
     ).toEqual([
       seg("Space", "toggle", "env-browse.toggle"),
       seg("s", "secret", "env-browse.secret"),
+      seg("^s", "save", "env.save"),
       seg("r", "reveal", "env-browse.reveal"),
       seg("^d", "revert", "env-browse.revert"),
-      seg("^s", "save", "env.save"),
     ])
   })
 })

--- a/tests/unit/requestFinder.test.ts
+++ b/tests/unit/requestFinder.test.ts
@@ -47,6 +47,15 @@ const jsonPlaceholderEnv: Environment = {
 }
 
 describe("requestFinder", () => {
+  it("does not resolve declared secrets in finder URLs", () => {
+    expect(
+      resolveFinderUrl("https://example.com/$TOKEN/$PUBLIC", {
+        name: "dev",
+        vars: { TOKEN: "secret", PUBLIC: "visible" },
+        secretVars: { TOKEN: "keychain" },
+      }),
+    ).toBe("https://example.com/$TOKEN/visible")
+  })
   it("shows all requests for an empty query and derives folders", () => {
     const items = requestFinderItems(requests)
     expect(searchRequests(items, "")).toHaveLength(3)

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -11,10 +11,30 @@ import { createTestRender } from "./testRender"
 import { act, useEffect, useRef } from "react"
 import { mkdtemp, rm, readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { ThemeProvider } from "../src/ui/theme"
 import { useEnvironmentEditor } from "../src/hooks/useEnvironmentEditor"
 import { env } from "../src/env"
+import {
+  setSecretBackendForTests,
+  setStoredSecret,
+  type SecretBackend,
+} from "../src/secrets"
+
+function memoryBackend(): SecretBackend {
+  const values = new Map<string, string>()
+  return {
+    async get({ service, name }) {
+      return values.get(`${service}:${name}`) ?? null
+    },
+    async set({ service, name, value }) {
+      values.set(`${service}:${name}`, value)
+    },
+    async delete({ service, name }) {
+      return values.delete(`${service}:${name}`)
+    },
+  }
+}
 
 const testRender = createTestRender()
 
@@ -78,6 +98,8 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
   })
 
   afterEach(async () => {
+    delete process.env.NOODLE_PROCESS_SECRET
+    setSecretBackendForTests(undefined)
     await rm(dir, { recursive: true, force: true })
   })
 
@@ -739,5 +761,103 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     await renderOnce()
     expect(ref.current!.editState.row).toBe(0)
     expect(ref.current!.editState.addingRow).toBe(false)
+  })
+
+  it("requires and records an explicit replacement when unmarking a process secret", async () => {
+    process.env.NOODLE_PROCESS_SECRET = "process-only"
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { NOODLE_PROCESS_SECRET: "process" },
+    })
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => {
+      ref.current!.toggleSecret(0)
+    })
+    await renderOnce()
+    expect(ref.current!.secretConfirmRowId).not.toBeNull()
+
+    act(() => {
+      ref.current!.toggleSecret(0)
+    })
+    await renderOnce()
+    expect(ref.current!.draft!.varRows[0]).toMatchObject({
+      secret: false,
+      originSecret: true,
+    })
+    expect(ref.current!.draft!.varRows[0]!.valueChanged).toBeUndefined()
+
+    act(() => {
+      ref.current!.activateVar(0, false, "value")
+    })
+    await renderOnce()
+    expect(ref.current!.editValue).toBe("")
+
+    act(() => {
+      ref.current!.setEditValue("explicit-plaintext")
+    })
+    await renderOnce()
+    act(() => {
+      ref.current!.commitEdit()
+    })
+    await renderOnce()
+
+    expect(ref.current!.draft!.varRows[0]).toMatchObject({
+      value: "explicit-plaintext",
+      valueChanged: true,
+    })
+  })
+
+  it("rejects unmarking a keychain secret without an explicit replacement", async () => {
+    setSecretBackendForTests(memoryBackend())
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { TOKEN: "keychain" },
+    })
+    await setStoredSecret(dirname(dir), "alpha", "TOKEN", "keychain-value")
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => {
+      ref.current!.toggleSecret(0)
+    })
+    await renderOnce()
+    act(() => {
+      ref.current!.toggleSecret(0)
+    })
+    await renderOnce()
+
+    expect(ref.current!.draft!.varRows[0]!.secret).toBe(false)
+    expect(ref.current!.draft!.varRows[0]!.valueChanged).toBeUndefined()
+
+    await act(async () => {
+      await ref.current!.save()
+    })
+    await renderOnce()
+    expect(ref.current!.error).toBe(
+      'Enter a plaintext value before unmarking "TOKEN"',
+    )
+    expect(await readFile(join(dir, "alpha.env"), "utf8")).toContain(
+      "# @secret TOKEN",
+    )
   })
 })

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -25,18 +25,22 @@ import {
 function memoryBackend(): SecretBackend & {
   values: Map<string, string>
   failDelete: boolean
+  failSet: boolean
 } {
   const values = new Map<string, string>()
   const result: SecretBackend & {
     values: Map<string, string>
     failDelete: boolean
+    failSet: boolean
   } = {
     values,
     failDelete: false,
+    failSet: false,
     async get({ service, name }) {
       return values.get(`${service}:${name}`) ?? null
     },
     async set({ service, name, value }) {
+      if (result.failSet) throw new Error("backend set unavailable")
       values.set(`${service}:${name}`, value)
     },
     async delete({ service, name }) {
@@ -909,6 +913,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
   })
 
   it("requires and records an explicit replacement when unmarking a process secret", async () => {
+    setSecretBackendForTests(memoryBackend())
     process.env.NOODLE_PROCESS_SECRET = "process-only"
     await env.saveEnvironment(dir, {
       name: "alpha",
@@ -1073,5 +1078,42 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     expect(await getStoredSecret(dirname(dir), "alpha", "TOKEN")).toBe(
       "keychain-value",
     )
+  })
+
+  it("reports rollback failures after an environment save fails", async () => {
+    const backend = memoryBackend()
+    setSecretBackendForTests(backend)
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { TOKEN: "keychain" },
+    })
+    await setStoredSecret(dirname(dir), "alpha", "TOKEN", "keychain-value")
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => ref.current!.toggleSecret(0))
+    await renderOnce()
+    backend.failSet = true
+    const saveSpy = spyOn(env, "saveEnvironment").mockRejectedValue(
+      new Error("environment save unavailable"),
+    )
+    try {
+      await act(async () => ref.current!.save())
+      await renderOnce()
+      expect(ref.current!.error).toContain("environment save unavailable")
+      expect(ref.current!.error).toContain("rollback failed")
+      expect(ref.current!.error).toContain("backend set unavailable")
+    } finally {
+      saveSpy.mockRestore()
+    }
   })
 })

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -16,6 +16,7 @@ import { ThemeProvider } from "../src/ui/theme"
 import { useEnvironmentEditor } from "../src/hooks/useEnvironmentEditor"
 import { env } from "../src/env"
 import {
+  getStoredSecret,
   setSecretBackendForTests,
   setStoredSecret,
   type SecretBackend,
@@ -763,6 +764,79 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     expect(ref.current!.editState.addingRow).toBe(false)
   })
 
+  it("edits a keychain secret without dirtying it unchanged", async () => {
+    setSecretBackendForTests(memoryBackend())
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { TOKEN: "keychain" },
+    })
+    await setStoredSecret(dirname(dir), "alpha", "TOKEN", "keychain-value")
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => ref.current!.activateVar(0, false, "value"))
+    await renderOnce()
+    expect(ref.current!.editValue).toBe("keychain-value")
+
+    act(() => ref.current!.commitEdit())
+    await renderOnce()
+    expect(ref.current!.dirty).toBe(false)
+    expect(ref.current!.draft!.varRows[0]!.valueChanged).toBeUndefined()
+
+    act(() => ref.current!.activateVar(0, false, "value"))
+    await renderOnce()
+    act(() => ref.current!.setEditValue("updated-keychain-value"))
+    await renderOnce()
+    act(() => ref.current!.commitEdit())
+    await renderOnce()
+    expect(ref.current!.dirty).toBe(true)
+    expect(ref.current!.draft!.varRows[0]!.valueChanged).toBe(true)
+
+    await act(async () => ref.current!.save())
+    await renderOnce()
+    expect(await getStoredSecret(dirname(dir), "alpha", "TOKEN")).toBe(
+      "updated-keychain-value",
+    )
+  })
+
+  it("keeps active process-sourced secrets read-only", async () => {
+    process.env.NOODLE_PROCESS_SECRET = "process-only"
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { NOODLE_PROCESS_SECRET: "process" },
+    })
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => ref.current!.activateVar(0, false, "value"))
+    await renderOnce()
+    expect(ref.current!.editState.mode).toBe("inactive")
+
+    act(() => ref.current!.enterBrowse())
+    await renderOnce()
+    act(() => ref.current!.enterEdit())
+    await renderOnce()
+    expect(ref.current!.editState.mode).toBe("browsing")
+  })
+
   it("requires and records an explicit replacement when unmarking a process secret", async () => {
     process.env.NOODLE_PROCESS_SECRET = "process-only"
     await env.saveEnvironment(dir, {
@@ -785,23 +859,26 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       ref.current!.toggleSecret(0)
     })
     await renderOnce()
-    expect(ref.current!.secretConfirmRowId).not.toBeNull()
-
-    act(() => {
-      ref.current!.toggleSecret(0)
-    })
-    await renderOnce()
     expect(ref.current!.draft!.varRows[0]).toMatchObject({
       secret: false,
       originSecret: true,
     })
     expect(ref.current!.draft!.varRows[0]!.valueChanged).toBeUndefined()
 
+    await act(async () => ref.current!.save())
+    await renderOnce()
+    expect(ref.current!.error).toBe(
+      'Enter a plaintext value before unmarking "NOODLE_PROCESS_SECRET"',
+    )
+    expect(await readFile(join(dir, "alpha.env"), "utf8")).toContain(
+      "# @secret NOODLE_PROCESS_SECRET",
+    )
+
     act(() => {
       ref.current!.activateVar(0, false, "value")
     })
     await renderOnce()
-    expect(ref.current!.editValue).toBe("")
+    expect(ref.current!.editValue).toBe("process-only")
 
     act(() => {
       ref.current!.setEditValue("explicit-plaintext")
@@ -816,9 +893,43 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       value: "explicit-plaintext",
       valueChanged: true,
     })
+
+    await act(async () => ref.current!.save())
+    await renderOnce()
+    expect(ref.current!.error).toBeNull()
+    const saved = await readFile(join(dir, "alpha.env"), "utf8")
+    expect(saved).toContain("NOODLE_PROCESS_SECRET=explicit-plaintext")
+    expect(saved).not.toContain("# @secret NOODLE_PROCESS_SECRET")
   })
 
-  it("rejects unmarking a keychain secret without an explicit replacement", async () => {
+  it("restores an unsaved plaintext value after toggling secret off", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => ref.current!.toggleSecret(0))
+    await renderOnce()
+    act(() => ref.current!.toggleSecret(0))
+    await renderOnce()
+
+    expect(ref.current!.draft!.varRows[0]).toMatchObject({
+      secret: false,
+      originSecret: false,
+      value: "val",
+    })
+    act(() => ref.current!.activateVar(0, false, "value"))
+    await renderOnce()
+    expect(ref.current!.editValue).toBe("val")
+  })
+
+  it("moves a keychain secret to plaintext with one toggle", async () => {
     setSecretBackendForTests(memoryBackend())
     await env.saveEnvironment(dir, {
       name: "alpha",
@@ -841,10 +952,6 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       ref.current!.toggleSecret(0)
     })
     await renderOnce()
-    act(() => {
-      ref.current!.toggleSecret(0)
-    })
-    await renderOnce()
 
     expect(ref.current!.draft!.varRows[0]!.secret).toBe(false)
     expect(ref.current!.draft!.varRows[0]!.valueChanged).toBeUndefined()
@@ -853,11 +960,10 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       await ref.current!.save()
     })
     await renderOnce()
-    expect(ref.current!.error).toBe(
-      'Enter a plaintext value before unmarking "TOKEN"',
-    )
-    expect(await readFile(join(dir, "alpha.env"), "utf8")).toContain(
-      "# @secret TOKEN",
-    )
+    expect(ref.current!.error).toBeNull()
+    const saved = await readFile(join(dir, "alpha.env"), "utf8")
+    expect(saved).toContain("TOKEN=keychain-value")
+    expect(saved).not.toContain("# @secret TOKEN")
+    expect(await getStoredSecret(dirname(dir), "alpha", "TOKEN")).toBeNull()
   })
 })

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -22,9 +22,17 @@ import {
   type SecretBackend,
 } from "../src/secrets"
 
-function memoryBackend(): SecretBackend {
+function memoryBackend(): SecretBackend & {
+  values: Map<string, string>
+  failDelete: boolean
+} {
   const values = new Map<string, string>()
-  return {
+  const result: SecretBackend & {
+    values: Map<string, string>
+    failDelete: boolean
+  } = {
+    values,
+    failDelete: false,
     async get({ service, name }) {
       return values.get(`${service}:${name}`) ?? null
     },
@@ -32,9 +40,11 @@ function memoryBackend(): SecretBackend {
       values.set(`${service}:${name}`, value)
     },
     async delete({ service, name }) {
+      if (result.failDelete) throw new Error("backend delete unavailable")
       return values.delete(`${service}:${name}`)
     },
   }
+  return result
 }
 
 const testRender = createTestRender()
@@ -122,6 +132,32 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       await ref.current!.cloneEnv("alpha-copy")
     })
     expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports source load failures while cloning", async () => {
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    const loadSpy = spyOn(env, "loadEnvironment").mockRejectedValue(
+      new Error("source load failed"),
+    )
+    try {
+      await act(async () => {
+        await ref.current!.cloneEnv("alpha-copy")
+      })
+      await renderOnce()
+      expect(ref.current!.error).toBe("source load failed")
+    } finally {
+      loadSpy.mockRestore()
+    }
   })
 
   it("creates and selects a new empty environment without activating it", async () => {
@@ -406,6 +442,41 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
       .then(() => true)
       .catch(() => false)
     expect(after).toBe(false)
+  })
+
+  it("keeps an environment retryable when secret cleanup fails", async () => {
+    const backend = memoryBackend()
+    setSecretBackendForTests(backend)
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { TOKEN: "keychain" },
+    })
+    await setStoredSecret(dirname(dir), "alpha", "TOKEN", "keychain-value")
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    backend.failDelete = true
+    await act(async () => {
+      await ref.current!.deleteEnv()
+    })
+    await renderOnce()
+
+    expect(ref.current!.error).toContain("secret delete failed")
+    expect(await readFile(join(dir, "alpha.env"), "utf8")).toContain(
+      "# @secret TOKEN",
+    )
+    expect(await getStoredSecret(dirname(dir), "alpha", "TOKEN")).toBe(
+      "keychain-value",
+    )
   })
 
   it("calls onEnvsChanged after save with rename", async () => {
@@ -965,5 +1036,42 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     expect(saved).toContain("TOKEN=keychain-value")
     expect(saved).not.toContain("# @secret TOKEN")
     expect(await getStoredSecret(dirname(dir), "alpha", "TOKEN")).toBeNull()
+  })
+
+  it("keeps a secret declared when keychain cleanup fails", async () => {
+    const backend = memoryBackend()
+    setSecretBackendForTests(backend)
+    await env.saveEnvironment(dir, {
+      name: "alpha",
+      vars: {},
+      secretVars: { TOKEN: "keychain" },
+    })
+    await setStoredSecret(dirname(dir), "alpha", "TOKEN", "keychain-value")
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => ref.current!.toggleSecret(0))
+    await renderOnce()
+    backend.failDelete = true
+    await act(async () => {
+      await ref.current!.save()
+    })
+    await renderOnce()
+
+    expect(ref.current!.error).toContain("secret delete failed")
+    expect(await readFile(join(dir, "alpha.env"), "utf8")).toContain(
+      "# @secret TOKEN",
+    )
+    expect(await getStoredSecret(dirname(dir), "alpha", "TOKEN")).toBe(
+      "keychain-value",
+    )
   })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Environment values can now be declared as secrets with a `# @secret KEY` marker and blank placeholder in `.env` files. Values are stored in the OS keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager via `Bun.secrets`) instead of the `.env` file, resolved with precedence process env > keychain.

- New `noodle secret set/list/delete` CLI subcommands with interactive prompt or `--stdin`
- `collection_id` in `settings.yml` keeps keychain entries stable when a collection moves
- Secret values stay masked in the env editor and are excluded from timeline history, codegen, request search, HAR, and exports
- Replaces the previous server-response redaction with keychain-backed redaction of known secret values

### How did you verify your code works?

- `bun test` passes (new tests for `src/secrets`, timeline filestore/format, env editor, CLI)
- `bun run lint` passes
- `bun run typecheck` passes
- Exercised `noodle secret set/list/delete` against a local collection

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure environment secret storage using process variables and the credential store.
  - Added CLI commands to set, list, and delete secrets.
  - Added masked editing, reveal controls, status indicators, and secret-aware cloning.
  - Added stable collection identifiers and automatic collection setup.
- **Security**
  - Secrets are excluded from persisted files and redacted from history, requests, errors, and exports.
  - Secret placeholders remain unresolved during code generation and request browsing.
- **Documentation**
  - Documented secret handling, storage precedence, masking, persistence, and CLI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->