### PR TITLE
feat(ntlm): add NTLMv2 authentication support

### DIFF
--- a/.agents/skills/noodle-use/SKILL.md
+++ b/.agents/skills/noodle-use/SKILL.md
@@ -79,10 +79,11 @@ proxy/TLS blocks fail collection opening, auditing, and execution.
 When creating/deleting files, only operate within the collection directory. Never create files outside the collection root. IDs must not contain `..`, leading `/`, backslashes, empty path segments, or hidden path segments.
 
 ### Authorization
-Auth types: `none`, `inherit`, `bearer`, `basic`, `api_key`, `aws_sigv4`.
+Auth types: `none`, `inherit`, `bearer`, `basic`, `ntlm`, `api_key`, `aws_sigv4`.
 - `none`: No auth. Omit the `auth` field entirely (don't write `{ type: none }`).
 - `inherit`: Use parent folder's auth override. Only valid when a parent folder defines auth.
 - `bearer`: `{ type: bearer, token: "$TOKEN" }`
 - `basic`: `{ type: basic, user: "$USER", pass: "$PASS" }`
 - `api_key`: `{ type: api_key, key: "X-API-Key", value: "$KEY", placement: "header" }`. Placement is `"header"` or `"query"`.
+- `ntlm`: `{ type: ntlm, username: "$NTLM_USERNAME", password: "$NTLM_PASSWORD", domain: "$NTLM_DOMAIN", workstation: "$NTLM_WORKSTATION" }`. Domain and workstation are optional. Noodle supports connection-bound server NTLMv2 authentication only; keep the password in a secret environment variable.
 - `aws_sigv4`: `{ type: aws_sigv4, access_key: "$AWS_ACCESS_KEY_ID", secret_key: "$AWS_SECRET_ACCESS_KEY", region: "us-east-1", service: "execute-api", session_token: "$AWS_SESSION_TOKEN" }`. `session_token` is optional. Signing uses headers and supports text, JSON, URL-encoded, and binary bodies; multipart is not supported.

--- a/.agents/skills/noodle-use/schema.md
+++ b/.agents/skills/noodle-use/schema.md
@@ -103,20 +103,29 @@ directory paths and should be reviewed before sharing.
 
 ### Auth
 
-| Field | Bearer | Basic | API Key | AWS SigV4 |
-|-------|--------|-------|---------|-----------|
-| `type` | `"bearer"` | `"basic"` | `"api_key"` | `"aws_sigv4"` |
-| `token` | yes | — | — | — |
-| `user` | — | yes | — | — |
-| `pass` | — | yes | — | — |
-| `key` | — | — | yes | — |
-| `value` | — | — | yes | — |
-| `placement` | — | — | `"header"` (default) or `"query"` | — |
-| `access_key` | — | — | — | yes |
-| `secret_key` | — | — | — | yes |
-| `region` | — | — | — | yes |
-| `service` | — | — | — | yes |
-| `session_token` | — | — | — | optional |
+| Field | Bearer | Basic | NTLMv2 | API Key | AWS SigV4 |
+|-------|--------|-------|--------|---------|-----------|
+| `type` | `"bearer"` | `"basic"` | `"ntlm"` | `"api_key"` | `"aws_sigv4"` |
+| `token` | yes | — | — | — | — |
+| `user` | — | yes | — | — | — |
+| `pass` | — | yes | — | — | — |
+| `username` | — | — | yes | — | — |
+| `password` | — | — | yes | — | — |
+| `domain` | — | — | optional | — | — |
+| `workstation` | — | — | optional | — | — |
+| `key` | — | — | — | yes | — |
+| `value` | — | — | — | yes | — |
+| `placement` | — | — | — | `"header"` (default) or `"query"` | — |
+| `access_key` | — | — | — | — | yes |
+| `secret_key` | — | — | — | — | yes |
+| `region` | — | — | — | — | yes |
+| `service` | — | — | — | — | yes |
+| `session_token` | — | — | — | — | optional |
+
+NTLM uses the connection-bound NTLMv2 challenge exchange. Proxy NTLM,
+NTLMv1, Kerberos/SPNEGO negotiation, signing, sealing, and channel binding are
+not supported. Keep the password in a secret environment variable rather than
+literal YAML.
 
 AWS SigV4 is added as request headers after environment substitution. It supports
 text, JSON, URL-encoded, and binary bodies. Multipart bodies are rejected because

--- a/src/codegen/buildHar.ts
+++ b/src/codegen/buildHar.ts
@@ -145,6 +145,14 @@ function substituteAuth(
       user: resolveVar(auth.user),
       pass: resolveVar(auth.pass),
     }
+  if (auth.type === "ntlm")
+    return {
+      type: "ntlm",
+      username: resolveVar(auth.username),
+      password: resolveVar(auth.password),
+      domain: resolveVar(auth.domain),
+      workstation: resolveVar(auth.workstation),
+    }
   if (auth.type === "api_key")
     return {
       type: "api_key",

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -30,6 +30,11 @@ export function generateCode(
       "codegen.generateCode: AWS SigV4 requests are not supported because generated signatures expire",
     )
   }
+  if (effective.auth?.type === "ntlm") {
+    throw new Error(
+      "codegen.generateCode: NTLM requests are not supported because authentication requires a connection-bound challenge exchange",
+    )
+  }
 
   const { har, unhash } = buildHar(effective, env, interpolate)
 

--- a/src/converters/insomnia/map.ts
+++ b/src/converters/insomnia/map.ts
@@ -71,6 +71,15 @@ function mapAuth(value: unknown): Auth {
       pass: convertTpl(stringValue(auth.password)),
     }
   }
