### PR TITLE
feat(auth): Add AWS Signature v4 authentication support

### DIFF
--- a/.agents/skills/noodle-use/SKILL.md
+++ b/.agents/skills/noodle-use/SKILL.md
@@ -79,9 +79,10 @@ proxy/TLS blocks fail collection opening, auditing, and execution.
 When creating/deleting files, only operate within the collection directory. Never create files outside the collection root. IDs must not contain `..`, leading `/`, backslashes, empty path segments, or hidden path segments.
 
 ### Authorization
-Auth types: `none`, `inherit`, `bearer`, `basic`, `api_key`.
+Auth types: `none`, `inherit`, `bearer`, `basic`, `api_key`, `aws_sigv4`.
 - `none`: No auth. Omit the `auth` field entirely (don't write `{ type: none }`).
 - `inherit`: Use parent folder's auth override. Only valid when a parent folder defines auth.
 - `bearer`: `{ type: bearer, token: "$TOKEN" }`
 - `basic`: `{ type: basic, user: "$USER", pass: "$PASS" }`
 - `api_key`: `{ type: api_key, key: "X-API-Key", value: "$KEY", placement: "header" }`. Placement is `"header"` or `"query"`.
+- `aws_sigv4`: `{ type: aws_sigv4, access_key: "$AWS_ACCESS_KEY_ID", secret_key: "$AWS_SECRET_ACCESS_KEY", region: "us-east-1", service: "execute-api", session_token: "$AWS_SESSION_TOKEN" }`. `session_token` is optional. Signing uses headers and supports text, JSON, URL-encoded, and binary bodies; multipart is not supported.

--- a/.agents/skills/noodle-use/schema.md
+++ b/.agents/skills/noodle-use/schema.md
@@ -103,15 +103,25 @@ directory paths and should be reviewed before sharing.
 
 ### Auth
 
-| Field | Bearer | Basic | API Key |
-|-------|--------|-------|---------|
-| `type` | `"bearer"` | `"basic"` | `"api_key"` |
-| `token` | yes | — | — |
-| `user` | — | yes | — |
-| `pass` | — | yes | — |
-| `key` | — | — | yes |
-| `value` | — | — | yes |
-| `placement` | — | — | `"header"` (default) or `"query"` |
+| Field | Bearer | Basic | API Key | AWS SigV4 |
+|-------|--------|-------|---------|-----------|
+| `type` | `"bearer"` | `"basic"` | `"api_key"` | `"aws_sigv4"` |
+| `token` | yes | — | — | — |
+| `user` | — | yes | — | — |
+| `pass` | — | yes | — | — |
+| `key` | — | — | yes | — |
+| `value` | — | — | yes | — |
+| `placement` | — | — | `"header"` (default) or `"query"` | — |
+| `access_key` | — | — | — | yes |
+| `secret_key` | — | — | — | yes |
+| `region` | — | — | — | yes |
+| `service` | — | — | — | yes |
+| `session_token` | — | — | — | optional |
+
+AWS SigV4 is added as request headers after environment substitution. It supports
+text, JSON, URL-encoded, and binary bodies. Multipart bodies are rejected because
+their runtime-generated boundary and bytes cannot be signed reliably in advance.
+Keep credentials in secret environment variables rather than literal YAML.
 
 ### Binary body
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,9 +8,10 @@
         "@opentui/core": "^0.4.5",
         "@opentui/keymap": "^0.4.5",
         "@opentui/react": "^0.4.5",
+        "aws4": "^1.13.2",
         "citty": "^0.2.2",
         "httpsnippet": "^3.0.10",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "jsonc-parser": "^3.3.1",
         "jsonpath-plus": "^10.4.0",
         "postman-collection": "^5.3.1",
@@ -18,15 +19,16 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/aws4": "^1.11.6",
         "@types/js-yaml": "^4.0.9",
-        "@types/react": "^19.2.17",
+        "@types/react": "^19.2.18",
         "bun-types": "^1.3.14",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "husky": "^9.1.7",
-        "lint-staged": "^17.2.0",
+        "lint-staged": "^17.3.0",
         "prettier": "^3.9.6",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.65.0",
+        "typescript-eslint": "^8.66.0",
       },
     },
   },
@@ -90,6 +92,8 @@
 
     "@opentui/react": ["@opentui/react@0.4.5", "", { "dependencies": { "@opentui/core": "0.4.5", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-n88Vx0cMmAu++/S14WscjvdcT46IDcxve02jMtcfHQ9j6cySRHfILfGEpOB7xxc8RpCwQceEyOjkKkfzPzm6Jg=="],
 
+    "@types/aws4": ["@types/aws4@1.11.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-5CnVUkHNyLGpD9AnOcK66YyP0qvIh6nhJJoeK8zSl5YKikUcUbdB7SlHevUYVqicgeh6j5AJa1qa/h08dSZHoA=="],
+
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -135,6 +139,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "aws4": ["aws4@1.13.2", "", {}, "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@opentui/core": "^0.4.5",
     "@opentui/keymap": "^0.4.5",
     "@opentui/react": "^0.4.5",
+    "aws4": "^1.13.2",
     "citty": "^0.2.2",
     "httpsnippet": "^3.0.10",
     "js-yaml": "^4.3.1",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/aws4": "^1.11.6",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.18",
     "bun-types": "^1.3.14",

--- a/src/codegen/buildHar.ts
+++ b/src/codegen/buildHar.ts
@@ -152,6 +152,17 @@ function substituteAuth(
       value: resolveVar(auth.value),
       placement: auth.placement,
     }
+  if (auth.type === "aws_sigv4")
+    return {
+      type: "aws_sigv4",
+      access_key: resolveVar(auth.access_key),
+      secret_key: resolveVar(auth.secret_key),
+      region: resolveVar(auth.region),
+      service: resolveVar(auth.service),
+      ...(auth.session_token
+        ? { session_token: resolveVar(auth.session_token) }
+        : {}),
+    }
   return auth
 }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -25,6 +25,12 @@ export function generateCode(
       ? request
       : mergeFolderOverrides(request, collection, request.id)
 
+  if (effective.auth?.type === "aws_sigv4") {
+    throw new Error(
+      "codegen.generateCode: AWS SigV4 requests are not supported because generated signatures expire",
+    )
+  }
+
   const { har, unhash } = buildHar(effective, env, interpolate)
 
   try {

--- a/src/converters/openapi/export.ts
+++ b/src/converters/openapi/export.ts
@@ -314,6 +314,9 @@ function securityFor(
   } else if (auth.type === "basic") {
     name = "basicAuth"
     schemes[name] ??= { type: "http", scheme: "basic" }
+  } else if (auth.type === "aws_sigv4") {
+    name = "awsSigV4"
+    schemes[name] ??= { type: "http", scheme: "AWS4-HMAC-SHA256" }
   } else {
     const suffix = auth.key
       .replace(/[^a-zA-Z0-9]+/g, " ")

--- a/src/converters/postman/export.ts
+++ b/src/converters/postman/export.ts
@@ -60,7 +60,7 @@ function postmanAuth(auth: Auth | undefined): PostmanObject | undefined {
       },
       { key: "region", value: toPostmanTpl(auth.region), type: "string" },
       { key: "service", value: toPostmanTpl(auth.service), type: "string" },
-      { key: "addAuthDataToQuery", value: "false", type: "boolean" },
+      { key: "addAuthDataToQuery", value: false, type: "boolean" },
     ]
     if (auth.session_token) {
       awsv4.push({

--- a/src/converters/postman/export.ts
+++ b/src/converters/postman/export.ts
@@ -46,6 +46,31 @@ function postmanAuth(auth: Auth | undefined): PostmanObject | undefined {
       ],
     }
   }
+  if (auth.type === "aws_sigv4") {
+    const awsv4 = [
+      {
+        key: "accessKey",
+        value: toPostmanTpl(auth.access_key),
+        type: "string",
+      },
+      {
+        key: "secretKey",
+        value: toPostmanTpl(auth.secret_key),
+        type: "string",
+      },
+      { key: "region", value: toPostmanTpl(auth.region), type: "string" },
+      { key: "service", value: toPostmanTpl(auth.service), type: "string" },
+      { key: "addAuthDataToQuery", value: "false", type: "boolean" },
+    ]
+    if (auth.session_token) {
+      awsv4.push({
+        key: "sessionToken",
+        value: toPostmanTpl(auth.session_token),
+        type: "string",
+      })
+    }
+    return { type: "awsv4", awsv4 }
+  }
   return {
     type: "apikey",
     apikey: [

--- a/src/converters/postman/map.ts
+++ b/src/converters/postman/map.ts
@@ -93,6 +93,18 @@ function mapAuth(
       placement: rawPlacement.includes("query") ? "query" : "header",
     }
   }
+  if (type === "awsv4") {
+    return {
+      type: "aws_sigv4",
+      access_key: convertTpl(params?.get("accessKey") ?? ""),
+      secret_key: convertTpl(params?.get("secretKey") ?? ""),
+      region: convertTpl(params?.get("region") ?? ""),
+      service: convertTpl(params?.get("service") ?? ""),
+      ...(params?.get("sessionToken")
+        ? { session_token: convertTpl(params.get("sessionToken")!) }
+        : {}),
+    }
+  }
 
   return { type: "none" }
 }

--- a/src/hooks/draftUtils.ts
+++ b/src/hooks/draftUtils.ts
@@ -191,6 +191,15 @@ export function authEqual(
   if (a.type === "api_key" && b.type === "api_key") {
     return a.key === b.key && a.value === b.value && a.placement === b.placement
   }
+  if (a.type === "aws_sigv4" && b.type === "aws_sigv4") {
+    return (
+      a.access_key === b.access_key &&
+      a.secret_key === b.secret_key &&
+      a.region === b.region &&
+      a.service === b.service &&
+      a.session_token === b.session_token
+    )
+  }
   return false
 }
 
@@ -273,6 +282,14 @@ export function defaultAuth(authType: Auth["type"]): Auth {
       return { type: "basic", user: "", pass: "" }
     case "api_key":
       return { type: "api_key", key: "", value: "", placement: "header" }
+    case "aws_sigv4":
+      return {
+        type: "aws_sigv4",
+        access_key: "",
+        secret_key: "",
+        region: "",
+        service: "",
+      }
     default:
       return { type: "none" }
   }

--- a/src/hooks/draftUtils.ts
+++ b/src/hooks/draftUtils.ts
@@ -197,7 +197,7 @@ export function authEqual(
       a.secret_key === b.secret_key &&
       a.region === b.region &&
       a.service === b.service &&
-      a.session_token === b.session_token
+      (a.session_token ?? "") === (b.session_token ?? "")
     )
   }
   return false

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -38,6 +38,7 @@ function rowCount(req: Request | null): SectionRowCount {
     if (a.type === "bearer") authRows = 2
     else if (a.type === "basic") authRows = 3
     else if (a.type === "api_key") authRows = 4
+    else if (a.type === "aws_sigv4") authRows = 6
   }
   const body =
     req.bodyType === "none"
@@ -99,6 +100,13 @@ function currentValueFor(
       if (row === 1) return a.key
       if (row === 2) return a.value
       if (row === 3) return a.placement
+    }
+    if (a.type === "aws_sigv4") {
+      if (row === 1) return a.access_key
+      if (row === 2) return a.secret_key
+      if (row === 3) return a.region
+      if (row === 4) return a.service
+      if (row === 5) return a.session_token ?? ""
     }
     return ""
   }
@@ -711,6 +719,19 @@ export function useEditBrowse(
           if (row === 1) draftMutators.setAuthField("api_key", "key", val)
           else if (row === 2)
             draftMutators.setAuthField("api_key", "value", val)
+        } else if (currentAuth.type === "aws_sigv4") {
+          const fields = [
+            "",
+            "access_key",
+            "secret_key",
+            "region",
+            "service",
+            "session_token",
+          ]
+          const authField = fields[row]
+          if (authField) {
+            draftMutators.setAuthField("aws_sigv4", authField, val)
+          }
         }
       }
     } else if (field === "settings") {

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -67,6 +67,7 @@ function folderRowCount(folder: Folder | null): FolderRowCount {
     if (a.type === "bearer") authRows = 2
     else if (a.type === "basic") authRows = 3
     else if (a.type === "api_key") authRows = 4
+    else if (a.type === "aws_sigv4") authRows = 6
   }
   return {
     meta: 1,
@@ -105,6 +106,13 @@ function folderCurrentValueFor(
       if (row === 1) return a.key
       if (row === 2) return a.value
       if (row === 3) return a.placement
+    }
+    if (a.type === "aws_sigv4") {
+      if (row === 1) return a.access_key
+      if (row === 2) return a.secret_key
+      if (row === 3) return a.region
+      if (row === 4) return a.service
+      if (row === 5) return a.session_token ?? ""
     }
     return ""
   }
@@ -410,6 +418,19 @@ export function useFolderEditBrowse(
           if (row === 1) draftMutators.setAuthField("api_key", "key", val)
           else if (row === 2)
             draftMutators.setAuthField("api_key", "value", val)
+        } else if (currentAuth.type === "aws_sigv4") {
+          const fields = [
+            "",
+            "access_key",
+            "secret_key",
+            "region",
+            "service",
+            "session_token",
+          ]
+          const authField = fields[row]
+          if (authField) {
+            draftMutators.setAuthField("aws_sigv4", authField, val)
+          }
         }
       }
     } else if (field === "headers") {

--- a/src/lang/folder.ts
+++ b/src/lang/folder.ts
@@ -79,6 +79,15 @@ type RawFolderAuth =
       placement?: string
       [k: string]: unknown
     }
+  | {
+      type: "aws_sigv4"
+      access_key: string
+      secret_key: string
+      region: string
+      service: string
+      session_token?: string
+      [k: string]: unknown
+    }
   | { type: string; [k: string]: unknown }
 
 function parseFolderAuth(value: unknown): Auth {
@@ -115,6 +124,27 @@ function parseFolderAuth(value: unknown): Auth {
     }
     const placement = a.placement === "query" ? "query" : "header"
     return { type: "api_key", key: a.key, value: a.value, placement }
+  }
+  if (a.type === "aws_sigv4") {
+    if (
+      typeof a.access_key !== "string" ||
+      typeof a.secret_key !== "string" ||
+      typeof a.region !== "string" ||
+      typeof a.service !== "string" ||
+      (a.session_token !== undefined && typeof a.session_token !== "string")
+    ) {
+      throw new Error(
+        'lang.parseFolder: auth.aws_sigv4 requires "access_key", "secret_key", "region", and "service"; "session_token" must be a string when present',
+      )
+    }
+    return {
+      type: "aws_sigv4",
+      access_key: a.access_key,
+      secret_key: a.secret_key,
+      region: a.region,
+      service: a.service,
+      ...(a.session_token ? { session_token: a.session_token } : {}),
+    }
   }
   throw new Error(`lang.parseFolder: invalid auth.type "${String(a.type)}"`)
 }
