### PR TITLE
feat(secrets): store proxy credentials and TLS passphrases in secure vault

### DIFF
--- a/collections/settings.yml
+++ b/collections/settings.yml
@@ -1,6 +1,7 @@
 collection_id: de92de2f-f40b-48ab-bdbc-64d58f72e9d9
 name: Noodle Collection
 description: This is a sample collection designed to help Noodle developers.
+timeline_max_entries: 50
 environment: development
 proxy:
   mode: inherit

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -15,7 +15,12 @@ import * as yaml from "js-yaml"
 import { readFileSync } from "node:fs"
 import { loadConfig } from "../hooks/useConfig"
 import { takeSystemProxyFromEnv, type SystemProxySettings } from "../proxy"
-import type { CollectionSettings } from "../schema"
+import type { CollectionSettings, ProxyCredentials } from "../schema"
+import {
+  loadAppProxyCredentials,
+  loadCollectionProxyCredentials,
+  loadTlsPassphrases,
+} from "../secrets"
 import {
   CodeEditorRenderable,
   CodeEditorScrollBarRenderable,
@@ -61,11 +66,17 @@ export function resolveStartupCollectionDir(
 
 export async function bootstrap(options: BootstrapOptions): Promise<void> {
   const capturedSystemProxy = takeSystemProxyFromEnv()
-  let collectionPaths: string[] = []
+  let collectionPaths: string[]
+  let appProxy
   try {
-    collectionPaths = loadConfig(CONFIG_DIR).collections
-  } catch {
-    // config unavailable
+    const config = loadConfig(CONFIG_DIR)
+    collectionPaths = config.collections
+    appProxy = config.proxy
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`error: ${message}\n`)
+    process.exit(1)
+    return
   }
   const collectionDir = resolveStartupCollectionDir(options, collectionPaths)
 
@@ -110,6 +121,29 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
       process.stderr.write(`error: ${message}\n`)
       process.exit(1)
     }
+  }
+
+  let initialAppProxyCredentials: ProxyCredentials = {}
+  let initialCollectionProxyCredentials: ProxyCredentials = {}
+  let initialTlsPassphrases: Record<string, string> = {}
+  let initialSettingsSecretError: string | undefined
+  try {
+    ;[
+      initialAppProxyCredentials,
+      initialCollectionProxyCredentials,
+      initialTlsPassphrases,
+    ] = await Promise.all([
+      loadAppProxyCredentials(appProxy),
+      mode === "collection"
+        ? loadCollectionProxyCredentials(collectionDir, initialSettings.proxy)
+        : Promise.resolve({}),
+      mode === "collection"
+        ? loadTlsPassphrases(collectionDir, initialSettings.tls)
+        : Promise.resolve({}),
+    ])
+  } catch (error) {
+    initialSettingsSecretError =
+      error instanceof Error ? error.message : String(error)
   }
 
   let lastRequestId: string | undefined