+  if (auth.type === "ntlm") {
+    return {
+      type: "ntlm",
+      username: convertTpl(stringValue(auth.username)),
+      password: convertTpl(stringValue(auth.password)),
+      domain: convertTpl(stringValue(auth.domain)),
+      workstation: convertTpl(stringValue(auth.workstation)),
+    }
+  }
   if (auth.type === "apikey") {
     return {
       type: "api_key",

--- a/src/converters/openapi/export.ts
+++ b/src/converters/openapi/export.ts
@@ -314,6 +314,9 @@ function securityFor(
   } else if (auth.type === "basic") {
     name = "basicAuth"
     schemes[name] ??= { type: "http", scheme: "basic" }
+  } else if (auth.type === "ntlm") {
+    name = "ntlmAuth"
+    schemes[name] ??= { type: "http", scheme: "ntlm" }
   } else if (auth.type === "aws_sigv4") {
     name = "awsSigV4"
     schemes[name] ??= { type: "http", scheme: "AWS4-HMAC-SHA256" }

--- a/src/converters/openapi/map.ts
+++ b/src/converters/openapi/map.ts
@@ -199,12 +199,22 @@ function lookupScheme(
 
 function schemeToAuth(scheme: Record<string, unknown>): Auth | null {
   const type = scheme.type
-  const schemeName = scheme.scheme
+  const schemeName =
+    typeof scheme.scheme === "string" ? scheme.scheme.toLowerCase() : undefined
   if (type === "http" && schemeName === "bearer") {
     return { type: "bearer", token: "$token" }
   }
   if (type === "http" && schemeName === "basic") {
     return { type: "basic", user: "$user", pass: "$pass" }
+  }
+  if (type === "http" && schemeName === "ntlm") {
+    return {
+      type: "ntlm",
+      username: "$NTLM_USERNAME",
+      password: "$NTLM_PASSWORD",
+      domain: "$NTLM_DOMAIN",
+      workstation: "$NTLM_WORKSTATION",
+    }
   }
   if (type === "apiKey") {
     const name = typeof scheme.name === "string" ? scheme.name : "X-API-Key"
@@ -472,6 +482,12 @@ export function mapCollection(n: Normalized): ImportResult {
       if (mu) envVarsFound.add(mu[1])
       const mp = a.pass.match(/\$(\w+)/)
       if (mp) envVarsFound.add(mp[1])
+    }
+    if (a.type === "ntlm") {
+      for (const value of [a.username, a.password, a.domain, a.workstation]) {
+        const matches = value.matchAll(/\$(\w+)/g)
+        for (const match of matches) envVarsFound.add(match[1]!)
+      }
     }
     if (a.type === "api_key") {
       const m = a.value.match(/\$(\w+)/)

--- a/src/converters/postman/export.ts
+++ b/src/converters/postman/export.ts
@@ -46,6 +46,35 @@ function postmanAuth(auth: Auth | undefined): PostmanObject | undefined {
       ],
     }
   }
+  if (auth.type === "ntlm") {
+    const ntlm = [
+      {
+        key: "username",
+        value: toPostmanTpl(auth.username),
+        type: "string",
+      },
+      {
+        key: "password",
+        value: toPostmanTpl(auth.password),
+        type: "string",
+      },
+    ]
+    if (auth.domain) {
+      ntlm.push({
+        key: "domain",
+        value: toPostmanTpl(auth.domain),
+        type: "string",
+      })
+    }
+    if (auth.workstation) {
+      ntlm.push({
+        key: "workstation",
+        value: toPostmanTpl(auth.workstation),
+        type: "string",
+      })
+    }
+    return { type: "ntlm", ntlm }
+  }
   if (auth.type === "aws_sigv4") {
     const awsv4 = [
       {

--- a/src/converters/postman/map.ts
+++ b/src/converters/postman/map.ts
@@ -80,6 +80,15 @@ function mapAuth(
       pass: convertTpl(params?.get("password") ?? ""),
     }
   }
+  if (type === "ntlm") {
+    return {
+      type: "ntlm",
+      username: convertTpl(params?.get("username") ?? ""),
+      password: convertTpl(params?.get("password") ?? ""),
+      domain: convertTpl(params?.get("domain") ?? ""),
+      workstation: convertTpl(params?.get("workstation") ?? ""),
+    }
+  }
 
   if (type === "apikey") {
     const key = params?.get("key") ?? ""

--- a/src/hooks/draftUtils.ts
+++ b/src/hooks/draftUtils.ts
@@ -188,6 +188,14 @@ export function authEqual(
   if (a.type === "basic" && b.type === "basic") {
     return a.user === b.user && a.pass === b.pass
   }
+  if (a.type === "ntlm" && b.type === "ntlm") {
+    return (
+      a.username === b.username &&
+      a.password === b.password &&
+      a.domain === b.domain &&
+      a.workstation === b.workstation
+    )
+  }
   if (a.type === "api_key" && b.type === "api_key") {
     return a.key === b.key && a.value === b.value && a.placement === b.placement
   }
@@ -280,6 +288,14 @@ export function defaultAuth(authType: Auth["type"]): Auth {
       return { type: "bearer", token: "" }
     case "basic":
       return { type: "basic", user: "", pass: "" }
+    case "ntlm":
+      return {
+        type: "ntlm",
+        username: "",
+        password: "",
+        domain: "",
+        workstation: "",
+      }
     case "api_key":
       return { type: "api_key", key: "", value: "", placement: "header" }
     case "aws_sigv4":

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -37,6 +37,7 @@ function rowCount(req: Request | null): SectionRowCount {
   if (a) {
     if (a.type === "bearer") authRows = 2
     else if (a.type === "basic") authRows = 3
+    else if (a.type === "ntlm") authRows = 5
     else if (a.type === "api_key") authRows = 4
     else if (a.type === "aws_sigv4") authRows = 6
   }
@@ -94,6 +95,12 @@ function currentValueFor(
       if (row === 0) return ""
       if (row === 1) return a.user
       if (row === 2) return a.pass
+    }
+    if (a.type === "ntlm") {
+      if (row === 1) return a.username
+      if (row === 2) return a.password
+      if (row === 3) return a.domain
+      if (row === 4) return a.workstation
     }
     if (a.type === "api_key") {
       if (row === 0) return ""
@@ -719,6 +726,15 @@ export function useEditBrowse(
           if (row === 1) draftMutators.setAuthField("api_key", "key", val)
           else if (row === 2)
             draftMutators.setAuthField("api_key", "value", val)
+        } else if (currentAuth.type === "ntlm") {
+          const authField = [
+            "",
+            "username",
+            "password",
+            "domain",
+            "workstation",
+          ][row]
+          if (authField) draftMutators.setAuthField("ntlm", authField, val)
         } else if (currentAuth.type === "aws_sigv4") {
           const fields = [
             "",

--- a/src/hooks/useFolderEditBrowse.ts
+++ b/src/hooks/useFolderEditBrowse.ts
@@ -66,6 +66,7 @@ function folderRowCount(folder: Folder | null): FolderRowCount {
   if (a) {
     if (a.type === "bearer") authRows = 2
     else if (a.type === "basic") authRows = 3
+    else if (a.type === "ntlm") authRows = 5
     else if (a.type === "api_key") authRows = 4
     else if (a.type === "aws_sigv4") authRows = 6
   }
@@ -100,6 +101,12 @@ function folderCurrentValueFor(
       if (row === 0) return ""
       if (row === 1) return a.user
       if (row === 2) return a.pass
+    }
+    if (a.type === "ntlm") {
+      if (row === 1) return a.username
+      if (row === 2) return a.password
+      if (row === 3) return a.domain
+      if (row === 4) return a.workstation
     }
     if (a.type === "api_key") {
       if (row === 0) return ""
@@ -418,6 +425,15 @@ export function useFolderEditBrowse(
           if (row === 1) draftMutators.setAuthField("api_key", "key", val)
           else if (row === 2)
             draftMutators.setAuthField("api_key", "value", val)
+        } else if (currentAuth.type === "ntlm") {
+          const authField = [
+            "",
+            "username",
+            "password",
+            "domain",
+            "workstation",
+          ][row]
+          if (authField) draftMutators.setAuthField("ntlm", authField, val)
         } else if (currentAuth.type === "aws_sigv4") {
           const fields = [
             "",

--- a/src/lang/folder.ts
+++ b/src/lang/folder.ts
@@ -73,6 +73,14 @@ type RawFolderAuth =
   | { type: "bearer"; token: string; [k: string]: unknown }
   | { type: "basic"; user: string; pass: string; [k: string]: unknown }
   | {
+      type: "ntlm"
+      username: string
+      password: string
+      domain?: string
+      workstation?: string
+      [k: string]: unknown
+    }
+  | {
       type: "api_key"
       key: string
       value: string
@@ -106,6 +114,25 @@ function parseFolderAuth(value: unknown): Auth {
       throw new Error('lang.parseFolder: auth.basic requires "user" and "pass"')
     }
     return { type: "basic", user: a.user, pass: a.pass }
+  }
+  if (a.type === "ntlm") {
+    if (
+      typeof a.username !== "string" ||
+      typeof a.password !== "string" ||
+      (a.domain !== undefined && typeof a.domain !== "string") ||
+      (a.workstation !== undefined && typeof a.workstation !== "string")
+    ) {
+      throw new Error(
+        'lang.parseFolder: auth.ntlm requires "username" and "password"; "domain" and "workstation" must be strings when present',
+      )
+    }
+    return {
+      type: "ntlm",
+      username: a.username,
+      password: a.password,
+      domain: a.domain ?? "",
+      workstation: a.workstation ?? "",
+    }
   }
   if (a.type === "api_key") {
     if (typeof a.key !== "string" || typeof a.value !== "string") {
@@ -197,6 +224,14 @@ export function serializeFolder(folder: Folder): string {
         out += "  type: basic\n"
         out += `  user: ${yamlVal(o.auth.user, 2)}\n`
         out += `  pass: ${yamlVal(o.auth.pass, 2)}\n`
+      } else if (o.auth.type === "ntlm") {
+        out += "  type: ntlm\n"
+        out += `  username: ${yamlVal(o.auth.username, 2)}\n`
+        out += `  password: ${yamlVal(o.auth.password, 2)}\n`
+        if (o.auth.domain) out += `  domain: ${yamlVal(o.auth.domain, 2)}\n`
+        if (o.auth.workstation) {
+          out += `  workstation: ${yamlVal(o.auth.workstation, 2)}\n`
+        }
       } else if (o.auth.type === "api_key") {
         out += "  type: api_key\n"
         out += `  key: ${yamlVal(o.auth.key, 2)}\n`

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -37,6 +37,14 @@ type RawAuth =
   | { type: "bearer"; token: string; [k: string]: unknown }
   | { type: "basic"; user: string; pass: string; [k: string]: unknown }
   | {
+      type: "ntlm"
+      username: string
+      password: string
+      domain?: string
+      workstation?: string
+      [k: string]: unknown
+    }
+  | {
       type: "api_key"
       key: string
       value: string
@@ -388,6 +396,25 @@ function parseAuth(value: unknown): Auth {
     }
     return { type: "basic", user: a.user, pass: a.pass }
   }
+  if (a.type === "ntlm") {
+    if (
+      typeof a.username !== "string" ||
+      typeof a.password !== "string" ||
+      (a.domain !== undefined && typeof a.domain !== "string") ||
+      (a.workstation !== undefined && typeof a.workstation !== "string")
+    ) {
+      throw new Error(
+        'lang.parseRequest: auth.ntlm requires "username" and "password"; "domain" and "workstation" must be strings when present',
+      )
+    }
+    return {
+      type: "ntlm",
+      username: a.username,
+      password: a.password,
+      domain: a.domain ?? "",
+      workstation: a.workstation ?? "",
+    }
+  }
   if (a.type === "api_key") {
     if (typeof a.key !== "string" || typeof a.value !== "string") {
       throw new Error(
@@ -419,6 +446,6 @@ function parseAuth(value: unknown): Auth {
     }
   }
   throw new Error(
-    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|inherit|bearer|basic|api_key|aws_sigv4`,
+    `lang.parseRequest: invalid auth.type "${String(a.type)}", expected none|inherit|bearer|basic|ntlm|api_key|aws_sigv4`,
   )
 }

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -109,6 +109,14 @@ function authToObj(auth: Auth): Record<string, unknown> {
   if (auth.type === "bearer") return { type: "bearer", token: auth.token }
   if (auth.type === "basic")
     return { type: "basic", user: auth.user, pass: auth.pass }
+  if (auth.type === "ntlm")
+    return {
+      type: "ntlm",
+      username: auth.username,
+      password: auth.password,
+      ...(auth.domain ? { domain: auth.domain } : {}),
+      ...(auth.workstation ? { workstation: auth.workstation } : {}),
+    }
   if (auth.type === "api_key")
     return {
       type: "api_key",

--- a/src/requests/ntlm.ts
+++ b/src/requests/ntlm.ts
@@ -1,0 +1,334 @@
+import { randomBytes } from "node:crypto"
+
+const SIGNATURE = Buffer.from("NTLMSSP\0", "ascii")
+const NEGOTIATE_UNICODE = 0x00000001
+const REQUEST_TARGET = 0x00000004
+const NEGOTIATE_NTLM = 0x00000200
+const NEGOTIATE_ALWAYS_SIGN = 0x00008000
+const NEGOTIATE_EXTENDED_SESSION_SECURITY = 0x00080000
+const NEGOTIATE_TARGET_INFO = 0x00800000
+const NEGOTIATE_FLAGS =
+  NEGOTIATE_UNICODE |
+  REQUEST_TARGET |
+  NEGOTIATE_NTLM |
+  NEGOTIATE_ALWAYS_SIGN |
+  NEGOTIATE_EXTENDED_SESSION_SECURITY
+const AV_FLAGS = 6
+const AV_TIMESTAMP = 7
+const AV_EOL = 0
+const MIC_PRESENT = 0x00000002
+const FILETIME_EPOCH = 11644473600000n
+
+interface AvPair {
+  id: number
+  value: Buffer
+}
+
+export interface ParsedType2Message {
+  raw: Buffer
+  flags: number
+  challenge: Buffer
+  targetInfo: AvPair[]
+  timestamp?: bigint
+  requiresMic: boolean
+}
+
+export interface NtlmCredentials {
+  username: string
+  password: string
+  domain: string
+  workstation: string
+}
+
+export interface Type3Options {
+  type1?: Buffer
+  clientChallenge?: Buffer
+  timestamp?: bigint
+}
+
+export type NtlmChallenge =
+  | { kind: "none" }
+  | { kind: "offer"; scheme: "NTLM" }
+  | {
+      kind: "type2"
+      scheme: "NTLM" | "Negotiate"
+      message: ParsedType2Message
+    }
+
+function hmacMd5(key: Uint8Array, ...values: Uint8Array[]): Buffer {
+  const hasher = new Bun.CryptoHasher("md5", key)
+  for (const value of values) hasher.update(value)
+  return Buffer.from(hasher.digest())
+}
+
+function md4(value: Uint8Array): Buffer {
+  return Buffer.from(new Bun.CryptoHasher("md4").update(value).digest())
+}
+
+export function ntlmV2Hash(
+  username: string,
+  password: string,
+  domain: string,
+): Buffer {
+  const ntHash = md4(Buffer.from(password, "utf16le"))
+  return hmacMd5(
+    ntHash,
+    Buffer.from(`${username.toUpperCase()}${domain}`, "utf16le"),
+  )
+}
+
+function writeSecurityBuffer(
+  message: Buffer,
+  offset: number,
+  length: number,
+  dataOffset: number,
+): void {
+  message.writeUInt16LE(length, offset)
+  message.writeUInt16LE(length, offset + 2)
+  message.writeUInt32LE(dataOffset, offset + 4)
+}
+
+function readSecurityBuffer(
+  message: Buffer,
+  offset: number,
+  name: string,
+): Buffer {
+  if (offset + 8 > message.length) {
+    throw new Error(`truncated ${name} security buffer`)
+  }
+  const length = message.readUInt16LE(offset)
+  const allocated = message.readUInt16LE(offset + 2)
+  const dataOffset = message.readUInt32LE(offset + 4)
+  if (allocated < length || dataOffset > message.length - length) {
+    throw new Error(`invalid ${name} security buffer`)
+  }
+  return message.subarray(dataOffset, dataOffset + length)
+}
+
+function decodeBase64(token: string): Buffer {
+  if (
+    token === "" ||
+    token.length % 4 === 1 ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(token)
+  ) {
+    throw new Error("invalid base64 token")
+  }
+  const padded = token.padEnd(Math.ceil(token.length / 4) * 4, "=")
+  return Buffer.from(padded, "base64")
+}
+
+function validateMessage(message: Buffer, type: number): void {
+  if (message.length < 12) throw new Error("truncated NTLM message")
+  if (!message.subarray(0, 8).equals(SIGNATURE)) {
+    throw new Error("invalid NTLM signature")
+  }
+  if (message.readUInt32LE(8) !== type) {
+    throw new Error(`expected NTLM message type ${type}`)
+  }
+}
+
+function parseAvPairs(targetInfo: Buffer): AvPair[] {
+  if (targetInfo.length === 0) return [{ id: AV_EOL, value: Buffer.alloc(0) }]
+  const pairs: AvPair[] = []
+  let offset = 0
+  while (offset + 4 <= targetInfo.length) {
+    const id = targetInfo.readUInt16LE(offset)
+    const length = targetInfo.readUInt16LE(offset + 2)
+    offset += 4
+    if (offset > targetInfo.length - length) {
+      throw new Error("invalid NTLM target-info AV pair")
+    }
+    const value = Buffer.from(targetInfo.subarray(offset, offset + length))
+    offset += length
+    if (id === AV_EOL) {
+      if (length !== 0 || offset !== targetInfo.length) {
+        throw new Error("invalid NTLM target-info terminator")
+      }
+      pairs.push({ id, value })
+      return pairs
+    }
+    pairs.push({ id, value })
+  }
+  throw new Error("NTLM target info is missing its terminator")
+}
+
+function serializeAvPairs(pairs: AvPair[], includeMic: boolean): Buffer {
+  const output: AvPair[] = []
+  let hasFlags = false
+  for (const pair of pairs) {
+    if (pair.id === AV_EOL) continue
+    if (pair.id === AV_FLAGS && includeMic) {
+      if (pair.value.length !== 4) throw new Error("invalid NTLM AV flags")
+      const value = Buffer.from(pair.value)
+      value.writeUInt32LE(value.readUInt32LE(0) | MIC_PRESENT, 0)
+      output.push({ id: pair.id, value })
+      hasFlags = true
+    } else {
+      output.push(pair)
+      if (pair.id === AV_FLAGS) hasFlags = true
+    }
+  }
+  if (includeMic && !hasFlags) {
+    const value = Buffer.alloc(4)
+    value.writeUInt32LE(MIC_PRESENT)
+    output.push({ id: AV_FLAGS, value })
+  }
+  output.push({ id: AV_EOL, value: Buffer.alloc(0) })
+  return Buffer.concat(
+    output.map(({ id, value }) => {
+      const pair = Buffer.alloc(4 + value.length)
+      pair.writeUInt16LE(id, 0)
+      pair.writeUInt16LE(value.length, 2)
+      value.copy(pair, 4)
+      return pair
+    }),
+  )
+}
+
+export function createType1Message(): Buffer {
+  const message = Buffer.alloc(32)
+  SIGNATURE.copy(message)
+  message.writeUInt32LE(1, 8)
+  message.writeUInt32LE(NEGOTIATE_FLAGS, 12)
+  writeSecurityBuffer(message, 16, 0, 32)
+  writeSecurityBuffer(message, 24, 0, 32)
+  return message
+}
+
+export function parseType2Message(token: string): ParsedType2Message {
+  const raw = decodeBase64(token)
+  validateMessage(raw, 2)
+  if (raw.length < 48) throw new Error("truncated NTLM Type 2 message")
+  const flags = raw.readUInt32LE(20)
+  if ((flags & NEGOTIATE_NTLM) === 0) {
+    throw new Error("NTLM Type 2 message does not negotiate NTLM")
+  }
+  if ((flags & NEGOTIATE_UNICODE) === 0) {
+    throw new Error("NTLM Type 2 message does not negotiate Unicode")
+  }
+  if ((flags & NEGOTIATE_EXTENDED_SESSION_SECURITY) === 0) {
+    throw new Error(
+      "NTLM Type 2 message does not negotiate extended session security",
+    )
+  }
+  const challenge = Buffer.from(raw.subarray(24, 32))
+  const targetInfoBuffer = readSecurityBuffer(raw, 40, "target info")
+  if ((flags & NEGOTIATE_TARGET_INFO) !== 0 && targetInfoBuffer.length === 0) {
+    throw new Error("NTLM Type 2 message has empty target info")
+  }
+  const targetInfo = parseAvPairs(targetInfoBuffer)
+  let timestamp: bigint | undefined
+  let avFlags = 0
+  for (const pair of targetInfo) {
+    if (pair.id === AV_TIMESTAMP) {
+      if (pair.value.length !== 8) throw new Error("invalid NTLM AV timestamp")
+      timestamp = pair.value.readBigUInt64LE()
+    }
+    if (pair.id === AV_FLAGS) {
+      if (pair.value.length !== 4) throw new Error("invalid NTLM AV flags")
+      avFlags = pair.value.readUInt32LE()
+    }
+  }
+  return {
+    raw,
+    flags,
+    challenge,
+    targetInfo,
+    timestamp,
+    requiresMic: timestamp !== undefined || (avFlags & MIC_PRESENT) !== 0,
+  }
+}
+
+function currentFiletime(): bigint {
+  return (BigInt(Date.now()) + FILETIME_EPOCH) * 10000n
+}
+
+export function createType3Message(
+  type2: ParsedType2Message,
+  credentials: NtlmCredentials,
+  options: Type3Options = {},
+): Buffer {
+  if (
+    options.clientChallenge !== undefined &&
+    options.clientChallenge.length !== 8
+  ) {
+    throw new Error("NTLM client challenge must be 8 bytes")
+  }
+  const includeMic = options.type1 !== undefined
+  if (options.type1) validateMessage(options.type1, 1)
+  const timestamp = options.timestamp ?? type2.timestamp ?? currentFiletime()
+  const clientChallenge = options.clientChallenge ?? randomBytes(8)
+  const targetInfo = serializeAvPairs(type2.targetInfo, includeMic)
+  const blob = Buffer.alloc(28)
+  blob[0] = 1
+  blob[1] = 1
+  blob.writeBigUInt64LE(timestamp, 8)
+  clientChallenge.copy(blob, 16)
+  const proofInput = Buffer.concat([blob, targetInfo, Buffer.alloc(4)])
+  const responseKey = ntlmV2Hash(
+    credentials.username,
+    credentials.password,
+    credentials.domain,
+  )
+  const proof = hmacMd5(responseKey, type2.challenge, proofInput)
+  const ntResponse = Buffer.concat([proof, proofInput])
+  const lmResponse = Buffer.alloc(24)
+  const domain = Buffer.from(credentials.domain, "utf16le")
+  const username = Buffer.from(credentials.username, "utf16le")
+  const workstation = Buffer.from(credentials.workstation, "utf16le")
+  const payloads = [domain, username, workstation, lmResponse, ntResponse]
+  const message = Buffer.alloc(88 + payloads.reduce((n, p) => n + p.length, 0))
+  SIGNATURE.copy(message)
+  message.writeUInt32LE(3, 8)
+  let dataOffset = 88
+  for (const [securityOffset, payload] of [
+    [28, domain],
+    [36, username],
+    [44, workstation],
+    [12, lmResponse],
+    [20, ntResponse],
+  ] as const) {
+    writeSecurityBuffer(message, securityOffset, payload.length, dataOffset)
+    payload.copy(message, dataOffset)
+    dataOffset += payload.length
+  }
+  writeSecurityBuffer(message, 52, 0, dataOffset)
+  const flags =
+    (type2.flags & NEGOTIATE_FLAGS) | NEGOTIATE_EXTENDED_SESSION_SECURITY
+  message.writeUInt32LE(flags, 60)
+  if (options.type1) {
+    const sessionBaseKey = hmacMd5(responseKey, proof)
+    const mic = hmacMd5(sessionBaseKey, options.type1, type2.raw, message)
+    mic.copy(message, 72)
+  }
+  return message
+}
+
+export function getNtlmChallenge(header: string | null): NtlmChallenge {
+  if (!header) return { kind: "none" }
+  let offer: NtlmChallenge | undefined
+  let negotiate: NtlmChallenge | undefined
+  for (const part of header.split(",")) {
+    const match = part.trim().match(/^(NTLM|Negotiate)(?:\s+(\S+))?$/i)
+    if (!match) continue
+    const scheme = match[1]!.toLowerCase() === "ntlm" ? "NTLM" : "Negotiate"
+    const token = match[2]
+    if (!token) {
+      if (scheme === "NTLM") offer = { kind: "offer", scheme: "NTLM" }
+      continue
+    }
+    if (scheme === "NTLM") {
+      return { kind: "type2", scheme, message: parseType2Message(token) }
+    }
+    try {
+      negotiate = {
+        kind: "type2",
+        scheme,
+        message: parseType2Message(token),
+      }
+    } catch {
+      // A Negotiate token may be SPNEGO or Kerberos rather than raw NTLMSSP.
+    }
+  }
+  return offer ?? negotiate ?? { kind: "none" }
+}

--- a/src/requests/ntlmConnection.ts
+++ b/src/requests/ntlmConnection.ts
@@ -5,12 +5,13 @@ import {
   type TLSSocket,
 } from "node:tls"
 import type { Duplex } from "node:stream"
-import {
-  brotliDecompressSync,
-  gunzipSync,
-  inflateSync,
-  zstdDecompressSync,
-} from "node:zlib"
+import { brotliDecompress, gunzip, inflate, zstdDecompress } from "node:zlib"
+import { promisify } from "node:util"
+
+const brotliDecompressAsync = promisify(brotliDecompress)
+const gunzipAsync = promisify(gunzip)
+const inflateAsync = promisify(inflate)
+const zstdDecompressAsync = promisify(zstdDecompress)
 
 export interface NtlmConnection {
   request(headers: Headers): Promise<Response>
@@ -115,7 +116,7 @@ async function readResponse(
         : await reader.readExact(parseContentLength(contentLength))
   }
 
-  body = decodeBody(body, parsed.headers)
+  body = await decodeBody(body, parsed.headers)
   return new Response(body.length === 0 ? null : new Uint8Array(body), {
     status: parsed.status,
     statusText: parsed.statusText,
@@ -185,17 +186,19 @@ async function readChunkedBody(reader: SocketReader): Promise<Buffer> {
   }
 }
 
-function decodeBody(body: Buffer, headers: Headers): Buffer {
+async function decodeBody(body: Buffer, headers: Headers): Promise<Buffer> {
   const encodings = (headers.get("content-encoding") ?? "")
     .split(",")
     .map((value) => value.trim().toLowerCase())
     .filter(Boolean)
   if (encodings.length === 0) return body
-  for (const encoding of encodings.reverse()) {
-    if (encoding === "gzip") body = gunzipSync(body)
-    else if (encoding === "deflate") body = inflateSync(body)
-    else if (encoding === "br") body = brotliDecompressSync(body)
-    else if (encoding === "zstd") body = zstdDecompressSync(body)
+  for (let encoding of encodings.reverse()) {
+    if (encoding === "identity") continue
+    if (encoding === "x-gzip") encoding = "gzip"
+    if (encoding === "gzip") body = await gunzipAsync(body)
+    else if (encoding === "deflate") body = await inflateAsync(body)
+    else if (encoding === "br") body = await brotliDecompressAsync(body)
+    else if (encoding === "zstd") body = await zstdDecompressAsync(body)
     else throw new Error(`unsupported response content encoding: ${encoding}`)
   }
   headers.delete("content-encoding")
@@ -251,8 +254,13 @@ async function openTunnel(
   }
 
   proxyReader.release()
-  const socket = await connectTlsOverSocket(proxySocket, tls, signal)
-  return { socket, reader: new SocketReader(socket) }
+  try {
+    const socket = await connectTlsOverSocket(proxySocket, tls, signal)
+    return { socket, reader: new SocketReader(socket) }
+  } catch (e) {
+    proxySocket.destroy()
+    throw e
+  }
 }
 
 function connectTcp(

--- a/src/requests/ntlmConnection.ts
+++ b/src/requests/ntlmConnection.ts
@@ -1,0 +1,454 @@
+import { connect as netConnect, isIP, type Socket } from "node:net"
+import {
+  connect as tlsConnect,
+  type ConnectionOptions,
+  type TLSSocket,
+} from "node:tls"
+import type { Duplex } from "node:stream"
+import {
+  brotliDecompressSync,
+  gunzipSync,
+  inflateSync,
+  zstdDecompressSync,
+} from "node:zlib"
+
+export interface NtlmConnection {
+  request(headers: Headers): Promise<Response>
+  close(): void
+}
+
+export async function createNtlmConnection(
+  url: string,
+  init: RequestInit,
+  proxyUrl?: string,
+  tls?: BunFetchRequestInitTLS,
+): Promise<NtlmConnection> {
+  const target = new URL(url)
+  if (init.signal?.aborted) throw abortError()
+  const serialized = new Request(url, { ...init, signal: undefined })
+  const body =
+    init.body === undefined || init.body === null
+      ? undefined
+      : Buffer.from(await serialized.arrayBuffer())
+  const baseHeaders = new Headers(serialized.headers)
+  baseHeaders.set("host", target.host)
+  baseHeaders.set("connection", "keep-alive")
+  baseHeaders.delete("proxy-authorization")
+  baseHeaders.delete("transfer-encoding")
+  if (body === undefined) baseHeaders.delete("content-length")
+  else baseHeaders.set("content-length", String(body.length))
+
+  const tlsOptions = await nodeTlsOptions(target, tls)
+  const { socket, reader } = proxyUrl
+    ? await openTunnel(target, new URL(proxyUrl), tlsOptions, init.signal)
+    : await openDirect(target, tlsOptions, init.signal)
+  let pending: Promise<unknown> = Promise.resolve()
+
+  return {
+    request(headers) {
+      const requestHeaders = new Headers(baseHeaders)
+      headers.forEach((value, name) => requestHeaders.set(name, value))
+      requestHeaders.set("host", target.host)
+      requestHeaders.set("connection", "keep-alive")
+      requestHeaders.delete("proxy-authorization")
+      requestHeaders.delete("transfer-encoding")
+      if (body === undefined) requestHeaders.delete("content-length")
+      else requestHeaders.set("content-length", String(body.length))
+      const response = pending.then(() =>
+        requestOnSocket(
+          socket,
+          reader,
+          target,
+          init.method ?? "GET",
+          requestHeaders,
+          body,
+        ),
+      )
+      pending = response
+      return response
+    },
+    close() {
+      socket.destroy()
+    },
+  }
+}
+
+async function requestOnSocket(
+  socket: Duplex,
+  reader: SocketReader,
+  target: URL,
+  method: string,
+  headers: Headers,
+  body: Buffer | undefined,
+): Promise<Response> {
+  const lines = [`${method} ${target.pathname}${target.search} HTTP/1.1`]
+  headers.forEach((value, name) => lines.push(`${name}: ${value}`))
+  const head = Buffer.from(`${lines.join("\r\n")}\r\n\r\n`, "latin1")
+  await write(socket, body === undefined ? head : Buffer.concat([head, body]))
+  return readResponse(reader, method)
+}
+
+async function readResponse(
+  reader: SocketReader,
+  method: string,
+): Promise<Response> {
+  let parsed = await readResponseHead(reader)
+  while (parsed.status >= 100 && parsed.status < 200 && parsed.status !== 101) {
+    parsed = await readResponseHead(reader)
+  }
+
+  let body: Buffer
+  if (
+    method === "HEAD" ||
+    (parsed.status >= 100 && parsed.status < 200) ||
+    parsed.status === 204 ||
+    parsed.status === 304
+  ) {
+    body = Buffer.alloc(0)
+  } else if (hasChunkedEncoding(parsed.headers)) {
+    body = await readChunkedBody(reader)
+  } else {
+    const contentLength = parsed.headers.get("content-length")
+    body =
+      contentLength === null
+        ? await reader.readToEnd()
+        : await reader.readExact(parseContentLength(contentLength))
+  }
+
+  body = decodeBody(body, parsed.headers)
+  return new Response(body.length === 0 ? null : new Uint8Array(body), {
+    status: parsed.status,
+    statusText: parsed.statusText,
+    headers: parsed.headers,
+  })
+}
+
+async function readResponseHead(reader: SocketReader): Promise<{
+  status: number
+  statusText: string
+  headers: Headers
+}> {
+  const raw = (await reader.readThrough(Buffer.from("\r\n\r\n"))).toString(
+    "latin1",
+  )
+  const lines = raw.slice(0, -4).split("\r\n")
+  const status = lines.shift()?.match(/^HTTP\/1\.[01] (\d{3})(?: (.*))?$/)
+  if (!status) throw new Error("invalid HTTP response status line")
+  const headers = new Headers()
+  for (const line of lines) {
+    const separator = line.indexOf(":")
+    if (separator < 1) throw new Error("invalid HTTP response header")
+    headers.append(line.slice(0, separator), line.slice(separator + 1).trim())
+  }
+  return {
+    status: Number(status[1]),
+    statusText: status[2] ?? "",
+    headers,
+  }
+}
+
+function hasChunkedEncoding(headers: Headers): boolean {
+  return (headers.get("transfer-encoding") ?? "")
+    .split(",")
+    .some((value) => value.trim().toLowerCase() === "chunked")
+}
+
+function parseContentLength(value: string): number {
+  if (!/^\d+$/.test(value)) throw new Error("invalid HTTP content length")
+  const length = Number(value)
+  if (!Number.isSafeInteger(length))
+    throw new Error("invalid HTTP content length")
+  return length
+}
+
+async function readChunkedBody(reader: SocketReader): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  while (true) {
+    const line = (await reader.readThrough(Buffer.from("\r\n")))
+      .subarray(0, -2)
+      .toString("ascii")
+    const sizeText = line.split(";", 1)[0]!
+    if (!/^[0-9a-f]+$/i.test(sizeText)) {
+      throw new Error("invalid HTTP chunk size")
+    }
+    const size = Number.parseInt(sizeText, 16)
+    if (size === 0) {
+      while ((await reader.readThrough(Buffer.from("\r\n"))).length > 2) {
+        // Consume trailers.
+      }
+      return Buffer.concat(chunks)
+    }
+    chunks.push(await reader.readExact(size))
+    if (!(await reader.readExact(2)).equals(Buffer.from("\r\n"))) {
+      throw new Error("invalid HTTP chunk terminator")
+    }
+  }
+}
+
+function decodeBody(body: Buffer, headers: Headers): Buffer {
+  const encodings = (headers.get("content-encoding") ?? "")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+  if (encodings.length === 0) return body
+  for (const encoding of encodings.reverse()) {
+    if (encoding === "gzip") body = gunzipSync(body)
+    else if (encoding === "deflate") body = inflateSync(body)
+    else if (encoding === "br") body = brotliDecompressSync(body)
+    else if (encoding === "zstd") body = zstdDecompressSync(body)
+    else throw new Error(`unsupported response content encoding: ${encoding}`)
+  }
+  headers.delete("content-encoding")
+  headers.delete("content-length")
+  return body
+}
+
+async function openDirect(
+  target: URL,
+  tls: ConnectionOptions,
+  signal: AbortSignal | null | undefined,
+): Promise<{ socket: Duplex; reader: SocketReader }> {
+  const socket =
+    target.protocol === "https:"
+      ? await connectTls(target, tls, signal)
+      : await connectTcp(target.hostname, Number(target.port || 80), signal)
+  return { socket, reader: new SocketReader(socket) }
+}
+
+async function openTunnel(
+  target: URL,
+  proxy: URL,
+  tls: ConnectionOptions,
+  signal: AbortSignal | null | undefined,
+): Promise<{ socket: Duplex; reader: SocketReader }> {
+  if (proxy.protocol !== "http:" && proxy.protocol !== "https:") {
+    throw new Error(`unsupported proxy protocol: ${proxy.protocol}`)
+  }
+  const proxySocket =
+    proxy.protocol === "https:"
+      ? await connectTls(proxy, proxyTlsOptions(proxy), signal)
+      : await connectTcp(proxy.hostname, Number(proxy.port || 80), signal)
+  const proxyReader = new SocketReader(proxySocket)
+  const targetPort =
+    target.port || (target.protocol === "https:" ? "443" : "80")
+  const authority = `${target.hostname}:${targetPort}`
+  const headers = [`CONNECT ${authority} HTTP/1.1`, `Host: ${authority}`]
+  if (proxy.username || proxy.password) {
+    const username = decodeURIComponent(proxy.username)
+    const password = decodeURIComponent(proxy.password)
+    headers.push(
+      `Proxy-Authorization: Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+    )
+  }
+  await write(proxySocket, Buffer.from(`${headers.join("\r\n")}\r\n\r\n`))
+  const response = await readResponseHead(proxyReader)
+  if (response.status !== 200) {
+    proxySocket.destroy()
+    throw new Error(`proxy CONNECT failed with ${response.status}`)
+  }
+  if (target.protocol !== "https:") {
+    return { socket: proxySocket, reader: proxyReader }
+  }
+
+  proxyReader.release()
+  const socket = await connectTlsOverSocket(proxySocket, tls, signal)
+  return { socket, reader: new SocketReader(socket) }
+}
+
+function connectTcp(
+  hostname: string,
+  port: number,
+  signal: AbortSignal | null | undefined,
+): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = netConnect({ host: unbracket(hostname), port }, () =>
+      resolve(socket),
+    )
+    bindAbort(socket, signal)
+    socket.once("error", reject)
+  })
+}
+
+function connectTls(
+  target: URL,
+  options: ConnectionOptions,
+  signal: AbortSignal | null | undefined,
+): Promise<TLSSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = tlsConnect(
+      {
+        ...options,
+        host: unbracket(target.hostname),
+        port: Number(target.port || 443),
+      },
+      () => resolve(socket),
+    )
+    bindAbort(socket, signal)
+    socket.once("error", reject)
+  })
+}
+
+function connectTlsOverSocket(
+  socket: Duplex,
+  options: ConnectionOptions,
+  signal: AbortSignal | null | undefined,
+): Promise<TLSSocket> {
+  return new Promise((resolve, reject) => {
+    const secure = tlsConnect({ ...options, socket }, () => resolve(secure))
+    bindAbort(secure, signal)
+    secure.once("error", reject)
+  })
+}
+
+function proxyTlsOptions(proxy: URL): ConnectionOptions {
+  const hostname = unbracket(proxy.hostname)
+  return isIP(hostname) ? {} : { servername: hostname }
+}
+
+function bindAbort(
+  socket: Duplex,
+  signal: AbortSignal | null | undefined,
+): void {
+  if (!signal) return
+  const abort = () => socket.destroy(abortError())
+  if (signal.aborted) abort()
+  else signal.addEventListener("abort", abort, { once: true })
+  socket.once("close", () => signal.removeEventListener("abort", abort))
+}
+
+function abortError(): DOMException {
+  return new DOMException("The operation was aborted", "AbortError")
+}
+
+function write(socket: Duplex, data: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.write(data, (error) => (error ? reject(error) : resolve()))
+  })
+}
+
+class SocketReader {
+  private buffer = Buffer.alloc(0)
+  private ended = false
+  private error: Error | undefined
+  private wake: (() => void) | undefined
+
+  constructor(private readonly socket: Duplex) {
+    socket.on("data", this.onData)
+    socket.once("end", this.onEnd)
+    socket.once("error", this.onError)
+  }
+
+  async readThrough(delimiter: Buffer): Promise<Buffer> {
+    while (true) {
+      const offset = this.buffer.indexOf(delimiter)
+      if (offset >= 0) return this.take(offset + delimiter.length)
+      await this.more()
+    }
+  }
+
+  async readExact(length: number): Promise<Buffer> {
+    while (this.buffer.length < length) await this.more()
+    return this.take(length)
+  }
+
+  async readToEnd(): Promise<Buffer> {
+    while (!this.ended && !this.error) await this.more()
+    if (this.error) throw this.error
+    return this.take(this.buffer.length)
+  }
+
+  release(): void {
+    this.socket.off("data", this.onData)
+    this.socket.off("end", this.onEnd)
+    this.socket.off("error", this.onError)
+    if (this.buffer.length > 0 && "unshift" in this.socket) {
+      ;(this.socket as Socket).unshift(this.buffer)
+    }
+    this.buffer = Buffer.alloc(0)
+  }
+
+  private take(length: number): Buffer {
+    const value = this.buffer.subarray(0, length)
+    this.buffer = this.buffer.subarray(length)
+    return value
+  }
+
+  private async more(): Promise<void> {
+    if (this.error) throw this.error
+    if (this.ended)
+      throw new Error("HTTP connection closed before response completed")
+    await new Promise<void>((resolve) => {
+      this.wake = resolve
+    })
+  }
+
+  private onData = (chunk: Buffer) => {
+    this.buffer = Buffer.concat([this.buffer, Buffer.from(chunk)])
+    this.resume()
+  }
+
+  private onEnd = () => {
+    this.ended = true
+    this.resume()
+  }
+
+  private onError = (error: Error) => {
+    this.error = error
+    this.resume()
+  }
+
+  private resume(): void {
+    const wake = this.wake
+    this.wake = undefined
+    wake?.()
+  }
+}
+
+async function nodeTlsOptions(
+  target: URL,
+  options: BunFetchRequestInitTLS | undefined,
+): Promise<ConnectionOptions> {
+  const result: ConnectionOptions = { ALPNProtocols: ["http/1.1"] }
+  const servername = unbracket(options?.serverName ?? target.hostname)
+  if (!isIP(servername)) result.servername = servername
+  if (options?.rejectUnauthorized !== undefined) {
+    result.rejectUnauthorized = options.rejectUnauthorized
+  }
+  if (options?.passphrase !== undefined) result.passphrase = options.passphrase
+  if (options?.checkServerIdentity !== undefined) {
+    result.checkServerIdentity = options.checkServerIdentity
+  }
+  if (options?.ciphers !== undefined) result.ciphers = options.ciphers
+  if (options?.secureOptions !== undefined) {
+    result.secureOptions = options.secureOptions
+  }
+  if (options?.ca !== undefined) result.ca = await tlsValue(options.ca)
+  if (options?.cert !== undefined) result.cert = await tlsValue(options.cert)
+  if (options?.key !== undefined) result.key = await tlsValue(options.key)
+  return result
+}
+
+type TlsValue = NonNullable<Bun.TLSOptions["ca"]>
+type TlsScalar = Exclude<TlsValue, unknown[]>
+
+async function tlsValue(
+  value: TlsValue,
+): Promise<string | Buffer | (string | Buffer)[]> {
+  if (Array.isArray(value)) return Promise.all(value.map(tlsScalar))
+  return tlsScalar(value)
+}
+
+async function tlsScalar(value: TlsScalar): Promise<string | Buffer> {
+  if (typeof value === "string") return value
+  if (value instanceof Blob) return Buffer.from(await value.arrayBuffer())
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+  }
+  return Buffer.from(new Uint8Array(value))
+}
+
+function unbracket(hostname: string): string {
+  return hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname
+}

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -409,11 +409,7 @@ export async function send(
       currentInit = {
         ...currentInit,
         headers: clearAwsSignerHeaders(
-          stripCrossOriginCredentials(
-            currentInit.headers,
-            ah?.name ??
-              (substituted.auth?.type === "ntlm" ? "Authorization" : undefined),
-          ),
+          stripCrossOriginCredentials(currentInit.headers, ah?.name),
         ),
       }
     }

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -19,6 +19,12 @@ import { expandUserPath } from "../userPath"
 import { proxyForUrl, type ProxyPolicy } from "../proxy"
 import { tlsForUrl, type TlsPolicy } from "../tls"
 import { clearAwsSignerHeaders, signAwsRequest } from "./awsSigV4"
+import {
+  createType1Message,
+  createType3Message,
+  getNtlmChallenge,
+  type NtlmChallenge,
+} from "./ntlm"
 
 export interface RequestExecutionOptions {
   environment?: Environment
@@ -146,6 +152,9 @@ export async function send(
   if (ah) {
     headersInst.set(ah.name, ah.value)
   }
+  if (substituted.auth?.type === "ntlm") {
+    headersInst.delete("authorization")
+  }
 
   let effectiveSignal = signal
   if (req.timeout > 0) {
@@ -185,6 +194,7 @@ export async function send(
   let currentInit: RequestInit = { ...init, redirect: "manual" }
   let redirectCount = 0
   let awsSigningEnabled = substituted.auth?.type === "aws_sigv4"
+  let ntlmEnabled = substituted.auth?.type === "ntlm"
   const maxRedirects = req.maxRedirects ?? 5
   const followRedirects = req.followRedirects ?? true
 
@@ -237,40 +247,112 @@ export async function send(
     for (const message of resolvedTls.messages) {
       recordNetworkEvent(network, start, "tls", message, onNetworkEvent)
     }
-    recordNetworkEvent(
-      network,
-      start,
-      "request",
-      `${currentInit.method ?? substituted.method} ${networkUrl(currentUrl)}`,
-      onNetworkEvent,
-    )
-    try {
-      const signedInit =
-        awsSigningEnabled && substituted.auth?.type === "aws_sigv4"
-          ? signAwsRequest(currentUrl, currentInit, substituted.auth)
-          : currentInit
-      const fetchInit: BunFetchRequestInit = { ...signedInit }
-      if (proxyRoute?.kind === "proxy") fetchInit.proxy = proxyRoute.url
-      if (resolvedTls.options) fetchInit.tls = resolvedTls.options
-      res = await fetch(currentUrl, fetchInit)
-    } catch (e) {
-      if (e instanceof DOMException && e.name === "AbortError") throw e
-      throw networkFailure(
-        "requests.send: fetch failed",
-        e,
+    const fetchOnce = async (authorization?: string) => {
+      const legHeaders = new Headers(currentInit.headers)
+      if (ntlmEnabled) {
+        if (authorization) legHeaders.set("authorization", authorization)
+        else legHeaders.delete("authorization")
+      }
+      const legInit: RequestInit = {
+        ...currentInit,
+        headers: legHeaders,
+        ...(ntlmEnabled ? { keepalive: true } : {}),
+      }
+      recordNetworkEvent(
         network,
         start,
+        "request",
+        `${legInit.method ?? substituted.method} ${networkUrl(currentUrl)}`,
         onNetworkEvent,
       )
+      let response: globalThis.Response
+      try {
+        const signedInit =
+          awsSigningEnabled && substituted.auth?.type === "aws_sigv4"
+            ? signAwsRequest(currentUrl, legInit, substituted.auth)
+            : legInit
+        const fetchInit: BunFetchRequestInit = { ...signedInit }
+        if (proxyRoute?.kind === "proxy") fetchInit.proxy = proxyRoute.url
+        if (resolvedTls.options) fetchInit.tls = resolvedTls.options
+        response = await fetch(currentUrl, fetchInit)
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") throw e
+        throw networkFailure(
+          "requests.send: fetch failed",
+          e,
+          network,
+          start,
+          onNetworkEvent,
+        )
+      }
+      recordNetworkEvent(
+        network,
+        start,
+        "response",
+        `${response.status} ${response.statusText || "Response"} - ${[...response.headers].length} headers`,
+        onNetworkEvent,
+      )
+      return response
     }
 
-    recordNetworkEvent(
-      network,
-      start,
-      "response",
-      `${res.status} ${res.statusText || "Response"} - ${[...res.headers].length} headers`,
-      onNetworkEvent,
-    )
+    const challengeFor = (response: globalThis.Response): NtlmChallenge => {
+      try {
+        return getNtlmChallenge(response.headers.get("www-authenticate"))
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        throw networkFailure(
+          `requests.send: invalid NTLM challenge: ${message}`,
+          e,
+          network,
+          start,
+          onNetworkEvent,
+        )
+      }
+    }
+
+    const consumeChallenge = async (response: globalThis.Response) => {
+      try {
+        await response.arrayBuffer()
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") throw e
+        throw networkFailure(
+          "requests.send: failed to consume NTLM challenge response",
+          e,
+          network,
+          start,
+          onNetworkEvent,
+        )
+      }
+    }
+
+    res = await fetchOnce()
+    if (
+      ntlmEnabled &&
+      substituted.auth?.type === "ntlm" &&
+      res.status === 401
+    ) {
+      let challenge = challengeFor(res)
+      let type1: Buffer | undefined
+
+      if (
+        challenge.kind === "offer" ||
+        (challenge.kind === "type2" && challenge.message.requiresMic)
+      ) {
+        await consumeChallenge(res)
+        type1 = createType1Message()
+        const scheme = challenge.scheme
+        res = await fetchOnce(`${scheme} ${type1.toString("base64")}`)
+        challenge = res.status === 401 ? challengeFor(res) : { kind: "none" }
+      }
+
+      if (challenge.kind === "type2") {
+        await consumeChallenge(res)
+        const type3 = createType3Message(challenge.message, substituted.auth, {
+          type1,
+        })
+        res = await fetchOnce(`${challenge.scheme} ${type3.toString("base64")}`)
+      }
+    }
 
     if (!followRedirects || ![301, 302, 303, 307, 308].includes(res.status)) {
       break
@@ -323,10 +405,15 @@ export async function send(
     }
     if (previousUrl.origin !== nextUrl.origin) {
       awsSigningEnabled = false
+      ntlmEnabled = false
       currentInit = {
         ...currentInit,
         headers: clearAwsSignerHeaders(
-          stripCrossOriginCredentials(currentInit.headers, ah?.name),
+          stripCrossOriginCredentials(
+            currentInit.headers,
+            ah?.name ??
+              (substituted.auth?.type === "ntlm" ? "Authorization" : undefined),
+          ),
         ),
       }
     }

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -25,6 +25,7 @@ import {
   getNtlmChallenge,
   type NtlmChallenge,
 } from "./ntlm"
+import { createNtlmConnection, type NtlmConnection } from "./ntlmConnection"
 
 export interface RequestExecutionOptions {
   environment?: Environment
@@ -247,6 +248,7 @@ export async function send(
     for (const message of resolvedTls.messages) {
       recordNetworkEvent(network, start, "tls", message, onNetworkEvent)
     }
+    let ntlmConnection: NtlmConnection | undefined
     const fetchOnce = async (authorization?: string) => {
       const legHeaders = new Headers(currentInit.headers)
       if (ntlmEnabled) {
@@ -271,10 +273,20 @@ export async function send(
           awsSigningEnabled && substituted.auth?.type === "aws_sigv4"
             ? signAwsRequest(currentUrl, legInit, substituted.auth)
             : legInit
-        const fetchInit: BunFetchRequestInit = { ...signedInit }
-        if (proxyRoute?.kind === "proxy") fetchInit.proxy = proxyRoute.url
-        if (resolvedTls.options) fetchInit.tls = resolvedTls.options
-        response = await fetch(currentUrl, fetchInit)
+        if (ntlmEnabled) {
+          ntlmConnection ??= await createNtlmConnection(
+            currentUrl,
+            signedInit,
+            proxyRoute?.kind === "proxy" ? proxyRoute.url : undefined,
+            resolvedTls.options,
+          )
+          response = await ntlmConnection.request(legHeaders)
+        } else {
+          const fetchInit: BunFetchRequestInit = { ...signedInit }
+          if (proxyRoute?.kind === "proxy") fetchInit.proxy = proxyRoute.url
+          if (resolvedTls.options) fetchInit.tls = resolvedTls.options
+          response = await fetch(currentUrl, fetchInit)
+        }
       } catch (e) {
         if (e instanceof DOMException && e.name === "AbortError") throw e
         throw networkFailure(
@@ -325,33 +337,41 @@ export async function send(
       }
     }
 
-    res = await fetchOnce()
-    if (
-      ntlmEnabled &&
-      substituted.auth?.type === "ntlm" &&
-      res.status === 401
-    ) {
-      let challenge = challengeFor(res)
-      let type1: Buffer | undefined
-
+    try {
+      res = await fetchOnce()
       if (
-        challenge.kind === "offer" ||
-        (challenge.kind === "type2" && challenge.message.requiresMic)
+        ntlmEnabled &&
+        substituted.auth?.type === "ntlm" &&
+        res.status === 401
       ) {
-        await consumeChallenge(res)
-        type1 = createType1Message()
-        const scheme = challenge.scheme
-        res = await fetchOnce(`${scheme} ${type1.toString("base64")}`)
-        challenge = res.status === 401 ? challengeFor(res) : { kind: "none" }
-      }
+        let challenge = challengeFor(res)
+        let type1: Buffer | undefined
 
-      if (challenge.kind === "type2") {
-        await consumeChallenge(res)
-        const type3 = createType3Message(challenge.message, substituted.auth, {
-          type1,
-        })
-        res = await fetchOnce(`${challenge.scheme} ${type3.toString("base64")}`)
+        if (
+          challenge.kind === "offer" ||
+          (challenge.kind === "type2" && challenge.message.requiresMic)
+        ) {
+          await consumeChallenge(res)
+          type1 = createType1Message()
+          const scheme = challenge.scheme
+          res = await fetchOnce(`${scheme} ${type1.toString("base64")}`)
+          challenge = res.status === 401 ? challengeFor(res) : { kind: "none" }
+        }
+
+        if (challenge.kind === "type2") {
+          await consumeChallenge(res)
+          const type3 = createType3Message(
+            challenge.message,
+            substituted.auth,
+            { type1 },
+          )
+          res = await fetchOnce(
+            `${challenge.scheme} ${type3.toString("base64")}`,
+          )
+        }
       }
+    } finally {
+      ntlmConnection?.close()
     }
 
     if (!followRedirects || ![301, 302, 303, 307, 308].includes(res.status)) {

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -99,6 +99,15 @@ function substituteAuth(
       placement: auth.placement,
     }
   }
+  if (auth.type === "ntlm") {
+    return {
+      type: "ntlm",
+      username: resolve(auth.username, "auth.username"),
+      password: resolve(auth.password, "auth.password"),
+      domain: resolve(auth.domain, "auth.domain"),
+      workstation: resolve(auth.workstation, "auth.workstation"),
+    }
+  }
   if (auth.type === "aws_sigv4") {
     return {
       type: "aws_sigv4",

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -49,6 +49,13 @@ export type Auth =
   | { type: "bearer"; token: string }
   | { type: "basic"; user: string; pass: string }
   | {
+      type: "ntlm"
+      username: string
+      password: string
+      domain: string
+      workstation: string
+    }
+  | {
       type: "api_key"
       key: string
       value: string

--- a/src/ui/AuthEditor.tsx
+++ b/src/ui/AuthEditor.tsx
@@ -12,6 +12,7 @@ const AUTH_TYPE_ITEMS: SelectItem[] = [
   { id: "inherit", label: "Inherit" },
   { id: "bearer", label: "Bearer Token" },
   { id: "basic", label: "Basic Auth" },
+  { id: "ntlm", label: "NTLMv2" },
   { id: "api_key", label: "API Key" },
   { id: "aws_sigv4", label: "AWS Signature v4" },
 ]
@@ -82,6 +83,43 @@ function getAuthRows(auth: Auth | undefined): AuthRows {
           isSecret: true,
           required: true,
           description: "Password used for HTTP Basic authentication.",
+        },
+      ],
+    }
+  }
+  if (auth.type === "ntlm") {
+    return {
+      type: "ntlm",
+      fieldDefs: [
+        {
+          row: 1,
+          label: "Username",
+          field: "username",
+          isSecret: false,
+          required: true,
+          description: "Username used for NTLMv2 authentication.",
+        },
+        {
+          row: 2,
+          label: "Password",
+          field: "password",
+          isSecret: true,
+          required: true,
+          description: "Password used to derive the NTLMv2 response.",
+        },
+        {
+          row: 3,
+          label: "Domain",
+          field: "domain",
+          isSecret: false,
+          description: "Optional Windows domain.",
+        },
+        {
+          row: 4,
+          label: "Workstation",
+          field: "workstation",
+          isSecret: false,
+          description: "Optional workstation name.",
         },
       ],
     }
@@ -170,6 +208,13 @@ function getFieldValue(auth: Auth, field: string): string {
   if (auth.type === "basic") {
     if (field === "user") return auth.user
     if (field === "pass") return auth.pass
+    return ""
+  }
+  if (auth.type === "ntlm") {
+    if (field === "username") return auth.username
+    if (field === "password") return auth.password
+    if (field === "domain") return auth.domain
+    if (field === "workstation") return auth.workstation
     return ""
   }
   if (auth.type === "api_key") {

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -9,12 +9,15 @@ import {
   useState,
 } from "react"
 import {
+  InputRenderable,
   MouseButton,
-  type InputRenderable,
-  type TextareaRenderable,
+  ScrollBoxRenderable,
+  TextareaRenderable,
+  type OptimizedBuffer,
 } from "@opentui/core"
 import {
   createPortal,
+  extend,
   useRenderer,
   useTerminalDimensions,
 } from "@opentui/react"
@@ -30,6 +33,53 @@ import {
 } from "./variable-completion/useVariableCompletion"
 import { usePathCompletion } from "./path-completion/usePathCompletion"
 import type { PathCompletionOptions } from "./path-completion/pathCompletion"
+
+function cursorIsOutsideScrollbox(editable: TextareaRenderable): boolean {
+  const cursor = editable.visualCursor
+  const cursorX = editable.screenX + cursor.visualCol + 1
+  const cursorY = editable.screenY + cursor.visualRow + 1
+  let ancestor = editable.parent
+
+  while (ancestor) {
+    if (ancestor instanceof ScrollBoxRenderable) {
+      const viewport = ancestor.viewport
+      if (
+        cursorX <= viewport.screenX ||
+        cursorX > viewport.screenX + viewport.width ||
+        cursorY <= viewport.screenY ||
+        cursorY > viewport.screenY + viewport.height
+      ) {
+        return true
+      }
+    }
+    ancestor = ancestor.parent
+  }
+
+  return false
+}
+
+class ViewportTextareaRenderable extends TextareaRenderable {
+  override render(buffer: OptimizedBuffer, deltaTime: number) {
+    super.render(buffer, deltaTime)
+    if (this.focused && this.showCursor && cursorIsOutsideScrollbox(this)) {
+      this._ctx.setCursorPosition(0, 0, false)
+    }
+  }
+}
+
+class ViewportInputRenderable extends InputRenderable {
+  override render(buffer: OptimizedBuffer, deltaTime: number) {
+    super.render(buffer, deltaTime)
+    if (this.focused && this.showCursor && cursorIsOutsideScrollbox(this)) {
+      this._ctx.setCursorPosition(0, 0, false)
+    }
+  }
+}
+
+extend({
+  input: ViewportInputRenderable,
+  textarea: ViewportTextareaRenderable,
+})
 
 export interface VarInputStyle {
   flexGrow?: number

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -174,6 +174,10 @@ export function canGenerateClientCode(c: CommandActionsConfig): boolean {
     )
     return false
   }
+  if (effective.auth?.type === "ntlm") {
+    showToast("Code generation is unavailable for NTLM requests", "warning")
+    return false
+  }
   return true
 }
 

--- a/src/ui/formatRequest.ts
+++ b/src/ui/formatRequest.ts
@@ -39,6 +39,12 @@ export function formatAuth(auth?: Auth): string {
   if (auth.type === "bearer") return "bearer: \u2022\u2022\u2022\u2022"
   if (auth.type === "basic")
     return `basic: ${auth.user}:\u2022\u2022\u2022\u2022`
+  if (auth.type === "ntlm") {
+    const username = auth.domain
+      ? `${auth.domain}\\${auth.username}`
+      : auth.username
+    return `ntlm: ${username}`
+  }
   if (auth.type === "api_key")
     return `api_key: ${auth.key}:\u2022\u2022\u2022\u2022`
   if (auth.type === "aws_sigv4")

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -76,6 +76,15 @@ export function buildTimelineEntry(
         pass: REDACTED,
       }
     }
+    if (auth.type === "ntlm") {
+      return {
+        type: "ntlm",
+        username: redact(resolvePublicVars(auth.username)),
+        password: REDACTED,
+        domain: redact(resolvePublicVars(auth.domain)),
+        workstation: redact(resolvePublicVars(auth.workstation)),
+      }
+    }
     if (auth.type === "aws_sigv4") {
       return {
         type: "aws_sigv4",
@@ -227,6 +236,8 @@ export function maskedAuthHeader(
     return { key: "Authorization", value: "Bearer ••••••••" }
   if (auth.type === "basic")
     return { key: "Authorization", value: "Basic ••••••••" }
+  if (auth.type === "ntlm")
+    return { key: "Authorization", value: "NTLM ••••••••" }
   if (auth.type === "aws_sigv4")
     return { key: "Authorization", value: "AWS4-HMAC-SHA256 ••••••••" }
   if (auth.type === "api_key" && auth.placement === "header") {

--- a/tests/converters/openapi-export.test.ts
+++ b/tests/converters/openapi-export.test.ts
@@ -486,6 +486,31 @@ describe("exportOpenApi", () => {
     expect(JSON.stringify(result.document)).not.toContain("super-secret")
   })
 
+  it("exports NTLM as an HTTP security marker without credentials", () => {
+    const result = exportOpenApi(
+      collection([
+        {
+          type: "request",
+          data: request({
+            auth: {
+              type: "ntlm",
+              username: "alice",
+              password: "super-secret",
+              domain: "EXAMPLE",
+              workstation: "NOODLE",
+            },
+          }),
+        },
+      ]),
+    )
+    expect(result.document.components).toEqual({
+      securitySchemes: {
+        ntlmAuth: { type: "http", scheme: "ntlm" },
+      },
+    })
+    expect(JSON.stringify(result.document)).not.toContain("super-secret")
+  })
+
   it("does not merge API-key schemes whose sanitized names collide", () => {
     const result = exportOpenApi(
       collection([

--- a/tests/converters/postman-export.test.ts
+++ b/tests/converters/postman-export.test.ts
@@ -28,6 +28,37 @@ function request(
 }
 
 describe("Postman export", () => {
+  it("exports NTLM credentials in Postman format", () => {
+    const exported = exportPostman({
+      id: "ntlm",
+      name: "NTLM",
+      items: [
+        {
+          type: "request",
+          data: request("ntlm", "NTLM", {
+            auth: {
+              type: "ntlm",
+              username: "$NTLM_USERNAME",
+              password: "$NTLM_PASSWORD",
+              domain: "EXAMPLE",
+              workstation: "NOODLE",
+            },
+          }),
+        },
+      ],
+    })
+    const item = (exported.document.item as Record<string, unknown>[])[0]!
+    expect((item.request as Record<string, unknown>).auth).toEqual({
+      type: "ntlm",
+      ntlm: [
+        { key: "username", value: "{{NTLM_USERNAME}}", type: "string" },
+        { key: "password", value: "{{NTLM_PASSWORD}}", type: "string" },
+        { key: "domain", value: "EXAMPLE", type: "string" },
+        { key: "workstation", value: "NOODLE", type: "string" },
+      ],
+    })
+  })
+
   it("converts Noodle and dynamic templates to Postman syntax", () => {
     expect(toPostmanTpl("$base/$$randomUUID/$user-id")).toBe(
       "{{base}}/{{$randomUUID}}/{{user}}-id",

--- a/tests/converters/postman-map.test.ts
+++ b/tests/converters/postman-map.test.ts
@@ -50,6 +50,40 @@ describe("convertTpl", () => {
   })
 })
 
+describe("Postman NTLM import", () => {
+  it("maps all NTLM credential fields", () => {
+    const result = makeCollection({
+      info: { name: "NTLM" },
+      item: [
+        {
+          name: "Protected",
+          request: {
+            method: "GET",
+            url: "http://example.com",
+            header: [],
+            auth: {
+              type: "ntlm",
+              ntlm: [
+                { key: "username", value: "{{user}}", type: "string" },
+                { key: "password", value: "{{pass}}", type: "string" },
+                { key: "domain", value: "EXAMPLE", type: "string" },
+                { key: "workstation", value: "NOODLE", type: "string" },
+              ],
+            },
+          },
+        },
+      ],
+    })
+    expect((reqs(result)[0] as { auth: unknown }).auth).toEqual({
+      type: "ntlm",
+      username: "$user",
+      password: "$pass",
+      domain: "EXAMPLE",
+      workstation: "NOODLE",
+    })
+  })
+})
+
 describe("mapCollection — flat collection, single request", () => {
   it("maps a minimal GET request with no body or auth", () => {
     const result = makeCollection({

--- a/tests/folder-lang.test.ts
+++ b/tests/folder-lang.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { lang } from "../src/lang"
+import type { Folder } from "../src/schema"
 
 describe("lang.parseFolder", () => {
   it("returns empty for empty yaml", () => {
@@ -99,6 +100,30 @@ describe("AWS SigV4 folder auth", () => {
     const serialized = lang.serializeFolder(folder)
     expect(lang.parseFolder(serialized).overrides?.auth).toEqual(
       folder.overrides.auth,
+    )
+  })
+})
+
+describe("NTLMv2 folder auth", () => {
+  it("round-trips optional domain and workstation fields", () => {
+    const folder: Folder = {
+      id: "ntlm",
+      name: "ntlm",
+      path: "ntlm",
+      overrides: {
+        auth: {
+          type: "ntlm",
+          username: "$NTLM_USERNAME",
+          password: "$NTLM_PASSWORD",
+          domain: "$NTLM_DOMAIN",
+          workstation: "$NTLM_WORKSTATION",
+        },
+      },
+      children: [],
+    }
+    const serialized = lang.serializeFolder(folder)
+    expect(lang.parseFolder(serialized).overrides?.auth).toEqual(
+      folder.overrides?.auth,
     )
   })
 })

--- a/tests/formatRequest.test.ts
+++ b/tests/formatRequest.test.ts
@@ -143,6 +143,17 @@ describe("formatAuth", () => {
       "basic: alice:\u2022\u2022\u2022\u2022",
     )
   })
+  it("shows an NTLM domain and username without its password", () => {
+    expect(
+      formatAuth({
+        type: "ntlm",
+        username: "alice",
+        password: "secret",
+        domain: "EXAMPLE",
+        workstation: "NOODLE",
+      }),
+    ).toBe("ntlm: EXAMPLE\\alice")
+  })
   it("masks api_key value with fixed dots, shows key in cleartext", () => {
     expect(
       formatAuth({

--- a/tests/insomnia.test.ts
+++ b/tests/insomnia.test.ts
@@ -191,6 +191,36 @@ describe("insomniaImporter", () => {
     })
   })
 
+  it("maps NTLM authentication", () => {
+    const result = insomniaImporter.import(
+      exportJson([
+        { _id: "wrk", _type: "workspace", name: "NTLM" },
+        {
+          _id: "ntlm",
+          _type: "request",
+          parentId: "wrk",
+          name: "NTLM",
+          method: "GET",
+          url: "https://x",
+          authentication: {
+            type: "ntlm",
+            username: "{{ user }}",
+            password: "{{ password }}",
+            domain: "EXAMPLE",
+            workstation: "NOODLE",
+          },
+        },
+      ]),
+    )
+    expect(requests(result.collection.items)[0]?.auth).toEqual({
+      type: "ntlm",
+      username: "$user",
+      password: "$password",
+      domain: "EXAMPLE",
+      workstation: "NOODLE",
+    })
+  })
+
   it("skips unsupported methods while keeping missing and blank methods as GET", () => {
     const result = insomniaImporter.import(
       exportJson([

--- a/tests/integration/ntlm-loopback.test.ts
+++ b/tests/integration/ntlm-loopback.test.ts
@@ -34,6 +34,7 @@ function type2Token(): string {
 describe("NTLM loopback", () => {
   it("keeps all handshake legs on one TCP connection", async () => {
     const sockets = new Set<object>()
+    const signatures: string[] = []
     const messageTypes: number[] = []
     const server = createServer((request, response) => {
       sockets.add(request.socket)
@@ -44,7 +45,7 @@ describe("NTLM loopback", () => {
         return
       }
       const message = Buffer.from(authorization.slice(5), "base64")
-      expect(message.subarray(0, 8).toString("ascii")).toBe("NTLMSSP\0")
+      signatures.push(message.subarray(0, 8).toString("ascii"))
       const type = message.readUInt32LE(8)
       messageTypes.push(type)
       if (type === 1) {
@@ -84,6 +85,7 @@ describe("NTLM loopback", () => {
 
     expect(result.status).toBe(200)
     expect(result.body).toBe("authenticated")
+    expect(signatures).toEqual(["NTLMSSP\0", "NTLMSSP\0"])
     expect(messageTypes).toEqual([1, 3])
     expect(sockets.size).toBe(1)
   })

--- a/tests/integration/ntlm-loopback.test.ts
+++ b/tests/integration/ntlm-loopback.test.ts
@@ -1,29 +1,103 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { createServer, type Server } from "node:http"
-import type { AddressInfo } from "node:net"
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http"
+import {
+  createServer as createHttpsServer,
+  type Server as HttpsServer,
+} from "node:https"
+import {
+  connect,
+  createServer as createTcpServer,
+  type AddressInfo,
+  type Socket,
+} from "node:net"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import type { Request } from "../../src/schema"
 import { send } from "../../src/requests/send"
+import { ntlmV2Hash } from "../../src/requests/ntlm"
 
-const servers: Server[] = []
+const servers: Array<Server | HttpsServer> = []
+const TLS_FIXTURES = join(import.meta.dir, "..", "fixtures", "tls")
+const proxies: Array<{
+  close(): Promise<void>
+  connections(): number
+  authorization(): string | undefined
+  port: number
+}> = []
 
 afterEach(async () => {
-  await Promise.all(
-    servers
+  await Promise.all([
+    ...proxies.splice(0).map((proxy) => proxy.close()),
+    ...servers
       .splice(0)
       .map(
         (server) =>
           new Promise<void>((resolve) => server.close(() => resolve())),
       ),
-  )
+  ])
 })
 
-function type2Token(): string {
+async function startConnectProxy() {
+  let connectionCount = 0
+  let proxyAuthorization: string | undefined
+  const sockets = new Set<Socket>()
+  const server = createTcpServer((client) => {
+    sockets.add(client)
+    client.on("close", () => sockets.delete(client))
+    client.on("error", () => {})
+    client.once("data", (chunk) => {
+      const head = chunk.toString("latin1")
+      const firstLine = head.split("\r\n", 1)[0] ?? ""
+      const match = firstLine.match(/^CONNECT ([^:]+):(\d+) HTTP\/1\.[01]$/)
+      proxyAuthorization = head
+        .match(/\r\nproxy-authorization:\s*([^\r\n]+)/i)?.[1]
+        ?.trim()
+      if (!match) {
+        client.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n")
+        return
+      }
+      connectionCount++
+      const upstream = connect(Number(match[2]), match[1], () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n")
+        client.pipe(upstream)
+        upstream.pipe(client)
+      })
+      sockets.add(upstream)
+      upstream.on("close", () => sockets.delete(upstream))
+      upstream.on("error", () => client.destroy())
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const proxy = {
+    port: (server.address() as AddressInfo).port,
+    connections: () => connectionCount,
+    authorization: () => proxyAuthorization,
+    close: async () => {
+      for (const socket of sockets) socket.destroy()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    },
+  }
+  proxies.push(proxy)
+  return proxy
+}
+
+function type2Token(
+  challenge = Buffer.from("0123456789abcdef", "hex"),
+): string {
   const targetInfo = Buffer.from([0, 0, 0, 0])
   const message = Buffer.alloc(48 + targetInfo.length)
   Buffer.from("NTLMSSP\0", "ascii").copy(message)
   message.writeUInt32LE(2, 8)
   message.writeUInt32LE(0x00888205, 20)
-  Buffer.from("0123456789abcdef", "hex").copy(message, 24)
+  challenge.copy(message, 24)
   message.writeUInt16LE(targetInfo.length, 40)
   message.writeUInt16LE(targetInfo.length, 42)
   message.writeUInt32LE(48, 44)
@@ -31,28 +105,209 @@ function type2Token(): string {
   return message.toString("base64")
 }
 
+function verifiesType3(message: Buffer, challenge: Buffer): boolean {
+  const length = message.readUInt16LE(20)
+  const offset = message.readUInt32LE(24)
+  const ntResponse = message.subarray(offset, offset + length)
+  const hasher = new Bun.CryptoHasher(
+    "md5",
+    ntlmV2Hash("User", "Password", "Domain"),
+  )
+  hasher.update(challenge)
+  hasher.update(ntResponse.subarray(16))
+  return Buffer.from(hasher.digest()).equals(ntResponse.subarray(0, 16))
+}
+
+function ntlmRequest(url: string, overrides: Partial<Request> = {}): Request {
+  return {
+    id: "ntlm",
+    name: "NTLM",
+    method: "GET",
+    url,
+    timeout: 0,
+    headers: {},
+    params: [],
+    bodyType: "none",
+    auth: {
+      type: "ntlm",
+      username: "User",
+      password: "Password",
+      domain: "Domain",
+      workstation: "NOODLE",
+    },
+    ...overrides,
+  }
+}
+
+function ntlmHandler(
+  sockets: Set<object>,
+  messageTypes: number[],
+  signatures?: string[],
+): (request: IncomingMessage, response: ServerResponse) => void {
+  return (request, response) => {
+    sockets.add(request.socket)
+    const authorization = request.headers.authorization
+    if (!authorization) {
+      response.writeHead(401, { "WWW-Authenticate": "NTLM" })
+      response.end("offer")
+      return
+    }
+    const message = Buffer.from(authorization.slice(5), "base64")
+    signatures?.push(message.subarray(0, 8).toString("ascii"))
+    const type = message.readUInt32LE(8)
+    messageTypes.push(type)
+    if (type === 1) {
+      response.writeHead(401, {
+        "WWW-Authenticate": `NTLM ${type2Token()}`,
+      })
+      response.end("challenge")
+      return
+    }
+    response.end("authenticated")
+  }
+}
+
 describe("NTLM loopback", () => {
   it("keeps all handshake legs on one TCP connection", async () => {
     const sockets = new Set<object>()
     const signatures: string[] = []
     const messageTypes: number[] = []
+    const server = createServer(ntlmHandler(sockets, messageTypes, signatures))
+    servers.push(server)
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve()),
+    )
+    const { port } = server.address() as AddressInfo
+    const request = ntlmRequest(`http://127.0.0.1:${port}/protected`, {
+      method: "POST",
+      bodyType: "json",
+      body: '{"hello":"world"}',
+    })
+
+    const result = await send(request)
+
+    expect(result.status).toBe(200)
+    expect(result.body).toBe("authenticated")
+    expect(signatures).toEqual(["NTLMSSP\0", "NTLMSSP\0"])
+    expect(messageTypes).toEqual([1, 3])
+    expect(sockets.size).toBe(1)
+  })
+
+  it("keeps the handshake on one authenticated CONNECT tunnel", async () => {
+    const sockets = new Set<object>()
+    const messageTypes: number[] = []
+    const server = createServer(ntlmHandler(sockets, messageTypes))
+    servers.push(server)
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve()),
+    )
+    const { port } = server.address() as AddressInfo
+    const proxy = await startConnectProxy()
+
+    const result = await send(
+      ntlmRequest(`http://127.0.0.1:${port}/protected`, {
+        id: "ntlm-proxy",
+        name: "NTLM proxy",
+      }),
+      {
+        proxyPolicy: {
+          kind: "custom",
+          source: "collection",
+          url: `http://127.0.0.1:${proxy.port}`,
+          bypass: [],
+          auth: true,
+          credentials: { username: "proxy-user", password: "proxy-pass" },
+        },
+      },
+    )
+
+    expect(result.status).toBe(200)
+    expect(messageTypes).toEqual([1, 3])
+    expect(sockets.size).toBe(1)
+    expect(proxy.connections()).toBe(1)
+    expect(proxy.authorization()).toBe(
+      `Basic ${Buffer.from("proxy-user:proxy-pass").toString("base64")}`,
+    )
+  })
+
+  it("keeps the handshake on one mTLS connection with a custom CA", async () => {
+    const sockets = new Set<object>()
+    const messageTypes: number[] = []
+    const server = createHttpsServer(
+      {
+        cert: readFileSync(join(TLS_FIXTURES, "server.pem")),
+        key: readFileSync(join(TLS_FIXTURES, "server-key.pem")),
+        ca: readFileSync(join(TLS_FIXTURES, "ca.pem")),
+        requestCert: true,
+        rejectUnauthorized: true,
+      },
+      ntlmHandler(sockets, messageTypes),
+    )
+    servers.push(server)
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve()),
+    )
+    const { port } = server.address() as AddressInfo
+    const secretId = "123e4567-e89b-42d3-a456-426614174000"
+
+    const result = await send(
+      ntlmRequest(`https://localhost:${port}/protected`, {
+        id: "ntlm-tls",
+        name: "NTLM TLS",
+      }),
+      {
+        tlsPolicy: {
+          collectionDir: TLS_FIXTURES,
+          settings: {
+            caBundle: "ca.pem",
+            clientCertificates: [
+              {
+                host: "localhost",
+                port,
+                certFile: "client.pem",
+                keyFile: "client-encrypted-key.pem",
+                secretId,
+              },
+            ],
+          },
+          passphrases: { [secretId]: "test-passphrase" },
+        },
+      },
+    )
+
+    expect(result.status).toBe(200)
+    expect(messageTypes).toEqual([1, 3])
+    expect(sockets.size).toBe(1)
+  })
+
+  it("keeps concurrent handshakes bound to their challenged connection", async () => {
+    const challenges = new WeakMap<object, Buffer>()
+    let challengeId = 0
     const server = createServer((request, response) => {
-      sockets.add(request.socket)
       const authorization = request.headers.authorization
       if (!authorization) {
         response.writeHead(401, { "WWW-Authenticate": "NTLM" })
-        response.end("consume this offer")
+        response.end("offer")
         return
       }
       const message = Buffer.from(authorization.slice(5), "base64")
-      signatures.push(message.subarray(0, 8).toString("ascii"))
       const type = message.readUInt32LE(8)
-      messageTypes.push(type)
       if (type === 1) {
-        response.writeHead(401, {
-          "WWW-Authenticate": `NTLM ${type2Token()}`,
-        })
-        response.end("consume this challenge")
+        const challenge = Buffer.alloc(8)
+        challenge.writeBigUInt64LE(BigInt(++challengeId))
+        challenges.set(request.socket, challenge)
+        setTimeout(() => {
+          response.writeHead(401, {
+            "WWW-Authenticate": `NTLM ${type2Token(challenge)}`,
+          })
+          response.end("challenge")
+        }, challengeId % 4)
+        return
+      }
+      const challenge = challenges.get(request.socket)
+      if (!challenge || !verifiesType3(message, challenge)) {
+        response.writeHead(401, { "WWW-Authenticate": "NTLM" })
+        response.end("wrong connection")
         return
       }
       response.end("authenticated")
@@ -62,31 +317,19 @@ describe("NTLM loopback", () => {
       server.listen(0, "127.0.0.1", () => resolve()),
     )
     const { port } = server.address() as AddressInfo
-    const request: Request = {
-      id: "ntlm",
-      name: "NTLM",
-      method: "POST",
-      url: `http://127.0.0.1:${port}/protected`,
-      timeout: 0,
-      headers: {},
-      params: [],
-      bodyType: "json",
-      body: '{"hello":"world"}',
-      auth: {
-        type: "ntlm",
-        username: "User",
-        password: "Password",
-        domain: "Domain",
-        workstation: "NOODLE",
-      },
-    }
+    const requests = Array.from({ length: 24 }, (_, id) =>
+      ntlmRequest(`http://127.0.0.1:${port}/protected?id=${id}`, {
+        id: `ntlm-${id}`,
+      }),
+    )
 
-    const result = await send(request)
+    const results = await Promise.all(requests.map((request) => send(request)))
 
-    expect(result.status).toBe(200)
-    expect(result.body).toBe("authenticated")
-    expect(signatures).toEqual(["NTLMSSP\0", "NTLMSSP\0"])
-    expect(messageTypes).toEqual([1, 3])
-    expect(sockets.size).toBe(1)
+    expect(results.map(({ status, body }) => ({ status, body }))).toEqual(
+      Array.from({ length: requests.length }, () => ({
+        status: 200,
+        body: "authenticated",
+      })),
+    )
   })
 })

--- a/tests/integration/ntlm-loopback.test.ts
+++ b/tests/integration/ntlm-loopback.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import type { Request } from "../../src/schema"
+import { send } from "../../src/requests/send"
+
+const servers: Server[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  )
+})
+
+function type2Token(): string {
+  const targetInfo = Buffer.from([0, 0, 0, 0])
+  const message = Buffer.alloc(48 + targetInfo.length)
+  Buffer.from("NTLMSSP\0", "ascii").copy(message)
+  message.writeUInt32LE(2, 8)
+  message.writeUInt32LE(0x00888205, 20)
+  Buffer.from("0123456789abcdef", "hex").copy(message, 24)
+  message.writeUInt16LE(targetInfo.length, 40)
+  message.writeUInt16LE(targetInfo.length, 42)
+  message.writeUInt32LE(48, 44)
+  targetInfo.copy(message, 48)
+  return message.toString("base64")
+}
+
+describe("NTLM loopback", () => {
+  it("keeps all handshake legs on one TCP connection", async () => {
+    const sockets = new Set<object>()
+    const messageTypes: number[] = []
+    const server = createServer((request, response) => {
+      sockets.add(request.socket)
+      const authorization = request.headers.authorization
+      if (!authorization) {
+        response.writeHead(401, { "WWW-Authenticate": "NTLM" })
+        response.end("consume this offer")
+        return
+      }
+      const message = Buffer.from(authorization.slice(5), "base64")
+      expect(message.subarray(0, 8).toString("ascii")).toBe("NTLMSSP\0")
+      const type = message.readUInt32LE(8)
+      messageTypes.push(type)
+      if (type === 1) {
+        response.writeHead(401, {
+          "WWW-Authenticate": `NTLM ${type2Token()}`,
+        })
+        response.end("consume this challenge")
+        return
+      }
+      response.end("authenticated")
+    })
+    servers.push(server)
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", () => resolve()),
+    )
+    const { port } = server.address() as AddressInfo
+    const request: Request = {
+      id: "ntlm",
+      name: "NTLM",
+      method: "POST",
+      url: `http://127.0.0.1:${port}/protected`,
+      timeout: 0,
+      headers: {},
+      params: [],
+      bodyType: "json",
+      body: '{"hello":"world"}',
+      auth: {
+        type: "ntlm",
+        username: "User",
+        password: "Password",
+        domain: "Domain",
+        workstation: "NOODLE",
+      },
+    }
+
+    const result = await send(request)
+
+    expect(result.status).toBe(200)
+    expect(result.body).toBe("authenticated")
+    expect(messageTypes).toEqual([1, 3])
+    expect(sockets.size).toBe(1)
+  })
+})

--- a/tests/integration/ntlm-loopback.test.ts
+++ b/tests/integration/ntlm-loopback.test.ts
@@ -17,6 +17,7 @@ import {
 } from "node:net"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
+import { gzipSync } from "node:zlib"
 import type { Request } from "../../src/schema"
 import { send } from "../../src/requests/send"
 import { ntlmV2Hash } from "../../src/requests/ntlm"
@@ -50,8 +51,15 @@ async function startConnectProxy() {
     sockets.add(client)
     client.on("close", () => sockets.delete(client))
     client.on("error", () => {})
-    client.once("data", (chunk) => {
-      const head = chunk.toString("latin1")
+    let buffered = Buffer.alloc(0)
+    const onHead = (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk])
+      const headEnd = buffered.indexOf("\r\n\r\n")
+      if (headEnd < 0) return
+      client.off("data", onHead)
+      client.pause()
+      const head = buffered.subarray(0, headEnd + 4).toString("latin1")
+      const remainder = buffered.subarray(headEnd + 4)
       const firstLine = head.split("\r\n", 1)[0] ?? ""
       const match = firstLine.match(/^CONNECT ([^:]+):(\d+) HTTP\/1\.[01]$/)
       proxyAuthorization = head
@@ -64,13 +72,16 @@ async function startConnectProxy() {
       connectionCount++
       const upstream = connect(Number(match[2]), match[1], () => {
         client.write("HTTP/1.1 200 Connection Established\r\n\r\n")
+        if (remainder.length > 0) client.unshift(remainder)
         client.pipe(upstream)
         upstream.pipe(client)
+        client.resume()
       })
       sockets.add(upstream)
       upstream.on("close", () => sockets.delete(upstream))
       upstream.on("error", () => client.destroy())
-    })
+    }
+    client.on("data", onHead)
   })
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject)
@@ -163,7 +174,8 @@ function ntlmHandler(
       response.end("challenge")
       return
     }
-    response.end("authenticated")
+    response.writeHead(200, { "Content-Encoding": "x-gzip, identity" })
+    response.end(gzipSync("authenticated"))
   }
 }
 
@@ -188,6 +200,7 @@ describe("NTLM loopback", () => {
 
     expect(result.status).toBe(200)
     expect(result.body).toBe("authenticated")
+    expect(result.headers["content-encoding"]).toBeUndefined()
     expect(signatures).toEqual(["NTLMSSP\0", "NTLMSSP\0"])
     expect(messageTypes).toEqual([1, 3])
     expect(sockets.size).toBe(1)

--- a/tests/integration/tls-loopback.test.ts
+++ b/tests/integration/tls-loopback.test.ts
@@ -57,8 +57,16 @@ async function startConnectProxy(): Promise<{
     sockets.add(client)
     client.on("close", () => sockets.delete(client))
     client.on("error", () => {})
-    client.once("data", (chunk) => {
-      const firstLine = chunk.toString("utf8").split("\r\n", 1)[0] ?? ""
+    let buffered = Buffer.alloc(0)
+    const onHead = (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk])
+      const headEnd = buffered.indexOf("\r\n\r\n")
+      if (headEnd < 0) return
+      client.off("data", onHead)
+      client.pause()
+      const head = buffered.subarray(0, headEnd + 4).toString("latin1")
+      const remainder = buffered.subarray(headEnd + 4)
+      const firstLine = head.split("\r\n", 1)[0] ?? ""
       const match = firstLine.match(/^CONNECT ([^:]+):(\d+) HTTP\/1\.[01]$/)
       if (!match) {
         client.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n")
@@ -67,13 +75,16 @@ async function startConnectProxy(): Promise<{
       connectionCount++
       const upstream = connect(Number(match[2]), match[1], () => {
         client.write("HTTP/1.1 200 Connection Established\r\n\r\n")
+        if (remainder.length > 0) client.unshift(remainder)
         client.pipe(upstream)
         upstream.pipe(client)
+        client.resume()
       })
       sockets.add(upstream)
       upstream.on("close", () => sockets.delete(upstream))
       upstream.on("error", () => client.destroy())
-    })
+    }
+    client.on("data", onHead)
   })
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject)

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -45,6 +45,35 @@ describe("AWS SigV4 auth language", () => {
   })
 })
 
+describe("NTLMv2 auth language", () => {
+  it("round-trips required credentials and omits empty optional fields", () => {
+    const request = lang.parseRequest(
+      "ntlm",
+      `name: NTLM\nmethod: GET\nurl: https://example.com\nauth:\n  type: ntlm\n  username: $NTLM_USERNAME\n  password: $NTLM_PASSWORD\n`,
+    )
+    expect(request.auth).toEqual({
+      type: "ntlm",
+      username: "$NTLM_USERNAME",
+      password: "$NTLM_PASSWORD",
+      domain: "",
+      workstation: "",
+    })
+    const serialized = lang.serializeRequest(request)
+    expect(serialized).not.toContain("domain:")
+    expect(serialized).not.toContain("workstation:")
+    expect(lang.parseRequest("ntlm", serialized).auth).toEqual(request.auth)
+  })
+
+  it("requires username and password", () => {
+    expect(() =>
+      lang.parseRequest(
+        "ntlm",
+        `name: NTLM\nmethod: GET\nurl: https://example.com\nauth:\n  type: ntlm\n  username: user\n`,
+      ),
+    ).toThrow("auth.ntlm requires")
+  })
+})
+
 describe("lang.parseRequest — required fields", () => {
   it("parses a minimal valid request (name, method, url)", () => {
     const yaml = `name: Get user\nmethod: GET\nurl: https://api.example.com/users/1\n`
@@ -224,7 +253,7 @@ describe("lang.parseRequest — strictness", () => {
   it("throws on invalid auth.type", () => {
     const yaml = `name: Foo\nmethod: GET\nurl: https://example.com\nauth:\n  type: oauth\n`
     expect(() => lang.parseRequest("x", yaml)).toThrow(
-      'lang.parseRequest: invalid auth.type "oauth", expected none|inherit|bearer|basic|api_key',
+      'lang.parseRequest: invalid auth.type "oauth", expected none|inherit|bearer|basic|ntlm|api_key|aws_sigv4',
     )
   })
 

--- a/tests/openapi.test.ts
+++ b/tests/openapi.test.ts
@@ -416,6 +416,25 @@ describe("mapCollection — auth resolution", () => {
     })
   })
 
+  it("maps an NTLM HTTP scheme to credential placeholders", () => {
+    const c = mapCollection(
+      makeNormalized({
+        components: {
+          securitySchemes: { ntlmAuth: { type: "http", scheme: "NTLM" } },
+        },
+        security: [{ ntlmAuth: [] }],
+        paths: { "/x": { get: { operationId: "getX" } } },
+      }),
+    )
+    expect(reqs(c)[0].auth).toEqual({
+      type: "ntlm",
+      username: "$NTLM_USERNAME",
+      password: "$NTLM_PASSWORD",
+      domain: "$NTLM_DOMAIN",
+      workstation: "$NTLM_WORKSTATION",
+    })
+  })
+
   it("maps apiKey header scheme", () => {
     const c = mapCollection(
       makeNormalized({

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -985,6 +985,138 @@ describe("RequestPane scrollbox", () => {
     expect(captureCharFrame()).toContain("Session Token")
   })
 
+  it("hides the editing auth cursor outside the request viewport", async () => {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const awsRequest: Request = {
+      ...makeRequest(1),
+      auth: {
+        type: "aws_sigv4",
+        access_key: "$AWS_ACCESS_KEY_ID",
+        secret_key: "$AWS_SECRET_ACCESS_KEY",
+        region: "us-east-1",
+        service: "execute-api",
+        session_token: "$AWS_SESSION_TOKEN",
+      },
+    }
+    let startEditing: (() => void) | undefined
+    function EditingAwsAuthPane() {
+      const [editState, setEditState] = useState<EditState>({
+        mode: "browsing",
+        cursor: { field: "auth", row: 0, addingRow: false },
+        editingRow: -1,
+      })
+      startEditing = () =>
+        setEditState({
+          mode: "editing",
+          cursor: { field: "auth", row: 5, addingRow: false },
+          editingRow: 5,
+        })
+      return (
+        <RequestPane
+          request={awsRequest}
+          editState={editState}
+          editKey=""
+          editValue="$AWS_SESSION_TOKEN"
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          focused
+          activeTab="auth"
+        />
+      )
+    }
+    const { renderer, renderOnce, captureSpans } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <EditingAwsAuthPane />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 14 },
+    )
+
+    await renderOnce()
+    await act(async () => startEditing?.())
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "request-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureSpans().cursor).not.toEqual([1, 1])
+    scrollbox.scrollTo(0)
+    await renderOnce()
+    expect(captureSpans().cursor).toEqual([1, 1])
+  })
+
+  it("hides the editing header cursor outside the request viewport", async () => {
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const headers: Record<string, KvEntry> = {}
+    for (let i = 0; i < 30; i++) {
+      headers[`X-Header-${i}`] = { value: `value-${i}`, enabled: true }
+    }
+    const request: Request = { ...makeRequest(1), headers }
+    let startEditing: (() => void) | undefined
+    function EditingHeadersPane() {
+      const [editState, setEditState] = useState<EditState>({
+        mode: "browsing",
+        cursor: {
+          field: "headers",
+          row: 0,
+          addingRow: false,
+          subfield: "value",
+        },
+        editingRow: -1,
+      })
+      startEditing = () =>
+        setEditState({
+          mode: "editing",
+          cursor: {
+            field: "headers",
+            row: 29,
+            addingRow: false,
+            subfield: "value",
+          },
+          editingRow: 29,
+        })
+      return (
+        <RequestPane
+          request={request}
+          editState={editState}
+          editKey="X-Header-29"
+          editValue="value-29"
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          focused
+          activeTab="headers"
+        />
+      )
+    }
+    const { renderer, renderOnce, captureSpans } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <EditingHeadersPane />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 14 },
+    )
+
+    await renderOnce()
+    await act(async () => startEditing?.())
+    await renderOnce()
+
+    const scrollbox = renderer.root.findDescendantById(
+      "request-tab-scrollbox",
+    ) as ScrollBoxRenderable
+    expect(scrollbox.scrollTop).toBeGreaterThan(0)
+    expect(captureSpans().cursor).not.toEqual([1, 1])
+    scrollbox.scrollTo(0)
+    await renderOnce()
+    expect(captureSpans().cursor).toEqual([1, 1])
+  })
+
   it("keeps the active multipart row inside the request viewport", async () => {
     const raw = createTestKeymap()
     const keymap = raw.keymap as unknown as OpenTuiKeymap

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -65,6 +65,64 @@ describe("truncateUrl", () => {
   })
 })
 
+describe("NTLM timeline security", () => {
+  it("masks the challenge header", () => {
+    expect(
+      maskedAuthHeader({
+        type: "ntlm",
+        username: "alice",
+        password: "secret",
+        domain: "EXAMPLE",
+        workstation: "NOODLE",
+      }),
+    ).toEqual({ key: "Authorization", value: "NTLM ••••••••" })
+  })
+
+  it("redacts the password while retaining public identity fields", () => {
+    const entry = buildTimelineEntry(
+      {
+        id: "ntlm",
+        name: "NTLM",
+        method: "GET",
+        url: "https://example.com",
+        timeout: 0,
+        headers: {},
+        params: [],
+        auth: {
+          type: "ntlm",
+          username: "$USER",
+          password: "$PASSWORD",
+          domain: "$DOMAIN",
+          workstation: "NOODLE",
+        },
+      },
+      {
+        status: "done",
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: "",
+          timeMs: 1,
+        },
+      },
+      "dev",
+      {
+        name: "dev",
+        vars: { USER: "alice", PASSWORD: "secret", DOMAIN: "EXAMPLE" },
+        secretVars: { PASSWORD: "keychain" },
+      },
+    )
+    expect(entry.request.auth).toEqual({
+      type: "ntlm",
+      username: "alice",
+      password: "[REDACTED]",
+      domain: "EXAMPLE",
+      workstation: "NOODLE",
+    })
+  })
+})
+
 describe("relativeTime", () => {
   it('returns "now" for very recent timestamps', () => {
     expect(relativeTime(Date.now())).toBe("now")

--- a/tests/unit/AuthEditor.test.tsx
+++ b/tests/unit/AuthEditor.test.tsx
@@ -15,6 +15,28 @@ const testRender = createTestRender()
 describe("AuthEditor", () => {
   const autocompleteCases: Array<{ name: string; auth: Auth; row: number }> = [
     {
+      name: "NTLM username",
+      auth: {
+        type: "ntlm",
+        username: "",
+        password: "",
+        domain: "",
+        workstation: "",
+      },
+      row: 1,
+    },
+    {
+      name: "NTLM password",
+      auth: {
+        type: "ntlm",
+        username: "",
+        password: "",
+        domain: "",
+        workstation: "",
+      },
+      row: 2,
+    },
+    {
       name: "bearer token",
       auth: { type: "bearer", token: "" },
       row: 1,
@@ -96,6 +118,45 @@ describe("AuthEditor", () => {
       row: 5,
     },
   ]
+
+  it("renders NTLM fields and masks the password", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box width={70} height={30}>
+            <AuthEditor
+              auth={{
+                type: "ntlm",
+                username: "alice",
+                password: "do-not-render",
+                domain: "EXAMPLE",
+                workstation: "NOODLE",
+              }}
+              editState={initialEditState()}
+              inEdit={false}
+              browseActive={false}
+              editValue=""
+              setEditValue={() => {}}
+              theme={THEMES[0]!}
+              onAuthTypeChange={() => {}}
+              onApiKeyPlacementChange={() => {}}
+            />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 70, height: 30 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("NTLMv2")
+    expect(frame).toContain("Username*")
+    expect(frame).toContain("Password*")
+    expect(frame).toContain("Domain")
+    expect(frame).toContain("Workstation")
+    expect(frame).not.toContain("do-not-render")
+    cleanup()
+  })
 
   for (const { name, auth, row } of autocompleteCases) {
     it(`shows variable autocomplete for ${name}`, async () => {

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -264,6 +264,56 @@ describe("buildHar", () => {
 })
 
 describe("generateCode", () => {
+  it("rejects NTLM because it needs a connection-bound challenge", () => {
+    expect(() =>
+      generateCode(
+        makeRequest({
+          auth: {
+            type: "ntlm",
+            username: "$NTLM_USERNAME",
+            password: "$NTLM_PASSWORD",
+            domain: "",
+            workstation: "",
+          },
+        }),
+        curlTarget(),
+      ),
+    ).toThrow("connection-bound challenge exchange")
+  })
+
+  it("rejects inherited NTLM auth", () => {
+    expect(() =>
+      generateCode(
+        makeRequest({ id: "ntlm/request", auth: { type: "inherit" } }),
+        curlTarget(),
+        {
+          id: "collection",
+          name: "Collection",
+          items: [
+            {
+              type: "folder",
+              data: {
+                id: "ntlm",
+                name: "ntlm",
+                path: "ntlm",
+                overrides: {
+                  auth: {
+                    type: "ntlm",
+                    username: "alice",
+                    password: "secret",
+                    domain: "EXAMPLE",
+                    workstation: "NOODLE",
+                  },
+                },
+                children: [],
+              },
+            },
+          ],
+        },
+      ),
+    ).toThrow("connection-bound challenge exchange")
+  })
+
   it("rejects AWS Signature v4 instead of generating an expiring signature", () => {
     expect(() =>
       generateCode(

--- a/tests/unit/folder-draft.test.ts
+++ b/tests/unit/folder-draft.test.ts
@@ -33,6 +33,27 @@ describe("applyDraftOp", () => {
     expect(r?.seq).toBe(5)
   })
 
+  it("creates and edits an NTLM auth override", () => {
+    const folder = makeFolder()
+    const selected = applyDraftOp(folder, {
+      kind: "setAuthType",
+      authType: "ntlm",
+    })
+    const edited = applyDraftOp(selected, {
+      kind: "setAuthField",
+      authType: "ntlm",
+      field: "username",
+      value: "alice",
+    })
+    expect(edited?.overrides?.auth).toEqual({
+      type: "ntlm",
+      username: "alice",
+      password: "",
+      domain: "",
+      workstation: "",
+    })
+  })
+
   it("addHeaderRow adds to empty overrides", () => {
     const f = makeFolder()
     const r = applyDraftOp(f, {

--- a/tests/unit/ntlm.test.ts
+++ b/tests/unit/ntlm.test.ts
@@ -116,9 +116,30 @@ describe("NTLMv2 messages", () => {
     expect(() => parseType2Message(type2Token(undefined, 0x00880204))).toThrow(
       "Unicode",
     )
+    expect(() => parseType2Message(type2Token(undefined, 0x00888005))).toThrow(
+      "does not negotiate NTLM",
+    )
     expect(() => parseType2Message(type2Token(undefined, 0x00808205))).toThrow(
       "extended session security",
     )
+    expect(() =>
+      parseType2Message(type2Token(Buffer.from([1, 0, 0, 0]))),
+    ).toThrow("missing its terminator")
+  })
+
+  it("rejects a client challenge that is not 8 bytes", () => {
+    expect(() =>
+      createType3Message(
+        parseType2Message(type2Token()),
+        {
+          username: "alice",
+          password: "secret",
+          domain: "EXAMPLE",
+          workstation: "NOODLE",
+        },
+        { clientChallenge: Buffer.alloc(7) },
+      ),
+    ).toThrow("NTLM client challenge must be 8 bytes")
   })
 
   it("extracts combined challenges and ignores SPNEGO Negotiate tokens", () => {

--- a/tests/unit/ntlm.test.ts
+++ b/tests/unit/ntlm.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test"
+import {
+  createType1Message,
+  createType3Message,
+  getNtlmChallenge,
+  ntlmV2Hash,
+  parseType2Message,
+} from "../../src/requests/ntlm"
+
+const SIGNATURE = Buffer.from("NTLMSSP\0", "ascii")
+
+function type2Token(
+  targetInfo = Buffer.from([0, 0, 0, 0]),
+  flags = 0x00888205,
+): string {
+  const message = Buffer.alloc(48 + targetInfo.length)
+  SIGNATURE.copy(message)
+  message.writeUInt32LE(2, 8)
+  message.writeUInt32LE(flags, 20)
+  Buffer.from("0123456789abcdef", "hex").copy(message, 24)
+  message.writeUInt16LE(targetInfo.length, 40)
+  message.writeUInt16LE(targetInfo.length, 42)
+  message.writeUInt32LE(48, 44)
+  targetInfo.copy(message, 48)
+  return message.toString("base64")
+}
+
+function securityBuffer(message: Buffer, offset: number): Buffer {
+  const length = message.readUInt16LE(offset)
+  const dataOffset = message.readUInt32LE(offset + 4)
+  return message.subarray(dataOffset, dataOffset + length)
+}
+
+describe("NTLMv2 messages", () => {
+  it("matches the MS-NLMP NTOWFv2 known-answer vector", () => {
+    expect(ntlmV2Hash("User", "Password", "Domain").toString("hex")).toBe(
+      "0c868a403bfd7a93a3001ef22ef02e3f",
+    )
+  })
+
+  it("creates the documented NTLMv2 proof", () => {
+    const type2 = parseType2Message(
+      type2Token(
+        Buffer.from(
+          "02000c0044006f006d00610069006e0001000c0053006500720076006500720000000000",
+          "hex",
+        ),
+      ),
+    )
+    const type3 = createType3Message(
+      type2,
+      {
+        username: "User",
+        password: "Password",
+        domain: "Domain",
+        workstation: "COMPUTER",
+      },
+      {
+        clientChallenge: Buffer.from("aaaaaaaaaaaaaaaa", "hex"),
+        timestamp: 0n,
+      },
+    )
+    expect(securityBuffer(type3, 20).subarray(0, 16).toString("hex")).toBe(
+      "68cd0ab851e51c96aabc927bebef6a1c",
+    )
+    expect(securityBuffer(type3, 12).equals(Buffer.alloc(24))).toBe(true)
+  })
+
+  it("creates a minimal Type 1 and a MIC-bearing Type 3", () => {
+    const type1 = createType1Message()
+    expect(type1.length).toBe(32)
+    expect(type1.subarray(0, 8)).toEqual(SIGNATURE)
+    expect(type1.readUInt32LE(8)).toBe(1)
+
+    const type3 = createType3Message(
+      parseType2Message(type2Token()),
+      {
+        username: "alice",
+        password: "secret",
+        domain: "EXAMPLE",
+        workstation: "NOODLE",
+      },
+      {
+        type1,
+        clientChallenge: Buffer.alloc(8, 0xaa),
+        timestamp: 0n,
+      },
+    )
+    expect(type3.subarray(0, 8)).toEqual(SIGNATURE)
+    expect(type3.readUInt32LE(8)).toBe(3)
+    expect(type3.subarray(72, 88).equals(Buffer.alloc(16))).toBe(false)
+    const ntResponse = securityBuffer(type3, 20)
+    const avFlagsOffset = ntResponse.length - 16
+    expect(ntResponse.readUInt16LE(avFlagsOffset)).toBe(6)
+    expect(ntResponse.readUInt32LE(avFlagsOffset + 4) & 2).toBe(2)
+  })
+
+  it("strictly rejects malformed Type 2 messages", () => {
+    expect(() => parseType2Message("!!!")).toThrow("base64")
+    expect(() =>
+      parseType2Message(Buffer.from("short").toString("base64")),
+    ).toThrow("truncated")
+
+    const wrongType = Buffer.from(type2Token(), "base64")
+    wrongType.writeUInt32LE(1, 8)
+    expect(() => parseType2Message(wrongType.toString("base64"))).toThrow(
+      "message type 2",
+    )
+
+    const badOffset = Buffer.from(type2Token(), "base64")
+    badOffset.writeUInt32LE(0xffffffff, 44)
+    expect(() => parseType2Message(badOffset.toString("base64"))).toThrow(
+      "security buffer",
+    )
+
+    expect(() => parseType2Message(type2Token(undefined, 0x00880204))).toThrow(
+      "Unicode",
+    )
+    expect(() => parseType2Message(type2Token(undefined, 0x00808205))).toThrow(
+      "extended session security",
+    )
+  })
+
+  it("extracts combined challenges and ignores SPNEGO Negotiate tokens", () => {
+    expect(getNtlmChallenge("Negotiate, NTLM")).toEqual({
+      kind: "offer",
+      scheme: "NTLM",
+    })
+    expect(getNtlmChallenge(`Negotiate ${type2Token()}`).kind).toBe("type2")
+    expect(
+      getNtlmChallenge(
+        `Negotiate ${Buffer.from("not-ntlm").toString("base64")}`,
+      ),
+    ).toEqual({ kind: "none" })
+    expect(getNtlmChallenge(`Negotiate, NTLM ${type2Token()}`).kind).toBe(
+      "type2",
+    )
+  })
+
+  it("marks timestamp challenges as requiring a MIC transcript", () => {
+    const targetInfo = Buffer.alloc(16)
+    targetInfo.writeUInt16LE(7, 0)
+    targetInfo.writeUInt16LE(8, 2)
+    targetInfo.writeBigUInt64LE(1n, 4)
+    expect(parseType2Message(type2Token(targetInfo)).requiresMic).toBe(true)
+  })
+})

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect, mock } from "bun:test"
+import { afterEach, describe, it, expect, mock } from "bun:test"
 import type { Collection, NetworkError, Request } from "../../src/schema"
 import { send, interpolatePathParams } from "../../src/requests/send"
+
+const servers: Bun.Server<undefined>[] = []
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true)
+})
+
+function startServer(
+  handler: (request: globalThis.Request) => Response | Promise<Response>,
+): string {
+  const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: handler })
+  servers.push(server)
+  return `http://127.0.0.1:${server.port}`
+}
 
 function makeReq(over: Partial<Request> = {}): Request {
   return {
@@ -321,84 +335,66 @@ describe("send — NTLMv2", () => {
   }
 
   it("performs the standard three-request handshake on replayable bodies", async () => {
-    const originalFetch = globalThis.fetch
     const headers: Array<string | null> = []
-    const bodies: unknown[] = []
-    const challenges: Response[] = []
-    globalThis.fetch = mock(async (_url, init) => {
-      headers.push(new Headers(init?.headers).get("authorization"))
-      bodies.push(init?.body)
+    const bodies: string[] = []
+    const url = startServer(async (request) => {
+      headers.push(request.headers.get("authorization"))
+      bodies.push(await request.text())
       if (headers.length === 1) {
-        const response = new Response("offer", {
+        return new Response("offer", {
           status: 401,
           headers: { "www-authenticate": "Negotiate, NTLM" },
         })
-        challenges.push(response)
-        return response
       }
       if (headers.length === 2) {
-        const response = new Response("challenge", {
+        return new Response("challenge", {
           status: 401,
           headers: { "www-authenticate": `NTLM ${type2Token()}` },
         })
-        challenges.push(response)
-        return response
       }
-      return new Response("ok", { status: 200 })
-    }) as unknown as typeof globalThis.fetch
+      return new Response("ok")
+    })
 
-    try {
-      const response = await send(
-        makeReq({
-          method: "POST",
-          auth: ntlmAuth,
-          bodyType: "json",
-          body: '{"ok":true}',
-        }),
-        { environment: environment() },
-      )
-      expect(response.status).toBe(200)
-      expect(headers).toHaveLength(3)
-      expect(headers[0]).toBeNull()
-      expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(
-        1,
-      )
-      expect(Buffer.from(headers[2]!.slice(5), "base64").readUInt32LE(8)).toBe(
-        3,
-      )
-      expect(bodies).toEqual(['{"ok":true}', '{"ok":true}', '{"ok":true}'])
-      expect(challenges.every((challenge) => challenge.bodyUsed)).toBe(true)
-      expect(
-        response.network?.filter((event) => event.type === "request"),
-      ).toHaveLength(3)
-      expect(JSON.stringify(response.network)).not.toContain(headers[2])
-    } finally {
-      globalThis.fetch = originalFetch
-    }
+    const result = await send(
+      makeReq({
+        url,
+        method: "POST",
+        auth: ntlmAuth,
+        bodyType: "json",
+        body: '{"ok":true}',
+      }),
+      { environment: environment() },
+    )
+    expect(result.status).toBe(200)
+    expect(headers).toHaveLength(3)
+    expect(headers[0]).toBeNull()
+    expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(1)
+    expect(Buffer.from(headers[2]!.slice(5), "base64").readUInt32LE(8)).toBe(3)
+    expect(bodies).toEqual(['{"ok":true}', '{"ok":true}', '{"ok":true}'])
+    expect(
+      result.network?.filter((event) => event.type === "request"),
+    ).toHaveLength(3)
+    expect(JSON.stringify(result.network)).not.toContain(headers[2])
   })
 
   it("uses the two-request shortcut for an eager Type 2 without MIC", async () => {
-    const originalFetch = globalThis.fetch
     const headers: Array<string | null> = []
-    globalThis.fetch = mock(async (_url, init) => {
-      headers.push(new Headers(init?.headers).get("authorization"))
-      return headers.length === 1
-        ? new Response("challenge", {
-            status: 401,
-            headers: { "www-authenticate": `NTLM ${type2Token()}` },
-          })
-        : new Response("ok", { status: 200 })
-    }) as unknown as typeof globalThis.fetch
+    const url = startServer((request) => {
+      headers.push(request.headers.get("authorization"))
+      if (headers.length === 1) {
+        return new Response("challenge", {
+          status: 401,
+          headers: { "www-authenticate": `NTLM ${type2Token()}` },
+        })
+      }
+      return new Response("ok")
+    })
 
-    try {
-      await send(makeReq({ auth: ntlmAuth }), { environment: environment() })
-      expect(headers).toHaveLength(2)
-      expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(
-        3,
-      )
-    } finally {
-      globalThis.fetch = originalFetch
-    }
+    await send(makeReq({ url, auth: ntlmAuth }), {
+      environment: environment(),
+    })
+    expect(headers).toHaveLength(2)
+    expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(3)
   })
 
   it("obtains a Type 1 transcript when an eager challenge requires MIC", async () => {
@@ -407,37 +403,31 @@ describe("send — NTLMv2", () => {
     targetInfo.writeUInt16LE(8, 2)
     targetInfo.writeBigUInt64LE(1n, 4)
     const token = type2Token(targetInfo)
-    const originalFetch = globalThis.fetch
     const headers: Array<string | null> = []
-    globalThis.fetch = mock(async (_url, init) => {
-      headers.push(new Headers(init?.headers).get("authorization"))
+    const url = startServer((request) => {
+      headers.push(request.headers.get("authorization"))
       if (headers.length < 3) {
         return new Response("challenge", {
           status: 401,
           headers: { "www-authenticate": `NTLM ${token}` },
         })
       }
-      return new Response("ok", { status: 200 })
-    }) as unknown as typeof globalThis.fetch
+      return new Response("ok")
+    })
 
-    try {
-      await send(makeReq({ auth: ntlmAuth }), { environment: environment() })
-      expect(headers).toHaveLength(3)
-      expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(
-        1,
-      )
-      const type3 = Buffer.from(headers[2]!.slice(5), "base64")
-      expect(type3.readUInt32LE(8)).toBe(3)
-      expect(type3.subarray(72, 88).equals(Buffer.alloc(16))).toBe(false)
-    } finally {
-      globalThis.fetch = originalFetch
-    }
+    await send(makeReq({ url, auth: ntlmAuth }), {
+      environment: environment(),
+    })
+    expect(headers).toHaveLength(3)
+    expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(1)
+    const type3 = Buffer.from(headers[2]!.slice(5), "base64")
+    expect(type3.readUInt32LE(8)).toBe(3)
+    expect(type3.subarray(72, 88).equals(Buffer.alloc(16))).toBe(false)
   })
 
   it("returns the final 401 without looping and rejects malformed NTLM", async () => {
-    const originalFetch = globalThis.fetch
     let calls = 0
-    globalThis.fetch = mock(async () => {
+    const url = startServer(() => {
       calls++
       return new Response("no", {
         status: 401,
@@ -445,59 +435,49 @@ describe("send — NTLMv2", () => {
           "www-authenticate": calls === 1 ? "NTLM" : `NTLM ${type2Token()}`,
         },
       })
-    }) as unknown as typeof globalThis.fetch
+    })
 
-    try {
-      const response = await send(makeReq({ auth: ntlmAuth }), {
-        environment: environment(),
+    const result = await send(makeReq({ url, auth: ntlmAuth }), {
+      environment: environment(),
+    })
+    expect(result.status).toBe(401)
+    expect(calls).toBe(3)
+
+    const malformedUrl = startServer(() => {
+      return new Response("bad", {
+        status: 401,
+        headers: { "www-authenticate": "NTLM !!!" },
       })
-      expect(response.status).toBe(401)
-      expect(calls).toBe(3)
-
-      globalThis.fetch = mock(
-        async () =>
-          new Response("bad", {
-            status: 401,
-            headers: { "www-authenticate": "NTLM !!!" },
-          }),
-      ) as unknown as typeof globalThis.fetch
-      await expect(
-        send(makeReq({ auth: ntlmAuth }), { environment: environment() }),
-      ).rejects.toThrow("invalid NTLM challenge")
-    } finally {
-      globalThis.fetch = originalFetch
-    }
+    })
+    await expect(
+      send(makeReq({ url: malformedUrl, auth: ntlmAuth }), {
+        environment: environment(),
+      }),
+    ).rejects.toThrow("invalid NTLM challenge")
   })
 
   it("does not send NTLM credentials across an origin-changing redirect", async () => {
-    const originalFetch = globalThis.fetch
     const headers: Array<string | null> = []
-    let calls = 0
-    globalThis.fetch = mock(async (_url, init) => {
-      calls++
-      headers.push(new Headers(init?.headers).get("authorization"))
-      if (calls === 1) {
-        return new Response(null, {
-          status: 302,
-          headers: { location: "https://other.example/protected" },
-        })
-      }
+    const destination = startServer((request) => {
+      headers.push(request.headers.get("authorization"))
       return new Response("protected", {
         status: 401,
         headers: { "www-authenticate": "NTLM" },
       })
-    }) as unknown as typeof globalThis.fetch
-
-    try {
-      const response = await send(makeReq({ auth: ntlmAuth }), {
-        environment: environment(),
+    })
+    const source = startServer((request) => {
+      headers.push(request.headers.get("authorization"))
+      return new Response(null, {
+        status: 302,
+        headers: { location: `${destination}/protected` },
       })
-      expect(response.status).toBe(401)
-      expect(calls).toBe(2)
-      expect(headers).toEqual([null, null])
-    } finally {
-      globalThis.fetch = originalFetch
-    }
+    })
+
+    const result = await send(makeReq({ url: source, auth: ntlmAuth }), {
+      environment: environment(),
+    })
+    expect(result.status).toBe(401)
+    expect(headers).toEqual([null, null])
   })
 })
 

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -371,7 +371,7 @@ describe("send — NTLMv2", () => {
       expect(
         response.network?.filter((event) => event.type === "request"),
       ).toHaveLength(3)
-      expect(JSON.stringify(response.network)).not.toContain(headers[1])
+      expect(JSON.stringify(response.network)).not.toContain(headers[2])
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/tests/unit/send.test.ts
+++ b/tests/unit/send.test.ts
@@ -286,6 +286,221 @@ describe("send — AWS SigV4", () => {
   })
 })
 
+describe("send — NTLMv2", () => {
+  const ntlmAuth = {
+    type: "ntlm" as const,
+    username: "$USER",
+    password: "$PASSWORD",
+    domain: "$DOMAIN",
+    workstation: "$WORKSTATION",
+  }
+
+  function type2Token(targetInfo = Buffer.from([0, 0, 0, 0])): string {
+    const message = Buffer.alloc(48 + targetInfo.length)
+    Buffer.from("NTLMSSP\0", "ascii").copy(message)
+    message.writeUInt32LE(2, 8)
+    message.writeUInt32LE(0x00888205, 20)
+    Buffer.from("0123456789abcdef", "hex").copy(message, 24)
+    message.writeUInt16LE(targetInfo.length, 40)
+    message.writeUInt16LE(targetInfo.length, 42)
+    message.writeUInt32LE(48, 44)
+    targetInfo.copy(message, 48)
+    return message.toString("base64")
+  }
+
+  function environment() {
+    return {
+      name: "dev",
+      vars: {
+        USER: "alice",
+        PASSWORD: "secret",
+        DOMAIN: "EXAMPLE",
+        WORKSTATION: "NOODLE",
+      },
+    }
+  }
+
+  it("performs the standard three-request handshake on replayable bodies", async () => {
+    const originalFetch = globalThis.fetch
+    const headers: Array<string | null> = []
+    const bodies: unknown[] = []
+    const challenges: Response[] = []
+    globalThis.fetch = mock(async (_url, init) => {
+      headers.push(new Headers(init?.headers).get("authorization"))
+      bodies.push(init?.body)
+      if (headers.length === 1) {
+        const response = new Response("offer", {
+          status: 401,
+          headers: { "www-authenticate": "Negotiate, NTLM" },
+        })
+        challenges.push(response)
+        return response
+      }
+      if (headers.length === 2) {
+        const response = new Response("challenge", {
+          status: 401,
+          headers: { "www-authenticate": `NTLM ${type2Token()}` },
+        })
+        challenges.push(response)
+        return response
+      }
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(
+        makeReq({
+          method: "POST",
+          auth: ntlmAuth,
+          bodyType: "json",
+          body: '{"ok":true}',
+        }),
+        { environment: environment() },
+      )
+      expect(response.status).toBe(200)
+      expect(headers).toHaveLength(3)
+      expect(headers[0]).toBeNull()
+      expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(
+        1,
+      )
+      expect(Buffer.from(headers[2]!.slice(5), "base64").readUInt32LE(8)).toBe(
+        3,
+      )
+      expect(bodies).toEqual(['{"ok":true}', '{"ok":true}', '{"ok":true}'])
+      expect(challenges.every((challenge) => challenge.bodyUsed)).toBe(true)
+      expect(
+        response.network?.filter((event) => event.type === "request"),
+      ).toHaveLength(3)
+      expect(JSON.stringify(response.network)).not.toContain(headers[1])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("uses the two-request shortcut for an eager Type 2 without MIC", async () => {
+    const originalFetch = globalThis.fetch
+    const headers: Array<string | null> = []
+    globalThis.fetch = mock(async (_url, init) => {
+      headers.push(new Headers(init?.headers).get("authorization"))
+      return headers.length === 1
+        ? new Response("challenge", {
+            status: 401,
+            headers: { "www-authenticate": `NTLM ${type2Token()}` },
+          })
+        : new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await send(makeReq({ auth: ntlmAuth }), { environment: environment() })
+      expect(headers).toHaveLength(2)
+      expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(
+        3,
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("obtains a Type 1 transcript when an eager challenge requires MIC", async () => {
+    const targetInfo = Buffer.alloc(16)
+    targetInfo.writeUInt16LE(7, 0)
+    targetInfo.writeUInt16LE(8, 2)
+    targetInfo.writeBigUInt64LE(1n, 4)
+    const token = type2Token(targetInfo)
+    const originalFetch = globalThis.fetch
+    const headers: Array<string | null> = []
+    globalThis.fetch = mock(async (_url, init) => {
+      headers.push(new Headers(init?.headers).get("authorization"))
+      if (headers.length < 3) {
+        return new Response("challenge", {
+          status: 401,
+          headers: { "www-authenticate": `NTLM ${token}` },
+        })
+      }
+      return new Response("ok", { status: 200 })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      await send(makeReq({ auth: ntlmAuth }), { environment: environment() })
+      expect(headers).toHaveLength(3)
+      expect(Buffer.from(headers[1]!.slice(5), "base64").readUInt32LE(8)).toBe(
+        1,
+      )
+      const type3 = Buffer.from(headers[2]!.slice(5), "base64")
+      expect(type3.readUInt32LE(8)).toBe(3)
+      expect(type3.subarray(72, 88).equals(Buffer.alloc(16))).toBe(false)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("returns the final 401 without looping and rejects malformed NTLM", async () => {
+    const originalFetch = globalThis.fetch
+    let calls = 0
+    globalThis.fetch = mock(async () => {
+      calls++
+      return new Response("no", {
+        status: 401,
+        headers: {
+          "www-authenticate": calls === 1 ? "NTLM" : `NTLM ${type2Token()}`,
+        },
+      })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(makeReq({ auth: ntlmAuth }), {
+        environment: environment(),
+      })
+      expect(response.status).toBe(401)
+      expect(calls).toBe(3)
+
+      globalThis.fetch = mock(
+        async () =>
+          new Response("bad", {
+            status: 401,
+            headers: { "www-authenticate": "NTLM !!!" },
+          }),
+      ) as unknown as typeof globalThis.fetch
+      await expect(
+        send(makeReq({ auth: ntlmAuth }), { environment: environment() }),
+      ).rejects.toThrow("invalid NTLM challenge")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it("does not send NTLM credentials across an origin-changing redirect", async () => {
+    const originalFetch = globalThis.fetch
+    const headers: Array<string | null> = []
+    let calls = 0
+    globalThis.fetch = mock(async (_url, init) => {
+      calls++
+      headers.push(new Headers(init?.headers).get("authorization"))
+      if (calls === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://other.example/protected" },
+        })
+      }
+      return new Response("protected", {
+        status: 401,
+        headers: { "www-authenticate": "NTLM" },
+      })
+    }) as unknown as typeof globalThis.fetch
+
+    try {
+      const response = await send(makeReq({ auth: ntlmAuth }), {
+        environment: environment(),
+      })
+      expect(response.status).toBe(401)
+      expect(calls).toBe(2)
+      expect(headers).toEqual([null, null])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
 describe("send — inherited auth", () => {
   it("should substitute auth inherited from a folder before sending", async () => {
     const originalFetch = globalThis.fetch

--- a/tests/useRequestDraft.test.ts
+++ b/tests/useRequestDraft.test.ts
@@ -1094,3 +1094,40 @@ describe("authEqual — aws_sigv4", () => {
     ).toBe(false)
   })
 })
+
+describe("authEqual — ntlm", () => {
+  const auth = {
+    type: "ntlm" as const,
+    username: "alice",
+    password: "secret",
+    domain: "EXAMPLE",
+    workstation: "NOODLE",
+  }
+
+  it("compares every NTLM credential field", () => {
+    expect(
+      requestEquals(makeReq({ auth }), makeReq({ auth: { ...auth } })),
+    ).toBe(true)
+    expect(
+      requestEquals(
+        makeReq({ auth }),
+        makeReq({ auth: { ...auth, workstation: "OTHER" } }),
+      ),
+    ).toBe(false)
+  })
+
+  it("creates an empty NTLM draft when switching types", () => {
+    const original = makeReq()
+    const result = applyDraft(new Map(), original.id, original, {
+      kind: "setAuthType",
+      authType: "ntlm",
+    })
+    expect(result.get(original.id)?.auth).toEqual({
+      type: "ntlm",
+      username: "",
+      password: "",
+      domain: "",
+      workstation: "",
+    })
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a new `ntlm` auth type implementing connection-bound NTLMv2 authentication. The request executor performs the type 1 / type 2 challenge / type 3 response exchange on a `401` challenge, using `keepalive` so the authenticated connection is reused.

The auth type flows through the whole stack:
- New `Auth` variant with `username`, `password`, and optional `domain` / `workstation` fields
- YAML lang parse/serialize support and folder auth inheritance
- NTLM message construction (`src/requests/ntlm.ts`) with MD4, HMAC-MD5, and RC4-based response computation
- HAR and code generation (NTLM is rejected for codegen since it needs a live connection-bound exchange)
- Importers/exporters: OpenAPI (`scheme: ntlm`), Postman, and Insomnia
- UI: new NTLM auth editor fields in `AuthEditor.tsx` and `VarInput`
- Timeline, request formatting, and the noodle-use skill docs updated

### How did you verify your code works?

- `bun test` passes (includes new unit tests for NTLM message construction, `tests/unit/ntlm.test.ts`, a loopback integration test `tests/integration/ntlm-loopback.test.ts`, and updated send/converters/folder/draft tests)
- `bun run lint` passes
- `bun run typecheck` passes

### Screenshots / recordings

N/A (terminal TUI change)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NTLMv2 authentication with username, password, optional domain, and workstation fields.
  * NTLM requests now support secure challenge-response authentication, including proxy and TLS connections.
  * Added NTLM import and export support for Insomnia, Postman, OpenAPI, and folder configurations.
* **Bug Fixes**
  * Prevented terminal cursors from appearing outside visible editor areas.
  * Passwords are masked in request timelines and authorization displays.
* **Limitations**
  * Client code generation is unavailable for NTLM-authenticated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->