@@ -172,6 +202,15 @@ export function serializeFolder(folder: Folder): string {
         out += `  key: ${yamlVal(o.auth.key, 2)}\n`
         out += `  value: ${yamlVal(o.auth.value, 2)}\n`
         out += `  placement: ${o.auth.placement}\n`
+      } else if (o.auth.type === "aws_sigv4") {
+        out += "  type: aws_sigv4\n"
+        out += `  access_key: ${yamlVal(o.auth.access_key, 2)}\n`
+        out += `  secret_key: ${yamlVal(o.auth.secret_key, 2)}\n`
+        out += `  region: ${yamlVal(o.auth.region, 2)}\n`
+        out += `  service: ${yamlVal(o.auth.service, 2)}\n`
+        if (o.auth.session_token) {
+          out += `  session_token: ${yamlVal(o.auth.session_token, 2)}\n`
+        }
       }
     }
   }

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -43,6 +43,15 @@ type RawAuth =
       placement?: string
       [k: string]: unknown
     }
+  | {
+      type: "aws_sigv4"
+      access_key: string
+      secret_key: string
+      region: string
+      service: string
+      session_token?: string
+      [k: string]: unknown
+    }
   | { type: string; [k: string]: unknown }
 
 interface RawRequest {
@@ -388,7 +397,28 @@ function parseAuth(value: unknown): Auth {
     const placement = a.placement === "query" ? "query" : "header"
     return { type: "api_key", key: a.key, value: a.value, placement }
   }
+  if (a.type === "aws_sigv4") {
+    if (
+      typeof a.access_key !== "string" ||
+      typeof a.secret_key !== "string" ||
+      typeof a.region !== "string" ||
+      typeof a.service !== "string" ||
+      (a.session_token !== undefined && typeof a.session_token !== "string")
+    ) {
+      throw new Error(
+        'lang.parseRequest: auth.aws_sigv4 requires "access_key", "secret_key", "region", and "service"; "session_token" must be a string when present',
+      )
+    }
+    return {
+      type: "aws_sigv4",
+      access_key: a.access_key,
+      secret_key: a.secret_key,
+      region: a.region,
+      service: a.service,
+      ...(a.session_token ? { session_token: a.session_token } : {}),
+    }
+  }
   throw new Error(
-    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|inherit|bearer|basic|api_key`,
+    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|inherit|bearer|basic|api_key|aws_sigv4`,
   )
 }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -116,5 +116,14 @@ function authToObj(auth: Auth): Record<string, unknown> {
       value: auth.value,
       placement: auth.placement,
     }
+  if (auth.type === "aws_sigv4")
+    return {
+      type: "aws_sigv4",
+      access_key: auth.access_key,
+      secret_key: auth.secret_key,
+      region: auth.region,
+      service: auth.service,
+      ...(auth.session_token ? { session_token: auth.session_token } : {}),
+    }
   return { type: "none" }
 }

--- a/src/requests/awsSigV4.ts
+++ b/src/requests/awsSigV4.ts
@@ -1,0 +1,83 @@
+import { sign } from "aws4"
+import type { Auth } from "../schema"
+
+export type AwsSigV4Auth = Extract<Auth, { type: "aws_sigv4" }>
+
+const SIGNER_HEADERS = [
+  "authorization",
+  "x-amz-date",
+  "x-amz-security-token",
+  "x-amz-content-sha256",
+]
+
+function required(value: string, field: string): void {
+  if (value.trim() === "") {
+    throw new Error(`requests.send: AWS SigV4 requires auth.${field}`)
+  }
+}
+
+export function clearAwsSignerHeaders(headers: Headers): Headers {
+  const clean = new Headers(headers)
+  for (const name of SIGNER_HEADERS) clean.delete(name)
+  return clean
+}
+
+export function signAwsRequest(
+  url: string,
+  init: RequestInit,
+  auth: AwsSigV4Auth,
+  signingDate?: Date,
+): RequestInit {
+  required(auth.access_key, "access_key")
+  required(auth.secret_key, "secret_key")
+  required(auth.region, "region")
+  required(auth.service, "service")
+
+  const parsed = new URL(url)
+  const headers = clearAwsSignerHeaders(new Headers(init.headers))
+  if (signingDate) {
+    headers.set(
+      "x-amz-date",
+      signingDate.toISOString().replace(/[:-]|\.\d{3}/g, ""),
+    )
+  }
+
+  const body = init.body
+  if (
+    body !== undefined &&
+    body !== null &&
+    typeof body !== "string" &&
+    !Buffer.isBuffer(body) &&
+    !(body instanceof Uint8Array)
+  ) {
+    throw new Error(
+      "requests.send: AWS SigV4 only supports text and buffered binary bodies",
+    )
+  }
+
+  const signed = sign(
+    {
+      hostname: parsed.hostname,
+      port: parsed.port ? Number(parsed.port) : undefined,
+      method: init.method,
+      path: `${parsed.pathname}${parsed.search}`,
+      headers: Object.fromEntries(headers.entries()),
+      body:
+        typeof body === "string"
+          ? body
+          : body instanceof Uint8Array
+            ? Buffer.from(body)
+            : undefined,
+      service: auth.service,
+      region: auth.region,
+      doNotEncodePath: auth.service === "s3",
+    },
+    {
+      accessKeyId: auth.access_key,
+      secretAccessKey: auth.secret_key,
+      sessionToken: auth.session_token || undefined,
+    },
+  )
+
+  return { ...init, headers: new Headers(signed.headers as HeadersInit) }
+}

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -18,6 +18,7 @@ import { withDefaultHttpsScheme } from "./url"
 import { expandUserPath } from "../userPath"
 import { proxyForUrl, type ProxyPolicy } from "../proxy"
 import { tlsForUrl, type TlsPolicy } from "../tls"