@@ -170,6 +204,10 @@ export async function bootstrap(options: BootstrapOptions): Promise<void> {
           envList={envList}
           initialEnvName={initialEnvName}
           initialSettings={initialSettings}
+          initialAppProxyCredentials={initialAppProxyCredentials}
+          initialCollectionProxyCredentials={initialCollectionProxyCredentials}
+          initialTlsPassphrases={initialTlsPassphrases}
+          initialSettingsSecretError={initialSettingsSecretError}
           noProxy={options.noProxy}
           insecure={options.insecure}
           systemProxy={options.systemProxy ?? capturedSystemProxy}

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -43,6 +43,9 @@ import {
   deleteStoredSecret,
   ensureCollectionId,
   getStoredSecret,
+  loadAppProxyCredentials,
+  loadCollectionProxyCredentials,
+  loadTlsPassphrases,
   setStoredSecret,
 } from "../secrets"
 import { environmentSecretValues, redactKnownSecrets } from "../secrets/redact"
@@ -536,7 +539,13 @@ async function runRequest(
   proxyPolicy?: ProxyPolicy,
   tlsPolicy?: TlsPolicy,
 ): Promise<RequestRunResult> {
-  const secretValues = environmentSecretValues(environment)
+  const secretValues = [
+    ...environmentSecretValues(environment),
+    ...(proxyPolicy?.kind === "custom"
+      ? Object.values(proxyPolicy.credentials ?? {})
+      : []),
+    ...Object.values(tlsPolicy?.passphrases ?? {}),
+  ].filter((value): value is string => Boolean(value))
   const redact = (value: string) => redactKnownSecrets(value, secretValues)
   try {
     const response = await executor.send(request, {
@@ -582,12 +591,13 @@ export async function collectionRun(
   const settings = await loadSettings(dir)
   const collection = await filestore.loadCollection(dir)
   const environment = await environmentFor(dir, settings, environmentName)
-  const policy = proxyPolicyFor(
+  const policy = await proxyPolicyFor(
+    dir,
     settings,
     noProxy,
     systemProxy ?? takeSystemProxyFromEnv(),
   )
-  const tlsPolicy = tlsPolicyFor(dir, settings, insecure)
+  const tlsPolicy = await tlsPolicyFor(dir, settings, insecure)
   const requests = flattenRequests(collection.items)
   const results: RequestRunResult[] = []
   onProgress?.(0, requests.length)
@@ -644,32 +654,51 @@ export async function requestRun(
     collection,
     request,
     await environmentFor(dir, settings, environmentName),
-    proxyPolicyFor(settings, noProxy, systemProxy ?? takeSystemProxyFromEnv()),
-    tlsPolicyFor(dir, settings, insecure),
+    await proxyPolicyFor(
+      dir,
+      settings,
+      noProxy,
+      systemProxy ?? takeSystemProxyFromEnv(),
+    ),
+    await tlsPolicyFor(dir, settings, insecure),
   )
   onProgress?.(1, 1)
   return { result, failed: result.ok === false }
 }
 
-function tlsPolicyFor(
+async function tlsPolicyFor(
   dir: string,
   settings: CollectionSettings,
   insecure: boolean,
-): TlsPolicy {
-  return { collectionDir: dir, settings: settings.tls, insecure }
+): Promise<TlsPolicy> {
+  const passphrases = await loadTlsPassphrases(dir, settings.tls)
+  return {
+    collectionDir: dir,
+    settings: settings.tls,
+    insecure,
+    ...(Object.keys(passphrases).length > 0 ? { passphrases } : {}),
+  }
 }
 
-function proxyPolicyFor(
+async function proxyPolicyFor(
+  dir: string,
   settings: CollectionSettings,
   noProxy: boolean,
   systemProxy: SystemProxySettings,
-): ProxyPolicy {
-  return resolveProxyPolicy({
+): Promise<ProxyPolicy> {
+  const appProxy = loadConfig(CONFIG_DIR).proxy
+  const policy = resolveProxyPolicy({
     noProxy,
-    appProxy: loadConfig(CONFIG_DIR).proxy,
+    appProxy,
     collectionProxy: settings.proxy,
     systemProxy,
   })
+  if (policy.kind !== "custom" || !policy.auth) return policy
+  const credentials =
+    policy.source === "collection"
+      ? await loadCollectionProxyCredentials(dir, settings.proxy)
+      : await loadAppProxyCredentials(appProxy)
+  return { ...policy, credentials }
 }
 export async function environmentSet(
   key: string,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import * as yaml from "js-yaml"
 import type { AppProxySettings } from "../schema"
-import { parseAppProxy } from "../proxy"
+import { parseAppProxyStrict } from "../proxy"
 
 export const CONFIG_FILE_NAME = "config.yml"
 export interface NoodleConfig {
@@ -50,32 +50,33 @@ export function normalizeConfig(config: NoodleConfig): NoodleConfig {
     ...config,
     collections: normalizeCollectionPaths(config.collections),
   }
-  if (config.proxy !== undefined) normalized.proxy = config.proxy
+  if (config.proxy !== undefined) {
+    normalized.proxy = parseAppProxyStrict(config.proxy)
+  }
   return normalized
 }
 export function loadConfig(configDir: string): NoodleConfig {
+  let data: unknown
   try {
-    const data = yaml.load(
-      readFileSync(join(configDir, CONFIG_FILE_NAME), "utf8"),
-    )
-    if (!data || typeof data !== "object") return { ...DEFAULT_CONFIG }
-    const obj = data as Record<string, unknown>
-    return normalizeConfig({
-      theme: typeof obj.theme === "string" ? obj.theme : DEFAULT_CONFIG.theme,
-      layout:
-        obj.layout === "side-by-side" ? "side-by-side" : DEFAULT_CONFIG.layout,
-      confirm_undo_all:
-        typeof obj.confirm_undo_all === "boolean"
-          ? obj.confirm_undo_all
-          : DEFAULT_CONFIG.confirm_undo_all,
-      collections: Array.isArray(obj.collections)
-        ? obj.collections.filter((v): v is string => typeof v === "string")
-        : [],
-      proxy: parseAppProxy(obj.proxy),
-    })
+    data = yaml.load(readFileSync(join(configDir, CONFIG_FILE_NAME), "utf8"))
   } catch {
     return { ...DEFAULT_CONFIG }
   }
+  if (!data || typeof data !== "object") return { ...DEFAULT_CONFIG }
+  const obj = data as Record<string, unknown>
+  return normalizeConfig({
+    theme: typeof obj.theme === "string" ? obj.theme : DEFAULT_CONFIG.theme,
+    layout:
+      obj.layout === "side-by-side" ? "side-by-side" : DEFAULT_CONFIG.layout,
+    confirm_undo_all:
+      typeof obj.confirm_undo_all === "boolean"
+        ? obj.confirm_undo_all
+        : DEFAULT_CONFIG.confirm_undo_all,
+    collections: Array.isArray(obj.collections)
+      ? obj.collections.filter((v): v is string => typeof v === "string")
+      : [],
+    proxy: obj.proxy === undefined ? undefined : parseAppProxyStrict(obj.proxy),
+  })
 }
 export function saveConfig(configDir: string, config: NoodleConfig): void {
   mkdirSync(configDir, { recursive: true })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,11 @@
 import type {
   AppProxySettings,
   CollectionProxySettings,
-  Environment,
+  ProxyCredentials,
+  ProxySettings,
 } from "./schema"
-import { isVariableReference } from "./variableReference"
 
-const VAR_RE = /\$(\w+)/g
+const VARIABLE_RE = /\$\w+/
 const PROXY_ENV_KEYS = [
   "HTTP_PROXY",
   "HTTPS_PROXY",
@@ -25,9 +25,6 @@ export interface StructuredProxyFields {
   protocol: "http" | "https"
   hostname: string
   port: string
-  auth: boolean
-  username: string
-  password: string
 }
 
 export type StructuredProxyBuildResult = { url: string } | { error: string }
@@ -39,6 +36,8 @@ export type ProxyPolicy =
       source: "global" | "collection"
       url: string
       bypass: string[]
+      auth?: boolean
+      credentials?: ProxyCredentials
     }
   | { kind: "system"; source: "system"; settings: SystemProxySettings }
 
@@ -65,13 +64,18 @@ export function normalizeBypass(value: unknown): string[] {
 
 export function parseAppProxy(value: unknown): AppProxySettings | undefined {
   if (value === undefined) return undefined
-  if (!isRecord(value) || typeof value.mode !== "string") return undefined
-  if (value.mode === "system") return { mode: "system" }
-  if (value.mode === "off") return { mode: "off" }
-  if (value.mode !== "custom" || typeof value.url !== "string") return undefined
-  const url = value.url.trim()
-  if (validateProxyTemplate(url) !== null) return undefined
-  return customProxy(url, normalizeBypass(value.bypass))
+  try {
+    return parseAppProxyStrict(value)
+  } catch {
+    return undefined
+  }
+}
+
+export function parseAppProxyStrict(
+  value: unknown,
+  path = "proxy",
+): AppProxySettings {
+  return parseProxyStrict(value, path, "app") as AppProxySettings
 }
 
 export function parseCollectionProxy(
@@ -89,24 +93,37 @@ export function parseCollectionProxyStrict(
   value: unknown,
   path = "proxy",
 ): CollectionProxySettings {
+  return parseProxyStrict(value, path, "collection") as CollectionProxySettings
+}
+
+function parseProxyStrict(
+  value: unknown,
+  path: string,
+  scope: "app" | "collection",
+): AppProxySettings | CollectionProxySettings {
   if (!isRecord(value)) throw new Error(`${path}: must be a mapping`)
   const unknownKey = Object.keys(value).find(
-    (key) => !["mode", "url", "bypass"].includes(key),
+    (key) => !["mode", "url", "bypass", "auth"].includes(key),
   )
   if (unknownKey) throw new Error(`${path}: unknown key "${unknownKey}"`)
   if (typeof value.mode !== "string") {
     throw new Error(`${path}.mode: must be a string`)
   }
-  if (value.mode === "inherit" || value.mode === "off") {
-    if (value.url !== undefined || value.bypass !== undefined) {
+  const defaultMode = scope === "app" ? "system" : "inherit"
+  if (value.mode === defaultMode || value.mode === "off") {
+    if (
+      value.url !== undefined ||
+      value.bypass !== undefined ||
+      value.auth !== undefined
+    ) {
       throw new Error(
-        `${path}: mode "${value.mode}" does not accept url or bypass`,
+        `${path}: mode "${value.mode}" does not accept url, bypass, or auth`,
       )
     }
     return { mode: value.mode }
   }
   if (value.mode !== "custom") {
-    throw new Error(`${path}.mode: expected inherit, off, or custom`)
+    throw new Error(`${path}.mode: expected ${defaultMode}, off, or custom`)
   }
   if (typeof value.url !== "string") {
     throw new Error(`${path}.url: must be a string`)
@@ -118,10 +135,13 @@ export function parseCollectionProxyStrict(
   ) {
     throw new Error(`${path}.bypass: must be a list of strings`)
   }
+  if (value.auth !== undefined && typeof value.auth !== "boolean") {
+    throw new Error(`${path}.auth: must be a boolean`)
+  }
   const url = value.url.trim()
   const error = validateProxyTemplate(url)
   if (error !== null) throw new Error(`${path}.url: ${error}`)
-  return customProxy(url, normalizeBypass(value.bypass))
+  return customProxy(url, normalizeBypass(value.bypass), value.auth)
 }
 
 export function systemProxyFromEnv(
@@ -145,7 +165,6 @@ export function takeSystemProxyFromEnv(
 
 export function createProxyFetcher(
   policy: ProxyPolicy,
-  env?: Environment | null,
   fetcher: (
     input: RequestInfo | URL,
     init?: RequestInit,
@@ -158,7 +177,7 @@ export function createProxyFetcher(
         : input instanceof URL
           ? input.href
           : input.url
-    const route = proxyForUrl(policy, target, env ?? undefined)
+    const route = proxyForUrl(policy, target)
     const fetchInit: BunFetchRequestInit = { ...init }
     if (route.kind === "proxy") fetchInit.proxy = route.url
     else delete fetchInit.proxy
@@ -168,7 +187,6 @@ export function createProxyFetcher(
 
 export function environmentForProxyPolicy(
   policy: ProxyPolicy,
-  env?: Environment | null,
   baseEnv: Record<string, string | undefined> = process.env,
 ): Record<string, string | undefined> {
   const result = { ...baseEnv }
@@ -180,12 +198,7 @@ export function environmentForProxyPolicy(
     return result
   }
 
-  let url = policy.url
-  try {
-    url = resolveProxyUrl(url, env?.vars)
-  } catch {
-    // Keep the template so the subprocess reports the same unresolved proxy.
-  }
+  const url = resolvedCustomProxyUrl(policy)
   setProxyEnvironment(result, {
     http: url,
     https: url,
@@ -198,11 +211,15 @@ export function resolveProxyPolicy({
   noProxy = false,
   appProxy,
   collectionProxy,
+  appCredentials,
+  collectionCredentials,
   systemProxy,
 }: {
   noProxy?: boolean
   appProxy?: AppProxySettings
   collectionProxy?: CollectionProxySettings
+  appCredentials?: ProxyCredentials
+  collectionCredentials?: ProxyCredentials
   systemProxy: SystemProxySettings
 }): ProxyPolicy {
   if (noProxy) return { kind: "direct", source: "cli" }
@@ -210,21 +227,31 @@ export function resolveProxyPolicy({
     return { kind: "direct", source: "collection" }
   }
   if (collectionProxy?.mode === "custom") {
-    return {
+    const policy: ProxyPolicy = {
       kind: "custom",
       source: "collection",
       url: collectionProxy.url,
       bypass: collectionProxy.bypass ?? [],
     }
+    if (collectionProxy.auth) {
+      policy.auth = true
+      policy.credentials = collectionCredentials
+    }
+    return policy
   }
   if (appProxy?.mode === "off") return { kind: "direct", source: "global" }
   if (appProxy?.mode === "custom") {
-    return {
+    const policy: ProxyPolicy = {
       kind: "custom",
       source: "global",
       url: appProxy.url,
       bypass: appProxy.bypass ?? [],
     }
+    if (appProxy.auth) {
+      policy.auth = true
+      policy.credentials = appCredentials
+    }
+    return policy
   }
   return { kind: "system", source: "system", settings: systemProxy }
 }
@@ -232,7 +259,6 @@ export function resolveProxyPolicy({
 export function proxyForUrl(
   policy: ProxyPolicy | undefined,
   target: string,
-  env?: Environment,
 ): ProxyRoute {
   if (!policy) return { kind: "direct", reason: "unconfigured" }
   if (policy.kind === "direct") {
@@ -252,7 +278,7 @@ export function proxyForUrl(
     return {
       kind: "proxy",
       source: policy.source,
-      url: resolveProxyUrl(policy.url, env?.vars),
+      url: resolvedCustomProxyUrl(policy),
     }
   }
 
@@ -266,58 +292,22 @@ export function proxyForUrl(
     : { kind: "direct", reason: "unconfigured" }
 }
 
-export function resolveProxyUrl(
-  template: string,
-  variables?: Record<string, string | undefined>,
-): string {
-  const normalized = encodeLiteralProxyCredentialDollars(template)
-  const url = normalized.replace(VAR_RE, (_, name: string) => {
-    const value = variables?.[name]
-    if (!variables || !Object.hasOwn(variables, name) || value === undefined) {
-      throw new Error(`proxy: unresolved variable "${name}" in proxy.url`)
-    }
-    return value
-  })
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch (e) {
-    throw new Error("proxy: invalid proxy URL", { cause: e })
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error("proxy: URL must use http or https")
-  }
-  return url
-}
-
-function encodeLiteralProxyCredentialDollars(template: string): string {
-  const match = template.match(/^([a-z][a-z\d+.-]*:\/\/)([^/?#]*)(.*)$/i)
-  if (!match) return template
-  const [, scheme, authority, suffix] = match
-  const at = authority!.lastIndexOf("@")
-  if (at === -1) return template
-
-  const userInfo = authority!.slice(0, at)
-  const colon = userInfo.indexOf(":")
-  const encode = (value: string) =>
-    isVariableReference(value) ? value : value.replaceAll("$", "%24")
-  const credentials =
-    colon === -1
-      ? encode(userInfo)
-      : `${encode(userInfo.slice(0, colon))}:${encode(userInfo.slice(colon + 1))}`
-  return `${scheme}${credentials}${authority!.slice(at)}${suffix}`
-}
-
 export function validateProxyTemplate(template: string): string | null {
   const value = template.trim()
   if (!value) return "Proxy URL is required"
+  if (/^[a-z][a-z\d+.-]*:\/\/[^/?#]*@/i.test(value)) {
+    return "Proxy URL cannot contain credentials; configure authentication in Settings"
+  }
+  if (VARIABLE_RE.test(value)) {
+    return "Proxy URL cannot contain variables; configure authentication in Settings"
+  }
   try {
-    const parseable = value
-      .replace(/:\$\w+(?=[/?#]|$)/g, ":8080")
-      .replace(VAR_RE, "proxy-variable")
-    const parsed = new URL(parseable)
+    const parsed = new URL(value)
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return "Proxy URL must use http or https"
+    }
+    if (parsed.username || parsed.password) {
+      return "Proxy URL cannot contain credentials; configure authentication in Settings"
     }
     return null
   } catch {
@@ -332,30 +322,19 @@ export function parseStructuredProxyTemplate(
   if (validateProxyTemplate(template) !== null) return null
 
   const match = template.match(
-    /^(https?):\/\/(?:([^:/?#@\s]+)(?::([^:/?#@\s]+))?@)?(\[[^\]]+\]|[^:/?#@\s]+)(?::(\d+))?$/,
+    /^(https?):\/\/(\[[^\]]+\]|[^:/?#@\s]+)(?::(\d+))?$/,
   )
   if (!match) return null
 
-  const [, protocol, username, password, rawHostname, port] = match
+  const [, protocol, rawHostname, port] = match
   const hostname = rawHostname!.startsWith("[")
     ? rawHostname.slice(1, -1)
     : rawHostname!
-  let decodedUsername: string
-  let decodedPassword: string
-  try {
-    decodedUsername = username ? decodeURIComponent(username) : ""
-    decodedPassword = password ? decodeURIComponent(password) : ""
-  } catch {
-    return null
-  }
 
   return {
     protocol: protocol as "http" | "https",
     hostname,
     port: port ?? "",
-    auth: username !== undefined,
-    username: decodedUsername,
-    password: decodedPassword,
   }
 }
 
@@ -376,37 +355,43 @@ export function buildStructuredProxyTemplate(
     }
   }
 
-  if (fields.auth) {
-    if (!fields.username) return { error: "Proxy username is required" }
-  }
-
   const host =
     hostname.includes(":") && !hostname.startsWith("[")
       ? `[${hostname}]`
       : hostname
-  const credentials = fields.auth
-    ? `${encodeProxyCredential(fields.username)}${
-        fields.password ? `:${encodeProxyCredential(fields.password)}` : ""
-      }@`
-    : ""
-  const url = `${fields.protocol}://${credentials}${host}${port ? `:${port}` : ""}`
+  const url = `${fields.protocol}://${host}${port ? `:${port}` : ""}`
   const validationError = validateProxyTemplate(url)
   return validationError ? { error: validationError } : { url }
-}
-
-function encodeProxyCredential(value: string): string {
-  return isVariableReference(value) ? value : encodeURIComponent(value)
 }
 
 function customProxy<T extends AppProxySettings | CollectionProxySettings>(
   url: string,
   bypass: string[],
+  auth: unknown,
 ): T {
-  return (
-    bypass.length > 0
-      ? { mode: "custom", url, bypass }
-      : { mode: "custom", url }
-  ) as T
+  const result: ProxySettings = {
+    mode: "custom",
+    url,
+  }
+  if (bypass.length > 0) result.bypass = bypass
+  if (auth === true) result.auth = true
+  return result as T
+}
+
+function resolvedCustomProxyUrl(
+  policy: Extract<ProxyPolicy, { kind: "custom" }>,
+): string {
+  if (!policy.auth) return policy.url
+  const username = policy.credentials?.username
+  if (!username) {
+    throw new Error(
+      `proxy: authentication is enabled for the ${policy.source} proxy, but its username secret is missing`,
+    )
+  }
+  const url = new URL(policy.url)
+  url.username = username
+  url.password = policy.credentials?.password ?? ""
+  return url.toString()
 }
 
 export function redactProxyUrl(value: string): string {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -170,7 +170,10 @@ export function createProxyFetcher(
     init?: RequestInit,
   ) => Promise<Response> = globalThis.fetch,
 ) {
-  return (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const target =
       typeof input === "string"
         ? input

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -172,9 +172,21 @@ export async function send(
   const followRedirects = req.followRedirects ?? true
 
   while (true) {
-    const proxyRoute = proxyPolicy
-      ? proxyForUrl(proxyPolicy, currentUrl)
-      : undefined
+    let proxyRoute
+    try {
+      proxyRoute = proxyPolicy
+        ? proxyForUrl(proxyPolicy, currentUrl)
+        : undefined
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      throw networkFailure(
+        `requests.send: ${msg}`,
+        e,
+        network,
+        start,
+        onNetworkEvent,
+      )
+    }
     if (proxyRoute) {
       recordNetworkEvent(
         network,

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -173,7 +173,7 @@ export async function send(
 
   while (true) {
     const proxyRoute = proxyPolicy
-      ? proxyForUrl(proxyPolicy, currentUrl, env)
+      ? proxyForUrl(proxyPolicy, currentUrl)
       : undefined
     if (proxyRoute) {
       recordNetworkEvent(
@@ -194,7 +194,7 @@ export async function send(
     }
     let resolvedTls
     try {
-      resolvedTls = await tlsForUrl(substituted, currentUrl, env, tlsPolicy)
+      resolvedTls = await tlsForUrl(substituted, currentUrl, tlsPolicy)
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       throw networkFailure(

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -177,7 +177,7 @@ export interface ClientCertificateProfile {
   port?: number
   certFile: string
   keyFile: string
-  passphrase?: string
+  secretId?: string
   enabled?: boolean
 }
 
@@ -191,6 +191,12 @@ export interface ProxySettings {
   mode: "custom"
   url: string
   bypass?: string[]
+  auth?: boolean
+}
+
+export interface ProxyCredentials {
+  username?: string
+  password?: string
 }
 
 export type AppProxySettings =

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -185,9 +185,10 @@ export async function loadCollectionProxyCredentials(
   proxy: CollectionProxySettings | undefined,
 ): Promise<ProxyCredentials> {
   if (proxy?.mode !== "custom" || proxy.auth !== true) return {}
+  const collectionId = await ensureCollectionId(collectionDir)
   const [username, password] = await Promise.all([
-    getCollectionSettingSecret(collectionDir, "proxy:username"),
-    getCollectionSettingSecret(collectionDir, "proxy:password"),
+    getSecret(collectionSettingSecretAccount(collectionId, "proxy:username")),
+    getSecret(collectionSettingSecretAccount(collectionId, "proxy:password")),
   ])
   return {
     username: username ?? undefined,
@@ -206,14 +207,18 @@ export async function loadTlsPassphrases(
         .filter((id): id is string => id !== undefined),
     ),
   ]
+  if (ids.length === 0) return {}
+  const collectionId = await ensureCollectionId(collectionDir)
   const entries = await Promise.all(
     ids.map(
       async (id) =>
         [
           id,
-          await getCollectionSettingSecret(
-            collectionDir,
-            `tls:${id}:passphrase`,
+          await getSecret(
+            collectionSettingSecretAccount(
+              collectionId,
+              `tls:${id}:passphrase`,
+            ),
           ),
         ] as const,
     ),
@@ -253,8 +258,11 @@ export async function applySettingsSecretTransaction(
         else await mutation.set(snapshot)
       }
     } catch (rollbackError) {
-      throw new Error(
-        `settings secret update failed and rollback also failed: ${
+      throw new AggregateError(
+        [error, rollbackError],
+        `settings secret update failed (${
+          error instanceof Error ? error.message : String(error)
+        }) and rollback also failed: ${
           rollbackError instanceof Error
             ? rollbackError.message
             : String(rollbackError)

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -3,7 +3,13 @@ import { link, mkdir, readFile, unlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { loadSettings } from "../filestore/load"
 import { saveSettings } from "../filestore/save"
-import type { SecretStatus } from "../schema"
+import type {
+  AppProxySettings,
+  CollectionProxySettings,
+  CollectionTlsSettings,
+  ProxyCredentials,
+  SecretStatus,
+} from "../schema"
 
 export const SECRET_SERVICE = "dev.noodlerest.noodle"
 
@@ -29,9 +35,7 @@ export function setSecretBackendForTests(
 function backend(): SecretBackend {
   const candidate = testBackend ?? Bun.secrets
   if (!candidate) {
-    throw new Error(
-      "secure credential storage is unavailable in this Bun runtime",
-    )
+    throw new Error("secure credential storage is unavailable on this system")
   }
   return candidate
 }
@@ -58,6 +62,208 @@ export function secretAccount(
     .update(key)
     .digest("hex")
   return `${collectionId}:${digest}`
+}
+
+export type AppSettingSecret = "proxy:username" | "proxy:password"
+export type CollectionSettingSecret =
+  "proxy:username" | "proxy:password" | `tls:${string}:passphrase`
+
+export function appSettingSecretAccount(secret: AppSettingSecret): string {
+  return `app:settings:${secret}`
+}
+
+export function collectionSettingSecretAccount(
+  collectionId: string,
+  secret: CollectionSettingSecret,
+): string {
+  return `${collectionId}:settings:${secret}`
+}
+
+async function getSecret(name: string): Promise<string | null> {
+  try {
+    return await backend().get({ service: SECRET_SERVICE, name })
+  } catch (error) {
+    throw storageError("read", error)
+  }
+}
+
+async function setSecret(name: string, value: string): Promise<void> {
+  if (value.length === 0) throw new Error("secret value must not be empty")
+  try {
+    await backend().set({
+      service: SECRET_SERVICE,
+      name,
+      value,
+      allowUnrestrictedAccess: false,
+    })
+  } catch (error) {
+    throw storageError("write", error)
+  }
+}
+
+async function deleteSecret(name: string): Promise<boolean> {
+  try {
+    return await backend().delete({ service: SECRET_SERVICE, name })
+  } catch (error) {
+    throw storageError("delete", error)
+  }
+}
+
+export function getAppSettingSecret(
+  secret: AppSettingSecret,
+): Promise<string | null> {
+  return getSecret(appSettingSecretAccount(secret))
+}
+
+export function setAppSettingSecret(
+  secret: AppSettingSecret,
+  value: string,
+): Promise<void> {
+  return setSecret(appSettingSecretAccount(secret), value)
+}
+
+export function deleteAppSettingSecret(
+  secret: AppSettingSecret,
+): Promise<boolean> {
+  return deleteSecret(appSettingSecretAccount(secret))
+}
+
+export async function getCollectionSettingSecret(
+  collectionDir: string,
+  secret: CollectionSettingSecret,
+): Promise<string | null> {
+  return getSecret(
+    collectionSettingSecretAccount(
+      await ensureCollectionId(collectionDir),
+      secret,
+    ),
+  )
+}
+
+export async function setCollectionSettingSecret(
+  collectionDir: string,
+  secret: CollectionSettingSecret,
+  value: string,
+): Promise<void> {
+  return setSecret(
+    collectionSettingSecretAccount(
+      await ensureCollectionId(collectionDir),
+      secret,
+    ),
+    value,
+  )
+}
+
+export async function deleteCollectionSettingSecret(
+  collectionDir: string,
+  secret: CollectionSettingSecret,
+): Promise<boolean> {
+  return deleteSecret(
+    collectionSettingSecretAccount(
+      await ensureCollectionId(collectionDir),
+      secret,
+    ),
+  )
+}
+
+export async function loadAppProxyCredentials(
+  proxy: AppProxySettings | undefined,
+): Promise<ProxyCredentials> {
+  if (proxy?.mode !== "custom" || proxy.auth !== true) return {}
+  const [username, password] = await Promise.all([
+    getAppSettingSecret("proxy:username"),
+    getAppSettingSecret("proxy:password"),
+  ])
+  return {
+    username: username ?? undefined,
+    password: password ?? undefined,
+  }
+}
+
+export async function loadCollectionProxyCredentials(
+  collectionDir: string,
+  proxy: CollectionProxySettings | undefined,
+): Promise<ProxyCredentials> {
+  if (proxy?.mode !== "custom" || proxy.auth !== true) return {}
+  const [username, password] = await Promise.all([
+    getCollectionSettingSecret(collectionDir, "proxy:username"),
+    getCollectionSettingSecret(collectionDir, "proxy:password"),
+  ])
+  return {
+    username: username ?? undefined,
+    password: password ?? undefined,
+  }
+}
+
+export async function loadTlsPassphrases(
+  collectionDir: string,
+  tls: CollectionTlsSettings | undefined,
+): Promise<Record<string, string>> {
+  const ids = [
+    ...new Set(
+      (tls?.clientCertificates ?? [])
+        .map((profile) => profile.secretId)
+        .filter((id): id is string => id !== undefined),
+    ),
+  ]
+  const entries = await Promise.all(
+    ids.map(
+      async (id) =>
+        [
+          id,
+          await getCollectionSettingSecret(
+            collectionDir,
+            `tls:${id}:passphrase`,
+          ),
+        ] as const,
+    ),
+  )
+  return Object.fromEntries(
+    entries.filter(
+      (entry): entry is readonly [string, string] => entry[1] !== null,
+    ),
+  )
+}
+
+export interface SecretMutation {
+  get: () => Promise<string | null>
+  set: (value: string) => Promise<void>
+  delete: () => Promise<boolean>
+  value?: string
+}
+
+export async function applySettingsSecretTransaction(
+  mutations: SecretMutation[],
+  persist: () => Promise<void> | void,
+): Promise<void> {
+  const snapshots = await Promise.all(
+    mutations.map((mutation) => mutation.get()),
+  )
+  try {
+    for (const mutation of mutations) {
+      if (mutation.value) await mutation.set(mutation.value)
+      else await mutation.delete()
+    }
+    await persist()
+  } catch (error) {
+    try {
+      for (const [index, mutation] of mutations.entries()) {
+        const snapshot = snapshots[index]
+        if (snapshot === null) await mutation.delete()
+        else await mutation.set(snapshot)
+      }
+    } catch (rollbackError) {
+      throw new Error(
+        `settings secret update failed and rollback also failed: ${
+          rollbackError instanceof Error
+            ? rollbackError.message
+            : String(rollbackError)
+        }`,
+        { cause: rollbackError },
+      )
+    }
+    throw error
+  }
 }
 
 async function reserveCollectionId(collectionDir: string): Promise<string> {

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -2,16 +2,15 @@ import { isAbsolute, resolve } from "node:path"
 import type {
   ClientCertificateProfile,
   CollectionTlsSettings,
-  Environment,
   Request,
 } from "./schema"
 import { expandUserPath } from "./userPath"
-import { isVariableReference, variableReferenceName } from "./variableReference"
 
 export interface TlsPolicy {
   collectionDir: string
   settings?: CollectionTlsSettings
   insecure?: boolean
+  passphrases?: Record<string, string>
 }
 
 export interface ResolvedTls {
@@ -89,9 +88,7 @@ export function collectionTlsToYaml(
           key_file: profile.keyFile,
         }
         if (profile.port !== undefined) value.port = profile.port
-        if (profile.passphrase !== undefined) {
-          value.passphrase = profile.passphrase
-        }
+        if (profile.secretId !== undefined) value.secret_id = profile.secretId
         if (profile.enabled !== undefined) value.enabled = profile.enabled
         return value
       })
@@ -103,7 +100,6 @@ export function collectionTlsToYaml(
 export async function tlsForUrl(
   request: Pick<Request, "tls">,
   url: string,
-  env: Environment | undefined,
   policy: TlsPolicy | undefined,
 ): Promise<ResolvedTls> {
   const parsed = new URL(url)
@@ -141,8 +137,14 @@ export async function tlsForUrl(
     const keyPath = resolveTlsPath(profile.keyFile, policy.collectionDir)
     options.cert = await requiredFile(certPath, "client certificate")
     options.key = await requiredFile(keyPath, "client key")
-    if (profile.passphrase) {
-      options.passphrase = resolvePassphrase(profile.passphrase, env)
+    if (profile.secretId) {
+      const passphrase = policy.passphrases?.[profile.secretId]
+      if (passphrase === undefined) {
+        throw new Error(
+          `TLS client certificate for ${profile.host} has a missing passphrase secret`,
+        )
+      }
+      options.passphrase = passphrase
     }
     messages.push(`TLS client certificate selected for ${profile.host}`)
   }
@@ -211,6 +213,12 @@ function parseClientCertificate(
   path: string,
 ): ClientCertificateProfile {
   if (!isRecord(value)) throw invalid(path, "must be a mapping")
+  if (Object.hasOwn(value, "passphrase")) {
+    throw invalid(
+      `${path}.passphrase`,
+      "is no longer supported; remove it and configure the passphrase in Settings",
+    )
+  }
   const unknownKey = Object.keys(value).find(
     (key) =>
       ![
@@ -218,7 +226,7 @@ function parseClientCertificate(
         "port",
         "cert_file",
         "key_file",
-        "passphrase",
+        "secret_id",
         "enabled",
       ].includes(key),
   )
@@ -239,21 +247,17 @@ function parseClientCertificate(
   ) {
     throw invalid(`${path}.port`, "must be an integer from 1 to 65535")
   }
-  if (value.passphrase !== undefined && typeof value.passphrase !== "string") {
-    throw invalid(`${path}.passphrase`, "must be a string")
+  if (
+    value.secret_id !== undefined &&
+    (typeof value.secret_id !== "string" ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        value.secret_id,
+      ))
+  ) {
+    throw invalid(`${path}.secret_id`, "must be a UUID")
   }
   if (value.enabled !== undefined && typeof value.enabled !== "boolean") {
     throw invalid(`${path}.enabled`, "must be a boolean")
-  }
-  if (
-    typeof value.passphrase === "string" &&
-    value.passphrase.trim() &&
-    !isVariableReference(value.passphrase)
-  ) {
-    throw invalid(
-      `${path}.passphrase`,
-      "must be an exact $VARNAME reference; move the secret to an environment file",
-    )
   }
   if (
     value.enabled !== false &&
@@ -271,10 +275,7 @@ function parseClientCertificate(
     port: value.port as number | undefined,
     certFile: value.cert_file,
     keyFile: value.key_file,
-    passphrase:
-      typeof value.passphrase === "string" && value.passphrase.trim()
-        ? value.passphrase
-        : undefined,
+    secretId: value.secret_id as string | undefined,
     enabled: value.enabled as boolean | undefined,
   }
 }
@@ -288,18 +289,8 @@ function isEmptyClientCertificateProfile(
     profile.certFile.trim() === "" &&
     profile.keyFile.trim() === "" &&
     profile.port === undefined &&
-    !profile.passphrase?.trim()
+    !profile.secretId
   )
-}
-
-function resolvePassphrase(value: string, env?: Environment): string {
-  const name = variableReferenceName(value)
-  if (!name || !env || !Object.hasOwn(env.vars, name)) {
-    throw new Error(
-      `tls: unresolved variable "${name ?? value}" in client certificate passphrase`,
-    )
-  }
-  return env.vars[name]!
 }
 
 async function requiredFile(path: string, label: string): Promise<Bun.BunFile> {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -70,12 +70,20 @@ function sameCertificateProfile(
 function certificateProfileIndex(
   profiles: ClientCertificateProfile[],
   target: ClientCertificateProfile,
+  preferredIndex?: number,
 ): number {
   if (target.secretId) {
     const index = profiles.findIndex(
       (profile) => profile.secretId === target.secretId,
     )
     if (index !== -1) return index
+  }
+  if (
+    preferredIndex !== undefined &&
+    profiles[preferredIndex] &&
+    sameCertificateProfile(profiles[preferredIndex], target)
+  ) {
+    return preferredIndex
   }
   const index = profiles.findIndex((profile) =>
     sameCertificateProfile(profile, target),
@@ -104,6 +112,7 @@ function rebaseTlsSettings(
       const currentIndex = certificateProfileIndex(
         currentProfiles,
         previousProfile,
+        index,
       )
       if (currentIndex === -1) continue
       currentProfiles[currentIndex] = {
@@ -437,7 +446,7 @@ export function App({
 
   const handleAppProxyCredentialsChange = useCallback(
     async (credentials: ProxyCredentials) => {
-      if (config.proxy?.mode !== "custom") return false
+      if (config.proxy?.mode !== "custom" || !credentials.username) return false
       try {
         const proxy: AppProxySettings = {
           ...config.proxy,
@@ -482,7 +491,12 @@ export function App({
   const handleCollectionProxyCredentialsChange = useCallback(
     async (credentials: ProxyCredentials) => {
       const current = settingsRef.current.proxy
-      if (mode !== "collection" || current?.mode !== "custom") return false
+      if (
+        mode !== "collection" ||
+        current?.mode !== "custom" ||
+        !credentials.username
+      )
+        return false
       const dir = activeCollectionDirRef.current
       try {
         await persistCollectionSettingsTransaction(
@@ -606,6 +620,7 @@ export function App({
             const targetIndex = certificateProfileIndex(
               currentProfiles,
               profile,
+              index,
             )
             if (!currentProfiles[targetIndex]) return settings
             return {
@@ -706,6 +721,7 @@ export function App({
             const targetIndex = certificateProfileIndex(
               currentProfiles,
               profile,
+              index,
             )
             if (!currentProfiles[targetIndex]) return settings
             return {
@@ -933,10 +949,14 @@ export function App({
           }
         }
 
-        while (true) {
-          const pending = settingsSaveChainRef.current
-          await pending
-          if (pending === settingsSaveChainRef.current) break
+        const pending = settingsSaveChainRef.current
+        await pending
+        if (pending !== settingsSaveChainRef.current) {
+          showToast(
+            "Settings changed while switching collections; try again",
+            "error",
+          )
+          return
         }
         setEnvNames(nextEnvNames)
         setEnvColors(nextEnvColors)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { randomUUID } from "node:crypto"
 import { join, resolve } from "node:path"
 import { AppInner } from "./AppInner"
 import { appendCollectionPath, useConfig } from "../hooks/useConfig"
@@ -19,25 +20,116 @@ import { saveKeybinds } from "./keybindConfig"
 import { classifyPath, type CollectionMode } from "../collectionPath"
 import type {
   AppProxySettings,
+  ClientCertificateProfile,
   CollectionProxySettings,
   CollectionSettings,
+  CollectionTlsSettings,
+  ProxyCredentials,
 } from "../schema"
 import type { SystemProxySettings } from "../proxy"
 import { resolveCollectionRegistration } from "./settings/collectionRegistry"
-import { queueCollectionSettingsSave } from "./settings/settingsPersistence"
+import {
+  queueCollectionSettingsSave,
+  type CollectionSettingsUpdate,
+} from "./settings/settingsPersistence"
 import type {
   CollectionSettingsCategory,
   GlobalSettingsCategory,
   SettingsScope,
 } from "./settings/SettingsView"
+import {
+  applySettingsSecretTransaction,
+  deleteAppSettingSecret,
+  deleteCollectionSettingSecret,
+  getAppSettingSecret,
+  getCollectionSettingSecret,
+  ensureCollectionId,
+  loadCollectionProxyCredentials,
+  loadTlsPassphrases,
+  setAppSettingSecret,
+  setCollectionSettingSecret,
+  type SecretMutation,
+} from "../secrets"
 
 const CONFIG_DIR = `${process.env.HOME ?? "~"}/.config/noodle`
+
+function sameCertificateProfile(
+  left: ClientCertificateProfile,
+  right: ClientCertificateProfile,
+): boolean {
+  return (
+    left.host === right.host &&
+    left.port === right.port &&
+    left.certFile === right.certFile &&
+    left.keyFile === right.keyFile &&
+    left.secretId === right.secretId &&
+    left.enabled === right.enabled
+  )
+}
+
+function certificateProfileIndex(
+  profiles: ClientCertificateProfile[],
+  target: ClientCertificateProfile,
+): number {
+  if (target.secretId) {
+    const index = profiles.findIndex(
+      (profile) => profile.secretId === target.secretId,
+    )
+    if (index !== -1) return index
+  }
+  const index = profiles.findIndex((profile) =>
+    sameCertificateProfile(profile, target),
+  )
+  return index
+}
+
+function rebaseTlsSettings(
+  current: CollectionTlsSettings | undefined,
+  previous: CollectionTlsSettings | undefined,
+  next: CollectionTlsSettings | undefined,
+): CollectionTlsSettings | undefined {
+  if (!next) return undefined
+  const result = { ...current }
+  if (previous?.verify !== next.verify) result.verify = next.verify
+  if (previous?.caBundle !== next.caBundle) result.caBundle = next.caBundle
+
+  const previousProfiles = previous?.clientCertificates ?? []
+  const nextProfiles = next.clientCertificates ?? []
+  const currentProfiles = [...(current?.clientCertificates ?? [])]
+  if (nextProfiles.length === previousProfiles.length) {
+    for (const [index, profile] of nextProfiles.entries()) {
+      const previousProfile = previousProfiles[index]
+      if (!previousProfile || sameCertificateProfile(previousProfile, profile))
+        continue
+      const currentIndex = certificateProfileIndex(
+        currentProfiles,
+        previousProfile,
+      )
+      if (currentIndex === -1) continue
+      currentProfiles[currentIndex] = {
+        ...profile,
+        secretId: currentProfiles[currentIndex]?.secretId,
+      }
+    }
+    result.clientCertificates = currentProfiles
+  } else if (nextProfiles.length > previousProfiles.length) {
+    result.clientCertificates = [
+      ...currentProfiles,
+      ...nextProfiles.slice(previousProfiles.length),
+    ]
+  }
+  return result
+}
 
 export function App({
   collectionDir,
   envList: initialEnvList,
   initialEnvName,
   initialSettings = {},
+  initialAppProxyCredentials = {},
+  initialCollectionProxyCredentials = {},
+  initialTlsPassphrases = {},
+  initialSettingsSecretError,
   noProxy = false,
   insecure = false,
   systemProxy,
@@ -50,6 +142,10 @@ export function App({
   envList: string[]
   initialEnvName?: string
   initialSettings?: CollectionSettings
+  initialAppProxyCredentials?: ProxyCredentials
+  initialCollectionProxyCredentials?: ProxyCredentials
+  initialTlsPassphrases?: Record<string, string>
+  initialSettingsSecretError?: string
   noProxy?: boolean
   insecure?: boolean
   systemProxy: SystemProxySettings
@@ -71,18 +167,27 @@ export function App({
   const [mode, setMode] = useState<CollectionMode>(initialMode)
   const [reloadKey, setReloadKey] = useState(0)
   const [settings, setSettings] = useState<CollectionSettings>(initialSettings)
+  const [appProxyCredentials, setAppProxyCredentials] = useState(
+    initialAppProxyCredentials,
+  )
+  const [collectionProxyCredentials, setCollectionProxyCredentials] = useState(
+    initialCollectionProxyCredentials,
+  )
+  const [tlsPassphrases, setTlsPassphrases] = useState(initialTlsPassphrases)
   const [registeredCollectionSettings, setRegisteredCollectionSettings] =
     useState<Record<string, CollectionSettings>>({})
   const settingsRef = useRef(initialSettings)
   const persistedSettingsRef = useRef(initialSettings)
   const activeCollectionDirRef = useRef(initialCollectionDir)
   const settingsSaveChainRef = useRef<Promise<void>>(Promise.resolve())
+  const pendingSettingsUpdatesRef = useRef<CollectionSettingsUpdate[]>([])
   const settingsPersistence = useMemo(
     () => ({
       activeCollectionDir: activeCollectionDirRef,
       currentSettings: settingsRef,
       persistedSettings: persistedSettingsRef,
       saveChain: settingsSaveChainRef,
+      pendingUpdates: pendingSettingsUpdatesRef,
     }),
     [],
   )
@@ -109,6 +214,15 @@ export function App({
   const [envColors, setEnvColors] = useState<
     Record<string, string | undefined>
   >({})
+
+  useEffect(() => {
+    if (initialSettingsSecretError) {
+      showToast(
+        `Failed to load settings secrets: ${initialSettingsSecretError}`,
+        "error",
+      )
+    }
+  }, [initialSettingsSecretError])
 
   const activeEnvironmentsDir = useMemo(
     () => join(activeCollectionDir, ".environments"),
@@ -259,13 +373,21 @@ export function App({
   const handleCollectionProxyChange = useCallback(
     (proxy: CollectionProxySettings) => {
       if (mode !== "collection") return false
-      const nextSettings = { ...settingsRef.current, proxy }
-      settingsRef.current = nextSettings
-      setSettings(nextSettings)
-      queueCollectionSettingsSave(
+      void queueCollectionSettingsSave(
         settingsPersistence,
         activeCollectionDir,
-        nextSettings,
+        (settings) => ({
+          ...settings,
+          proxy:
+            proxy.mode === "custom"
+              ? {
+                  ...proxy,
+                  ...(settings.proxy?.mode === "custom" && settings.proxy.auth
+                    ? { auth: true }
+                    : {}),
+                }
+              : proxy,
+        }),
         saveSettings,
         setSettings,
         () => showToast("Failed to save proxy settings", "error"),
@@ -273,6 +395,348 @@ export function App({
       return true
     },
     [activeCollectionDir, mode, settingsPersistence],
+  )
+
+  const persistCollectionSettingsTransaction = useCallback(
+    (
+      dir: string,
+      update: CollectionSettingsUpdate,
+      mutations: SecretMutation[],
+    ) =>
+      queueCollectionSettingsSave(
+        settingsPersistence,
+        dir,
+        update,
+        async (collectionDir, nextSettings) => {
+          const collectionId =
+            nextSettings.collectionId ??
+            (await ensureCollectionId(collectionDir))
+          if (!nextSettings.collectionId) {
+            persistedSettingsRef.current = {
+              ...persistedSettingsRef.current,
+              collectionId,
+            }
+          }
+          const persisted = { ...nextSettings, collectionId }
+          await applySettingsSecretTransaction(mutations, () =>
+            saveSettings(collectionDir, persisted),
+          )
+          return persisted
+        },
+        setSettings,
+        () => {},
+        (persisted) => {
+          setRegisteredCollectionSettings((current) => ({
+            ...current,
+            [dir]: persisted,
+          }))
+        },
+      ),
+    [settingsPersistence],
+  )
+
+  const handleAppProxyCredentialsChange = useCallback(
+    async (credentials: ProxyCredentials) => {
+      if (config.proxy?.mode !== "custom") return false
+      try {
+        const proxy: AppProxySettings = {
+          ...config.proxy,
+          auth: true,
+        }
+        await applySettingsSecretTransaction(
+          [
+            {
+              get: () => getAppSettingSecret("proxy:username"),
+              set: (value) => setAppSettingSecret("proxy:username", value),
+              delete: () => deleteAppSettingSecret("proxy:username"),
+              value: credentials.username,
+            },
+            {
+              get: () => getAppSettingSecret("proxy:password"),
+              set: (value) => setAppSettingSecret("proxy:password", value),
+              delete: () => deleteAppSettingSecret("proxy:password"),
+              value: credentials.password,
+            },
+          ],
+          () => {
+            if (
+              !updateGlobalConfig({ proxy }, "Failed to save proxy settings")
+            ) {
+              throw new Error("failed to persist proxy settings")
+            }
+          },
+        )
+        setAppProxyCredentials(credentials)
+        return true
+      } catch (error) {
+        showToast(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        )
+        return false
+      }
+    },
+    [config.proxy, updateGlobalConfig],
+  )
+
+  const handleCollectionProxyCredentialsChange = useCallback(
+    async (credentials: ProxyCredentials) => {
+      const current = settingsRef.current.proxy
+      if (mode !== "collection" || current?.mode !== "custom") return false
+      const dir = activeCollectionDirRef.current
+      try {
+        await persistCollectionSettingsTransaction(
+          dir,
+          (settings) => ({
+            ...settings,
+            proxy:
+              settings.proxy?.mode === "custom"
+                ? { ...settings.proxy, auth: true }
+                : settings.proxy,
+          }),
+          [
+            {
+              get: () => getCollectionSettingSecret(dir, "proxy:username"),
+              set: (value) =>
+                setCollectionSettingSecret(dir, "proxy:username", value),
+              delete: () =>
+                deleteCollectionSettingSecret(dir, "proxy:username"),
+              value: credentials.username,
+            },
+            {
+              get: () => getCollectionSettingSecret(dir, "proxy:password"),
+              set: (value) =>
+                setCollectionSettingSecret(dir, "proxy:password", value),
+              delete: () =>
+                deleteCollectionSettingSecret(dir, "proxy:password"),
+              value: credentials.password,
+            },
+          ],
+        )
+        setCollectionProxyCredentials(credentials)
+        return true
+      } catch (error) {
+        showToast(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        )
+        return false
+      }
+    },
+    [mode, persistCollectionSettingsTransaction],
+  )
+
+  const handleProxyAuthDisable = useCallback(
+    async (scope: "app" | "collection") => {
+      const current = scope === "app" ? config.proxy : settingsRef.current.proxy
+      if (current?.mode !== "custom") return false
+      const proxy = {
+        ...current,
+        auth: undefined,
+      }
+      const dir = activeCollectionDirRef.current
+      try {
+        const names = ["proxy:username", "proxy:password"] as const
+        const mutations = names.map((name) => ({
+          get: () =>
+            scope === "app"
+              ? getAppSettingSecret(name)
+              : getCollectionSettingSecret(dir, name),
+          set: (value: string) =>
+            scope === "app"
+              ? setAppSettingSecret(name, value)
+              : setCollectionSettingSecret(dir, name, value),
+          delete: () =>
+            scope === "app"
+              ? deleteAppSettingSecret(name)
+              : deleteCollectionSettingSecret(dir, name),
+        }))
+        if (scope === "app") {
+          await applySettingsSecretTransaction(mutations, () => {
+            if (
+              !updateGlobalConfig(
+                { proxy: proxy as AppProxySettings },
+                "Failed to save proxy settings",
+              )
+            ) {
+              throw new Error("failed to persist proxy settings")
+            }
+          })
+        } else {
+          await persistCollectionSettingsTransaction(
+            dir,
+            (settings) => ({
+              ...settings,
+              proxy:
+                settings.proxy?.mode === "custom"
+                  ? { ...settings.proxy, auth: undefined }
+                  : settings.proxy,
+            }),
+            mutations,
+          )
+        }
+        if (scope === "app") setAppProxyCredentials({})
+        else setCollectionProxyCredentials({})
+        return true
+      } catch (error) {
+        showToast(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        )
+        return false
+      }
+    },
+    [config.proxy, persistCollectionSettingsTransaction, updateGlobalConfig],
+  )
+
+  const handleTlsPassphraseChange = useCallback(
+    async (index: number, value: string) => {
+      if (mode !== "collection") return false
+      const currentTls = settingsRef.current.tls ?? {}
+      const profiles = currentTls.clientCertificates ?? []
+      const profile = profiles[index]
+      if (!profile) return false
+      const secretId = profile.secretId ?? randomUUID()
+      const dir = activeCollectionDirRef.current
+      try {
+        await persistCollectionSettingsTransaction(
+          dir,
+          (settings) => {
+            const currentProfiles = settings.tls?.clientCertificates ?? []
+            const targetIndex = certificateProfileIndex(
+              currentProfiles,
+              profile,
+            )
+            if (!currentProfiles[targetIndex]) return settings
+            return {
+              ...settings,
+              tls: {
+                ...settings.tls,
+                clientCertificates: currentProfiles.map((item, current) =>
+                  current === targetIndex
+                    ? {
+                        ...item,
+                        secretId: value ? secretId : undefined,
+                      }
+                    : item,
+                ),
+              },
+            }
+          },
+          [
+            {
+              get: () =>
+                getCollectionSettingSecret(dir, `tls:${secretId}:passphrase`),
+              set: (secret) =>
+                setCollectionSettingSecret(
+                  dir,
+                  `tls:${secretId}:passphrase`,
+                  secret,
+                ),
+              delete: () =>
+                deleteCollectionSettingSecret(
+                  dir,
+                  `tls:${secretId}:passphrase`,
+                ),
+              value: value || undefined,
+            },
+          ],
+        )
+        setTlsPassphrases((current) => {
+          const next = { ...current }
+          if (
+            value &&
+            settingsRef.current.tls?.clientCertificates?.some(
+              (item) => item.secretId === secretId,
+            )
+          ) {
+            next[secretId] = value
+          } else {
+            delete next[secretId]
+          }
+          return next
+        })
+        return true
+      } catch (error) {
+        showToast(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        )
+        return false
+      }
+    },
+    [mode, persistCollectionSettingsTransaction],
+  )
+
+  const handleTlsProfileRemove = useCallback(
+    async (index: number) => {
+      if (mode !== "collection") return false
+      const currentTls = settingsRef.current.tls ?? {}
+      const profiles = currentTls.clientCertificates ?? []
+      const profile = profiles[index]
+      if (!profile) return false
+      const dir = activeCollectionDirRef.current
+      try {
+        const mutations = profile.secretId
+          ? [
+              {
+                get: () =>
+                  getCollectionSettingSecret(
+                    dir,
+                    `tls:${profile.secretId}:passphrase`,
+                  ),
+                set: (value: string) =>
+                  setCollectionSettingSecret(
+                    dir,
+                    `tls:${profile.secretId}:passphrase`,
+                    value,
+                  ),
+                delete: () =>
+                  deleteCollectionSettingSecret(
+                    dir,
+                    `tls:${profile.secretId}:passphrase`,
+                  ),
+              },
+            ]
+          : []
+        await persistCollectionSettingsTransaction(
+          dir,
+          (settings) => {
+            const currentProfiles = settings.tls?.clientCertificates ?? []
+            const targetIndex = certificateProfileIndex(
+              currentProfiles,
+              profile,
+            )
+            if (!currentProfiles[targetIndex]) return settings
+            return {
+              ...settings,
+              tls: {
+                ...settings.tls,
+                clientCertificates: currentProfiles.filter(
+                  (_, current) => current !== targetIndex,
+                ),
+              },
+            }
+          },
+          mutations,
+        )
+        if (profile.secretId) {
+          setTlsPassphrases((current) => {
+            const next = { ...current }
+            delete next[profile.secretId!]
+            return next
+          })
+        }
+        return true
+      } catch (error) {
+        showToast(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        )
+        return false
+      }
+    },
+    [mode, persistCollectionSettingsTransaction],
   )
 
   const handleCollectionSettingsChange = useCallback(
@@ -289,19 +753,26 @@ export function App({
         previous.timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES
       const nextLimit =
         nextSettings.timelineMaxEntries ?? DEFAULT_TIMELINE_MAX_ENTRIES
-      settingsRef.current = nextSettings
-      setSettings(nextSettings)
-      queueCollectionSettingsSave(
+      void queueCollectionSettingsSave(
         settingsPersistence,
         activeCollectionDir,
-        nextSettings,
+        (settings) => {
+          if (!("tls" in patch)) {
+            return { ...settings, ...patch }
+          }
+          return {
+            ...settings,
+            ...patch,
+            tls: rebaseTlsSettings(settings.tls, previous.tls, patch.tls),
+          }
+        },
         saveSettings,
         setSettings,
         () => showToast("Failed to save collection settings", "error"),
-        () => {
+        (persisted) => {
           setRegisteredCollectionSettings((current) => ({
             ...current,
-            [activeCollectionDir]: nextSettings,
+            [activeCollectionDir]: persisted,
           }))
           if (nextLimit < previousLimit) {
             pruneTimeline(activeCollectionDir, nextLimit).catch(() =>
@@ -330,18 +801,19 @@ export function App({
   const handleEnvChange = useCallback(
     (name: string | null) => {
       const envName = name ?? undefined
-      const nextSettings = { ...settingsRef.current, environment: envName }
-      settingsRef.current = nextSettings
-      setSettings(nextSettings)
       if (mode === "collection") {
-        queueCollectionSettingsSave(
+        void queueCollectionSettingsSave(
           settingsPersistence,
           activeCollectionDir,
-          nextSettings,
+          (settings) => ({ ...settings, environment: envName }),
           saveSettings,
           setSettings,
           () => showToast("Failed to save active environment", "error"),
         )
+      } else {
+        const nextSettings = { ...settingsRef.current, environment: envName }
+        settingsRef.current = nextSettings
+        setSettings(nextSettings)
       }
     },
     [activeCollectionDir, mode, settingsPersistence],
@@ -444,11 +916,35 @@ export function App({
           }
         }
 
+        let nextCollectionProxyCredentials: ProxyCredentials = {}
+        let nextTlsPassphrases: Record<string, string> = {}
+        if (nextMode === "collection") {
+          try {
+            ;[nextCollectionProxyCredentials, nextTlsPassphrases] =
+              await Promise.all([
+                loadCollectionProxyCredentials(normalized, nextSettings.proxy),
+                loadTlsPassphrases(normalized, nextSettings.tls),
+              ])
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error)
+            showToast(`Failed to load settings secrets: ${message}`, "error")
+            return
+          }
+        }
+
+        while (true) {
+          const pending = settingsSaveChainRef.current
+          await pending
+          if (pending === settingsSaveChainRef.current) break
+        }
         setEnvNames(nextEnvNames)
         setEnvColors(nextEnvColors)
         settingsRef.current = nextSettings
         persistedSettingsRef.current = nextSettings
         setSettings(nextSettings)
+        setCollectionProxyCredentials(nextCollectionProxyCredentials)
+        setTlsPassphrases(nextTlsPassphrases)
         setLastRequestId(nextLastRequestId)
         setInitialEnvNameState(undefined)
         setActiveCollectionDir(normalized)
@@ -504,8 +1000,11 @@ export function App({
         onEnvListChanged={handleEnvListChanged}
         settingsEnv={settingsEnv}
         appProxy={config.proxy}
+        appProxyCredentials={appProxyCredentials}
         collectionProxy={settings.proxy}
+        collectionProxyCredentials={collectionProxyCredentials}
         collectionTls={settings.tls}
+        tlsPassphrases={tlsPassphrases}
         collectionName={settings.name}
         collectionDescription={settings.description}
         timelineMaxEntries={settings.timelineMaxEntries}
@@ -514,6 +1013,13 @@ export function App({
         systemProxy={systemProxy}
         onAppProxyChange={handleAppProxyChange}
         onCollectionProxyChange={handleCollectionProxyChange}
+        onAppProxyCredentialsChange={handleAppProxyCredentialsChange}
+        onCollectionProxyCredentialsChange={
+          handleCollectionProxyCredentialsChange
+        }
+        onProxyAuthDisable={handleProxyAuthDisable}
+        onTlsPassphraseChange={handleTlsPassphraseChange}
+        onTlsProfileRemove={handleTlsProfileRemove}
         onCollectionSettingsChange={handleCollectionSettingsChange}
         initialLastRequestId={lastRequestId}
         collectionPaths={collectionPaths}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -26,6 +26,7 @@ import type {
   CollectionProxySettings,
   CollectionSettings,
   CollectionTlsSettings,
+  ProxyCredentials,
   Request as NoodleRequest,
   Method,
 } from "../schema"
@@ -129,8 +130,11 @@ export function AppInner({
   onEnvListChanged,
   settingsEnv,
   appProxy,
+  appProxyCredentials,
   collectionProxy,
+  collectionProxyCredentials,
   collectionTls,
+  tlsPassphrases,
   collectionName,
   collectionDescription,
   timelineMaxEntries,
@@ -139,6 +143,11 @@ export function AppInner({
   systemProxy,
   onAppProxyChange,
   onCollectionProxyChange,
+  onAppProxyCredentialsChange,
+  onCollectionProxyCredentialsChange,
+  onProxyAuthDisable,
+  onTlsPassphraseChange,
+  onTlsProfileRemove,
   onCollectionSettingsChange,
   initialLastRequestId,
   collectionPaths,
@@ -179,8 +188,11 @@ export function AppInner({
   onEnvListChanged: () => Promise<void>
   settingsEnv?: string
   appProxy?: AppProxySettings
+  appProxyCredentials: ProxyCredentials
   collectionProxy?: CollectionProxySettings
+  collectionProxyCredentials: ProxyCredentials
   collectionTls?: CollectionTlsSettings
+  tlsPassphrases: Record<string, string>
   collectionName?: string
   collectionDescription?: string
   timelineMaxEntries?: number
@@ -189,6 +201,15 @@ export function AppInner({
   systemProxy: SystemProxySettings
   onAppProxyChange: (proxy: AppProxySettings) => boolean
   onCollectionProxyChange: (proxy: CollectionProxySettings) => boolean
+  onAppProxyCredentialsChange: (
+    credentials: ProxyCredentials,
+  ) => Promise<boolean>
+  onCollectionProxyCredentialsChange: (
+    credentials: ProxyCredentials,
+  ) => Promise<boolean>
+  onProxyAuthDisable: (scope: "app" | "collection") => Promise<boolean>
+  onTlsPassphraseChange: (index: number, value: string) => Promise<boolean>
+  onTlsProfileRemove: (index: number) => Promise<boolean>
   onCollectionSettingsChange: (
     patch: Pick<
       CollectionSettings,
@@ -495,6 +516,11 @@ export function AppInner({
         result,
         envNameRef.current,
         envStateRef.current.activeEnv,
+        [
+          ...Object.values(appProxyCredentials),
+          ...Object.values(collectionProxyCredentials),
+          ...Object.values(tlsPassphrases),
+        ].filter((value): value is string => Boolean(value)),
       ),
     )
   }
@@ -505,24 +531,34 @@ export function AppInner({
         noProxy,
         appProxy,
         collectionProxy,
+        appCredentials: appProxyCredentials,
+        collectionCredentials: collectionProxyCredentials,
         systemProxy,
       }),
-    [noProxy, appProxy, collectionProxy, systemProxy],
+    [
+      noProxy,
+      appProxy,
+      collectionProxy,
+      appProxyCredentials,
+      collectionProxyCredentials,
+      systemProxy,
+    ],
   )
   const tlsPolicy = useMemo<TlsPolicy>(
     () => ({
       collectionDir,
       settings: collectionTls,
       insecure,
+      passphrases: tlsPassphrases,
     }),
-    [collectionDir, collectionTls, insecure],
+    [collectionDir, collectionTls, insecure, tlsPassphrases],
   )
   const updateDependencies = useMemo(
     () => ({
-      fetcher: createProxyFetcher(proxyPolicy, envState.activeEnv),
-      env: environmentForProxyPolicy(proxyPolicy, envState.activeEnv),
+      fetcher: createProxyFetcher(proxyPolicy),
+      env: environmentForProxyPolicy(proxyPolicy),
     }),
-    [proxyPolicy, envState.activeEnv],
+    [proxyPolicy],
   )
 
   const {
@@ -1427,14 +1463,16 @@ export function AppInner({
             layout={layout}
             confirmUndoAll={confirmUndoAll}
             appProxy={appProxy}
+            appProxyCredentials={appProxyCredentials}
             collectionProxy={collectionProxy}
+            collectionProxyCredentials={collectionProxyCredentials}
             collectionTls={collectionTls}
+            tlsPassphrases={tlsPassphrases}
             collectionName={collectionName}
             collectionDescription={collectionDescription}
             timelineMaxEntries={timelineMaxEntries}
             noProxy={noProxy}
             insecure={insecure}
-            activeEnv={envState.activeEnv}
             envNames={envState.names}
             activeEnvName={envState.activeName}
             keybinds={keybinds}
@@ -1457,6 +1495,13 @@ export function AppInner({
             onConfirmUndoAllChange={onConfirmUndoAllChange}
             onAppProxyChange={onAppProxyChange}
             onCollectionProxyChange={onCollectionProxyChange}
+            onAppProxyCredentialsChange={onAppProxyCredentialsChange}
+            onCollectionProxyCredentialsChange={
+              onCollectionProxyCredentialsChange
+            }
+            onProxyAuthDisable={onProxyAuthDisable}
+            onTlsPassphraseChange={onTlsPassphraseChange}
+            onTlsProfileRemove={onTlsProfileRemove}
             onCollectionSettingsChange={onCollectionSettingsChange}
             onEnvironmentChange={envState.select}
             onKeybindChange={onKeybindChange}

--- a/src/ui/settings/ProxySettingsForm.tsx
+++ b/src/ui/settings/ProxySettingsForm.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type {
   AppProxySettings,
   CollectionProxySettings,
-  Environment,
+  ProxyCredentials,
 } from "../../schema"
 import {
   buildStructuredProxyTemplate,
@@ -15,9 +15,9 @@ import {
 } from "../../proxy"
 import { Checkbox } from "../Checkbox"
 import { Select, type SelectItem } from "../Select"
-import { VarInput, type VarInputHandle } from "../VarInput"
 import { useTheme } from "../theme"
 import { SettingsField } from "./SettingsField"
+import { SecretInput } from "./SecretInput"
 
 type EditorMode = "fields" | "advanced"
 type ProxyMode = "system" | "inherit" | "custom" | "off"
@@ -37,6 +37,7 @@ interface FormValues {
   mode: ProxyMode
   editor: EditorMode
   fields: StructuredProxyFields
+  auth: boolean
   url: string
   bypass: string
 }
@@ -61,9 +62,6 @@ const EMPTY_FIELDS: StructuredProxyFields = {
   protocol: "http",
   hostname: "",
   port: "",
-  auth: false,
-  username: "",
-  password: "",
 }
 
 function valuesFor(
@@ -75,6 +73,7 @@ function valuesFor(
       mode: fallback,
       editor: "fields",
       fields: EMPTY_FIELDS,
+      auth: false,
       url: "",
       bypass: "",
     }
@@ -84,6 +83,7 @@ function valuesFor(
       mode: "off",
       editor: "fields",
       fields: EMPTY_FIELDS,
+      auth: false,
       url: "",
       bypass: "",
     }
@@ -93,6 +93,7 @@ function valuesFor(
     mode: "custom",
     editor: fields ? "fields" : "advanced",
     fields: fields ?? EMPTY_FIELDS,
+    auth: proxy.auth === true,
     url: proxy.url,
     bypass: (proxy.bypass ?? []).join(", "),
   }
@@ -101,20 +102,24 @@ function valuesFor(
 export function ProxySettingsForm({
   scope,
   proxy,
-  activeEnv,
+  credentials = {},
   focused,
   noProxy = false,
   onChange,
+  onCredentialsChange = async () => false,
+  onAuthDisable = async () => false,
   onExit,
   onFieldFocus,
   onTextInputFocusChange,
 }: {
   scope: "app" | "collection"
   proxy?: AppProxySettings | CollectionProxySettings
-  activeEnv?: Environment | null
+  credentials?: ProxyCredentials
   focused: boolean
   noProxy?: boolean
   onChange: (proxy: AppProxySettings | CollectionProxySettings) => boolean
+  onCredentialsChange?: (credentials: ProxyCredentials) => Promise<boolean>
+  onAuthDisable?: () => Promise<boolean>
   onExit?: () => void
   onFieldFocus?: (field: Field) => void
   onTextInputFocusChange?: (active: boolean) => void
@@ -127,31 +132,49 @@ export function ProxySettingsForm({
   valuesRef.current = values
   const [field, setField] = useState<Field>("mode")
   const [error, setError] = useState<string | null>(null)
+  const [usernameDraft, setUsernameDraft] = useState<string>()
   const [selectOpen, setSelectOpen] = useState(false)
   const hostnameRef = useRef<InputRenderable | null>(null)
   const portRef = useRef<InputRenderable | null>(null)
-  const usernameRef = useRef<VarInputHandle | null>(null)
-  const passwordRef = useRef<VarInputHandle | null>(null)
-  const urlRef = useRef<VarInputHandle | null>(null)
+  const urlRef = useRef<InputRenderable | null>(null)
   const bypassRef = useRef<InputRenderable | null>(null)
   const lastPublishedRef = useRef<string | null>(null)
+  const savedCredentialsRef = useRef(credentials)
+  const credentialSaveChainRef = useRef<Promise<void>>(Promise.resolve())
+  const pendingCredentialSavesRef = useRef(0)
+  const disablingAuthRef = useRef(false)
   const proxyFingerprint = `${scope}:${JSON.stringify(proxy)}`
+  const proxyRef = useRef(proxy)
+  proxyRef.current = proxy
+  const credentialFingerprint = JSON.stringify(credentials)
+
+  useEffect(() => {
+    if (pendingCredentialSavesRef.current === 0) {
+      savedCredentialsRef.current = credentials
+    }
+  }, [credentialFingerprint, credentials])
 
   useEffect(() => {
     if (lastPublishedRef.current === proxyFingerprint) return
-    const next = valuesFor(proxy, fallback)
+    const next = valuesFor(proxyRef.current, fallback)
     valuesRef.current = next
     setValues(next)
-    setField("mode")
     setError(null)
-  }, [fallback, proxy, proxyFingerprint])
+  }, [fallback, proxyFingerprint])
 
   const focusOrder = useMemo<Field[]>(
     () =>
       values.mode !== "custom"
         ? ["mode"]
         : values.editor === "advanced"
-          ? ["mode", "editor", "proxy-url", "bypass"]
+          ? [
+              "mode",
+              "editor",
+              "proxy-url",
+              "bypass",
+              "auth",
+              ...(values.auth ? (["username", "password"] as const) : []),
+            ]
           : [
               "mode",
               "editor",
@@ -160,9 +183,7 @@ export function ProxySettingsForm({
               "port",
               "bypass",
               "auth",
-              ...(values.fields.auth
-                ? (["username", "password"] as const)
-                : []),
+              ...(values.auth ? (["username", "password"] as const) : []),
             ],
     [values],
   )
@@ -194,15 +215,21 @@ export function ProxySettingsForm({
       }
       setError(null)
       const bypass = normalizeBypass(next.bypass.split(","))
-      const output: AppProxySettings | CollectionProxySettings =
-        bypass.length > 0
-          ? { mode: "custom", url, bypass }
-          : { mode: "custom", url }
+      const persistedAuth =
+        proxyRef.current?.mode === "custom" && proxyRef.current.auth === true
+      const output: AppProxySettings | CollectionProxySettings = {
+        mode: "custom",
+        url,
+        ...(bypass.length > 0 ? { bypass } : {}),
+        ...(next.auth && (persistedAuth || credentials.username)
+          ? { auth: true }
+          : {}),
+      }
       if (!onChange(output)) return "failed"
       lastPublishedRef.current = `${scope}:${JSON.stringify(output)}`
       return "saved"
     },
-    [onChange, scope],
+    [credentials.username, onChange, scope],
   )
 
   const update = useCallback(
@@ -240,6 +267,78 @@ export function ProxySettingsForm({
     [publish],
   )
 
+  const saveCredentials = useCallback(
+    (patch: Partial<ProxyCredentials>) => {
+      pendingCredentialSavesRef.current++
+      const pending = credentialSaveChainRef.current.then(async () => {
+        const next = { ...savedCredentialsRef.current, ...patch }
+        const saved = await onCredentialsChange(next)
+        if (saved) savedCredentialsRef.current = next
+        return saved
+      })
+      credentialSaveChainRef.current = pending.then(
+        () => {},
+        () => {},
+      )
+      void pending.then(
+        () => pendingCredentialSavesRef.current--,
+        () => pendingCredentialSavesRef.current--,
+      )
+      return pending
+    },
+    [onCredentialsChange],
+  )
+
+  const disableAuth = useCallback(async () => {
+    if (disablingAuthRef.current) return false
+    disablingAuthRef.current = true
+    const current = valuesRef.current
+    const disabled = {
+      ...current,
+      auth: false,
+    }
+    valuesRef.current = disabled
+    setValues(disabled)
+    setUsernameDraft(undefined)
+    setError(null)
+    try {
+      const stored = proxyRef.current
+      if (
+        pendingCredentialSavesRef.current === 0 &&
+        (stored?.mode !== "custom" || stored.auth !== true)
+      ) {
+        return true
+      }
+      await credentialSaveChainRef.current
+      const saved = await onAuthDisable()
+      if (saved) {
+        savedCredentialsRef.current = {}
+        return true
+      }
+      const latest = valuesRef.current
+      const restored = {
+        ...latest,
+        auth: true,
+      }
+      valuesRef.current = restored
+      setValues(restored)
+      setError("Could not disable proxy authentication")
+      return false
+    } catch (error) {
+      const latest = valuesRef.current
+      const restored = {
+        ...latest,
+        auth: true,
+      }
+      valuesRef.current = restored
+      setValues(restored)
+      setError(error instanceof Error ? error.message : String(error))
+      return false
+    } finally {
+      disablingAuthRef.current = false
+    }
+  }, [onAuthDisable])
+
   const switchEditor = useCallback(
     (editor: EditorMode) => {
       if (editor === values.editor) return
@@ -254,7 +353,12 @@ export function ProxySettingsForm({
           }
           update({ editor }, false)
           setError(null)
-        } else update({ editor, fields })
+        } else {
+          update({
+            editor,
+            fields,
+          })
+        }
       } else {
         const result = buildStructuredProxyTemplate(values.fields)
         if ("error" in result) {
@@ -301,10 +405,17 @@ export function ProxySettingsForm({
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           commitCurrent()
-        } else if (ctx.event.name === "space" && field === "auth") {
+        } else if (
+          (ctx.event.name === "space" || ctx.event.name === "return") &&
+          field === "auth"
+        ) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
-          updateFields({ auth: !values.fields.auth })
+          if (values.auth) {
+            void disableAuth()
+          } else {
+            update({ auth: true }, Boolean(credentials.username))
+          }
         }
       },
       { priority: 100 },
@@ -317,9 +428,11 @@ export function ProxySettingsForm({
     focused,
     keymap,
     onExit,
+    disableAuth,
     selectOpen,
-    updateFields,
-    values.fields.auth,
+    update,
+    credentials.username,
+    values.auth,
   ])
 
   useEffect(() => {
@@ -337,8 +450,6 @@ export function ProxySettingsForm({
     )
     if (field === "hostname") hostnameRef.current?.focus()
     else if (field === "port") portRef.current?.focus()
-    else if (field === "username") usernameRef.current?.focus()
-    else if (field === "password") passwordRef.current?.focus()
     else if (field === "proxy-url") urlRef.current?.focus()
     else if (field === "bypass") bypassRef.current?.focus()
   }, [field, focused, onFieldFocus, onTextInputFocusChange])
@@ -356,14 +467,21 @@ export function ProxySettingsForm({
           { id: "off", label: "Off (direct connections)" },
         ]
 
-  const variableEnv = activeEnv ?? null
-  const credentialStorage = scope === "app" ? "app config" : "settings.yml"
-  const credentialDescription = `Optional. Enter credentials directly (stored in ${credentialStorage}) or use $VARNAME from the active environment.`
-  const advancedCredentialDescription = `Credentials are optional. Enter them directly (stored in ${credentialStorage}) or use $VARNAME from the active environment.`
+  useEffect(() => {
+    setUsernameDraft(undefined)
+  }, [credentials.username, proxyFingerprint])
+  const credentialDescription =
+    "Credentials are stored securely and are revealed only while focused."
+  const advancedCredentialDescription =
+    "Enter only the proxy URL here. Configure credentials with the secret fields below."
 
-  const errorField = proxyErrorField(error, values.editor)
+  const displayedError =
+    values.auth && !(usernameDraft ?? credentials.username)
+      ? "Username is required when proxy authentication is enabled"
+      : error
+  const errorField = proxyErrorField(displayedError, values.editor)
   const fieldError = (target: Field) =>
-    errorField === target ? (error ?? undefined) : undefined
+    errorField === target ? (displayedError ?? undefined) : undefined
 
   return (
     <box style={{ flexDirection: "column", gap: 1 }}>
@@ -386,7 +504,18 @@ export function ProxySettingsForm({
         focused={focused && field === "mode"}
         onOpenChange={setSelectOpen}
         onActivate={() => setField("mode")}
-        onChange={(mode) => update({ mode: mode as ProxyMode })}
+        onChange={(mode) => {
+          const nextMode = mode as ProxyMode
+          if (
+            values.mode === "custom" &&
+            nextMode !== "custom" &&
+            values.auth
+          ) {
+            void disableAuth().then((saved) => {
+              if (saved) update({ mode: nextMode })
+            })
+          } else update({ mode: nextMode })
+        }}
       />
       {values.mode === "custom" && (
         <>
@@ -450,15 +579,14 @@ export function ProxySettingsForm({
               />
             </>
           ) : (
-            <VariableField
+            <TextField
               id="settings-proxy-proxy-url"
               label="Proxy URL"
               inputRef={urlRef}
               value={values.url}
-              placeholder="http://$PROXY_USER:$PROXY_PASSWORD@proxy:8080"
+              placeholder="http://proxy.example:8080"
               focused={focused && field === "proxy-url"}
               error={fieldError("proxy-url")}
-              env={variableEnv}
               hint={advancedCredentialDescription}
               onFocus={() => setField("proxy-url")}
               onChange={(url) => update({ url }, false)}
@@ -475,56 +603,125 @@ export function ProxySettingsForm({
             onChange={(bypass) => update({ bypass })}
             hint="Optional. Comma-separated; supports *, hosts, .domains, IPs, and ports."
           />
-          {values.editor === "fields" && (
-            <>
-              <SettingsField
-                id="settings-proxy-auth"
-                title="Proxy authentication (optional)"
-                description={credentialDescription}
-                active={focused && field === "auth"}
-                onMouseDown={() => {
-                  setField("auth")
-                  updateFields({ auth: !values.fields.auth })
-                }}
-              >
-                <Checkbox checked={values.fields.auth} theme={theme} />
-              </SettingsField>
-              {values.fields.auth && (
-                <>
-                  <VariableField
-                    id="settings-proxy-username"
-                    label="Username"
-                    inputRef={usernameRef}
-                    value={values.fields.username}
-                    placeholder="username or $PROXY_USER"
-                    hint="Required for authentication. Enter a literal value or use $VARNAME from the active environment."
-                    focused={focused && field === "username"}
-                    error={fieldError("username")}
-                    env={variableEnv}
-                    onFocus={() => setField("username")}
-                    onChange={(username) => updateFields({ username })}
-                  />
-                  <VariableField
-                    id="settings-proxy-password"
-                    label="Password (optional)"
-                    inputRef={passwordRef}
-                    value={values.fields.password}
-                    placeholder="password or $PROXY_PASSWORD"
-                    hint="Optional. Enter a literal value or use $VARNAME from the active environment."
-                    focused={focused && field === "password"}
-                    error={fieldError("password")}
-                    env={variableEnv}
-                    onFocus={() => setField("password")}
-                    onChange={(password) => updateFields({ password })}
-                  />
-                </>
-              )}
-            </>
-          )}
+          <>
+            <SettingsField
+              id="settings-proxy-auth"
+              title="Proxy authentication (optional)"
+              description={credentialDescription}
+              active={focused && field === "auth"}
+              onMouseDown={() => {
+                setField("auth")
+                if (values.auth) {
+                  void disableAuth()
+                } else {
+                  update({ auth: true }, Boolean(credentials.username))
+                }
+              }}
+            >
+              <Checkbox checked={values.auth} theme={theme} />
+            </SettingsField>
+            {values.auth && (
+              <>
+                <SecretField
+                  id="settings-proxy-username"
+                  label="Username"
+                  value={credentials.username}
+                  hasValue={Boolean(credentials.username)}
+                  placeholder="username"
+                  hint="Required when proxy authentication is enabled."
+                  focused={focused && field === "username"}
+                  error={fieldError("username")}
+                  onFocus={() => setField("username")}
+                  onDraftChange={setUsernameDraft}
+                  onCommit={async (username) => {
+                    if (!username) {
+                      setError(
+                        "Proxy username is required when authentication is enabled",
+                      )
+                    }
+                    return saveCredentials({
+                      username: username || undefined,
+                    })
+                  }}
+                  onError={(message) => setError(message ?? null)}
+                />
+                <SecretField
+                  id="settings-proxy-password"
+                  label="Password (optional)"
+                  value={credentials.password}
+                  hasValue={Boolean(credentials.password)}
+                  placeholder="optional"
+                  hint="Optional. Clear the field to delete the stored password."
+                  focused={focused && field === "password"}
+                  error={fieldError("password")}
+                  onFocus={() => setField("password")}
+                  onCommit={(password) =>
+                    saveCredentials({
+                      password: password || undefined,
+                    })
+                  }
+                  onError={(message) => setError(message ?? null)}
+                />
+              </>
+            )}
+          </>
         </>
       )}
-      {error && !errorField && <text fg={theme.error}>{error}</text>}
+      {displayedError && !errorField && (
+        <text fg={theme.error}>{displayedError}</text>
+      )}
     </box>
+  )
+}
+
+function SecretField({
+  id,
+  label,
+  value,
+  hasValue,
+  placeholder,
+  focused,
+  onFocus,
+  onCommit,
+  onDraftChange,
+  onError,
+  hint,
+  error,
+}: {
+  id: string
+  label: string
+  value?: string
+  hasValue?: boolean
+  placeholder: string
+  focused: boolean
+  onFocus: () => void
+  onCommit: (value: string) => Promise<boolean>
+  onDraftChange?: (value: string) => void
+  onError: (message?: string) => void
+  hint?: string
+  error?: string
+}) {
+  return (
+    <SettingsField
+      id={id}
+      title={label}
+      active={focused}
+      description={hint}
+      error={error}
+    >
+      <box style={{ flexGrow: 1, minWidth: 0, height: 1, overflow: "hidden" }}>
+        <SecretInput
+          value={value}
+          hasValue={hasValue}
+          focused={focused}
+          placeholder={placeholder}
+          onFocus={onFocus}
+          onCommit={onCommit}
+          onDraftChange={onDraftChange}
+          onError={onError}
+        />
+      </box>
+    </SettingsField>
   )
 }
 
@@ -620,58 +817,6 @@ function TextField({
           textColor={theme.text}
           cursorColor={theme.primary}
           placeholderColor={theme.textMuted}
-          style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
-        />
-      </box>
-    </SettingsField>
-  )
-}
-
-function VariableField({
-  id,
-  label,
-  value,
-  placeholder,
-  focused,
-  env,
-  onFocus,
-  onChange,
-  inputRef,
-  hint,
-  error,
-}: {
-  id: string
-  label: string
-  value: string
-  placeholder: string
-  focused: boolean
-  env: Environment | null
-  onFocus: () => void
-  onChange: (value: string) => void
-  inputRef: { current: VarInputHandle | null }
-  hint?: string
-  error?: string
-}) {
-  return (
-    <SettingsField
-      id={id}
-      title={label}
-      active={focused}
-      description={hint}
-      error={error}
-    >
-      <box style={{ flexGrow: 1, minWidth: 0, height: 1, overflow: "hidden" }}>
-        <VarInput
-          ref={inputRef}
-          value={value}
-          env={env}
-          isEditing
-          isFocused={focused}
-          onChange={onChange}
-          placeholder={placeholder}
-          backgroundColor="transparent"
-          focusedBackgroundColor="transparent"
-          onFocus={onFocus}
           style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
         />
       </box>

--- a/src/ui/settings/ProxySettingsForm.tsx
+++ b/src/ui/settings/ProxySettingsForm.tsx
@@ -638,9 +638,10 @@ export function ProxySettingsForm({
                       setError(
                         "Proxy username is required when authentication is enabled",
                       )
+                      return false
                     }
                     return saveCredentials({
-                      username: username || undefined,
+                      username,
                     })
                   }}
                   onError={(message) => setError(message ?? null)}

--- a/src/ui/settings/SecretInput.tsx
+++ b/src/ui/settings/SecretInput.tsx
@@ -1,0 +1,172 @@
+import { MouseButton, type InputRenderable } from "@opentui/core"
+import { useKeymap } from "@opentui/keymap/react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTheme } from "../theme"
+
+export const SETTINGS_SECRET_MASK = "******"
+
+export function SecretInput({
+  value,
+  hasValue = value !== undefined && value !== "",
+  focused,
+  placeholder,
+  onFocus,
+  onCommit,
+  onDraftChange,
+  onError,
+}: {
+  value?: string
+  hasValue?: boolean
+  focused: boolean
+  placeholder: string
+  onFocus: () => void
+  onCommit: (value: string) => Promise<boolean>
+  onDraftChange?: (value: string) => void
+  onError?: (message?: string) => void
+}) {
+  const theme = useTheme()
+  const keymap = useKeymap()
+  const inputRef = useRef<InputRenderable | null>(null)
+  const previousFocused = useRef(false)
+  const cancelled = useRef(false)
+  const committing = useRef(false)
+  const mounted = useRef(true)
+  const lastCommittedDraft = useRef<string | undefined>(undefined)
+  const [draft, setDraft] = useState(value ?? "")
+  const [revealed, setRevealed] = useState(false)
+  const draftRef = useRef(draft)
+  const valueRef = useRef(value ?? "")
+  const onCommitRef = useRef(onCommit)
+  const onDraftChangeRef = useRef(onDraftChange)
+  const onErrorRef = useRef(onError)
+  draftRef.current = draft
+  valueRef.current = value ?? ""
+  onCommitRef.current = onCommit
+  onDraftChangeRef.current = onDraftChange
+  onErrorRef.current = onError
+
+  const cancel = useCallback(() => {
+    cancelled.current = true
+    draftRef.current = value ?? ""
+    setDraft(draftRef.current)
+    onDraftChange?.(draftRef.current)
+    setRevealed(false)
+    onError?.()
+  }, [onDraftChange, onError, value])
+
+  const commit = useCallback(async () => {
+    if (committing.current) return
+    const next = draftRef.current
+    if (next === valueRef.current || lastCommittedDraft.current === next) {
+      if (mounted.current) setRevealed(false)
+      return
+    }
+    committing.current = true
+    lastCommittedDraft.current = next
+    try {
+      if (await onCommitRef.current(next)) {
+        if (mounted.current) onErrorRef.current?.()
+      } else {
+        lastCommittedDraft.current = undefined
+        if (mounted.current) {
+          draftRef.current = valueRef.current
+          setDraft(valueRef.current)
+          onDraftChangeRef.current?.(valueRef.current)
+          onErrorRef.current?.("Could not save secret")
+        }
+      }
+    } catch (error) {
+      lastCommittedDraft.current = undefined
+      if (mounted.current) {
+        draftRef.current = valueRef.current
+        setDraft(valueRef.current)
+        onDraftChangeRef.current?.(valueRef.current)
+        onErrorRef.current?.(
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+    } finally {
+      committing.current = false
+      if (mounted.current) setRevealed(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      if (!cancelled.current) void commit()
+    }
+  }, [commit])
+
+  useEffect(() => {
+    const wasFocused = previousFocused.current
+    previousFocused.current = focused
+    if (focused && !wasFocused) {
+      cancelled.current = false
+      draftRef.current = value ?? ""
+      setDraft(draftRef.current)
+      onDraftChange?.(draftRef.current)
+      setRevealed(true)
+      queueMicrotask(() => inputRef.current?.focus())
+    } else if (!focused && wasFocused) {
+      if (!cancelled.current) void commit()
+      cancelled.current = false
+      setRevealed(false)
+    }
+  }, [commit, focused, onDraftChange, value])
+
+  useEffect(() => {
+    if (!focused || !revealed) return
+    const dispose = keymap.intercept(
+      "key",
+      (ctx) => {
+        if (ctx.event.name === "escape") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          cancel()
+        } else if (ctx.event.name === "return") {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          void commit()
+        }
+      },
+      { priority: 120 },
+    )
+    return dispose
+  }, [cancel, commit, focused, keymap, revealed])
+
+  const displayValue = revealed ? draft : hasValue ? SETTINGS_SECRET_MASK : ""
+  return (
+    <input
+      ref={inputRef}
+      value={displayValue}
+      placeholder={placeholder}
+      focused={focused && revealed}
+      onInput={(next) => {
+        draftRef.current = next
+        setDraft(next)
+        onDraftChange?.(next)
+      }}
+      onMouseDown={(event) => {
+        if (event.button !== MouseButton.LEFT) return
+        if (focused && !revealed) {
+          cancelled.current = false
+          draftRef.current = value ?? ""
+          setDraft(draftRef.current)
+          onDraftChange?.(draftRef.current)
+          setRevealed(true)
+          queueMicrotask(() => inputRef.current?.focus())
+        }
+        onFocus()
+      }}
+      backgroundColor="transparent"
+      focusedBackgroundColor="transparent"
+      textColor={theme.text}
+      cursorColor={theme.primary}
+      placeholderColor={theme.textMuted}
+      paddingX={0}
+      style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
+    />
+  )
+}

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -19,7 +19,7 @@ import type {
   CollectionProxySettings,
   CollectionSettings,
   CollectionTlsSettings,
-  Environment,
+  ProxyCredentials,
 } from "../../schema"
 import { DEFAULT_TIMELINE_MAX_ENTRIES } from "../../filestore"
 import type { Focus } from "../focus"
@@ -107,14 +107,16 @@ export function SettingsView({
   layout,
   confirmUndoAll,
   appProxy,
+  appProxyCredentials = {},
   collectionProxy,
+  collectionProxyCredentials = {},
   collectionTls,
+  tlsPassphrases = {},
   collectionName,
   collectionDescription,
   timelineMaxEntries,
   noProxy,
   insecure = false,
-  activeEnv,
   envNames,
   activeEnvName,
   keybinds,
@@ -129,6 +131,11 @@ export function SettingsView({
   onConfirmUndoAllChange,
   onAppProxyChange,
   onCollectionProxyChange,
+  onAppProxyCredentialsChange = async () => false,
+  onCollectionProxyCredentialsChange = async () => false,
+  onProxyAuthDisable = async () => false,
+  onTlsPassphraseChange = async () => false,
+  onTlsProfileRemove = async () => false,
   onCollectionSettingsChange,
   onEnvironmentChange,
   onKeybindChange,
@@ -145,14 +152,16 @@ export function SettingsView({
   layout: "stacked" | "side-by-side"
   confirmUndoAll: boolean
   appProxy?: AppProxySettings
+  appProxyCredentials?: ProxyCredentials
   collectionProxy?: CollectionProxySettings
+  collectionProxyCredentials?: ProxyCredentials
   collectionTls?: CollectionTlsSettings
+  tlsPassphrases?: Record<string, string>
   collectionName?: string
   collectionDescription?: string
   timelineMaxEntries?: number
   noProxy: boolean
   insecure?: boolean
-  activeEnv: Environment | null
   envNames: string[]
   activeEnvName: string | null
   keybinds: Keybinds
@@ -167,6 +176,15 @@ export function SettingsView({
   onConfirmUndoAllChange: (value: boolean) => void
   onAppProxyChange: (proxy: AppProxySettings) => boolean
   onCollectionProxyChange: (proxy: CollectionProxySettings) => boolean
+  onAppProxyCredentialsChange?: (
+    credentials: ProxyCredentials,
+  ) => Promise<boolean>
+  onCollectionProxyCredentialsChange?: (
+    credentials: ProxyCredentials,
+  ) => Promise<boolean>
+  onProxyAuthDisable?: (scope: "app" | "collection") => Promise<boolean>
+  onTlsPassphraseChange?: (index: number, value: string) => Promise<boolean>
+  onTlsProfileRemove?: (index: number) => Promise<boolean>
   onCollectionSettingsChange: (
     patch: Pick<
       CollectionSettings,
@@ -870,7 +888,11 @@ export function SettingsView({
                 <ProxySettingsForm
                   scope={scope === "global" ? "app" : "collection"}
                   proxy={scope === "global" ? appProxy : collectionProxy}
-                  activeEnv={activeEnv}
+                  credentials={
+                    scope === "global"
+                      ? appProxyCredentials
+                      : collectionProxyCredentials
+                  }
                   focused={focus === "settings-content"}
                   noProxy={noProxy}
                   onExit={() => onPaneFocus("settings-sidebar")}
@@ -883,6 +905,16 @@ export function SettingsView({
                           proxy as CollectionProxySettings,
                         )
                   }
+                  onCredentialsChange={(credentials) =>
+                    scope === "global"
+                      ? onAppProxyCredentialsChange(credentials)
+                      : onCollectionProxyCredentialsChange(credentials)
+                  }
+                  onAuthDisable={() =>
+                    onProxyAuthDisable(
+                      scope === "global" ? "app" : "collection",
+                    )
+                  }
                 />
               </>
             )}
@@ -894,13 +926,15 @@ export function SettingsView({
                 />
                 <TlsSettingsForm
                   settings={collectionTls}
-                  activeEnv={activeEnv}
+                  passphrases={tlsPassphrases}
                   focused={focus === "settings-content"}
                   insecure={insecure}
                   collectionDir={activeCollectionDir}
                   onExit={() => onPaneFocus("settings-sidebar")}
                   onTextInputFocusChange={setTlsTextInput}
                   onChange={(tls) => onCollectionSettingsChange({ tls })}
+                  onPassphraseChange={onTlsPassphraseChange}
+                  onRemoveProfile={onTlsProfileRemove}
                 />
               </>
             )}

--- a/src/ui/settings/TlsSettingsForm.tsx
+++ b/src/ui/settings/TlsSettingsForm.tsx
@@ -10,15 +10,14 @@ import {
 import type {
   ClientCertificateProfile,
   CollectionTlsSettings,
-  Environment,
 } from "../../schema"
 import { isValidTlsHost } from "../../tls"
-import { isVariableReference } from "../../variableReference"
 import { Checkbox } from "../Checkbox"
 import { LeftBar } from "../borders"
 import { VarInput } from "../VarInput"
 import { useTheme } from "../theme"
 import { SettingsField } from "./SettingsField"
+import { SecretInput } from "./SecretInput"
 
 const PROFILE_FIELD_COUNT = 7
 const ADD_PROFILE_FIELD = 2
@@ -26,20 +25,24 @@ const PROFILE_START_FIELD = 3
 
 export function TlsSettingsForm({
   settings,
-  activeEnv,
+  passphrases = {},
   focused,
   insecure,
   collectionDir,
   onChange,
+  onPassphraseChange,
+  onRemoveProfile,
   onExit,
   onTextInputFocusChange,
 }: {
   settings?: CollectionTlsSettings
-  activeEnv: Environment | null
+  passphrases?: Record<string, string>
   focused: boolean
   insecure: boolean
   collectionDir: string
   onChange: (settings: CollectionTlsSettings) => boolean
+  onPassphraseChange?: (index: number, value: string) => Promise<boolean>
+  onRemoveProfile?: (index: number) => Promise<boolean>
   onExit: () => void
   onTextInputFocusChange?: (focused: boolean) => void
 }) {
@@ -105,9 +108,10 @@ export function TlsSettingsForm({
 
   const removeProfile = useCallback(
     (index: number) => {
-      save({ clientCertificates: profiles.filter((_, i) => i !== index) })
+      if (onRemoveProfile) void onRemoveProfile(index)
+      else save({ clientCertificates: profiles.filter((_, i) => i !== index) })
     },
-    [profiles, save],
+    [onRemoveProfile, profiles, save],
   )
 
   useEffect(() => {
@@ -346,7 +350,6 @@ export function TlsSettingsForm({
               value={profile.certFile}
               placeholder="./certs/client-chain.pem"
               focused={focused && field === base + 3}
-              activeEnv={null}
               collectionDir={collectionDir}
               onFocus={() => setField(base + 3)}
               onChange={(certFile) => updateProfile(index, { certFile })}
@@ -358,22 +361,25 @@ export function TlsSettingsForm({
               value={profile.keyFile}
               placeholder="./certs/client-key.pem"
               focused={focused && field === base + 4}
-              activeEnv={null}
               collectionDir={collectionDir}
               onFocus={() => setField(base + 4)}
               onChange={(keyFile) => updateProfile(index, { keyFile })}
             />
             <PassphraseInput
               title="Passphrase (optional)"
-              description="Optional. Use $VARNAME for an environment value."
+              description="Stored securely and revealed only while focused."
               border={false}
-              value={profile.passphrase ?? ""}
-              placeholder="$MTLS_PASSPHRASE"
+              value={
+                profile.secretId ? passphrases[profile.secretId] : undefined
+              }
+              hasValue={Boolean(profile.secretId)}
+              placeholder="optional"
               focused={focused && field === base + 5}
-              activeEnv={activeEnv}
               onFocus={() => setField(base + 5)}
-              onChange={(passphrase) =>
-                updateProfile(index, { passphrase: passphrase || undefined })
+              onCommit={(passphrase) =>
+                onPassphraseChange
+                  ? onPassphraseChange(index, passphrase)
+                  : Promise.resolve(false)
               }
             />
             <RemoveCertificateButton
@@ -406,29 +412,23 @@ function PassphraseInput({
   description,
   border,
   value,
+  hasValue,
   placeholder,
   focused,
-  activeEnv,
   onFocus,
-  onChange,
+  onCommit,
 }: {
   title: string
   description: string
   border: boolean
-  value: string
+  value?: string
+  hasValue?: boolean
   placeholder: string
   focused: boolean
-  activeEnv: Environment | null
   onFocus: () => void
-  onChange: (value: string) => void
+  onCommit: (value: string) => Promise<boolean>
 }) {
-  const [draft, setDraft] = useState(value)
   const [error, setError] = useState<string>()
-
-  useEffect(() => {
-    setDraft(value)
-    setError(undefined)
-  }, [focused, value])
 
   return (
     <SettingsField
@@ -438,26 +438,14 @@ function PassphraseInput({
       border={border}
       active={focused}
     >
-      <VarInput
-        value={draft}
-        env={activeEnv}
-        isEditing
-        isFocused={focused}
-        onChange={(next) => {
-          setDraft(next)
-          if (next === "" || isVariableReference(next)) {
-            setError(undefined)
-            onChange(next)
-          } else {
-            setError("Use an exact $VARNAME reference; literals are not saved.")
-          }
-        }}
+      <SecretInput
+        value={value}
+        hasValue={hasValue}
+        focused={focused}
         onFocus={onFocus}
+        onCommit={onCommit}
+        onError={setError}
         placeholder={placeholder}
-        backgroundColor="transparent"
-        focusedBackgroundColor="transparent"
-        paddingX={0}
-        style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}
       />
     </SettingsField>
   )
@@ -623,7 +611,6 @@ function PathInput({
   value,
   placeholder,
   focused,
-  activeEnv,
   collectionDir,
   pathCompletion = true,
   onFocus,
@@ -635,7 +622,6 @@ function PathInput({
   value: string
   placeholder: string
   focused: boolean
-  activeEnv: Environment | null
   collectionDir: string
   pathCompletion?: boolean
   onFocus: () => void
@@ -650,7 +636,7 @@ function PathInput({
     >
       <VarInput
         value={value}
-        env={activeEnv}
+        env={null}
         isEditing
         isFocused={focused}
         onChange={onChange}

--- a/src/ui/settings/settingsPersistence.ts
+++ b/src/ui/settings/settingsPersistence.ts
@@ -1,44 +1,68 @@
 import type { CollectionSettings } from "../../schema"
 
+export type CollectionSettingsUpdate = (
+  settings: CollectionSettings,
+) => CollectionSettings
+
 export interface CollectionSettingsPersistence {
   activeCollectionDir: { current: string }
   currentSettings: { current: CollectionSettings }
   persistedSettings: { current: CollectionSettings }
   saveChain: { current: Promise<void> }
+  pendingUpdates: { current: CollectionSettingsUpdate[] }
+}
+
+function renderPendingSettings(
+  persistence: CollectionSettingsPersistence,
+  collectionDir: string,
+  setSettings: (settings: CollectionSettings) => void,
+): void {
+  if (persistence.activeCollectionDir.current !== collectionDir) return
+  const settings = persistence.pendingUpdates.current.reduce(
+    (current, update) => update(current),
+    persistence.persistedSettings.current,
+  )
+  persistence.currentSettings.current = settings
+  setSettings(settings)
 }
 
 export function queueCollectionSettingsSave(
   persistence: CollectionSettingsPersistence,
   collectionDir: string,
-  settings: CollectionSettings,
-  saveSettings: (dir: string, settings: CollectionSettings) => Promise<void>,
+  update: CollectionSettingsUpdate,
+  saveSettings: (
+    dir: string,
+    settings: CollectionSettings,
+  ) => Promise<void | CollectionSettings>,
   setSettings: (settings: CollectionSettings) => void,
   onError: () => void,
-  onSaved?: () => void,
-): void {
-  const save = persistence.saveChain.current.then(() =>
-    saveSettings(collectionDir, settings),
-  )
-  persistence.saveChain.current = save.catch(() => {})
-  save.then(
-    () => {
+  onSaved?: (settings: CollectionSettings) => void,
+): Promise<void> {
+  persistence.pendingUpdates.current.push(update)
+  renderPendingSettings(persistence, collectionDir, setSettings)
+
+  const save = persistence.saveChain.current.then(async () => {
+    try {
+      const current = persistence.persistedSettings.current
+      const next = update(current)
+      if (next === current) return
+      const persisted = (await saveSettings(collectionDir, next)) ?? next
       if (persistence.activeCollectionDir.current === collectionDir) {
-        persistence.persistedSettings.current = settings
+        persistence.persistedSettings.current = persisted
       }
-      if (persistence.currentSettings.current === settings) {
-        onSaved?.()
-      }
-    },
-    () => {
-      if (
-        persistence.activeCollectionDir.current === collectionDir &&
-        persistence.currentSettings.current === settings
-      ) {
-        persistence.currentSettings.current =
-          persistence.persistedSettings.current
-        setSettings(persistence.persistedSettings.current)
-      }
+    } catch (error) {
       onError()
-    },
-  )
+      throw error
+    } finally {
+      const index = persistence.pendingUpdates.current.indexOf(update)
+      if (index !== -1) persistence.pendingUpdates.current.splice(index, 1)
+      renderPendingSettings(persistence, collectionDir, setSettings)
+    }
+
+    if (persistence.pendingUpdates.current.length === 0) {
+      onSaved?.(persistence.persistedSettings.current)
+    }
+  })
+  persistence.saveChain.current = save.catch(() => {})
+  return save
 }

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -20,8 +20,12 @@ export function buildTimelineEntry(
   result: SendCompleteResult,
   envName?: string,
   environment?: Environment | null,
+  settingsSecrets: string[] = [],
 ): TimelineEntry {
-  const secretValues = environmentSecretValues(environment)
+  const secretValues = [
+    ...environmentSecretValues(environment),
+    ...settingsSecrets,
+  ]
   const redact = (value: string) => redactKnownSecrets(value, secretValues)
   const resolvePublicVars = (value: string) =>
     environment

--- a/tests/filestore.test.ts
+++ b/tests/filestore.test.ts
@@ -581,13 +581,13 @@ describe("filestore.loadSettings", () => {
   it("reads a collection proxy override", async () => {
     await writeFile(
       join(dir, "settings.yml"),
-      "proxy:\n  mode: custom\n  url: http://$PROXY@proxy.test:8080\n  bypass:\n    - localhost\n",
+      "proxy:\n  mode: custom\n  url: http://proxy.test:8080\n  bypass:\n    - localhost\n",
       "utf8",
     )
     expect(await loadSettings(dir)).toEqual({
       proxy: {
         mode: "custom",
-        url: "http://$PROXY@proxy.test:8080",
+        url: "http://proxy.test:8080",
         bypass: ["localhost"],
       },
     })
@@ -644,6 +644,34 @@ describe("filestore.saveSettings", () => {
     expect(await loadSettings(dir)).toEqual({ proxy: { mode: "off" } })
   })
 
+  it("round-trips proxy authentication metadata without credentials", async () => {
+    await saveSettings(dir, {
+      proxy: {
+        mode: "custom",
+        url: "http://proxy.test:8080",
+        auth: true,
+      },
+    })
+    const raw = await readFile(join(dir, "settings.yml"), "utf8")
+    expect(raw).toContain("auth: true")
+    expect(await loadSettings(dir)).toEqual({
+      proxy: {
+        mode: "custom",
+        url: "http://proxy.test:8080",
+        auth: true,
+      },
+    })
+    await expect(
+      saveSettings(dir, {
+        proxy: {
+          mode: "custom",
+          url: "http://must-not-persist:secret@proxy.test:8080",
+          auth: true,
+        },
+      }),
+    ).rejects.toThrow("Proxy URL cannot contain credentials")
+  })
+
   it("writes minimal file when environment is undefined", async () => {
     await saveSettings(dir, {})
     const content = await readFile(join(dir, "settings.yml"), "utf8")
@@ -676,12 +704,12 @@ describe("filestore.saveSettings", () => {
               host: "api.example.com",
               certFile: "client.pem",
               keyFile: "key.pem",
-              passphrase: "literal-secret",
+              secretId: "not-a-uuid",
             },
           ],
         },
       }),
-    ).rejects.toThrow("must be an exact $VARNAME reference")
+    ).rejects.toThrow("must be a UUID")
 
     expect(await readFile(join(dir, "settings.yml"), "utf8")).toBe(
       "environment: old\n",

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -18,12 +18,14 @@ import {
 import { collection as collectionCommand } from "../../src/app/commands/automation"
 import { env } from "../../src/env"
 import { executor } from "../../src/requests"
+import { setSecretBackendForTests, type SecretBackend } from "../../src/secrets"
 
 let dir: string
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "noodle-automation-"))
 })
 afterEach(async () => {
+  setSecretBackendForTests(undefined)
   await rm(dir, { recursive: true, force: true })
 })
 
@@ -382,6 +384,82 @@ describe("automation services", () => {
           bypass: [],
         },
         { kind: "direct", source: "cli" },
+      ])
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("does not read authenticated proxy secrets when --noproxy wins", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "proxy:\n  mode: custom\n  url: http://proxy.test:8080\n  auth: true\n",
+    )
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\n",
+    )
+    const unavailable: SecretBackend = {
+      get: async () => {
+        throw new Error("keychain unavailable")
+      },
+      set: async () => {},
+      delete: async () => false,
+    }
+    setSecretBackendForTests(unavailable)
+    const send = executor.send
+    const policies: unknown[] = []
+    executor.send = async (_request, options) => {
+      policies.push(options?.proxyPolicy)
+      return { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 1 }
+    }
+    try {
+      await collectionRun(dir, undefined, undefined, true)
+      expect(policies).toEqual([{ kind: "direct", source: "cli" }])
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("loads credentials only for the selected collection proxy", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "collection_id: 11111111-1111-4111-8111-111111111111\nproxy:\n  mode: custom\n  url: http://proxy.test:8080\n  auth: true\n",
+    )
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\n",
+    )
+    const reads: string[] = []
+    setSecretBackendForTests({
+      get: async ({ name }) => {
+        reads.push(name)
+        return name.endsWith("username") ? "alice" : "secret"
+      },
+      set: async () => {},
+      delete: async () => false,
+    })
+    const send = executor.send
+    const policies: unknown[] = []
+    executor.send = async (_request, options) => {
+      policies.push(options?.proxyPolicy)
+      return { status: 200, statusText: "OK", headers: {}, body: "", timeMs: 1 }
+    }
+    try {
+      await collectionRun(dir)
+      expect(reads.sort()).toEqual([
+        "11111111-1111-4111-8111-111111111111:settings:proxy:password",
+        "11111111-1111-4111-8111-111111111111:settings:proxy:username",
+      ])
+      expect(policies).toEqual([
+        {
+          kind: "custom",
+          source: "collection",
+          url: "http://proxy.test:8080",
+          bypass: [],
+          auth: true,
+          credentials: { username: "alice", password: "secret" },
+        },
       ])
     } finally {
       executor.send = send

--- a/tests/integration/tls-loopback.test.ts
+++ b/tests/integration/tls-loopback.test.ts
@@ -89,8 +89,12 @@ async function startConnectProxy(): Promise<{
   }
 }
 
-function tlsPolicy(settings?: CollectionTlsSettings, insecure = false) {
-  return { collectionDir: FIXTURES, settings, insecure }
+function tlsPolicy(
+  settings?: CollectionTlsSettings,
+  insecure = false,
+  passphrases?: Record<string, string>,
+) {
+  return { collectionDir: FIXTURES, settings, insecure, passphrases }
 }
 
 describe("TLS loopback integration", () => {
@@ -144,23 +148,24 @@ describe("TLS loopback integration", () => {
       }),
     ).rejects.toThrow("requests.send: fetch failed")
 
+    const secretId = "123e4567-e89b-42d3-a456-426614174000"
     const response = await send(request(url), {
-      environment: {
-        name: "test",
-        vars: { CLIENT_KEY_PASSPHRASE: "test-passphrase" },
-      },
-      tlsPolicy: tlsPolicy({
-        caBundle: "ca.pem",
-        clientCertificates: [
-          {
-            host: "localhost",
-            port: mtlsServer.port,
-            certFile: "client.pem",
-            keyFile: "client-encrypted-key.pem",
-            passphrase: "$CLIENT_KEY_PASSPHRASE",
-          },
-        ],
-      }),
+      tlsPolicy: tlsPolicy(
+        {
+          caBundle: "ca.pem",
+          clientCertificates: [
+            {
+              host: "localhost",
+              port: mtlsServer.port,
+              certFile: "client.pem",
+              keyFile: "client-encrypted-key.pem",
+              secretId,
+            },
+          ],
+        },
+        false,
+        { [secretId]: "test-passphrase" },
+      ),
     })
     expect(response.body).toBe("mutual")
   })

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -13,9 +13,18 @@ import {
 } from "../src/app/services"
 import {
   SECRET_SERVICE,
+  appSettingSecretAccount,
+  applySettingsSecretTransaction,
+  collectionSettingSecretAccount,
+  deleteAppSettingSecret,
+  deleteCollectionSettingSecret,
   deleteStoredSecret,
+  getAppSettingSecret,
+  getCollectionSettingSecret,
   secretAccount,
   setSecretBackendForTests,
+  setAppSettingSecret,
+  setCollectionSettingSecret,
   setStoredSecret,
   type SecretBackend,
 } from "../src/secrets"
@@ -51,6 +60,87 @@ afterEach(() => {
 })
 
 describe("secret storage", () => {
+  it("isolates app, collection, proxy, and TLS setting accounts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-settings-secret-"))
+    const collectionId = "123e4567-e89b-42d3-a456-426614174000"
+    const tlsId = "223e4567-e89b-42d3-a456-426614174000"
+    await saveSettings(root, { collectionId })
+    const backend = memoryBackend()
+    setSecretBackendForTests(backend)
+
+    await setAppSettingSecret("proxy:username", "app-user")
+    await setCollectionSettingSecret(root, "proxy:username", "collection-user")
+    await setCollectionSettingSecret(
+      root,
+      `tls:${tlsId}:passphrase`,
+      "tls-secret",
+    )
+
+    expect(await getAppSettingSecret("proxy:username")).toBe("app-user")
+    expect(await getCollectionSettingSecret(root, "proxy:username")).toBe(
+      "collection-user",
+    )
+    expect(
+      await getCollectionSettingSecret(root, `tls:${tlsId}:passphrase`),
+    ).toBe("tls-secret")
+    expect(appSettingSecretAccount("proxy:username")).toBe(
+      "app:settings:proxy:username",
+    )
+    expect(collectionSettingSecretAccount(collectionId, "proxy:password")).toBe(
+      `${collectionId}:settings:proxy:password`,
+    )
+  })
+
+  it("sets, replaces, deletes, and reports missing setting secrets", async () => {
+    const root = await mkdtemp(join(tmpdir(), "noodle-settings-secret-"))
+    await saveSettings(root, {
+      collectionId: "123e4567-e89b-42d3-a456-426614174000",
+    })
+    setSecretBackendForTests(memoryBackend())
+
+    expect(await getAppSettingSecret("proxy:password")).toBeNull()
+    await setAppSettingSecret("proxy:password", "first")
+    await setAppSettingSecret("proxy:password", "second")
+    expect(await getAppSettingSecret("proxy:password")).toBe("second")
+    expect(await deleteAppSettingSecret("proxy:password")).toBe(true)
+    expect(await deleteAppSettingSecret("proxy:password")).toBe(false)
+
+    await setCollectionSettingSecret(root, "proxy:password", "value")
+    expect(await deleteCollectionSettingSecret(root, "proxy:password")).toBe(
+      true,
+    )
+  })
+
+  it("restores setting secrets when persistence fails", async () => {
+    const backend = memoryBackend()
+    setSecretBackendForTests(backend)
+    await setAppSettingSecret("proxy:username", "old-user")
+    await setAppSettingSecret("proxy:password", "old-password")
+
+    await expect(
+      applySettingsSecretTransaction(
+        [
+          {
+            get: () => getAppSettingSecret("proxy:username"),
+            set: (value) => setAppSettingSecret("proxy:username", value),
+            delete: () => deleteAppSettingSecret("proxy:username"),
+            value: "new-user",
+          },
+          {
+            get: () => getAppSettingSecret("proxy:password"),
+            set: (value) => setAppSettingSecret("proxy:password", value),
+            delete: () => deleteAppSettingSecret("proxy:password"),
+          },
+        ],
+        () => {
+          throw new Error("disk full")
+        },
+      ),
+    ).rejects.toThrow("disk full")
+    expect(await getAppSettingSecret("proxy:username")).toBe("old-user")
+    expect(await getAppSettingSecret("proxy:password")).toBe("old-password")
+  })
+
   it("namespaces credentials and resolves process values before the keychain", async () => {
     const root = await mkdtemp(join(tmpdir(), "noodle-secret-"))
     const directory = join(root, ".environments")
@@ -156,6 +246,9 @@ describe("secret storage", () => {
     })
     await expect(env.loadEnvironment(directory, "dev")).rejects.toThrow(
       /secret read failed: backend unavailable.*credential|secret read failed: backend unavailable.*Secret Service/,
+    )
+    await expect(getAppSettingSecret("proxy:username")).rejects.toThrow(
+      "secret read failed: backend unavailable",
     )
   })
 })

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -141,6 +141,41 @@ describe("secret storage", () => {
     expect(await getAppSettingSecret("proxy:password")).toBe("old-password")
   })
 
+  it("preserves the update and rollback failures when both fail", async () => {
+    const updateError = new Error("disk full")
+    const rollbackError = new Error("credential store offline")
+    let error: Error | undefined
+
+    try {
+      await applySettingsSecretTransaction(
+        [
+          {
+            get: async () => "old-secret",
+            set: async (value) => {
+              if (value === "old-secret") throw rollbackError
+            },
+            delete: async () => false,
+            value: "new-secret",
+          },
+        ],
+        () => {
+          throw updateError
+        },
+      )
+    } catch (caught) {
+      error = caught as Error
+    }
+
+    expect(error?.message).toContain("disk full")
+    expect(error?.message).toContain("credential store offline")
+    expect(error).toBeInstanceOf(AggregateError)
+    expect((error as AggregateError).errors).toEqual([
+      updateError,
+      rollbackError,
+    ])
+    expect(error?.cause).toBe(rollbackError)
+  })
+
   it("namespaces credentials and resolves process values before the keychain", async () => {
     const root = await mkdtemp(join(tmpdir(), "noodle-secret-"))
     const directory = join(root, ".environments")

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -884,4 +884,28 @@ describe("buildTimelineEntry", () => {
     expect(entry.request.body).toBeUndefined()
     expect(entry.response?.size).toBe(0)
   })
+
+  it("redacts loaded settings secrets from timeline errors", () => {
+    const req = {
+      id: "settings-secret",
+      name: "Settings secret",
+      method: "GET" as const,
+      url: "https://api.example.com",
+      headers: {},
+      params: [],
+      timeout: 0,
+    }
+    const entry = buildTimelineEntry(
+      req,
+      {
+        status: "error" as const,
+        error: new Error("proxy rejected bun-proxy-password"),
+        request: req,
+      },
+      undefined,
+      undefined,
+      ["bun-proxy-password"],
+    )
+    expect(entry.error?.message).toBe("proxy rejected [REDACTED]")
+  })
 })

--- a/tests/unit/ProxySettingsForm.test.tsx
+++ b/tests/unit/ProxySettingsForm.test.tsx
@@ -315,6 +315,47 @@ describe("ProxySettingsForm", () => {
     cleanup()
   })
 
+  it("does not persist an empty username while authentication is enabled", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const commits: ProxyCredentials[] = []
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsForm
+            scope="app"
+            focused
+            proxy={{
+              mode: "custom",
+              url: "https://proxy.test:8443",
+              auth: true,
+            }}
+            credentials={{ username: "alice" }}
+            onChange={() => true}
+            onCredentialsChange={async (credentials) => {
+              commits.push(credentials)
+              return true
+            }}
+            onAuthDisable={async () => true}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 7; index++) {
+      await act(async () => host.press("down"))
+    }
+    for (let index = 0; index < 5; index++) {
+      await act(async () => mockInput.pressBackspace())
+    }
+    await act(async () => host.press("down"))
+    await renderOnce()
+
+    expect(commits).toEqual([])
+    expect(captureCharFrame()).toContain("Could not save secret")
+    cleanup()
+  })
+
   it("disables proxy authentication with Space", async () => {
     const { keymap, host, cleanup } = setupKeymap()
 
@@ -464,6 +505,10 @@ describe("ProxySettingsForm", () => {
     const firstSave = new Promise<void>((resolve) => {
       finishFirstSave = resolve
     })
+    let markSecondSaveStarted = () => {}
+    const secondSaveStarted = new Promise<void>((resolve) => {
+      markSecondSaveStarted = resolve
+    })
     const commits: ProxyCredentials[] = []
 
     function Harness() {
@@ -485,6 +530,7 @@ describe("ProxySettingsForm", () => {
           onCredentialsChange={async (next) => {
             commits.push(next)
             if (commits.length === 1) await firstSave
+            else markSecondSaveStarted()
             setCredentials(next)
             return true
           }}
@@ -513,8 +559,7 @@ describe("ProxySettingsForm", () => {
     expect(commits).toEqual([{ username: "alice2", password: "secret" }])
     await act(async () => {
       finishFirstSave()
-      await firstSave
-      await Promise.resolve()
+      await secondSaveStarted
     })
     expect(commits).toEqual([
       { username: "alice2", password: "secret" },
@@ -528,6 +573,10 @@ describe("ProxySettingsForm", () => {
     let finishFirstSave = () => {}
     const firstSave = new Promise<void>((resolve) => {
       finishFirstSave = resolve
+    })
+    let markSecondSaveStarted = () => {}
+    const secondSaveStarted = new Promise<void>((resolve) => {
+      markSecondSaveStarted = resolve
     })
     const commits: ProxyCredentials[] = []
 
@@ -550,6 +599,7 @@ describe("ProxySettingsForm", () => {
           onCredentialsChange={async (next) => {
             commits.push(next)
             if (commits.length === 1) await firstSave
+            else markSecondSaveStarted()
             setCredentials(next)
             return true
           }}
@@ -578,8 +628,7 @@ describe("ProxySettingsForm", () => {
     expect(commits).toEqual([{ username: "alice", password: "secret2" }])
     await act(async () => {
       finishFirstSave()
-      await firstSave
-      await Promise.resolve()
+      await secondSaveStarted
     })
     expect(commits).toEqual([
       { username: "alice", password: "secret2" },

--- a/tests/unit/ProxySettingsForm.test.tsx
+++ b/tests/unit/ProxySettingsForm.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { type BoxRenderable } from "@opentui/core"
+import { MouseButtons } from "@opentui/core/testing"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerDefaultKeys,
@@ -11,6 +12,7 @@ import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { ProxySettingsForm } from "../../src/ui/settings/ProxySettingsForm"
+import type { AppProxySettings, ProxyCredentials } from "../../src/schema"
 
 const testRender = createTestRender()
 
@@ -39,7 +41,6 @@ describe("ProxySettingsForm", () => {
             scope="app"
             focused
             proxy={{ mode: "custom", url: "http://proxy.test:8080" }}
-            activeEnv={null}
             onChange={() => true}
           />
         </ThemeProvider>
@@ -72,7 +73,6 @@ describe("ProxySettingsForm", () => {
             scope="app"
             focused
             proxy={{ mode: "system" }}
-            activeEnv={null}
             onChange={() => true}
           />
         </ThemeProvider>
@@ -112,10 +112,11 @@ describe("ProxySettingsForm", () => {
             focused
             proxy={{
               mode: "custom",
-              url: "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
+              url: "https://proxy.test:8443",
               bypass: ["localhost"],
+              auth: true,
             }}
-            activeEnv={null}
+            credentials={{ username: "alice", password: "secret" }}
             onChange={() => true}
           />
         </ThemeProvider>
@@ -136,77 +137,14 @@ describe("ProxySettingsForm", () => {
     expect(frame).toContain("Protocol used to connect")
     expect(frame).toContain("Hostname or IP address")
     expect(frame).toContain("Optional. Uses the protocol default")
-    expect(frame).toContain(
-      "Optional. Enter credentials directly (stored in app config) or use",
-    )
-    expect(frame).toContain("Required for authentication")
-    expect(frame).toContain("Enter a literal value or use $VARNAME")
+    expect(frame).toContain("Credentials are stored securely")
+    expect(frame).toContain("Required when proxy authentication is enabled")
     const lines = frame.split("\n")
     expect(
       lines.findIndex((line) => line.includes("Bypass hosts (optional)")),
     ).toBeLessThan(
       lines.findIndex((line) => line.includes("Proxy authentication")),
     )
-    cleanup()
-  })
-
-  it("describes optional collection credentials and where literals are stored", async () => {
-    const { keymap, cleanup } = setupKeymap()
-    const { renderOnce, captureCharFrame } = await testRender(
-      <KeymapProvider keymap={keymap}>
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ProxySettingsForm
-            scope="collection"
-            focused
-            proxy={{
-              mode: "custom",
-              url: "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
-            }}
-            activeEnv={{
-              name: "dev",
-              vars: { PROXY_USER: "alice", PROXY_PASSWORD: "secret" },
-            }}
-            onChange={() => true}
-          />
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 90, height: 30 },
-    )
-    await renderOnce()
-
-    expect(captureCharFrame()).toContain(
-      "Optional. Enter credentials directly (stored in settings.yml) or use",
-    )
-    expect(captureCharFrame()).toContain("from the active environment")
-    cleanup()
-  })
-
-  it("suggests active environment variables for an app proxy", async () => {
-    const { keymap, host, cleanup } = setupKeymap()
-    const { renderOnce, captureCharFrame, mockInput } = await testRender(
-      <KeymapProvider keymap={keymap}>
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ProxySettingsForm
-            scope="app"
-            focused
-            proxy={{ mode: "custom", url: "http://proxy.test/path" }}
-            activeEnv={{
-              name: "dev",
-              vars: { COLLECTION_PROXY_PASSWORD: "secret" },
-            }}
-            onChange={() => true}
-          />
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 90, height: 20 },
-    )
-    await renderOnce()
-    await act(async () => host.press("down"))
-    await act(async () => host.press("down"))
-    await act(async () => mockInput.typeText("$COLLECTION"))
-    await renderOnce()
-
-    expect(captureCharFrame()).toContain("$COLLECTION_PROXY_PASSWORD")
     cleanup()
   })
 
@@ -219,7 +157,6 @@ describe("ProxySettingsForm", () => {
             scope="app"
             focused
             proxy={{ mode: "custom", url: "http://proxy.test:8080" }}
-            activeEnv={null}
             onChange={() => true}
           />
         </ThemeProvider>
@@ -257,7 +194,6 @@ describe("ProxySettingsForm", () => {
             scope="collection"
             focused
             proxy={{ mode: "custom", url: "http://proxy.test/path" }}
-            activeEnv={null}
             onChange={() => true}
           />
         </ThemeProvider>
@@ -269,10 +205,10 @@ describe("ProxySettingsForm", () => {
     expect(frame).toContain("Advanced URL")
     expect(frame).toContain("Proxy URL")
     expect(frame).not.toContain("Hostname")
-    expect(frame).not.toContain("Proxy authentication")
+    expect(frame).toContain("Proxy authentication")
     expect(frame).not.toContain("Username")
     expect(frame).not.toContain("Password (optional)")
-    expect(frame).toContain("Credentials are optional")
+    expect(frame).toContain("Enter only the proxy URL here")
     cleanup()
   })
 
@@ -286,7 +222,6 @@ describe("ProxySettingsForm", () => {
             focused
             noProxy
             proxy={{ mode: "system" }}
-            activeEnv={null}
             onChange={() => true}
           />
         </ThemeProvider>
@@ -297,6 +232,422 @@ describe("ProxySettingsForm", () => {
     expect(captureCharFrame()).toContain(
       "disabled for this session by --no-proxy",
     )
+    cleanup()
+  })
+
+  it("masks stored credentials until focused and commits them on navigation", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const commits: unknown[] = []
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsForm
+            scope="app"
+            focused
+            proxy={{
+              mode: "custom",
+              url: "https://proxy.test:8443",
+              auth: true,
+            }}
+            credentials={{ username: "alice", password: "secret" }}
+            onChange={() => true}
+            onCredentialsChange={async (credentials) => {
+              commits.push(credentials)
+              return true
+            }}
+            onAuthDisable={async () => true}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Username: ******")
+    expect(captureCharFrame()).not.toContain("alice")
+    for (let index = 0; index < 7; index++) {
+      await act(async () => host.press("down"))
+    }
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Username: alice")
+    await act(async () => mockInput.typeText("2"))
+    expect(commits).toEqual([])
+    await act(async () => host.press("down"))
+    await renderOnce()
+    expect(commits).toHaveLength(1)
+    cleanup()
+  })
+
+  it("clears the required username error while a non-empty draft is visible", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsForm
+            scope="app"
+            focused
+            proxy={{
+              mode: "custom",
+              url: "https://proxy.test:8443",
+              auth: true,
+            }}
+            credentials={{}}
+            onChange={() => true}
+            onCredentialsChange={async () => true}
+            onAuthDisable={async () => true}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain(
+      "Username is required when proxy authentication is enabled",
+    )
+    for (let index = 0; index < 7; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => mockInput.typeText("alice"))
+    await renderOnce()
+    expect(captureCharFrame()).not.toContain(
+      "Username is required when proxy authentication is enabled",
+    )
+    await act(async () => host.press("escape"))
+    cleanup()
+  })
+
+  it("disables proxy authentication with Space", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+
+    function Harness() {
+      const [proxy, setProxy] = useState<AppProxySettings>({
+        mode: "custom",
+        url: "https://proxy.test:8443",
+        auth: true,
+      })
+      return (
+        <ProxySettingsForm
+          scope="app"
+          focused
+          proxy={proxy}
+          credentials={{ username: "alice" }}
+          onChange={(next) => {
+            setProxy(next as AppProxySettings)
+            return true
+          }}
+          onCredentialsChange={async () => true}
+          onAuthDisable={async () => {
+            setProxy({ mode: "custom", url: "https://proxy.test:8443" })
+            return true
+          }}
+        />
+      )
+    }
+
+    const { renderOnce, captureCharFrame, renderer, mockMouse } =
+      await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <Harness />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 90, height: 30 },
+      )
+    await renderOnce()
+    for (let index = 0; index < 6; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => host.press("space"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [ ]")
+    expect(captureCharFrame()).not.toContain("Username:")
+    const authRow = renderer.root.findDescendantById(
+      "settings-proxy-auth",
+    ) as BoxRenderable
+    await act(async () => {
+      await mockMouse.pressDown(
+        authRow.screenX + 1,
+        authRow.screenY,
+        MouseButtons.LEFT,
+      )
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [x]")
+    cleanup()
+  })
+
+  it("disables proxy authentication with Return", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+
+    function Harness() {
+      const [proxy, setProxy] = useState<AppProxySettings>({
+        mode: "custom",
+        url: "https://proxy.test:8443",
+        auth: true,
+      })
+      return (
+        <ProxySettingsForm
+          scope="app"
+          focused
+          proxy={proxy}
+          credentials={{ username: "alice" }}
+          onChange={(next) => {
+            setProxy(next as AppProxySettings)
+            return true
+          }}
+          onCredentialsChange={async () => true}
+          onAuthDisable={async () => {
+            setProxy({ mode: "custom", url: "https://proxy.test:8443" })
+            return true
+          }}
+        />
+      )
+    }
+
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 30 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 6; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => host.press("return"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [ ]")
+    cleanup()
+  })
+
+  it("disables local authentication when the invalid proxy was never persisted", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let disableCalls = 0
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ProxySettingsForm
+            scope="app"
+            focused
+            proxy={{ mode: "system" }}
+            onChange={() => true}
+            onAuthDisable={async () => {
+              disableCalls++
+              return false
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 30 },
+    )
+    await renderOnce()
+    await act(async () => host.press("return"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    for (let index = 0; index < 6; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => host.press("space"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [x]")
+    await act(async () => host.press("space"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [ ]")
+    expect(disableCalls).toBe(0)
+    cleanup()
+  })
+
+  it("merges a password commit behind a pending username save", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let finishFirstSave = () => {}
+    const firstSave = new Promise<void>((resolve) => {
+      finishFirstSave = resolve
+    })
+    const commits: ProxyCredentials[] = []
+
+    function Harness() {
+      const [credentials, setCredentials] = useState<ProxyCredentials>({
+        username: "alice",
+        password: "secret",
+      })
+      return (
+        <ProxySettingsForm
+          scope="app"
+          focused
+          proxy={{
+            mode: "custom",
+            url: "https://proxy.test:8443",
+            auth: true,
+          }}
+          credentials={credentials}
+          onChange={() => true}
+          onCredentialsChange={async (next) => {
+            commits.push(next)
+            if (commits.length === 1) await firstSave
+            setCredentials(next)
+            return true
+          }}
+          onAuthDisable={async () => true}
+        />
+      )
+    }
+
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 7; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => mockInput.typeText("2"))
+    await act(async () => host.press("down"))
+    await act(async () => mockInput.typeText("2"))
+    await act(async () => host.press("up"))
+
+    expect(commits).toEqual([{ username: "alice2", password: "secret" }])
+    await act(async () => {
+      finishFirstSave()
+      await firstSave
+      await Promise.resolve()
+    })
+    expect(commits).toEqual([
+      { username: "alice2", password: "secret" },
+      { username: "alice2", password: "secret2" },
+    ])
+    cleanup()
+  })
+
+  it("merges a username commit behind a pending password save", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let finishFirstSave = () => {}
+    const firstSave = new Promise<void>((resolve) => {
+      finishFirstSave = resolve
+    })
+    const commits: ProxyCredentials[] = []
+
+    function Harness() {
+      const [credentials, setCredentials] = useState<ProxyCredentials>({
+        username: "alice",
+        password: "secret",
+      })
+      return (
+        <ProxySettingsForm
+          scope="app"
+          focused
+          proxy={{
+            mode: "custom",
+            url: "https://proxy.test:8443",
+            auth: true,
+          }}
+          credentials={credentials}
+          onChange={() => true}
+          onCredentialsChange={async (next) => {
+            commits.push(next)
+            if (commits.length === 1) await firstSave
+            setCredentials(next)
+            return true
+          }}
+          onAuthDisable={async () => true}
+        />
+      )
+    }
+
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 8; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => mockInput.typeText("2"))
+    await act(async () => host.press("up"))
+    await act(async () => mockInput.typeText("2"))
+    await act(async () => host.press("down"))
+
+    expect(commits).toEqual([{ username: "alice", password: "secret2" }])
+    await act(async () => {
+      finishFirstSave()
+      await firstSave
+      await Promise.resolve()
+    })
+    expect(commits).toEqual([
+      { username: "alice", password: "secret2" },
+      { username: "alice2", password: "secret2" },
+    ])
+    cleanup()
+  })
+
+  it("keeps authentication disabled when a username commit is still pending", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let finishCredentialSave = () => {}
+    const credentialSave = new Promise<void>((resolve) => {
+      finishCredentialSave = resolve
+    })
+
+    function Harness() {
+      const [proxy, setProxy] = useState<AppProxySettings>({
+        mode: "custom",
+        url: "https://proxy.test:8443",
+        auth: true,
+      })
+      return (
+        <ProxySettingsForm
+          scope="app"
+          focused
+          proxy={proxy}
+          credentials={{}}
+          onChange={(next) => {
+            setProxy(next as AppProxySettings)
+            return true
+          }}
+          onCredentialsChange={async () => {
+            await credentialSave
+            setProxy({
+              mode: "custom",
+              url: "https://proxy.test:8443",
+              auth: true,
+            })
+            return true
+          }}
+          onAuthDisable={async () => {
+            setProxy({ mode: "custom", url: "https://proxy.test:8443" })
+            return true
+          }}
+        />
+      )
+    }
+
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 30 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 7; index++) {
+      await act(async () => host.press("down"))
+    }
+    await act(async () => mockInput.typeText("alice"))
+    await act(async () => host.press("up"))
+    await act(async () => host.press("space"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [ ]")
+    await act(async () => finishCredentialSave())
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Proxy authentication (optional): [ ]")
     cleanup()
   })
 })

--- a/tests/unit/SecretInput.test.tsx
+++ b/tests/unit/SecretInput.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test"
+import { act, useState } from "react"
+import {
+  registerDefaultKeys,
+  registerEnabledFields,
+} from "@opentui/keymap/addons"
+import { KeymapProvider, type KeymapProviderProps } from "@opentui/keymap/react"
+import { createTestKeymap } from "@opentui/keymap/testing"
+import { createTestRender } from "../testRender"
+import { SecretInput } from "../../src/ui/settings/SecretInput"
+import { ThemeProvider } from "../../src/ui/theme"
+
+const testRender = createTestRender()
+
+function setupKeymap() {
+  const { keymap, host, cleanup: hostCleanup } = createTestKeymap()
+  const disposeEnabled = registerEnabledFields(keymap)
+  const disposeKeys = registerDefaultKeys(keymap)
+  return {
+    keymap: keymap as unknown as KeymapProviderProps["keymap"],
+    host,
+    cleanup: () => {
+      disposeEnabled()
+      disposeKeys()
+      hostCleanup()
+    },
+  }
+}
+
+describe("SecretInput", () => {
+  it("commits a dirty draft when directly unmounted", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const commits: string[] = []
+    let hide = () => {}
+
+    function Harness() {
+      const [visible, setVisible] = useState(true)
+      hide = () => setVisible(false)
+      return visible ? (
+        <SecretInput
+          focused
+          placeholder="secret"
+          onFocus={() => {}}
+          onCommit={async (value) => {
+            commits.push(value)
+            return true
+          }}
+        />
+      ) : null
+    }
+
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 30, height: 3 },
+    )
+    await renderOnce()
+    await act(async () => mockInput.typeText("secret"))
+    await act(async () => hide())
+    await Promise.resolve()
+    expect(commits).toEqual(["secret"])
+    cleanup()
+  })
+
+  it("does not commit after Escape and unmount", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const commits: string[] = []
+    let hide = () => {}
+
+    function Harness() {
+      const [visible, setVisible] = useState(true)
+      hide = () => setVisible(false)
+      return visible ? (
+        <SecretInput
+          focused
+          placeholder="secret"
+          onFocus={() => {}}
+          onCommit={async (value) => {
+            commits.push(value)
+            return true
+          }}
+        />
+      ) : null
+    }
+
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 30, height: 3 },
+    )
+    await renderOnce()
+    await act(async () => mockInput.typeText("secret"))
+    await act(async () => host.press("escape"))
+    await act(async () => hide())
+    await Promise.resolve()
+    expect(commits).toEqual([])
+    cleanup()
+  })
+
+  it("does not commit twice when Return is followed by unmount", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const commits: string[] = []
+    let hide = () => {}
+
+    function Harness() {
+      const [visible, setVisible] = useState(true)
+      hide = () => setVisible(false)
+      return visible ? (
+        <SecretInput
+          focused
+          placeholder="secret"
+          onFocus={() => {}}
+          onCommit={async (value) => {
+            commits.push(value)
+            return true
+          }}
+        />
+      ) : null
+    }
+
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 30, height: 3 },
+    )
+    await renderOnce()
+    await act(async () => mockInput.typeText("secret"))
+    await act(async () => host.press("return"))
+    await act(async () => hide())
+    await Promise.resolve()
+    expect(commits).toEqual(["secret"])
+    cleanup()
+  })
+})

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -94,12 +94,12 @@ function Harness({
       layout="stacked"
       confirmUndoAll
       appProxy={appProxy}
+      appProxyCredentials={{ username: "alice", password: "secret" }}
       collectionProxy={{ mode: "inherit" }}
       collectionName={collectionSettings.name}
       collectionDescription={collectionSettings.description}
       timelineMaxEntries={collectionSettings.timelineMaxEntries}
       noProxy={false}
-      activeEnv={{ name: "development", vars: {} }}
       envNames={["development", "production"]}
       activeEnvName="development"
       keybinds={bindingDefaults()}
@@ -711,7 +711,8 @@ describe("SettingsView", () => {
             initialFocus="settings-content"
             appProxy={{
               mode: "custom",
-              url: "http://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8080",
+              url: "http://proxy.test:8080",
+              auth: true,
             }}
           />
         </ThemeProvider>

--- a/tests/unit/TlsSettingsForm.test.tsx
+++ b/tests/unit/TlsSettingsForm.test.tsx
@@ -375,6 +375,9 @@ describe("TlsSettingsForm", () => {
     await renderOnce()
     expect(captureCharFrame()).toContain("******")
     expect(captureCharFrame()).not.toContain("new-secret")
+    await act(async () => host.press("up"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("old-secret")
     cleanup()
   })
 

--- a/tests/unit/TlsSettingsForm.test.tsx
+++ b/tests/unit/TlsSettingsForm.test.tsx
@@ -15,6 +15,7 @@ import { auraTheme } from "../../src/ui/theme-data"
 import { TlsSettingsForm } from "../../src/ui/settings/TlsSettingsForm"
 
 const testRender = createTestRender()
+const TLS_SECRET_ID = "123e4567-e89b-42d3-a456-426614174000"
 
 function setupKeymap() {
   const { keymap, host, cleanup: hostCleanup } = createTestKeymap()
@@ -42,7 +43,6 @@ describe("TlsSettingsForm", () => {
             focused
             insecure={false}
             collectionDir="/tmp/collection"
-            activeEnv={null}
             settings={{ verify: true }}
             onChange={() => true}
             onExit={() => {}}
@@ -78,7 +78,7 @@ describe("TlsSettingsForm", () => {
               focused
               insecure={false}
               collectionDir="/tmp/collection"
-              activeEnv={{ name: "dev", vars: { PASS: "secret" } }}
+              passphrases={{ [TLS_SECRET_ID]: "secret" }}
               settings={{
                 verify: true,
                 caBundle: "./certs/ca.pem",
@@ -88,7 +88,7 @@ describe("TlsSettingsForm", () => {
                     port: 8443,
                     certFile: "./certs/client.pem",
                     keyFile: "./certs/key.pem",
-                    passphrase: "$PASS",
+                    secretId: TLS_SECRET_ID,
                   },
                 ],
               }}
@@ -110,6 +110,7 @@ describe("TlsSettingsForm", () => {
     expect(frame).toContain("Certificate chain")
     expect(frame).toContain("Private key")
     expect(frame).not.toContain("secret")
+    expect(frame).toContain("******")
     expect(frame).toContain("Exact host and port match")
     expect(frame).toContain("Bare hostname matched exactly")
     expect(frame).toContain("Private key paired with the certificate chain")
@@ -158,7 +159,6 @@ describe("TlsSettingsForm", () => {
             focused
             insecure={false}
             collectionDir="/tmp/collection"
-            activeEnv={null}
             settings={{ verify: true, clientCertificates: [] }}
             onChange={() => true}
             onExit={() => {}}
@@ -185,7 +185,6 @@ describe("TlsSettingsForm", () => {
             focused
             insecure={false}
             collectionDir="/tmp/collection"
-            activeEnv={null}
             settings={{
               clientCertificates: [
                 {
@@ -234,7 +233,6 @@ describe("TlsSettingsForm", () => {
             focused
             insecure={false}
             collectionDir="/tmp/collection"
-            activeEnv={null}
             onChange={(settings) => {
               changes.push(settings)
               return true
@@ -261,7 +259,6 @@ describe("TlsSettingsForm", () => {
             focused
             insecure
             collectionDir="/tmp/collection"
-            activeEnv={null}
             settings={{ verify: true }}
             onChange={() => true}
             onExit={() => {}}
@@ -277,7 +274,7 @@ describe("TlsSettingsForm", () => {
     cleanup()
   })
 
-  it("keeps invalid passphrases local and reverts them on blur", async () => {
+  it("keeps passphrase edits local until blur", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     const changes: unknown[] = []
     const { renderOnce, captureCharFrame, mockInput } = await testRender(
@@ -287,7 +284,6 @@ describe("TlsSettingsForm", () => {
             focused
             insecure={false}
             collectionDir="/tmp/collection"
-            activeEnv={{ name: "dev", vars: { PASS: "environment-secret" } }}
             settings={{
               clientCertificates: [
                 {
@@ -297,8 +293,9 @@ describe("TlsSettingsForm", () => {
                 },
               ],
             }}
-            onChange={(settings) => {
-              changes.push(settings)
+            onChange={() => true}
+            onPassphraseChange={async (_index, value) => {
+              changes.push(value)
               return true
             }}
             onExit={() => {}}
@@ -313,19 +310,17 @@ describe("TlsSettingsForm", () => {
     }
     await act(async () => mockInput.typeText("literal-secret"))
     await renderOnce()
-    expect(captureCharFrame()).toContain(
-      "Use an exact $VARNAME reference; literals are not saved.",
-    )
+    expect(captureCharFrame()).toContain("literal-secret")
     expect(changes).toEqual([])
 
     await act(async () => host.press("down"))
     await renderOnce()
+    expect(changes).toEqual(["literal-secret"])
     expect(captureCharFrame()).not.toContain("literal-secret")
-    expect(captureCharFrame()).not.toContain("environment-secret")
     cleanup()
   })
 
-  it("restores a persisted passphrase after a focused save rolls back", async () => {
+  it("restores a persisted passphrase after a failed commit", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     const initialSettings: CollectionTlsSettings = {
       clientCertificates: [
@@ -333,27 +328,25 @@ describe("TlsSettingsForm", () => {
           host: "api.example.com",
           certFile: "client.pem",
           keyFile: "key.pem",
-          passphrase: "$OLD",
+          secretId: TLS_SECRET_ID,
         },
       ],
     }
-    let rollback = () => {}
-
     function Harness() {
       const [settings, setSettings] =
         useState<CollectionTlsSettings>(initialSettings)
-      rollback = () => setSettings(initialSettings)
       return (
         <TlsSettingsForm
           focused
           insecure={false}
           collectionDir="/tmp/collection"
-          activeEnv={null}
+          passphrases={{ [TLS_SECRET_ID]: "old-secret" }}
           settings={settings}
           onChange={(next) => {
             setSettings(next)
             return true
           }}
+          onPassphraseChange={async () => false}
           onExit={() => {}}
         />
       )
@@ -371,17 +364,111 @@ describe("TlsSettingsForm", () => {
     for (let index = 0; index < 8; index++) {
       await act(async () => host.press("down"))
     }
-    for (let index = 0; index < 4; index++) {
+    for (let index = 0; index < 10; index++) {
       await act(async () => mockInput.pressBackspace())
     }
-    await act(async () => mockInput.typeText("$NEW"))
+    await act(async () => mockInput.typeText("new-secret"))
     await renderOnce()
-    expect(captureCharFrame()).toContain("$NEW")
+    expect(captureCharFrame()).toContain("new-secret")
 
-    await act(async () => rollback())
+    await act(async () => host.press("down"))
     await renderOnce()
-    expect(captureCharFrame()).toContain("$OLD")
-    expect(captureCharFrame()).not.toContain("$NEW")
+    expect(captureCharFrame()).toContain("******")
+    expect(captureCharFrame()).not.toContain("new-secret")
+    cleanup()
+  })
+
+  it("Escape cancels a passphrase edit and remasks the old value", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const commits: string[] = []
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <TlsSettingsForm
+            focused
+            insecure={false}
+            collectionDir="/tmp/collection"
+            passphrases={{ [TLS_SECRET_ID]: "old-secret" }}
+            settings={{
+              clientCertificates: [
+                {
+                  host: "api.example.com",
+                  certFile: "client.pem",
+                  keyFile: "key.pem",
+                  secretId: TLS_SECRET_ID,
+                },
+              ],
+            }}
+            onChange={() => true}
+            onPassphraseChange={async (_index, value) => {
+              commits.push(value)
+              return true
+            }}
+            onExit={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 8; index++) {
+      await act(async () => host.press("down"))
+    }
+    await renderOnce()
+    expect(captureCharFrame()).toContain("old-secret")
+    await act(async () => mockInput.typeText("edited"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("edited")
+    await act(async () => host.press("escape"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("******")
+    expect(captureCharFrame()).not.toContain("edited")
+    expect(commits).toEqual([])
+    cleanup()
+  })
+
+  it("commits an empty passphrase as a deletion", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const commits: string[] = []
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <TlsSettingsForm
+            focused
+            insecure={false}
+            collectionDir="/tmp/collection"
+            passphrases={{ [TLS_SECRET_ID]: "secret" }}
+            settings={{
+              clientCertificates: [
+                {
+                  host: "api.example.com",
+                  certFile: "client.pem",
+                  keyFile: "key.pem",
+                  secretId: TLS_SECRET_ID,
+                },
+              ],
+            }}
+            onChange={() => true}
+            onPassphraseChange={async (_index, value) => {
+              commits.push(value)
+              return true
+            }}
+            onExit={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 34 },
+    )
+    await renderOnce()
+    for (let index = 0; index < 8; index++) {
+      await act(async () => host.press("down"))
+    }
+    for (let index = 0; index < 6; index++) {
+      await act(async () => mockInput.pressBackspace())
+    }
+    await act(async () => host.press("down"))
+    await renderOnce()
+    expect(commits).toEqual([""])
     cleanup()
   })
 })

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -84,6 +84,28 @@ describe("proxy policy", () => {
     )
   })
 
+  it("rejects proxy fetches asynchronously when authentication is incomplete", async () => {
+    const fetcher = createProxyFetcher(
+      resolveProxyPolicy({
+        appProxy: {
+          mode: "custom",
+          url: "http://proxy.test:8080",
+          auth: true,
+        },
+        appCredentials: {},
+        systemProxy: system,
+      }),
+    )
+    let request: Promise<Response> | undefined
+
+    expect(() => {
+      request = fetcher("https://example.com")
+    }).not.toThrow()
+    await expect(request!).rejects.toThrow(
+      "authentication is enabled for the global proxy, but its username secret is missing",
+    )
+  })
+
   it("falls back to system HTTP and HTTPS proxies", () => {
     const policy = resolveProxyPolicy({ systemProxy: system })
 

--- a/tests/unit/proxy.test.ts
+++ b/tests/unit/proxy.test.ts
@@ -9,10 +9,8 @@ import {
   proxyForUrl,
   redactProxyUrl,
   resolveProxyPolicy,
-  resolveProxyUrl,
   systemProxyFromEnv,
   takeSystemProxyFromEnv,
-  type ProxyPolicy,
   validateProxyTemplate,
 } from "../../src/proxy"
 
@@ -22,25 +20,6 @@ describe("proxy policy", () => {
     HTTPS_PROXY: "http://system-https:8080",
     NO_PROXY: "localhost, .internal.test",
   })
-  const variableProxyUrl = "http://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8080"
-  const appPolicy: ProxyPolicy = {
-    kind: "custom",
-    source: "global",
-    url: variableProxyUrl,
-    bypass: [],
-  }
-  const collectionPolicy: ProxyPolicy = {
-    ...appPolicy,
-    source: "collection",
-  }
-  const collectionEnv = {
-    name: "dev",
-    vars: {
-      PROXY_USER: "collection-user",
-      PROXY_PASSWORD: "collection-password",
-    },
-  }
-
   it("prefers --noproxy over collection, app, and system settings", () => {
     const policy = resolveProxyPolicy({
       noProxy: true,
@@ -67,6 +46,42 @@ describe("proxy policy", () => {
       source: "collection",
       url: "http://collection:8080",
     })
+  })
+
+  it("injects Bun-backed credentials without environment overrides", () => {
+    const policy = resolveProxyPolicy({
+      appProxy: { mode: "custom", url: "https://proxy.test:8443", auth: true },
+      appCredentials: { username: "bun-user", password: "bun-password" },
+      systemProxy: system,
+    })
+    expect(proxyForUrl(policy, "https://example.com")).toEqual({
+      kind: "proxy",
+      source: "global",
+      url: "https://bun-user:bun-password@proxy.test:8443/",
+    })
+    expect(environmentForProxyPolicy(policy, {}).HTTPS_PROXY).toBe(
+      "https://bun-user:bun-password@proxy.test:8443/",
+    )
+  })
+
+  it("allows an optional proxy password and fails clearly without a username", () => {
+    const optionalPassword = resolveProxyPolicy({
+      appProxy: { mode: "custom", url: "http://proxy.test:8080", auth: true },
+      appCredentials: { username: "bun-user" },
+      systemProxy: system,
+    })
+    expect(proxyForUrl(optionalPassword, "https://example.com")).toMatchObject({
+      url: "http://bun-user@proxy.test:8080/",
+    })
+
+    const missing = resolveProxyPolicy({
+      appProxy: { mode: "custom", url: "http://proxy.test:8080", auth: true },
+      appCredentials: {},
+      systemProxy: system,
+    })
+    expect(() => proxyForUrl(missing, "https://example.com")).toThrow(
+      "authentication is enabled for the global proxy, but its username secret is missing",
+    )
   })
 
   it("falls back to system HTTP and HTTPS proxies", () => {
@@ -100,7 +115,6 @@ describe("proxy policy", () => {
     let init: RequestInit | undefined
     const fetcher = createProxyFetcher(
       resolveProxyPolicy({ systemProxy: system }),
-      undefined,
       async (_input, options) => {
         init = options
         return new Response()
@@ -116,7 +130,6 @@ describe("proxy policy", () => {
     let init: RequestInit | undefined
     const fetcher = createProxyFetcher(
       resolveProxyPolicy({ noProxy: true, systemProxy: system }),
-      undefined,
       async (_input, options) => {
         init = options
         return new Response()
@@ -133,7 +146,6 @@ describe("proxy policy", () => {
   it("restores resolved proxy settings for subprocesses", () => {
     const env = environmentForProxyPolicy(
       resolveProxyPolicy({ systemProxy: system }),
-      undefined,
       { PATH: "/usr/bin", HTTPS_PROXY: "http://ambient:8080" },
     )
 
@@ -146,72 +158,6 @@ describe("proxy policy", () => {
       NO_PROXY: "localhost,.internal.test",
       no_proxy: "localhost,.internal.test",
     })
-  })
-
-  it("resolves app and collection proxy variables from the active environment", () => {
-    expect(
-      proxyForUrl(appPolicy, "https://example.com", collectionEnv),
-    ).toEqual({
-      kind: "proxy",
-      source: "global",
-      url: "http://collection-user:collection-password@proxy.test:8080",
-    })
-    expect(
-      proxyForUrl(collectionPolicy, "https://example.com", collectionEnv),
-    ).toEqual({
-      kind: "proxy",
-      source: "collection",
-      url: "http://collection-user:collection-password@proxy.test:8080",
-    })
-  })
-
-  it("fails when the active environment cannot resolve custom proxy variables", () => {
-    expect(() =>
-      proxyForUrl(appPolicy, "https://example.com", {
-        name: "dev",
-        vars: {},
-      }),
-    ).toThrow('proxy: unresolved variable "PROXY_USER" in proxy.url')
-    expect(() =>
-      proxyForUrl(collectionPolicy, "https://example.com", {
-        name: "dev",
-        vars: {},
-      }),
-    ).toThrow('proxy: unresolved variable "PROXY_USER" in proxy.url')
-  })
-
-  it("uses active environment variables for app and collection subprocess proxies", () => {
-    const baseEnv = {
-      PATH: "/usr/bin",
-      PROXY_USER: "process-user",
-      PROXY_PASSWORD: "process-password",
-    }
-
-    expect(
-      environmentForProxyPolicy(appPolicy, collectionEnv, baseEnv).HTTPS_PROXY,
-    ).toBe("http://collection-user:collection-password@proxy.test:8080")
-    expect(
-      environmentForProxyPolicy(collectionPolicy, collectionEnv, baseEnv)
-        .HTTPS_PROXY,
-    ).toBe("http://collection-user:collection-password@proxy.test:8080")
-  })
-
-  it("uses the active environment for an app proxy in the fetch wrapper", async () => {
-    let init: RequestInit | undefined
-    const fetcher = createProxyFetcher(
-      appPolicy,
-      collectionEnv,
-      async (_input, options) => {
-        init = options
-        return new Response()
-      },
-    )
-
-    await fetcher("https://example.com")
-
-    expect((init as BunFetchRequestInit).proxy).toBe(
-      "http://collection-user:collection-password@proxy.test:8080",
-    )
   })
 
   it("bypasses wildcard, domain, port, and IPv6 entries", () => {
@@ -243,55 +189,30 @@ describe("proxy policy", () => {
 })
 
 describe("proxy validation", () => {
-  it("builds a structured proxy URL with variable credentials", () => {
+  it("parses auth metadata while keeping the persisted URL sanitized", () => {
     expect(
-      buildStructuredProxyTemplate({
-        protocol: "https",
-        hostname: "proxy.test",
-        port: "8443",
+      parseAppProxy({
+        mode: "custom",
+        url: "http://proxy.test:8080",
         auth: true,
-        username: "$PROXY_USER",
-        password: "$PROXY_PASSWORD",
       }),
     ).toEqual({
-      url: "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
+      mode: "custom",
+      url: "http://proxy.test:8080",
+      auth: true,
     })
   })
-
-  it("builds and parses literal credentials without losing special characters", () => {
+  it("builds and parses structured URLs without credentials", () => {
     const fields = {
       protocol: "https" as const,
       hostname: "proxy.test",
       port: "8443",
-      auth: true,
-      username: "alice@example.com",
-      password: "space and:colon$",
     }
 
     expect(buildStructuredProxyTemplate(fields)).toEqual({
-      url: "https://alice%40example.com:space%20and%3Acolon%24@proxy.test:8443",
+      url: "https://proxy.test:8443",
     })
-    expect(
-      parseStructuredProxyTemplate(
-        "https://alice%40example.com:space%20and%3Acolon%24@proxy.test:8443",
-      ),
-    ).toEqual(fields)
-  })
-
-  it("supports proxy authentication without a password", () => {
-    const fields = {
-      protocol: "http" as const,
-      hostname: "proxy.test",
-      port: "",
-      auth: true,
-      username: "alice",
-      password: "",
-    }
-
-    expect(buildStructuredProxyTemplate(fields)).toEqual({
-      url: "http://alice@proxy.test",
-    })
-    expect(parseStructuredProxyTemplate("http://alice@proxy.test")).toEqual(
+    expect(parseStructuredProxyTemplate("https://proxy.test:8443")).toEqual(
       fields,
     )
   })
@@ -301,21 +222,6 @@ describe("proxy validation", () => {
       protocol: "http",
       hostname: "192.168.1.20",
       port: "",
-      auth: false,
-      username: "",
-      password: "",
-    })
-    expect(
-      parseStructuredProxyTemplate(
-        "https://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8443",
-      ),
-    ).toEqual({
-      protocol: "https",
-      hostname: "proxy.test",
-      port: "8443",
-      auth: true,
-      username: "$PROXY_USER",
-      password: "$PROXY_PASSWORD",
     })
   })
 
@@ -324,9 +230,6 @@ describe("proxy validation", () => {
       protocol: "http" as const,
       hostname: "::1",
       port: "",
-      auth: false,
-      username: "",
-      password: "",
     }
     expect(buildStructuredProxyTemplate(fields)).toEqual({
       url: "http://[::1]",
@@ -346,9 +249,6 @@ describe("proxy validation", () => {
       protocol: "http" as const,
       hostname: "",
       port: "not-a-port",
-      auth: true,
-      username: "literal-user",
-      password: "",
     }
     expect(buildStructuredProxyTemplate(fields)).toEqual({
       error: "Proxy hostname is required",
@@ -363,68 +263,30 @@ describe("proxy validation", () => {
         port: "65536",
       }),
     ).toEqual({ error: "Proxy port must be between 1 and 65535" })
+  })
+
+  it("rejects credential variables and literal userinfo", () => {
+    expect(validateProxyTemplate("http://proxy.test:$PROXY_PORT")).toBe(
+      "Proxy URL cannot contain variables; configure authentication in Settings",
+    )
+    expect(validateProxyTemplate("http://alice:secret@proxy.test")).toBe(
+      "Proxy URL cannot contain credentials; configure authentication in Settings",
+    )
     expect(
-      buildStructuredProxyTemplate({
-        ...fields,
-        hostname: "proxy.test",
-        port: "8080",
-        username: "",
+      parseAppProxy({
+        mode: "custom",
+        url: "http://$PROXY_USER@proxy.test",
       }),
-    ).toEqual({ error: "Proxy username is required" })
-  })
-
-  it("resolves credentials from the provided variable source", () => {
+    ).toBeUndefined()
     expect(
-      resolveProxyUrl("http://$PROXY_USER:$PROXY_PASSWORD@proxy.test:8080", {
-        PROXY_USER: "alice",
-        PROXY_PASSWORD: "secret",
+      parseCollectionProxy({
+        mode: "custom",
+        url: "http://alice:secret@proxy.test",
       }),
-    ).toBe("http://alice:secret@proxy.test:8080")
+    ).toBeUndefined()
   })
 
-  it("treats dollar signs embedded in literal credentials as literals", () => {
-    expect(resolveProxyUrl("http://alice:pa$word@proxy.test")).toBe(
-      "http://alice:pa%24word@proxy.test",
-    )
-  })
-
-  it("validates and resolves a variable proxy port", () => {
-    const template = "http://proxy.test:$PROXY_PORT"
-    expect(validateProxyTemplate(template)).toBeNull()
-    expect(resolveProxyUrl(template, { PROXY_PORT: "8080" })).toBe(
-      "http://proxy.test:8080",
-    )
-  })
-
-  it("fails clearly for an unresolved proxy variable", () => {
-    expect(() => resolveProxyUrl("http://$PROXY@proxy.test", {})).toThrow(
-      'proxy: unresolved variable "PROXY" in proxy.url',
-    )
-  })
-
-  it("does not expose resolved credentials in invalid URL errors", () => {
-    expect(() =>
-      resolveProxyUrl("http://$PROXY_PASSWORD@proxy.test:invalid", {
-        PROXY_PASSWORD: "secret-value",
-      }),
-    ).toThrow("proxy: invalid proxy URL")
-    try {
-      resolveProxyUrl("http://$PROXY_PASSWORD@proxy.test:invalid", {
-        PROXY_PASSWORD: "secret-value",
-      })
-    } catch (error) {
-      expect(String(error)).not.toContain("secret-value")
-    }
-  })
-
-  it("accepts literal stored credentials and rejects invalid protocols", () => {
-    const custom = {
-      mode: "custom" as const,
-      url: "http://alice:secret@proxy.test",
-    }
-    expect(validateProxyTemplate(custom.url)).toBeNull()
-    expect(parseAppProxy(custom)).toEqual(custom)
-    expect(parseCollectionProxy(custom)).toEqual(custom)
+  it("rejects invalid protocols", () => {
     expect(validateProxyTemplate("socks5://proxy.test")).toBe(
       "Proxy URL must use http or https",
     )

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -174,6 +174,29 @@ describe("send — network trace", () => {
     }
   })
 
+  it("attaches network activity to incomplete proxy authentication", async () => {
+    let error: NetworkError | undefined
+    try {
+      await send(makeReq(), {
+        proxyPolicy: {
+          kind: "custom",
+          source: "global",
+          url: "http://proxy.test:8080",
+          bypass: [],
+          auth: true,
+          credentials: {},
+        },
+      })
+    } catch (caught) {
+      error = caught as NetworkError
+    }
+
+    expect(error?.message).toContain(
+      "authentication is enabled for the global proxy, but its username secret is missing",
+    )
+    expect(error?.network?.map((event) => event.type)).toEqual(["error"])
+  })
+
   it("passes the resolved proxy to fetch and reports the selected route", async () => {
     const originalFetch = globalThis.fetch
     let proxy: string | undefined

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -137,7 +137,7 @@ describe("send — param deduplication", () => {
 })
 
 describe("send — network trace", () => {
-  it("resolves an app proxy from the active Noodle environment", async () => {
+  it("uses Bun-backed app proxy credentials without environment overrides", async () => {
     const originalFetch = globalThis.fetch
     let proxy: string | undefined
     globalThis.fetch = mock(async (_url, init) => {
@@ -158,14 +158,17 @@ describe("send — network trace", () => {
         proxyPolicy: {
           kind: "custom",
           source: "global",
-          url: "http://$NOODLE_TEST_APP_PROXY_USER:$NOODLE_TEST_APP_PROXY_PASSWORD@proxy.test:8080",
+          url: "http://proxy.test:8080",
           bypass: [],
+          auth: true,
+          credentials: {
+            username: "bun-user",
+            password: "bun-password",
+          },
         },
       })
 
-      expect(proxy).toBe(
-        "http://collection-user:collection-password@proxy.test:8080",
-      )
+      expect(proxy).toBe("http://bun-user:bun-password@proxy.test:8080/")
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/tests/unit/settingsPersistence.test.ts
+++ b/tests/unit/settingsPersistence.test.ts
@@ -16,6 +16,16 @@ function deferred(): {
   return { promise, resolve, reject }
 }
 
+function persistence(settings: CollectionSettings) {
+  return {
+    activeCollectionDir: { current: "/collection" },
+    currentSettings: { current: settings },
+    persistedSettings: { current: settings },
+    saveChain: { current: Promise.resolve() },
+    pendingUpdates: { current: [] },
+  }
+}
+
 async function flush(): Promise<void> {
   await Promise.resolve()
   await Promise.resolve()
@@ -23,102 +33,14 @@ async function flush(): Promise<void> {
 
 describe("queueCollectionSettingsSave", () => {
   it("runs the success callback only after settings persist", async () => {
-    const persisted: CollectionSettings = { timelineMaxEntries: 10 }
-    const persistence = {
-      activeCollectionDir: { current: "/collection" },
-      currentSettings: { current: persisted },
-      persistedSettings: { current: {} },
-      saveChain: { current: Promise.resolve() },
-    }
-    let saved = false
-
-    queueCollectionSettingsSave(
-      persistence,
-      "/collection",
-      persisted,
-      async () => {},
-      () => {},
-      () => {},
-      () => {
-        saved = true
-      },
-    )
-    expect(saved).toBe(false)
-    await persistence.saveChain.current
-    await flush()
-    expect(saved).toBe(true)
-  })
-
-  it("restores persisted settings when superseded proxy and environment saves fail", async () => {
-    const persisted: CollectionSettings = { environment: "development" }
-    const proxySettings: CollectionSettings = {
-      ...persisted,
-      proxy: { mode: "off" },
-    }
-    const currentSettings: CollectionSettings = {
-      ...proxySettings,
-      environment: "production",
-    }
-    const proxySave = deferred()
-    const environmentSave = deferred()
-    const saves = [proxySave, environmentSave]
-    const persistence = {
-      activeCollectionDir: { current: "/collection" },
-      currentSettings: { current: proxySettings },
-      persistedSettings: { current: persisted },
-      saveChain: { current: Promise.resolve() },
-    }
-    let renderedSettings = proxySettings
-
-    queueCollectionSettingsSave(
-      persistence,
-      "/collection",
-      proxySettings,
-      () => saves.shift()!.promise,
-      (settings) => {
-        renderedSettings = settings
-      },
-      () => {},
-    )
-    persistence.currentSettings.current = currentSettings
-    queueCollectionSettingsSave(
-      persistence,
-      "/collection",
-      currentSettings,
-      () => saves.shift()!.promise,
-      (settings) => {
-        renderedSettings = settings
-      },
-      () => {},
-    )
-
-    await flush()
-    proxySave.reject(new Error("proxy save failed"))
-    await flush()
-    environmentSave.reject(new Error("environment save failed"))
-    await flush()
-
-    expect(persistence.currentSettings.current).toEqual(persisted)
-    expect(renderedSettings).toEqual(persisted)
-  })
-
-  it("skips the success callback for superseded settings", async () => {
+    const state = persistence({})
     const first = deferred()
-    const persistedSettings: CollectionSettings = { timelineMaxEntries: 50 }
-    const oldSettings: CollectionSettings = { timelineMaxEntries: 10 }
-    const currentSettings: CollectionSettings = { timelineMaxEntries: 50 }
-    const persistence = {
-      activeCollectionDir: { current: "/collection" },
-      currentSettings: { current: oldSettings },
-      persistedSettings: { current: persistedSettings },
-      saveChain: { current: Promise.resolve() },
-    }
     let saved = 0
 
-    queueCollectionSettingsSave(
-      persistence,
+    void queueCollectionSettingsSave(
+      state,
       "/collection",
-      oldSettings,
+      (settings) => ({ ...settings, timelineMaxEntries: 10 }),
       async () => first.promise,
       () => {},
       () => {},
@@ -126,20 +48,181 @@ describe("queueCollectionSettingsSave", () => {
         saved++
       },
     )
-    persistence.currentSettings.current = currentSettings
-    queueCollectionSettingsSave(
-      persistence,
+    expect(saved).toBe(0)
+    first.resolve()
+    await state.saveChain.current
+    expect(saved).toBe(1)
+  })
+
+  it("skips the success callback for a superseded mutation", async () => {
+    const state = persistence({})
+    const first = deferred()
+    let saved = 0
+
+    void queueCollectionSettingsSave(
+      state,
       "/collection",
-      currentSettings,
+      (settings) => ({ ...settings, timelineMaxEntries: 10 }),
+      async () => first.promise,
+      () => {},
+      () => {},
+      () => {
+        saved++
+      },
+    )
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({ ...settings, environment: "development" }),
       async () => {},
       () => {},
       () => {},
     )
 
     first.resolve()
-    await persistence.saveChain.current
-    await flush()
-
+    await state.saveChain.current
     expect(saved).toBe(0)
+  })
+
+  it("rebases later edits onto a delayed settings transaction", async () => {
+    const state = persistence({
+      proxy: { mode: "custom", url: "http://proxy.test" },
+    })
+    const transaction = deferred()
+    const saves: CollectionSettings[] = []
+
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({
+        ...settings,
+        proxy:
+          settings.proxy?.mode === "custom"
+            ? { ...settings.proxy, auth: true }
+            : settings.proxy,
+      }),
+      async (_dir, settings) => {
+        saves.push(settings)
+        await transaction.promise
+      },
+      () => {},
+      () => {},
+    )
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({
+        ...settings,
+        name: "Payments",
+      }),
+      async (_dir, settings) => {
+        saves.push(settings)
+      },
+      () => {},
+      () => {},
+    )
+
+    expect(state.currentSettings.current).toMatchObject({
+      name: "Payments",
+      proxy: { auth: true },
+    })
+    transaction.resolve()
+    await state.saveChain.current
+    expect(saves.at(-1)).toMatchObject({
+      name: "Payments",
+      proxy: { auth: true },
+    })
+    expect(state.persistedSettings.current).toEqual(saves.at(-1)!)
+  })
+
+  it("does not resurrect a TLS profile removed after a delayed passphrase save", async () => {
+    const state = persistence({
+      tls: {
+        clientCertificates: [
+          { host: "api.test", certFile: "cert.pem", keyFile: "key.pem" },
+        ],
+      },
+    })
+    const transaction = deferred()
+    const secretId = "secret-id"
+
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({
+        ...settings,
+        tls: {
+          ...settings.tls,
+          clientCertificates: settings.tls?.clientCertificates?.map(
+            (profile, index) =>
+              index === 0 ? { ...profile, secretId } : profile,
+          ),
+        },
+      }),
+      async () => transaction.promise,
+      () => {},
+      () => {},
+    )
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({
+        ...settings,
+        tls: {
+          ...settings.tls,
+          clientCertificates:
+            settings.tls?.clientCertificates?.filter(
+              (profile) => profile.secretId !== secretId,
+            ) ?? [],
+        },
+      }),
+      async () => {},
+      () => {},
+      () => {},
+    )
+
+    expect(state.currentSettings.current.tls?.clientCertificates).toEqual([])
+    transaction.resolve()
+    await state.saveChain.current
+    expect(state.persistedSettings.current.tls?.clientCertificates).toEqual([])
+  })
+
+  it("rolls back only a failed mutation and preserves later pending edits", async () => {
+    const state = persistence({ environment: "development" })
+    const proxySave = deferred()
+    const environmentSave = deferred()
+    let rendered = state.currentSettings.current
+
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({ ...settings, proxy: { mode: "off" } }),
+      async () => proxySave.promise,
+      (settings) => {
+        rendered = settings
+      },
+      () => {},
+    )
+    void queueCollectionSettingsSave(
+      state,
+      "/collection",
+      (settings) => ({ ...settings, environment: "production" }),
+      async () => environmentSave.promise,
+      (settings) => {
+        rendered = settings
+      },
+      () => {},
+    )
+
+    await flush()
+    proxySave.reject(new Error("proxy save failed"))
+    await flush()
+    expect(rendered).toEqual({ environment: "production" })
+
+    environmentSave.resolve()
+    await state.saveChain.current
+    expect(state.persistedSettings.current).toEqual({
+      environment: "production",
+    })
   })
 })

--- a/tests/unit/tls.test.ts
+++ b/tests/unit/tls.test.ts
@@ -8,6 +8,7 @@ import {
   findClientCertificate,
   isValidTlsHost,
   parseCollectionTls,
+  parseCollectionTlsStrict,
   resolveTlsPath,
   tlsForUrl,
 } from "../../src/tls"
@@ -48,7 +49,7 @@ describe("collection TLS settings", () => {
             port: 8443,
             cert_file: "./certs/client.pem",
             key_file: "./certs/key.pem",
-            passphrase: "$PASSPHRASE",
+            secret_id: "123e4567-e89b-42d3-a456-426614174000",
           },
         ],
       }),
@@ -61,7 +62,7 @@ describe("collection TLS settings", () => {
           port: 8443,
           certFile: "./certs/client.pem",
           keyFile: "./certs/key.pem",
-          passphrase: "$PASSPHRASE",
+          secretId: "123e4567-e89b-42d3-a456-426614174000",
           enabled: undefined,
         },
       ],
@@ -124,31 +125,43 @@ describe("collection TLS settings", () => {
     expect(isValidTlsHost("-")).toBe(false)
   })
 
-  it("accepts only exact environment references for key passphrases", () => {
-    expect(
-      parseCollectionTls({
-        client_certificates: [
+  it("rejects legacy literal and environment-reference passphrases", () => {
+    const legacy = {
+      client_certificates: [
+        {
+          host: "api.example.com",
+          cert_file: "client.pem",
+          key_file: "key.pem",
+          passphrase: "$PASS",
+        },
+      ],
+    }
+    expect(parseCollectionTls(legacy)).toBeUndefined()
+    expect(() => parseCollectionTlsStrict(legacy)).toThrow(
+      "passphrase: is no longer supported; remove it and configure the passphrase in Settings",
+    )
+  })
+
+  it("round-trips secret ids without a plaintext passphrase", async () => {
+    const secretId = "123e4567-e89b-42d3-a456-426614174000"
+    await saveSettings(dir, {
+      tls: {
+        clientCertificates: [
           {
             host: "api.example.com",
-            cert_file: "client.pem",
-            key_file: "key.pem",
-            passphrase: "pa$word",
+            certFile: "client.pem",
+            keyFile: "key.pem",
+            secretId,
           },
         ],
-      }),
-    ).toBeUndefined()
+      },
+    })
+    const raw = await readFile(join(dir, "settings.yml"), "utf8")
+    expect(raw).toContain(`secret_id: ${secretId}`)
+    expect(raw).not.toContain("passphrase:")
     expect(
-      parseCollectionTls({
-        client_certificates: [
-          {
-            host: "api.example.com",
-            cert_file: "client.pem",
-            key_file: "key.pem",
-            passphrase: "$PASS",
-          },
-        ],
-      })?.clientCertificates?.[0]?.passphrase,
-    ).toBe("$PASS")
+      (await loadSettings(dir)).tls?.clientCertificates?.[0]?.secretId,
+    ).toBe(secretId)
   })
 
   it("round-trips collection TLS settings", async () => {
@@ -253,10 +266,10 @@ describe("collection TLS settings", () => {
     await writeFile(join(dir, "client.pem"), "test cert")
     await writeFile(join(dir, "key.pem"), "test key")
 
+    const secretId = "123e4567-e89b-42d3-a456-426614174000"
     const resolved = await tlsForUrl(
       makeRequest({ tls: { verify: true } }),
       "https://api.example.com/path",
-      { name: "dev", vars: { PASS: "secret" } },
       {
         collectionDir: dir,
         settings: {
@@ -267,10 +280,11 @@ describe("collection TLS settings", () => {
               host: "api.example.com",
               certFile: "./client.pem",
               keyFile: "./key.pem",
-              passphrase: "$PASS",
+              secretId,
             },
           ],
         },
+        passphrases: { [secretId]: "secret" },
       },
     )
 
@@ -282,41 +296,52 @@ describe("collection TLS settings", () => {
     expect(resolved.messages).toContain("TLS verification enabled by request")
   })
 
-  it("does not resolve a client key passphrase from the process environment", async () => {
+  it("resolves a Bun-backed passphrase by secret id", async () => {
     await writeFile(join(dir, "client.pem"), "test cert")
     await writeFile(join(dir, "key.pem"), "test key")
-    const original = process.env.NOODLE_TEST_TLS_PASSPHRASE
-    process.env.NOODLE_TEST_TLS_PASSPHRASE = "process-secret"
-
-    try {
-      await expect(
-        tlsForUrl(makeRequest(), "https://api.example.com", undefined, {
-          collectionDir: dir,
-          settings: {
-            clientCertificates: [
-              {
-                host: "api.example.com",
-                certFile: "client.pem",
-                keyFile: "key.pem",
-                passphrase: "$NOODLE_TEST_TLS_PASSPHRASE",
-              },
-            ],
+    const secretId = "123e4567-e89b-42d3-a456-426614174000"
+    const resolved = await tlsForUrl(makeRequest(), "https://api.example.com", {
+      collectionDir: dir,
+      settings: {
+        clientCertificates: [
+          {
+            host: "api.example.com",
+            certFile: "client.pem",
+            keyFile: "key.pem",
+            secretId,
           },
-        }),
-      ).rejects.toThrow(
-        'tls: unresolved variable "NOODLE_TEST_TLS_PASSPHRASE" in client certificate passphrase',
-      )
-    } finally {
-      if (original === undefined) delete process.env.NOODLE_TEST_TLS_PASSPHRASE
-      else process.env.NOODLE_TEST_TLS_PASSPHRASE = original
-    }
+        ],
+      },
+      passphrases: { [secretId]: "bun-secret" },
+    })
+    expect(resolved.options?.passphrase).toBe("bun-secret")
+  })
+
+  it("fails clearly when a referenced TLS passphrase secret is missing", async () => {
+    await writeFile(join(dir, "client.pem"), "test cert")
+    await writeFile(join(dir, "key.pem"), "test key")
+    await expect(
+      tlsForUrl(makeRequest(), "https://api.example.com", {
+        collectionDir: dir,
+        settings: {
+          clientCertificates: [
+            {
+              host: "api.example.com",
+              certFile: "client.pem",
+              keyFile: "key.pem",
+              secretId: "123e4567-e89b-42d3-a456-426614174000",
+            },
+          ],
+        },
+        passphrases: {},
+      }),
+    ).rejects.toThrow("has a missing passphrase secret")
   })
 
   it("lets --insecure override saved verification", async () => {
     const resolved = await tlsForUrl(
       makeRequest({ tls: { verify: true } }),
       "https://example.com",
-      undefined,
       {
         collectionDir: dir,
         settings: { verify: true, caBundle: "missing.pem" },
@@ -334,7 +359,6 @@ describe("collection TLS settings", () => {
     const resolved = await tlsForUrl(
       makeRequest({ tls: { verify: false } }),
       "https://example.com",
-      undefined,
       {
         collectionDir: dir,
         settings: { caBundle: "missing.pem" },
@@ -347,18 +371,15 @@ describe("collection TLS settings", () => {
   })
 
   it("verifies certificates by default", async () => {
-    const resolved = await tlsForUrl(
-      makeRequest(),
-      "https://example.com",
-      undefined,
-      { collectionDir: dir },
-    )
+    const resolved = await tlsForUrl(makeRequest(), "https://example.com", {
+      collectionDir: dir,
+    })
     expect(resolved.options?.rejectUnauthorized).toBe(true)
   })
 
   it("fails before fetch when a configured certificate file is missing", async () => {
     await expect(
-      tlsForUrl(makeRequest(), "https://api.example.com", undefined, {
+      tlsForUrl(makeRequest(), "https://api.example.com", {
         collectionDir: dir,
         settings: {
           clientCertificates: [

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -115,17 +115,15 @@ describe("loadConfig", () => {
     expect(result.collections).toHaveLength(1)
   })
 
-  it("reads a custom app proxy", () => {
+  it("rejects legacy app proxy credentials", () => {
     writeFileSync(
       join(dir, CONFIG_FILE_NAME),
       "proxy:\n  mode: custom\n  url: http://$PROXY@proxy.test:8080\n  bypass:\n    - localhost\n",
       "utf8",
     )
-    expect(loadConfig(dir).proxy).toEqual({
-      mode: "custom",
-      url: "http://$PROXY@proxy.test:8080",
-      bypass: ["localhost"],
-    })
+    expect(() => loadConfig(dir)).toThrow(
+      "Proxy URL cannot contain credentials; configure authentication in Settings",
+    )
   })
 })
 


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves proxy credentials and TLS passphrases out of plaintext settings YAML and into the OS keychain (via the existing secrets backend). App-level and per-collection proxy credentials, plus per-client TLS passphrases, are now stored as keychain entries and referenced from settings files. Settings forms gain a `SecretInput` for masking and managing these secrets, including clearing a stored value.

### How did you verify your code works?

- Added `src/secrets` keychain helpers with tests in `tests/secrets.test.ts`
- Updated `proxy.ts`, `tls.ts`, `settingsPersistence.ts`, and the settings forms with unit tests (`ProxySettingsForm`, `TlsSettingsForm`, `SecretInput`, `settingsPersistence`, `proxy`, `tls`)
- Added integration coverage in `tests/integration/automation.test.ts` and updated `tls-loopback` tests
- Ran affected test suites (81 pass), `bun run lint`, and `bun run typecheck`

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure storage and management for proxy credentials and TLS certificate passphrases.
  * Added proxy authentication controls with masked credential entry and validation.
  * Added safer settings updates with rollback when saving fails.
  * Increased the timeline entry limit to 50.
* **Bug Fixes**
  * Improved configuration error reporting and prevented silent startup failures.
  * Redacted stored credentials and passphrases from requests and timeline errors.
  * Rejects insecure embedded proxy credentials and legacy inline TLS passphrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->