+import { clearAwsSignerHeaders, signAwsRequest } from "./awsSigV4"
 
 export interface RequestExecutionOptions {
   environment?: Environment
@@ -154,7 +155,22 @@ export async function send(
       : timeoutSignal
   }
 
-  const substitutedBody = await bodyForSend(substituted, headersInst)
+  if (
+    substituted.auth?.type === "aws_sigv4" &&
+    substituted.bodyType === "multipart"
+  ) {
+    throw new Error(
+      "requests.send: AWS SigV4 does not support multipart bodies",
+    )
+  }
+
+  let substitutedBody = await bodyForSend(substituted, headersInst)
+  if (
+    substituted.auth?.type === "aws_sigv4" &&
+    substitutedBody instanceof Blob
+  ) {
+    substitutedBody = Buffer.from(await substitutedBody.arrayBuffer())
+  }
   const init: RequestInit = {
     method: substituted.method,
     headers: headersInst,
@@ -168,6 +184,7 @@ export async function send(
   let currentUrl = finalUrl
   let currentInit: RequestInit = { ...init, redirect: "manual" }
   let redirectCount = 0
+  let awsSigningEnabled = substituted.auth?.type === "aws_sigv4"
   const maxRedirects = req.maxRedirects ?? 5
   const followRedirects = req.followRedirects ?? true
 
@@ -228,7 +245,11 @@ export async function send(
       onNetworkEvent,
     )
     try {
-      const fetchInit: BunFetchRequestInit = { ...currentInit }
+      const signedInit =
+        awsSigningEnabled && substituted.auth?.type === "aws_sigv4"
+          ? signAwsRequest(currentUrl, currentInit, substituted.auth)
+          : currentInit
+      const fetchInit: BunFetchRequestInit = { ...signedInit }
       if (proxyRoute?.kind === "proxy") fetchInit.proxy = proxyRoute.url
       if (resolvedTls.options) fetchInit.tls = resolvedTls.options
       res = await fetch(currentUrl, fetchInit)
@@ -301,9 +322,12 @@ export async function send(
       )
     }
     if (previousUrl.origin !== nextUrl.origin) {
+      awsSigningEnabled = false
       currentInit = {
         ...currentInit,
-        headers: stripCrossOriginCredentials(currentInit.headers, ah?.name),
+        headers: clearAwsSignerHeaders(
+          stripCrossOriginCredentials(currentInit.headers, ah?.name),
+        ),
       }
     }
     currentUrl = nextUrl.toString()

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -99,6 +99,18 @@ function substituteAuth(
       placement: auth.placement,
     }
   }
+  if (auth.type === "aws_sigv4") {
+    return {
+      type: "aws_sigv4",
+      access_key: resolve(auth.access_key, "auth.access_key"),
+      secret_key: resolve(auth.secret_key, "auth.secret_key"),
+      region: resolve(auth.region, "auth.region"),
+      service: resolve(auth.service, "auth.service"),
+      ...(auth.session_token
+        ? { session_token: resolve(auth.session_token, "auth.session_token") }
+        : {}),
+    }
+  }
   return {
     type: "basic",
     user: resolve(auth.user, "auth.user"),

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -54,6 +54,14 @@ export type Auth =
       value: string
       placement: "header" | "query"
     }
+  | {
+      type: "aws_sigv4"
+      access_key: string
+      secret_key: string
+      region: string
+      service: string
+      session_token?: string
+    }
 
 export interface Request {
   id: string

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -51,15 +51,38 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
   if (auth.type === "bearer") {
     return {
       type: "bearer",
-      fieldDefs: [{ row: 1, label: "Token", field: "token", isSecret: true }],
+      fieldDefs: [
+        {
+          row: 1,
+          label: "Token",
+          field: "token",
+          isSecret: true,
+          required: true,
+          description: "Bearer token sent in the Authorization header.",
+        },
+      ],
     }
   }
   if (auth.type === "basic") {
     return {
       type: "basic",
       fieldDefs: [
-        { row: 1, label: "Username", field: "user", isSecret: false },
-        { row: 2, label: "Password", field: "pass", isSecret: true },
+        {
+          row: 1,
+          label: "Username",
+          field: "user",
+          isSecret: false,
+          required: true,
+          description: "Username used for HTTP Basic authentication.",
+        },
+        {
+          row: 2,
+          label: "Password",
+          field: "pass",
+          isSecret: true,
+          required: true,
+          description: "Password used for HTTP Basic authentication.",
+        },
       ],
     }
   }
@@ -112,14 +135,29 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
   return {
     type: "api_key",
     fieldDefs: [
-      { row: 1, label: "Key", field: "key", isSecret: false },
-      { row: 2, label: "Value", field: "value", isSecret: true },
+      {
+        row: 1,
+        label: "Key",
+        field: "key",
+        isSecret: false,
+        required: true,
+        description: "Header or query parameter name for the API key.",
+      },
+      {
+        row: 2,
+        label: "Value",
+        field: "value",
+        isSecret: true,
+        required: true,
+        description: "API key value sent with the request.",
+      },
       {
         row: 3,
         label: "Add To",
         field: "placement",
         isSecret: false,
         isPlacement: true,
+        description: "Where to send the API key.",
       },
     ],
   }

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -155,6 +155,7 @@ export interface AuthEditorProps {
   editState: EditState
   inEdit: boolean
   browseActive: boolean
+  editValue: string
   setEditValue: (v: string) => void
   theme: Theme
   activeEnv?: Environment | null
@@ -173,6 +174,7 @@ export function AuthEditor({
   editState,
   inEdit,
   browseActive,
+  editValue,
   setEditValue,
   theme,
   activeEnv,
@@ -295,7 +297,7 @@ export function AuthEditor({
                 <>
                   <text fg={theme.textMuted}>{displayLabel}: </text>
                   <VarInput
-                    value={fieldValue}
+                    value={editValue}
                     env={activeEnv ?? null}
                     isEditing
                     useTextarea

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -13,6 +13,7 @@ const AUTH_TYPE_ITEMS: SelectItem[] = [
   { id: "bearer", label: "Bearer Token" },
   { id: "basic", label: "Basic Auth" },
   { id: "api_key", label: "API Key" },
+  { id: "aws_sigv4", label: "AWS Signature v4" },
 ]
 
 const PLACEMENT_ITEMS: SelectItem[] = [
@@ -26,6 +27,8 @@ interface FieldDef {
   field: string
   isSecret: boolean
   isPlacement?: boolean
+  description?: string
+  required?: boolean
 }
 
 interface AuthRows {
@@ -60,6 +63,52 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
       ],
     }
   }
+  if (auth.type === "aws_sigv4") {
+    return {
+      type: "aws_sigv4",
+      fieldDefs: [
+        {
+          row: 1,
+          label: "Access Key",
+          field: "access_key",
+          isSecret: false,
+          required: true,
+          description: "AWS access key ID used to identify the signer.",
+        },
+        {
+          row: 2,
+          label: "Secret Key",
+          field: "secret_key",
+          isSecret: true,
+          required: true,
+          description: "AWS secret access key used to derive the signature.",
+        },
+        {
+          row: 3,
+          label: "Region",
+          field: "region",
+          isSecret: false,
+          required: true,
+          description: "AWS region where the service request is sent.",
+        },
+        {
+          row: 4,
+          label: "Service",
+          field: "service",
+          isSecret: false,
+          required: true,
+          description: "AWS service name, such as execute-api or s3.",
+        },
+        {
+          row: 5,
+          label: "Session Token",
+          field: "session_token",
+          isSecret: true,
+          description: "Optional token for temporary AWS credentials.",
+        },
+      ],
+    }
+  }
   return {
     type: "api_key",
     fieldDefs: [
@@ -90,6 +139,13 @@ function getFieldValue(auth: Auth, field: string): string {
     if (field === "value") return auth.value
     if (field === "placement") return auth.placement
     return ""
+  }
+  if (auth.type === "aws_sigv4") {
+    if (field === "access_key") return auth.access_key
+    if (field === "secret_key") return auth.secret_key
+    if (field === "region") return auth.region
+    if (field === "service") return auth.service
+    if (field === "session_token") return auth.session_token ?? ""
   }
   return ""
 }
@@ -191,10 +247,12 @@ export function AuthEditor({
         const displayValue = def.isSecret
           ? maskIfSecret(fieldValue, true)
           : fieldValue
+        const displayLabel = `${def.label}${def.required ? "*" : ""}`
 
         return (
           <box
             key={def.field}
+            id={`${idPrefix}-${def.row}`}
             style={{
               flexDirection: "column",
               zIndex: def.isPlacement && placementSelectOpen ? 1 : undefined,
@@ -235,7 +293,7 @@ export function AuthEditor({
             >
               {isEditingRow && !def.isPlacement ? (
                 <>
-                  <text fg={theme.textMuted}>{def.label}: </text>
+                  <text fg={theme.textMuted}>{displayLabel}: </text>
                   <VarInput
                     value={fieldValue}
                     env={activeEnv ?? null}
@@ -246,7 +304,7 @@ export function AuthEditor({
                 </>
               ) : def.isPlacement ? (
                 <box style={{ flexDirection: "row", gap: 1 }}>
-                  <text fg={theme.text}>{def.label}: </text>
+                  <text fg={theme.text}>{displayLabel}: </text>
                   <Select
                     items={PLACEMENT_ITEMS}
                     value={fieldValue || "header"}
@@ -263,13 +321,22 @@ export function AuthEditor({
                 </box>
               ) : (
                 <VarInput
-                  value={`${def.label}: ${displayValue}`}
+                  value={`${displayLabel}: ${displayValue}`}
                   env={activeEnv ?? null}
                   isEditing={false}
                   baseColor={theme.text}
                 />
               )}
             </box>
+            {def.description && (
+              <text
+                fg={theme.textMuted}
+                wrapMode="word"
+                style={{ paddingLeft: 1 }}
+              >
+                {def.description}
+              </text>
+            )}
           </box>
         )
       })}

--- a/src/ui/FolderMetaTab.tsx
+++ b/src/ui/FolderMetaTab.tsx
@@ -38,6 +38,7 @@ export function FolderMetaTab({
     <box style={{ flexDirection: "column", gap: 1, padding: 1 }}>
       <text fg={theme.textMuted}>Edit folder metadata.</text>
       <box
+        id="folder-meta-field"
         border={[...LeftBar.border]}
         customBorderChars={LeftBar.customBorderChars}
         borderColor={

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -245,6 +245,7 @@ export function FolderPane({
                     editState={editState}
                     inEdit={inEdit}
                     browseActive={browseActive}
+                    editValue={editValue}
                     setEditValue={setEditValue}
                     theme={theme}
                     activeEnv={activeEnv}

--- a/src/ui/FolderPane.tsx
+++ b/src/ui/FolderPane.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useEffect, useMemo, useRef } from "react"
 import type { Folder, Environment, Auth } from "../schema"
 import type { EditState, FieldKind, FolderFieldKind } from "./editMode"
 import { Tabs } from "./Tabs"
@@ -69,6 +70,23 @@ export function FolderPane({
 }: FolderPaneProps) {
   const browseActive = editState.mode === "browsing"
   const inEdit = editState.mode === "editing"
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+
+  useEffect(() => {
+    if (editState.mode === "inactive") return
+    const { field, row, addingRow } = editState.cursor
+    if (field === "headers") {
+      scrollRef.current?.scrollChildIntoView(
+        addingRow ? "hdr-add" : `hdr-${row}`,
+      )
+    } else if (field === "auth") {
+      scrollRef.current?.scrollChildIntoView(
+        row === 0 ? "auth-field" : `auth-${row}`,
+      )
+    } else if (field === "meta") {
+      scrollRef.current?.scrollChildIntoView("folder-meta-field")
+    }
+  }, [editState.cursor, editState.mode])
 
   const { stats: activityStats, loading: activityLoading } = useFolderActivity(
     collectionDir,
@@ -147,6 +165,8 @@ export function FolderPane({
             }}
           >
             <scrollbox
+              id="folder-tab-scrollbox"
+              ref={scrollRef}
               scrollY
               style={{ flexGrow: 1, minHeight: 0, flexBasis: 0 }}
             >

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -136,10 +136,18 @@ export function RequestPane({
       )
     } else if (field === "body" && addingRow) {
       scrollRef.current?.scrollChildIntoView("body-add")
+    } else if (
+      field === "body" &&
+      row > 0 &&
+      (request?.bodyType === "multipart" || request?.bodyType === "urlencoded")
+    ) {
+      scrollRef.current?.scrollChildIntoView(`body-${row - 1}`)
+    } else if ((field === "auth" || field === "settings") && row > 0) {
+      scrollRef.current?.scrollChildIntoView(`${field}-${row}`)
     } else {
       scrollRef.current?.scrollChildIntoView(`${field}-field`)
     }
-  }, [editState.cursor, editState.mode])
+  }, [editState.cursor, editState.mode, request?.bodyType])
 
   const handleSelectOpenChange = useCallback(
     (open: boolean) => {

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -458,6 +458,7 @@ export function RequestPane({
                       editState={editState}
                       inEdit={inEdit}
                       browseActive={browseActive}
+                      editValue={editValue}
                       setEditValue={setEditValue}
                       theme={theme}
                       activeEnv={activeEnv}

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -11,6 +11,7 @@ import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
 import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
 import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
 import type { Collection } from "../schema"
+import { mergeFolderOverrides } from "../requests/mergeFolderOverrides"
 import type { SendState } from "./sendState"
 import type { ResponseQueryController } from "./responseQuery"
 
@@ -159,9 +160,21 @@ export function openResponseQuery(c: CommandActionsConfig): boolean {
 }
 
 export function canGenerateClientCode(c: CommandActionsConfig): boolean {
-  return (
-    c.focusedFolderPathRef.current === null && c.draftRef.current.draft !== null
-  )
+  if (c.focusedFolderPathRef.current !== null) return false
+  const request = c.draftRef.current.draft
+  if (!request) return false
+  const collection = c.collectionRef.current
+  const effective = collection
+    ? mergeFolderOverrides(request, collection, request.id)
+    : request
+  if (effective.auth?.type === "aws_sigv4") {
+    showToast(
+      "Code generation is unavailable for AWS SigV4 requests",
+      "warning",
+    )
+    return false
+  }
+  return true
 }
 
 export function cycleEnvironment(c: CommandActionsConfig): boolean {

--- a/src/ui/formatRequest.ts
+++ b/src/ui/formatRequest.ts
@@ -41,5 +41,7 @@ export function formatAuth(auth?: Auth): string {
     return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
   if (auth.type === "api_key")
     return `api_key: ${auth.key}:\u2022\u2022\u2022\u2022`
+  if (auth.type === "aws_sigv4")
+    return `aws_sigv4: ${auth.service}/${auth.region}`
   return "(none)"
 }

--- a/src/ui/request-pane/RequestBodyTab.tsx
+++ b/src/ui/request-pane/RequestBodyTab.tsx
@@ -234,11 +234,11 @@ export function BodySection({
       style={{
         flexDirection: "column",
         gap: 1,
-        flexGrow: 1,
-        flexShrink: 1,
-        flexBasis: 0,
+        flexGrow: isFormMode ? undefined : 1,
+        flexShrink: isFormMode ? 0 : 1,
+        flexBasis: isFormMode ? undefined : 0,
         minHeight: 0,
-        overflow: "hidden",
+        overflow: isFormMode ? undefined : "hidden",
       }}
     >
       {bodyType === "none" ? null : isFormMode ? (

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -66,40 +66,30 @@ export function buildTimelineEntry(
     if (auth.type === "bearer") {
       return {
         type: "bearer",
-        token: auth.token.includes("$")
-          ? redact(resolvePublicVars(auth.token))
-          : REDACTED,
+        token: REDACTED,
       }
     }
     if (auth.type === "basic") {
       return {
         type: "basic",
         user: redact(resolvePublicVars(auth.user)),
-        pass: auth.pass.includes("$")
-          ? redact(resolvePublicVars(auth.pass))
-          : REDACTED,
+        pass: REDACTED,
       }
     }
     if (auth.type === "aws_sigv4") {
-      const redactCredential = (value: string) =>
-        value.includes("$") ? redact(resolvePublicVars(value)) : REDACTED
       return {
         type: "aws_sigv4",
-        access_key: redactCredential(auth.access_key),
-        secret_key: redactCredential(auth.secret_key),
+        access_key: REDACTED,
+        secret_key: REDACTED,
         region: redact(resolvePublicVars(auth.region)),
         service: redact(resolvePublicVars(auth.service)),
-        ...(auth.session_token
-          ? { session_token: redactCredential(auth.session_token) }
-          : {}),
+        ...(auth.session_token ? { session_token: REDACTED } : {}),
       }
     }
     return {
       ...auth,
       key: redact(resolvePublicVars(auth.key)),
-      value: auth.value.includes("$")
-        ? redact(resolvePublicVars(auth.value))
-        : REDACTED,
+      value: REDACTED,
     }
   }
   return {

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -80,6 +80,20 @@ export function buildTimelineEntry(
           : REDACTED,
       }
     }
+    if (auth.type === "aws_sigv4") {
+      const redactCredential = (value: string) =>
+        value.includes("$") ? redact(resolvePublicVars(value)) : REDACTED
+      return {
+        type: "aws_sigv4",
+        access_key: redactCredential(auth.access_key),
+        secret_key: redactCredential(auth.secret_key),
+        region: redact(resolvePublicVars(auth.region)),
+        service: redact(resolvePublicVars(auth.service)),
+        ...(auth.session_token
+          ? { session_token: redactCredential(auth.session_token) }
+          : {}),
+      }
+    }
     return {
       ...auth,
       key: redact(resolvePublicVars(auth.key)),
@@ -223,6 +237,8 @@ export function maskedAuthHeader(
     return { key: "Authorization", value: "Bearer ••••••••" }
   if (auth.type === "basic")
     return { key: "Authorization", value: "Basic ••••••••" }
+  if (auth.type === "aws_sigv4")
+    return { key: "Authorization", value: "AWS4-HMAC-SHA256 ••••••••" }
   if (auth.type === "api_key" && auth.placement === "header") {
     return { key: auth.key, value: "••••••••" }
   }

--- a/tests/converters/openapi-export.test.ts
+++ b/tests/converters/openapi-export.test.ts
@@ -460,6 +460,32 @@ describe("exportOpenApi", () => {
     expect(JSON.stringify(result.document)).not.toContain("super-secret")
   })
 
+  it("exports AWS Signature v4 security without credentials", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            auth: {
+              type: "aws_sigv4",
+              access_key: "AKID",
+              secret_key: "super-secret",
+              region: "us-east-1",
+              service: "execute-api",
+            },
+          }),
+        },
+      ]),
+    )
+
+    expect(result.document.components).toEqual({
+      securitySchemes: {
+        awsSigV4: { type: "http", scheme: "AWS4-HMAC-SHA256" },
+      },
+    })
+    expect(JSON.stringify(result.document)).not.toContain("super-secret")
+  })
+
   it("does not merge API-key schemes whose sanitized names collide", () => {
     const result = exportOpenApi(
       collection([

--- a/tests/converters/postman-export.test.ts
+++ b/tests/converters/postman-export.test.ts
@@ -272,6 +272,19 @@ describe("Postman export", () => {
             },
           }),
         },
+        {
+          type: "request",
+          data: request("aws", "AWS", {
+            auth: {
+              type: "aws_sigv4",
+              access_key: "$AWS_ACCESS_KEY_ID",
+              secret_key: "$AWS_SECRET_ACCESS_KEY",
+              region: "us-east-1",
+              service: "execute-api",
+              session_token: "$AWS_SESSION_TOKEN",
+            },
+          }),
+        },
       ],
     }
 
@@ -308,6 +321,29 @@ describe("Postman export", () => {
         { key: "key", value: "{{key}}", type: "string" },
         { key: "value", value: "{{$randomUUID}}", type: "string" },
         { key: "in", value: "query", type: "string" },
+      ],
+    })
+    expect((items[5]!.request as Record<string, unknown>).auth).toEqual({
+      type: "awsv4",
+      awsv4: [
+        {
+          key: "accessKey",
+          value: "{{AWS_ACCESS_KEY_ID}}",
+          type: "string",
+        },
+        {
+          key: "secretKey",
+          value: "{{AWS_SECRET_ACCESS_KEY}}",
+          type: "string",
+        },
+        { key: "region", value: "us-east-1", type: "string" },
+        { key: "service", value: "execute-api", type: "string" },
+        { key: "addAuthDataToQuery", value: "false", type: "boolean" },
+        {
+          key: "sessionToken",
+          value: "{{AWS_SESSION_TOKEN}}",
+          type: "string",
+        },
       ],
     })
   })

--- a/tests/converters/postman-export.test.ts
+++ b/tests/converters/postman-export.test.ts
@@ -338,7 +338,7 @@ describe("Postman export", () => {
         },
         { key: "region", value: "us-east-1", type: "string" },
         { key: "service", value: "execute-api", type: "string" },
-        { key: "addAuthDataToQuery", value: "false", type: "boolean" },
+        { key: "addAuthDataToQuery", value: false, type: "boolean" },
         {
           key: "sessionToken",
           value: "{{AWS_SESSION_TOKEN}}",

--- a/tests/converters/postman-map.test.ts
+++ b/tests/converters/postman-map.test.ts
@@ -128,6 +128,41 @@ describe("mapCollection — auth variants", () => {
     expect(r.auth).toEqual({ type: "basic", user: "admin", pass: "pass" })
   })
 
+  it("maps AWS Signature v4 auth", () => {
+    const result = makeCollection({
+      info: { name: "Auth" },
+      item: [
+        {
+          name: "AWS Req",
+          request: {
+            method: "GET",
+            url: "https://service.us-east-1.amazonaws.com",
+            header: [],
+            auth: {
+              type: "awsv4",
+              awsv4: [
+                { key: "accessKey", value: "{{AWS_ACCESS_KEY_ID}}" },
+                { key: "secretKey", value: "{{AWS_SECRET_ACCESS_KEY}}" },
+                { key: "region", value: "us-east-1" },
+                { key: "service", value: "execute-api" },
+                { key: "sessionToken", value: "{{AWS_SESSION_TOKEN}}" },
+              ],
+            },
+          },
+        },
+      ],
+    })
+    const r = reqs(result)[0] as Record<string, unknown>
+    expect(r.auth).toEqual({
+      type: "aws_sigv4",
+      access_key: "$AWS_ACCESS_KEY_ID",
+      secret_key: "$AWS_SECRET_ACCESS_KEY",
+      region: "us-east-1",
+      service: "execute-api",
+      session_token: "$AWS_SESSION_TOKEN",
+    })
+  })
+
   it("maps standard API key fields and templates", () => {
     const result = makeCollection({
       info: { name: "Auth" },

--- a/tests/folder-lang.test.ts
+++ b/tests/folder-lang.test.ts
@@ -79,6 +79,30 @@ describe("lang.parseFolder", () => {
   })
 })
 
+describe("AWS SigV4 folder auth", () => {
+  it("round-trips inherited AWS signing configuration", () => {
+    const folder = {
+      id: "aws",
+      name: "aws",
+      path: "aws",
+      overrides: {
+        auth: {
+          type: "aws_sigv4" as const,
+          access_key: "$AWS_ACCESS_KEY_ID",
+          secret_key: "$AWS_SECRET_ACCESS_KEY",
+          region: "us-east-1",
+          service: "s3",
+        },
+      },
+      children: [],
+    }
+    const serialized = lang.serializeFolder(folder)
+    expect(lang.parseFolder(serialized).overrides?.auth).toEqual(
+      folder.overrides.auth,
+    )
+  })
+})
+
 describe("lang.serializeFolder", () => {
   it("serializes folder with name override", () => {
     const result = lang.serializeFolder({

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -15,6 +15,36 @@ function makeRequest(overrides: Partial<Request> = {}): Request {
   }
 }
 
+describe("AWS SigV4 auth language", () => {
+  it("parses and serializes credentials with an optional session token", () => {
+    const request = lang.parseRequest(
+      "aws",
+      `name: AWS\nmethod: GET\nurl: https://example.com\nauth:\n  type: aws_sigv4\n  access_key: $AWS_ACCESS_KEY_ID\n  secret_key: $AWS_SECRET_ACCESS_KEY\n  region: us-east-1\n  service: execute-api\n  session_token: $AWS_SESSION_TOKEN\n`,
+    )
+
+    expect(request.auth).toEqual({
+      type: "aws_sigv4",
+      access_key: "$AWS_ACCESS_KEY_ID",
+      secret_key: "$AWS_SECRET_ACCESS_KEY",
+      region: "us-east-1",
+      service: "execute-api",
+      session_token: "$AWS_SESSION_TOKEN",
+    })
+    expect(
+      lang.parseRequest("aws", lang.serializeRequest(request)).auth,
+    ).toEqual(request.auth)
+  })
+
+  it("requires all non-optional fields", () => {
+    expect(() =>
+      lang.parseRequest(
+        "aws",
+        `name: AWS\nmethod: GET\nurl: https://example.com\nauth:\n  type: aws_sigv4\n  access_key: key\n  secret_key: secret\n  region: us-east-1\n`,
+      ),
+    ).toThrow("auth.aws_sigv4 requires")
+  })
+})
+
 describe("lang.parseRequest — required fields", () => {
   it("parses a minimal valid request (name, method, url)", () => {
     const yaml = `name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\n`

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -145,6 +145,59 @@ describe("substitute — formData", () => {
   })
 })
 
+describe("substitute — AWS SigV4", () => {
+  it("substitutes every credential and scope field", () => {
+    const result = substitute(
+      makeReq({
+        auth: {
+          type: "aws_sigv4",
+          access_key: "$ACCESS",
+          secret_key: "$SECRET",
+          region: "$REGION",
+          service: "$SERVICE",
+          session_token: "$SESSION",
+        },
+      }),
+      {
+        name: "dev",
+        vars: {
+          ACCESS: "AKID",
+          SECRET: "secret",
+          REGION: "us-east-1",
+          SERVICE: "execute-api",
+          SESSION: "token",
+        },
+      },
+    )
+
+    expect(result.auth).toEqual({
+      type: "aws_sigv4",
+      access_key: "AKID",
+      secret_key: "secret",
+      region: "us-east-1",
+      service: "execute-api",
+      session_token: "token",
+    })
+  })
+
+  it("reports the unresolved AWS field", () => {
+    expect(() =>
+      substitute(
+        makeReq({
+          auth: {
+            type: "aws_sigv4",
+            access_key: "AKID",
+            secret_key: "$MISSING",
+            region: "us-east-1",
+            service: "execute-api",
+          },
+        }),
+        { name: "dev", vars: {} },
+      ),
+    ).toThrow('unresolved variable "MISSING" in auth.secret_key')
+  })
+})
+
 describe("substitute — params", () => {
   it("substitutes $var in param name and value", () => {
     const env: Environment = {

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -145,6 +145,59 @@ describe("substitute — formData", () => {
   })
 })
 
+describe("substitute — auth", () => {
+  it("should substitute a bearer token", () => {
+    const result = substitute(
+      makeReq({ auth: { type: "bearer", token: "$TOKEN" } }),
+      { name: "dev", vars: { TOKEN: "secret-token" } },
+    )
+
+    expect(result.auth).toEqual({ type: "bearer", token: "secret-token" })
+  })
+
+  it("should substitute basic auth credentials", () => {
+    const result = substitute(
+      makeReq({
+        auth: { type: "basic", user: "$USER", pass: "$PASSWORD" },
+      }),
+      {
+        name: "dev",
+        vars: { USER: "noodle", PASSWORD: "secret-password" },
+      },
+    )
+
+    expect(result.auth).toEqual({
+      type: "basic",
+      user: "noodle",
+      pass: "secret-password",
+    })
+  })
+
+  it("should substitute an API key while preserving its placement", () => {
+    const result = substitute(
+      makeReq({
+        auth: {
+          type: "api_key",
+          key: "$KEY_NAME",
+          value: "$KEY_VALUE",
+          placement: "header",
+        },
+      }),
+      {
+        name: "dev",
+        vars: { KEY_NAME: "X-Api-Key", KEY_VALUE: "secret-api-key" },
+      },
+    )
+
+    expect(result.auth).toEqual({
+      type: "api_key",
+      key: "X-Api-Key",
+      value: "secret-api-key",
+      placement: "header",
+    })
+  })
+})
+
 describe("substitute — AWS SigV4", () => {
   it("substitutes every credential and scope field", () => {
     const result = substitute(

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -4,10 +4,11 @@ import { createTestRender } from "./testRender"
 import { extend } from "@opentui/react"
 import { RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
-import type { Request, KvEntry, CollectionItem } from "../src/schema"
+import type { Request, KvEntry, CollectionItem, Folder } from "../src/schema"
 import type { VisibleNode } from "../src/ui/tree"
 import { Sidebar } from "../src/ui/Sidebar"
 import { RequestPane } from "../src/ui/RequestPane"
+import { FolderPane } from "../src/ui/FolderPane"
 import { ResponsePane } from "../src/ui/ResponsePane"
 import type { SendState } from "../src/ui/sendState"
 import { initialEditState } from "../src/ui/editMode"
@@ -928,6 +929,162 @@ describe("ResponsePane scrollbox", () => {
 })
 
 describe("RequestPane scrollbox", () => {
+  it("keeps the active AWS auth row inside the request viewport", async () => {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const awsRequest: Request = {
+      ...makeRequest(1),
+      auth: {
+        type: "aws_sigv4",
+        access_key: "$AWS_ACCESS_KEY_ID",
+        secret_key: "$AWS_SECRET_ACCESS_KEY",
+        region: "us-east-1",
+        service: "execute-api",
+        session_token: "$AWS_SESSION_TOKEN",
+      },
+    }
+    let setAuthRow: ((row: number) => void) | undefined
+    function AwsAuthPane() {
+      const [row, setRow] = useState(0)
+      setAuthRow = setRow
+      return (
+        <RequestPane
+          request={awsRequest}
+          editState={{
+            mode: "browsing",
+            cursor: { field: "auth", row, addingRow: false },
+            editingRow: -1,
+          }}
+          editKey=""
+          editValue=""
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          focused
+          activeTab="auth"
+        />
+      )
+    }
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <AwsAuthPane />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 14 },
+    )
+
+    await renderOnce()
+    await act(async () => setAuthRow?.(5))
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "request-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureCharFrame()).toContain("Session Token")
+  })
+
+  it("keeps the active multipart row inside the request viewport", async () => {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const request: Request = {
+      ...makeRequest(1),
+      bodyType: "multipart",
+      formData: Array.from({ length: 30 }, (_, i) => ({
+        name: `field-${i}`,
+        value: `value-${i}`,
+        enabled: true,
+        type: "text" as const,
+      })),
+    }
+    let setBodyRow: ((row: number) => void) | undefined
+    function MultipartPane() {
+      const [row, setRow] = useState(0)
+      setBodyRow = setRow
+      return (
+        <RequestPane
+          request={request}
+          editState={{
+            mode: "browsing",
+            cursor: { field: "body", row, addingRow: false },
+            editingRow: -1,
+          }}
+          editKey=""
+          editValue=""
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          focused
+          activeTab="body"
+        />
+      )
+    }
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <MultipartPane />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+
+    await renderOnce()
+    await act(async () => setBodyRow?.(30))
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "request-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureCharFrame()).toContain("field-29")
+  })
+
+  it("keeps the active request setting inside the request viewport", async () => {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    let setSettingsRow: ((row: number) => void) | undefined
+    function SettingsPane() {
+      const [row, setRow] = useState(0)
+      setSettingsRow = setRow
+      return (
+        <RequestPane
+          request={makeRequest(1)}
+          editState={{
+            mode: "browsing",
+            cursor: { field: "settings", row, addingRow: false },
+            editingRow: -1,
+          }}
+          editKey=""
+          editValue=""
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          focused
+          activeTab="settings"
+        />
+      )
+    }
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <SettingsPane />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+
+    await renderOnce()
+    await act(async () => setSettingsRow?.(3))
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "request-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureCharFrame()).toContain("TLS Verification")
+  })
+
   it("renders with many headers without overflowing", async () => {
     const manyHeaders: Record<string, KvEntry> = {}
     for (let i = 0; i < 30; i++) {
@@ -1169,6 +1326,106 @@ describe("RequestPane scrollbox", () => {
     const frame = captureCharFrame()
     expect(frame).toContain("id")
     expect(frame).toContain("complianceAuditId")
+  })
+})
+
+describe("FolderPane scrollbox", () => {
+  const awsAuth = {
+    type: "aws_sigv4" as const,
+    access_key: "$AWS_ACCESS_KEY_ID",
+    secret_key: "$AWS_SECRET_ACCESS_KEY",
+    region: "us-east-1",
+    service: "execute-api",
+    session_token: "$AWS_SESSION_TOKEN",
+  }
+
+  async function renderFolderPane(folder: Folder, activeTab: FieldKind) {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    let setFolderRow: ((row: number) => void) | undefined
+    function FolderScrollPane() {
+      const [row, setRow] = useState(0)
+      setFolderRow = setRow
+      return (
+        <FolderPane
+          collectionDir="/tmp/collection"
+          folder={folder}
+          focused
+          editState={{
+            mode: "browsing",
+            cursor: { field: activeTab, row, addingRow: false },
+            editingRow: -1,
+          }}
+          editKey=""
+          editValue=""
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          activeTab={activeTab}
+          onAuthTypeChange={() => {}}
+          onApiKeyPlacementChange={() => {}}
+          activeEnv={null}
+          theme={THEMES[0]!}
+        />
+      )
+    }
+    const rendered = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <FolderScrollPane />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+    return { ...rendered, setFolderRow: (row: number) => setFolderRow?.(row) }
+  }
+
+  it("keeps the active folder header inside the viewport", async () => {
+    const headers: Record<string, KvEntry> = {}
+    for (let i = 0; i < 30; i++) {
+      headers[`X-Folder-${i}`] = { value: `value-${i}`, enabled: true }
+    }
+    const folder: Folder = {
+      id: "api",
+      path: "api",
+      name: "API",
+      overrides: { headers },
+      children: [],
+    }
+    const { renderer, renderOnce, captureCharFrame, setFolderRow } =
+      await renderFolderPane(folder, "headers")
+
+    await renderOnce()
+    await act(async () => setFolderRow(29))
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "folder-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureCharFrame()).toContain("X-Folder-29")
+  })
+
+  it("keeps the active folder AWS auth row inside the viewport", async () => {
+    const folder: Folder = {
+      id: "api",
+      path: "api",
+      name: "API",
+      overrides: { auth: awsAuth },
+      children: [],
+    }
+    const { renderer, renderOnce, captureCharFrame, setFolderRow } =
+      await renderFolderPane(folder, "auth")
+
+    await renderOnce()
+    await act(async () => setFolderRow(5))
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "folder-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureCharFrame()).toContain("Session Token")
   })
 })
 

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -392,6 +392,18 @@ describe("maskedAuthHeader", () => {
         placement: "query",
       }),
     ).toBeNull()
+    expect(
+      maskedAuthHeader({
+        type: "aws_sigv4",
+        access_key: "AKID",
+        secret_key: "secret",
+        region: "us-east-1",
+        service: "execute-api",
+      }),
+    ).toEqual({
+      key: "Authorization",
+      value: "AWS4-HMAC-SHA256 ••••••••",
+    })
   })
 })
 
@@ -566,6 +578,57 @@ describe("buildTimelineEntry", () => {
     expect(entry.response?.headers["x-echo"]).toBe(secret)
     expect(entry.response?.body).toBe(`echo:${secret}`)
     expect(response.body).toBe(`echo:${secret}`)
+  })
+
+  it("redacts literal and secret-variable AWS credentials", () => {
+    const req = {
+      id: "req-aws",
+      name: "AWS",
+      method: "GET" as const,
+      url: "https://service.us-east-1.amazonaws.com",
+      headers: {},
+      params: [],
+      auth: {
+        type: "aws_sigv4" as const,
+        access_key: "literal-access",
+        secret_key: "$AWS_SECRET_ACCESS_KEY",
+        region: "us-east-1",
+        service: "execute-api",
+        session_token: "literal-session",
+      },
+      timeout: 0,
+    }
+    const entry = buildTimelineEntry(
+      req,
+      {
+        status: "done",
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "",
+          timeMs: 1,
+        },
+      },
+      "dev",
+      {
+        name: "dev",
+        vars: { AWS_SECRET_ACCESS_KEY: "resolved-secret" },
+        secretVars: { AWS_SECRET_ACCESS_KEY: "keychain" },
+      },
+    )
+
+    expect(entry.request.auth).toEqual({
+      type: "aws_sigv4",
+      access_key: "[REDACTED]",
+      secret_key: "$AWS_SECRET_ACCESS_KEY",
+      region: "us-east-1",
+      service: "execute-api",
+      session_token: "[REDACTED]",
+    })
+    expect(JSON.stringify(entry.request)).not.toContain("literal-access")
+    expect(JSON.stringify(entry.request)).not.toContain("literal-session")
+    expect(JSON.stringify(entry.request)).not.toContain("resolved-secret")
   })
 
   it("copies network activity into the saved entry", () => {

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -14,7 +14,7 @@ import {
   maskedAuthHeader,
   buildDetailRequestHeaders,
 } from "../src/ui/timeline/formatTimeline"
-import type { TimelineEntry } from "../src/schema"
+import type { Auth, TimelineEntry } from "../src/schema"
 
 describe("truncateUrl", () => {
   it("returns full URL when shorter than max", () => {
@@ -621,7 +621,7 @@ describe("buildTimelineEntry", () => {
     expect(entry.request.auth).toEqual({
       type: "aws_sigv4",
       access_key: "[REDACTED]",
-      secret_key: "$AWS_SECRET_ACCESS_KEY",
+      secret_key: "[REDACTED]",
       region: "us-east-1",
       service: "execute-api",
       session_token: "[REDACTED]",
@@ -629,6 +629,90 @@ describe("buildTimelineEntry", () => {
     expect(JSON.stringify(entry.request)).not.toContain("literal-access")
     expect(JSON.stringify(entry.request)).not.toContain("literal-session")
     expect(JSON.stringify(entry.request)).not.toContain("resolved-secret")
+  })
+
+  it("redacts auth secrets supplied through public variables", () => {
+    const result = {
+      status: "done" as const,
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "",
+        timeMs: 1,
+      },
+    }
+    const environment = {
+      name: "dev",
+      vars: {
+        USER: "alice",
+        KEY: "X-API-Key",
+        TOKEN: "public-token",
+        PASSWORD: "public-password",
+        API_VALUE: "public-api-value",
+        ACCESS: "public-access",
+        SECRET: "public-secret",
+        SESSION: "public-session",
+        REGION: "us-east-1",
+        SERVICE: "execute-api",
+      },
+    }
+    const auths: Auth[] = [
+      { type: "bearer", token: "$TOKEN" },
+      { type: "basic", user: "$USER", pass: "$PASSWORD" },
+      {
+        type: "api_key",
+        key: "$KEY",
+        value: "$API_VALUE",
+        placement: "header",
+      },
+      {
+        type: "aws_sigv4",
+        access_key: "$ACCESS",
+        secret_key: "$SECRET",
+        session_token: "$SESSION",
+        region: "$REGION",
+        service: "$SERVICE",
+      },
+    ]
+    const snapshots = auths.map(
+      (auth) =>
+        buildTimelineEntry(
+          {
+            id: "auth",
+            name: "Auth",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+            timeout: 0,
+            auth,
+          },
+          result,
+          "dev",
+          environment,
+        ).request.auth,
+    )
+
+    expect(snapshots).toEqual([
+      { type: "bearer", token: "[REDACTED]" },
+      { type: "basic", user: "alice", pass: "[REDACTED]" },
+      {
+        type: "api_key",
+        key: "X-API-Key",
+        value: "[REDACTED]",
+        placement: "header",
+      },
+      {
+        type: "aws_sigv4",
+        access_key: "[REDACTED]",
+        secret_key: "[REDACTED]",
+        session_token: "[REDACTED]",
+        region: "us-east-1",
+        service: "execute-api",
+      },
+    ])
+    expect(JSON.stringify(snapshots)).not.toContain("public-")
   })
 
   it("copies network activity into the saved entry", () => {
@@ -742,7 +826,7 @@ describe("buildTimelineEntry", () => {
     expect(entry.request.auth).toEqual({
       type: "basic",
       user: "42",
-      pass: "$TOKEN",
+      pass: "[REDACTED]",
     })
   })
 

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -2,15 +2,147 @@ import { describe, expect, it } from "bun:test"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
-import { act } from "react"
+import { act, useState } from "react"
 import { AuthEditor } from "../../src/ui/AuthEditor"
 import { initialEditState } from "../../src/ui/editMode"
 import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { setupKeymap } from "./_helpers"
+import type { Auth } from "../../src/schema"
 
 const testRender = createTestRender()
 
 describe("AuthEditor", () => {
+  const autocompleteCases: Array<{ name: string; auth: Auth; row: number }> = [
+    {
+      name: "bearer token",
+      auth: { type: "bearer", token: "" },
+      row: 1,
+    },
+    {
+      name: "basic username",
+      auth: { type: "basic", user: "", pass: "" },
+      row: 1,
+    },
+    {
+      name: "basic password",
+      auth: { type: "basic", user: "", pass: "" },
+      row: 2,
+    },
+    {
+      name: "API key name",
+      auth: { type: "api_key", key: "", value: "", placement: "header" },
+      row: 1,
+    },
+    {
+      name: "API key value",
+      auth: { type: "api_key", key: "", value: "", placement: "header" },
+      row: 2,
+    },
+    {
+      name: "AWS access key",
+      auth: {
+        type: "aws_sigv4",
+        access_key: "",
+        secret_key: "",
+        region: "",
+        service: "",
+      },
+      row: 1,
+    },
+    {
+      name: "AWS secret key",
+      auth: {
+        type: "aws_sigv4",
+        access_key: "",
+        secret_key: "",
+        region: "",
+        service: "",
+      },
+      row: 2,
+    },
+    {
+      name: "AWS region",
+      auth: {
+        type: "aws_sigv4",
+        access_key: "",
+        secret_key: "",
+        region: "",
+        service: "",
+      },
+      row: 3,
+    },
+    {
+      name: "AWS service",
+      auth: {
+        type: "aws_sigv4",
+        access_key: "",
+        secret_key: "",
+        region: "",
+        service: "",
+      },
+      row: 4,
+    },
+    {
+      name: "AWS session token",
+      auth: {
+        type: "aws_sigv4",
+        access_key: "",
+        secret_key: "",
+        region: "",
+        service: "",
+        session_token: "",
+      },
+      row: 5,
+    },
+  ]
+
+  for (const { name, auth, row } of autocompleteCases) {
+    it(`shows variable autocomplete for ${name}`, async () => {
+      const { keymap, cleanup } = setupKeymap()
+      function CompletionEditor() {
+        const [editValue, setEditValue] = useState("")
+        return (
+          <AuthEditor
+            auth={auth}
+            editState={{
+              mode: "editing",
+              cursor: { field: "auth", row, addingRow: false },
+              editingRow: row,
+            }}
+            inEdit
+            browseActive={false}
+            editValue={editValue}
+            setEditValue={setEditValue}
+            theme={THEMES[0]!}
+            activeEnv={{
+              name: "dev",
+              vars: { AWS_PROFILE: "development" },
+            }}
+            onAuthTypeChange={() => {}}
+            onApiKeyPlacementChange={() => {}}
+          />
+        )
+      }
+      const { renderOnce, captureCharFrame, mockInput } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box width={70} height={30}>
+              <CompletionEditor />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 70, height: 30 },
+      )
+      await renderOnce()
+
+      await act(async () => mockInput.typeText("$AWS"))
+      await renderOnce()
+
+      expect(captureCharFrame()).toContain("$AWS_PROFILE")
+      cleanup()
+    })
+  }
+
   it("renders AWS fields and masks secret values", async () => {
     const { keymap, cleanup } = setupKeymap()
     const { renderOnce, captureCharFrame } = await testRender(
@@ -29,6 +161,7 @@ describe("AuthEditor", () => {
               editState={initialEditState()}
               inEdit={false}
               browseActive={false}
+              editValue=""
               setEditValue={() => {}}
               theme={THEMES[0]!}
               onAuthTypeChange={() => {}}
@@ -73,6 +206,7 @@ describe("AuthEditor", () => {
               editState={initialEditState()}
               inEdit={false}
               browseActive={false}
+              editValue=""
               setEditValue={() => {}}
               theme={THEMES[0]!}
               onAuthTypeChange={() => {}}

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -11,6 +11,51 @@ import { setupKeymap } from "./_helpers"
 const testRender = createTestRender()
 
 describe("AuthEditor", () => {
+  it("renders AWS fields and masks secret values", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={70} height={30}>
+            <AuthEditor
+              auth={{
+                type: "aws_sigv4",
+                access_key: "$AWS_ACCESS_KEY_ID",
+                secret_key: "do-not-render",
+                region: "us-east-1",
+                service: "execute-api",
+                session_token: "also-secret",
+              }}
+              editState={initialEditState()}
+              inEdit={false}
+              browseActive={false}
+              setEditValue={() => {}}
+              theme={THEMES[0]!}
+              onAuthTypeChange={() => {}}
+              onApiKeyPlacementChange={() => {}}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 70, height: 30 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("AWS Signature v4")
+    expect(frame).toContain("Access Key*")
+    expect(frame).toContain("Secret Key*")
+    expect(frame).toContain("Region*")
+    expect(frame).toContain("Service*")
+    expect(frame).toContain("Session Token")
+    expect(frame).toContain("us-east-1")
+    expect(frame).toContain("execute-api")
+    expect(frame).toContain("AWS access key ID used to identify the signer.")
+    expect(frame).toContain("Optional token for temporary AWS credentials.")
+    expect(frame).not.toContain("do-not-render")
+    expect(frame).not.toContain("also-secret")
+    cleanup()
+  })
+
   it("activates the API key placement row before opening its select", async () => {
     const { keymap, cleanup } = setupKeymap()
     let focusedRow = -1

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { BoxRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
@@ -189,48 +190,127 @@ describe("AuthEditor", () => {
     cleanup()
   })
 
+  it("renders descriptions and required markers for other auth fields", async () => {
+    const cases: Array<{
+      auth: Auth
+      labels: string[]
+      descriptions: string[]
+    }> = [
+      {
+        auth: { type: "bearer", token: "token" },
+        labels: ["Token*"],
+        descriptions: ["Bearer token sent in the Authorization header."],
+      },
+      {
+        auth: { type: "basic", user: "user", pass: "pass" },
+        labels: ["Username*", "Password*"],
+        descriptions: [
+          "Username used for HTTP Basic authentication.",
+          "Password used for HTTP Basic authentication.",
+        ],
+      },
+      {
+        auth: {
+          type: "api_key",
+          key: "X-API-Key",
+          value: "secret",
+          placement: "header",
+        },
+        labels: ["Key*", "Value*", "Add To"],
+        descriptions: [
+          "Header or query parameter name for the API key.",
+          "API key value sent with the request.",
+          "Where to send the API key.",
+        ],
+      },
+    ]
+
+    for (const { auth, labels, descriptions } of cases) {
+      const { keymap, cleanup } = setupKeymap()
+      const { renderOnce, captureCharFrame } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box width={70} height={20}>
+              <AuthEditor
+                auth={auth}
+                editState={initialEditState()}
+                inEdit={false}
+                browseActive={false}
+                editValue=""
+                setEditValue={() => {}}
+                theme={THEMES[0]!}
+                onAuthTypeChange={() => {}}
+                onApiKeyPlacementChange={() => {}}
+              />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 70, height: 20 },
+      )
+      await renderOnce()
+      const frame = captureCharFrame()
+      for (const label of labels) expect(frame).toContain(label)
+      for (const description of descriptions) {
+        expect(frame).toContain(description)
+      }
+      cleanup()
+    }
+  })
+
   it("activates the API key placement row before opening its select", async () => {
     const { keymap, cleanup } = setupKeymap()
     let focusedRow = -1
-    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
-      <KeymapProvider keymap={keymap}>
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <box width={60} height={10}>
-            <AuthEditor
-              auth={{
-                type: "api_key",
-                key: "X-API-Key",
-                value: "secret",
-                placement: "header",
-              }}
-              editState={initialEditState()}
-              inEdit={false}
-              browseActive={false}
-              editValue=""
-              setEditValue={() => {}}
-              theme={THEMES[0]!}
-              onAuthTypeChange={() => {}}
-              onApiKeyPlacementChange={() => {}}
-              onFocusRow={(row) => {
-                focusedRow = row
-              }}
-            />
-          </box>
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 60, height: 10 },
-    )
+    const { renderOnce, captureCharFrame, mockMouse, renderer } =
+      await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box width={60} height={10}>
+              <AuthEditor
+                auth={{
+                  type: "api_key",
+                  key: "X-API-Key",
+                  value: "secret",
+                  placement: "header",
+                }}
+                editState={initialEditState()}
+                inEdit={false}
+                browseActive={false}
+                editValue=""
+                setEditValue={() => {}}
+                theme={THEMES[0]!}
+                onAuthTypeChange={() => {}}
+                onApiKeyPlacementChange={() => {}}
+                onFocusRow={(row) => {
+                  focusedRow = row
+                }}
+              />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 60, height: 10 },
+      )
     await renderOnce()
-    const rows = captureCharFrame().split("\n")
-    const y = rows.findIndex((row) => row.includes("Header"))
+    const placementRow = renderer.root.findDescendantById(
+      "auth-3",
+    ) as BoxRenderable
+    const placementLine = captureCharFrame().split("\n")[placementRow.screenY]!
+    const placementLabelX = placementLine.indexOf("Header")
 
     await act(async () => {
-      await mockMouse.click(50, y, MouseButtons.LEFT)
+      await mockMouse.click(
+        placementRow.screenX + 50,
+        placementRow.screenY,
+        MouseButtons.LEFT,
+      )
     })
     expect(focusedRow).toBe(-1)
 
     await act(async () => {
-      await mockMouse.click(rows[y]!.indexOf("Header"), y, MouseButtons.LEFT)
+      await mockMouse.click(
+        placementLabelX,
+        placementRow.screenY,
+        MouseButtons.LEFT,
+      )
     })
     expect(focusedRow).toBe(3)
     cleanup()

--- a/tests/unit/ProxySettingsForm.test.tsx
+++ b/tests/unit/ProxySettingsForm.test.tsx
@@ -410,6 +410,8 @@ describe("ProxySettingsForm", () => {
         authRow.screenY,
         MouseButtons.LEFT,
       )
+      await mockMouse.moveTo(89, 29)
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
     await renderOnce()
     expect(captureCharFrame()).toContain("Proxy authentication (optional): [x]")

--- a/tests/unit/awsSigV4.test.ts
+++ b/tests/unit/awsSigV4.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test"
+import { signAwsRequest } from "../../src/requests/awsSigV4"
+
+const auth = {
+  type: "aws_sigv4" as const,
+  access_key: "AKIDEXAMPLE",
+  secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+  region: "us-east-1",
+  service: "iam",
+}
+
+describe("AWS SigV4", () => {
+  it("matches the AWS IAM ListUsers signature example", () => {
+    const signed = signAwsRequest(
+      "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08",
+      {
+        method: "GET",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+        },
+      },
+      auth,
+      new Date("2015-08-30T12:36:00Z"),
+    )
+    const headers = new Headers(signed.headers)
+
+    expect(headers.get("x-amz-date")).toBe("20150830T123600Z")
+    expect(headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
+    )
+  })
+
+  it("adds a temporary credential token and replaces stale signer headers", () => {
+    const signed = signAwsRequest(
+      "https://sts.us-east-1.amazonaws.com/",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "stale",
+          "X-Amz-Date": "20000101T000000Z",
+          "X-Amz-Security-Token": "stale-token",
+        },
+        body: "Action=GetCallerIdentity&Version=2011-06-15",
+      },
+      { ...auth, service: "sts", session_token: "session-token" },
+      new Date("2026-08-12T12:00:00Z"),
+    )
+    const headers = new Headers(signed.headers)
+
+    expect(headers.get("x-amz-security-token")).toBe("session-token")
+    expect(headers.get("authorization")).toContain(
+      "Credential=AKIDEXAMPLE/20260812/us-east-1/sts/aws4_request",
+    )
+  })
+
+  it("rejects incomplete credentials without exposing their values", () => {
+    expect(() =>
+      signAwsRequest(
+        "https://example.com",
+        { method: "GET" },
+        { ...auth, secret_key: "" },
+      ),
+    ).toThrow("AWS SigV4 requires auth.secret_key")
+  })
+})

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -264,6 +264,57 @@ describe("buildHar", () => {
 })
 
 describe("generateCode", () => {
+  it("rejects AWS Signature v4 instead of generating an expiring signature", () => {
+    expect(() =>
+      generateCode(
+        makeRequest({
+          auth: {
+            type: "aws_sigv4",
+            access_key: "$AWS_ACCESS_KEY_ID",
+            secret_key: "$AWS_SECRET_ACCESS_KEY",
+            region: "us-east-1",
+            service: "execute-api",
+          },
+        }),
+        curlTarget(),
+      ),
+    ).toThrow("generated signatures expire")
+  })
+
+  it("rejects inherited AWS Signature v4 auth", () => {
+    expect(() =>
+      generateCode(
+        makeRequest({ id: "aws/request", auth: { type: "inherit" } }),
+        curlTarget(),
+        {
+          id: "col",
+          name: "col",
+          items: [
+            {
+              type: "folder",
+              data: {
+                id: "aws",
+                name: "aws",
+                path: "aws",
+                seq: 1,
+                overrides: {
+                  auth: {
+                    type: "aws_sigv4",
+                    access_key: "AKID",
+                    secret_key: "secret",
+                    region: "us-east-1",
+                    service: "execute-api",
+                  },
+                },
+                children: [],
+              },
+            },
+          ],
+        },
+      ),
+    ).toThrow("generated signatures expire")
+  })
+
   it("does not interpolate declared secrets", () => {
     const generated = generateCode(
       makeRequest({ url: "https://example.com/$TOKEN/$PUBLIC" }),

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -328,4 +328,20 @@ describe("folderEqual", () => {
     const b = makeFolder()
     expect(folderEqual(a, b)).toBe(true)
   })
+
+  it("treats missing and empty AWS session tokens as equal", () => {
+    const auth = {
+      type: "aws_sigv4" as const,
+      access_key: "access",
+      secret_key: "secret",
+      region: "us-east-1",
+      service: "execute-api",
+    }
+    const a = makeFolder({ overrides: { auth } })
+    const b = makeFolder({
+      overrides: { auth: { ...auth, session_token: "" } },
+    })
+
+    expect(folderEqual(a, b)).toBe(true)
+  })
 })

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock } from "bun:test"
-import type { NetworkError, Request } from "../../src/schema"
+import type { Collection, NetworkError, Request } from "../../src/schema"
 import { send, interpolatePathParams } from "../../src/requests/send"
 
 function makeReq(over: Partial<Request> = {}): Request {
@@ -179,6 +179,52 @@ describe("send — AWS SigV4", () => {
     }
   })
 
+  it("should substitute AWS auth fields before signing", async () => {
+    const originalFetch = globalThis.fetch
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (_url, init) => {
+      capturedInit = init
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await send(
+        makeReq({
+          auth: {
+            type: "aws_sigv4",
+            access_key: "$ACCESS",
+            secret_key: "$SECRET",
+            region: "$REGION",
+            service: "$SERVICE",
+            session_token: "$SESSION",
+          },
+        }),
+        {
+          environment: {
+            name: "dev",
+            vars: {
+              ACCESS: "AKIDEXAMPLE",
+              SECRET: "secret",
+              REGION: "us-west-2",
+              SERVICE: "execute-api",
+              SESSION: "session-token",
+            },
+          },
+        },
+      )
+
+      const headers = new Headers(capturedInit?.headers)
+      expect(headers.get("authorization")).toContain("Credential=AKIDEXAMPLE/")
+      expect(headers.get("authorization")).toContain(
+        "/us-west-2/execute-api/aws4_request",
+      )
+      expect(headers.get("authorization")).not.toContain("$")
+      expect(headers.get("x-amz-security-token")).toBe("session-token")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it("re-signs same-origin redirects and stops signing cross-origin hops", async () => {
     const originalFetch = globalThis.fetch
     const authorizations: Array<string | null> = []
@@ -234,6 +280,52 @@ describe("send — AWS SigV4", () => {
         ),
       ).rejects.toThrow("AWS SigV4 does not support multipart bodies")
       expect(calls).toBe(0)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe("send — inherited auth", () => {
+  it("should substitute auth inherited from a folder before sending", async () => {
+    const originalFetch = globalThis.fetch
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (_url, init) => {
+      capturedInit = init
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+    const collection: Collection = {
+      id: "collection",
+      name: "Collection",
+      items: [
+        {
+          type: "folder",
+          data: {
+            id: "api",
+            name: "API",
+            path: "api",
+            overrides: {
+              auth: { type: "bearer", token: "$FOLDER_TOKEN" },
+            },
+            children: [],
+          },
+        },
+      ],
+    }
+
+    try {
+      await send(makeReq({ auth: { type: "inherit" } }), {
+        collection,
+        requestPath: "api/test",
+        environment: {
+          name: "dev",
+          vars: { FOLDER_TOKEN: "inherited-token" },
+        },
+      })
+
+      expect(new Headers(capturedInit?.headers).get("authorization")).toBe(
+        "Bearer inherited-token",
+      )
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -136,6 +136,110 @@ describe("send — param deduplication", () => {
   })
 })
 
+describe("send — AWS SigV4", () => {
+  const awsAuth = {
+    type: "aws_sigv4" as const,
+    access_key: "AKIDEXAMPLE",
+    secret_key: "secret",
+    region: "us-east-1",
+    service: "execute-api",
+  }
+
+  it("signs the final URL and exact JSON body", async () => {
+    const originalFetch = globalThis.fetch
+    let capturedUrl = ""
+    let capturedInit: RequestInit | undefined
+    globalThis.fetch = mock(async (url, init) => {
+      capturedUrl = url.toString()
+      capturedInit = init
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await send(
+        makeReq({
+          method: "POST",
+          url: "https://api.example.com/items?existing=1",
+          params: [{ name: "filter", value: "active", enabled: true }],
+          bodyType: "json",
+          body: '{"ok":true}',
+          auth: awsAuth,
+        }),
+      )
+      const headers = new Headers(capturedInit?.headers)
+      expect(capturedUrl).toContain("existing=1&filter=active")
+      expect(capturedInit?.body).toBe('{"ok":true}')
+      expect(headers.get("authorization")).toContain("AWS4-HMAC-SHA256")
+      expect(headers.get("authorization")).toContain(
+        "/execute-api/aws4_request",
+      )
+      expect(headers.get("x-amz-date")).not.toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("re-signs same-origin redirects and stops signing cross-origin hops", async () => {
+    const originalFetch = globalThis.fetch
+    const authorizations: Array<string | null> = []
+    let calls = 0
+    globalThis.fetch = mock(async (_url, init) => {
+      calls++
+      authorizations.push(new Headers(init?.headers).get("authorization"))
+      if (calls === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "/next" },
+        })
+      }
+      if (calls === 2) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://other.example/final" },
+        })
+      }
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await send(
+        makeReq({ url: "https://api.example.com/start", auth: awsAuth }),
+      )
+      expect(authorizations[0]).toContain("AWS4-HMAC-SHA256")
+      expect(authorizations[1]).toContain("AWS4-HMAC-SHA256")
+      expect(authorizations[0]).not.toBe(authorizations[1])
+      expect(authorizations[2]).toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("rejects multipart before fetch", async () => {
+    const originalFetch = globalThis.fetch
+    let calls = 0
+    globalThis.fetch = mock(async () => {
+      calls++
+      return new Response("ok")
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await expect(
+        send(
+          makeReq({
+            method: "POST",
+            auth: awsAuth,
+            bodyType: "multipart",
+            formData: [],
+          }),
+        ),
+      ).rejects.toThrow("AWS SigV4 does not support multipart bodies")
+      expect(calls).toBe(0)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
 describe("send — network trace", () => {
   it("uses Bun-backed app proxy credentials without environment overrides", async () => {
     const originalFetch = globalThis.fetch

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -1066,3 +1066,31 @@ describe("authEqual — api_key", () => {
     expect(requestEquals(a, b)).toBe(false)
   })
 })
+
+describe("authEqual — aws_sigv4", () => {
+  const auth = {
+    type: "aws_sigv4" as const,
+    access_key: "access",
+    secret_key: "secret",
+    region: "us-east-1",
+    service: "execute-api",
+  }
+
+  it("treats a missing and empty session token as equal", () => {
+    expect(
+      requestEquals(
+        makeReq({ auth }),
+        makeReq({ auth: { ...auth, session_token: "" } }),
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps different non-empty session tokens unequal", () => {
+    expect(
+      requestEquals(
+        makeReq({ auth: { ...auth, session_token: "one" } }),
+        makeReq({ auth: { ...auth, session_token: "two" } }),
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature

### What does this PR do?

Adds AWS Signature v4 request signing as a new auth type (`aws_sigv4`). Request signing runs in `send.ts` via `aws4`, re-signs on redirects, and disables signing when redirecting cross-origin. Includes:

- `Auth` schema + YAML parse/serialize for requests and folders
- Auth editor UI support with required-field markers and descriptions
- Variable substitution and HAR codegen support (codegen refuses SigV4 because generated signatures expire)
- OpenAPI and Postman export mappings

Also fixes auth field editing in `AuthEditor` (use `editValue` instead of `fieldValue`) and adds required/description markers to auth fields.

### How did you verify your code works?

- New unit tests: `tests/unit/awsSigV4.test.ts`, expanded `send.test.ts`, `AuthEditor.test.tsx`, `codegen.test.ts`, folder/lang/timeline/export tests
- `bun test` passes
- `bun run lint` passes
- `bun run typecheck` passes

### Screenshots / recordings

N/A (terminal UI; SigV4 auth type selectable in the Auth editor).

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Signature Version 4 authentication with credential, region, service, and optional session-token fields.
  * Added AWS SigV4 signing for text, JSON, URL-encoded, and binary request bodies.
  * Added AWS SigV4 configuration, validation, variable substitution, masking, and secure timeline redaction.
  * Added Postman and OpenAPI import/export support.

* **Limitations**
  * Multipart requests and client code generation are not supported with AWS SigV4 authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->