### PR TITLE
feat(collection): Add repair view for invalid YAML files

### DIFF
--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -29,7 +29,6 @@ export function useCollection(
       return
     }
     setLoading(true)
-    setError(null)
     let cancelled = false
 
     const loader = browse ? loadCollectionBrowse : filestore.loadCollection
@@ -38,6 +37,7 @@ export function useCollection(
       .then((c) => {
         if (!cancelled) {
           setCollection(c)
+          setError(null)
           setLoading(false)
         }
       })

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -300,6 +300,8 @@ export function AppInner({
   )
   const items = collection?.items ?? []
   const collectionErrorCount = error ? extractFileErrors(error).length : 0
+  const effectiveCollectionMode =
+    collectionErrorCount > 0 ? ("invalid" as const) : mode
 
   const requestIds = useMemo(() => getRequestIds(items), [items])
   const { getTab, setTab } = useUIState(collectionDir, requestIds, isReadOnly)
@@ -1062,8 +1064,10 @@ export function AppInner({
   const collectionRef = useRef(collection)
   collectionRef.current = collection
 
-  const modeRef = useRef<"collection" | "browse" | "empty" | "invalid">(mode)
-  modeRef.current = collectionErrorCount > 0 ? "invalid" : mode
+  const modeRef = useRef(effectiveCollectionMode)
+  useLayoutEffect(() => {
+    modeRef.current = effectiveCollectionMode
+  }, [effectiveCollectionMode])
 
   const folderViewRef = useRef(false)
   folderViewRef.current = focusedFolder !== null || collectionErrorCount > 0
@@ -1463,7 +1467,7 @@ export function AppInner({
         folderDeletePathRef,
         getKeymapFocus: () => keymap.getData("app.focus") as string,
         getView: () => view,
-        getCollectionMode: () => (mode === "invalid" ? "empty" : mode),
+        getCollectionMode: () => effectiveCollectionMode,
         setLayout,
         onLayoutChange,
         setHelpVisible,
@@ -1505,7 +1509,7 @@ export function AppInner({
       setImportCollectionVisible,
       requestReload,
       view,
-      mode,
+      effectiveCollectionMode,
       paletteTarget,
       triggerUpdateCheck,
       proxyPolicy,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -113,6 +113,7 @@ import {
   runCollectionImport,
   type CollectionImportValues,
 } from "./collectionImport"
+import { extractFileErrors } from "../filestore/load"
 
 export function AppInner({
   collectionDir,
@@ -273,6 +274,10 @@ export function AppInner({
   const [responseBodyEditorAvailable, setResponseBodyEditorAvailable] =
     useState(false)
   const folderDeletePathRef = useRef<string | null>(null)
+  const requestDeleteFileRef = useRef<string | null>(null)
+  const collectionErrorDeleteRef = useRef<(() => void) | null>(null)
+  const collectionErrorSaveRef = useRef<(() => void) | null>(null)
+  const [collectionErrorDirty, setCollectionErrorDirty] = useState(false)
   const [paletteTarget, setPaletteTarget] =
     useState<CommandPaletteTarget | null>(null)
   const [jumpMode, setJumpMode] = useState(false)
@@ -294,6 +299,7 @@ export function AppInner({
     isBrowse,
   )
   const items = collection?.items ?? []
+  const collectionErrorCount = error ? extractFileErrors(error).length : 0
 
   const requestIds = useMemo(() => getRequestIds(items), [items])
   const { getTab, setTab } = useUIState(collectionDir, requestIds, isReadOnly)
@@ -640,7 +646,9 @@ export function AppInner({
       }
       if (next === "urlbar") setUrlbarSubFocus("select")
       if (mode === "collection" && next === "request") eb.enterBrowse()
-      if (mode === "collection" && next === "folder") folderEb.enterBrowse()
+      if (mode === "collection" && !error && next === "folder") {
+        folderEb.enterBrowse()
+      }
       if (next === "env-vars") envEditor.enterBrowse()
       setFocus(next)
     },
@@ -649,6 +657,7 @@ export function AppInner({
       eb.enterBrowse,
       envEditor.commitEdit,
       envEditor.enterBrowse,
+      error,
       focus,
       folderEb.commitEdit,
       folderEb.enterBrowse,
@@ -672,6 +681,7 @@ export function AppInner({
   const hasUnsavedChanges =
     draft.dirtyRequestIds.size > 0 ||
     folderDraft.dirtyPaths.size > 0 ||
+    collectionErrorDirty ||
     envEditor.dirty ||
     eb.editState.mode === "editing" ||
     folderEb.editState.mode === "editing" ||
@@ -819,13 +829,38 @@ export function AppInner({
     setCloneRequestVisible,
     setNewFolderVisible,
     setEditRequestVisible,
+    requestDeleteFileRef,
     setRequestDeletePending,
     setFolderDeletePending,
     onCollectionBootstrapped,
   })
   folderSaveRef.current = handleFolderSave
 
-  const paneMode = useEditModeSync({ focus, view, eb, folderEb, envEditor })
+  const paneMode = useEditModeSync({
+    focus,
+    view,
+    eb,
+    folderEb,
+    envEditor,
+    repairEditor: collectionErrorCount > 0,
+  })
+
+  const deleteCollectionErrorFile = useCallback(
+    (file: string) => {
+      if (!file.endsWith(".yml")) return
+      requestDeleteFileRef.current = file.slice(0, -4)
+      setRequestDeletePending(file)
+    },
+    [setRequestDeletePending],
+  )
+
+  const clearRequestDeletePending = useCallback(
+    (value: string | null) => {
+      if (value === null) requestDeleteFileRef.current = null
+      setRequestDeletePending(value)
+    },
+    [setRequestDeletePending],
+  )
 
   const displayTab = useMemo((): string | undefined => {
     if (focus === "request") return eb.activeTab
@@ -853,6 +888,7 @@ export function AppInner({
         tab: displayTab,
         bodyType: draft.draft?.bodyType,
         sendState: responseState,
+        collectionError: collectionErrorCount > 0,
         queryVisible,
         responseBodyEditorAvailable,
         settingsCategory,
@@ -868,6 +904,7 @@ export function AppInner({
       displayTab,
       draft.draft?.bodyType,
       responseState,
+      collectionErrorCount,
       queryVisible,
       responseBodyEditorAvailable,
       settingsCategory,
@@ -1026,10 +1063,10 @@ export function AppInner({
   collectionRef.current = collection
 
   const modeRef = useRef<"collection" | "browse" | "empty" | "invalid">(mode)
-  modeRef.current = mode
+  modeRef.current = collectionErrorCount > 0 ? "invalid" : mode
 
   const folderViewRef = useRef(false)
-  folderViewRef.current = focusedFolder !== null
+  folderViewRef.current = focusedFolder !== null || collectionErrorCount > 0
 
   // ── Keymap layers ──────────────────────────────────────────────────
   useAppKeymap({
@@ -1078,6 +1115,8 @@ export function AppInner({
       setEditRequestVisible,
       setCloneRequestVisible,
       setRequestDeletePending,
+      collectionErrorDeleteRef,
+      collectionErrorSaveRef,
     },
     folder: {
       folderEbRef,
@@ -1360,7 +1399,7 @@ export function AppInner({
     setCloneRequestVisible,
     onCloneRequestConfirm: handleCloneRequestConfirm,
     requestDeletePending,
-    setRequestDeletePending,
+    setRequestDeletePending: clearRequestDeletePending,
     onRequestDeleteConfirm: handleRequestDeleteConfirm,
     newFolderVisible,
     newFolderRef,
@@ -1555,6 +1594,13 @@ export function AppInner({
             onResponseBodyEditorAvailableChange={setResponseBodyEditorAvailable}
             onInitialize={() => setInitPending(true)}
             onCreateRequest={() => setNewRequestVisible(true)}
+            onCollectionErrorDelete={deleteCollectionErrorFile}
+            onCollectionErrorDirtyChange={setCollectionErrorDirty}
+            collectionErrorDeleteRef={collectionErrorDeleteRef}
+            collectionErrorSaveRef={collectionErrorSaveRef}
+            onCollectionErrorSaved={() =>
+              setCollectionReloadToken((current) => current + 1)
+            }
             mode={mode}
             jumpMode={jumpMode}
             onPaneFocus={focusPane}
@@ -1806,7 +1852,8 @@ export function AppInner({
         globalHints={hints.header}
         footerHints={hints.footer}
         collectionPath={collectionDir}
-        sendCommand={sendCommand}
+        errorCount={collectionErrorCount}
+        sendCommand={collectionErrorCount > 0 ? undefined : sendCommand}
         cookieStatus={cookieStorage.status}
         onHintActivate={handleHintActivate}
       />

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -421,6 +421,7 @@ export function AppOverlays({
           visible
           filePath={yamlEditor.filePath}
           requestName={yamlEditor.requestName}
+          saveKey={keybinds.request_save}
           activeEnv={activeEnv}
           kind={yamlEditor.kind}
           onSaved={() => {

--- a/src/ui/CollectionErrorView.tsx
+++ b/src/ui/CollectionErrorView.tsx
@@ -1,0 +1,339 @@
+import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
+import { useKeyboard, useTerminalDimensions } from "@opentui/react"
+import { useKeymap } from "@opentui/keymap/react"
+import { basename, isAbsolute, relative, resolve } from "node:path"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react"
+import type { CollectionFileError } from "../filestore/load"
+import type { Environment } from "../schema"
+import type { Focus } from "./focus"
+import { FullBorder, LeftBar } from "./borders"
+import { Frame } from "./Frame"
+import { SIDEBAR_WIDTH } from "./Sidebar"
+import { useTheme } from "./theme"
+import { Badge } from "./Badge"
+import { YamlFileEditor } from "./editor/YamlFileEditor"
+
+const noop = () => {}
+
+export function resolveCollectionErrorFile(
+  collectionDir: string,
+  file: string,
+): string | null {
+  const root = resolve(collectionDir)
+  const target = resolve(root, file)
+  const childPath = relative(root, target)
+  if (
+    childPath === "" ||
+    childPath.startsWith("..") ||
+    isAbsolute(childPath) ||
+    !target.endsWith(".yml")
+  ) {
+    return null
+  }
+  return target
+}
+
+export function CollectionErrorView({
+  collectionDir,
+  errors,
+  focus,
+  activeEnv,
+  onPaneFocus,
+  onDelete = noop,
+  onDirtyChange = noop,
+  deleteActionRef,
+  saveActionRef,
+  onSaved,
+}: {
+  collectionDir: string
+  errors: CollectionFileError[]
+  focus: Focus
+  activeEnv: Environment | null
+  onPaneFocus: (focus: Focus) => void
+  onDelete?: (file: string) => void
+  onDirtyChange?: (dirty: boolean) => void
+  deleteActionRef?: RefObject<(() => void) | null>
+  saveActionRef?: RefObject<(() => void) | null>
+  onSaved: () => void
+}) {
+  const theme = useTheme()
+  const keymap = useKeymap()
+  const { width: terminalWidth = 100 } = useTerminalDimensions()
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const [selectedFile, setSelectedFile] = useState(errors[0]?.file ?? "")
+  const [hoveredFile, setHoveredFile] = useState<string | null>(null)
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const [dirtyFiles, setDirtyFiles] = useState<Set<string>>(() => new Set())
+  const editorRef = useRef<{ save: () => void } | null>(null)
+
+  const selectedIndex = Math.max(
+    0,
+    errors.findIndex((error) => error.file === selectedFile),
+  )
+  const selectedError = errors[selectedIndex]
+  const filePath = selectedError
+    ? resolveCollectionErrorFile(collectionDir, selectedError.file)
+    : null
+  const sidebarWidth =
+    terminalWidth < 70
+      ? Math.max(18, Math.floor(terminalWidth * 0.4))
+      : SIDEBAR_WIDTH
+
+  useEffect(() => {
+    if (errors.some((error) => error.file === selectedFile)) return
+    setSelectedFile(errors[0]?.file ?? "")
+  }, [errors, selectedFile])
+
+  useEffect(() => {
+    const files = new Set(errors.map((error) => error.file))
+    setDirtyFiles((current) => {
+      const next = new Set([...current].filter((file) => files.has(file)))
+      if (
+        next.size === current.size &&
+        [...next].every((file) => current.has(file))
+      ) {
+        return current
+      }
+      return next
+    })
+  }, [errors])
+
+  useEffect(() => {
+    onDirtyChange(dirtyFiles.size > 0)
+  }, [dirtyFiles, onDirtyChange])
+
+  useEffect(() => {
+    return () => onDirtyChange(false)
+  }, [onDirtyChange])
+
+  useEffect(() => {
+    if (!selectedError) return
+    scrollRef.current?.scrollChildIntoView(`collection-error-${selectedIndex}`)
+  }, [selectedError, selectedIndex])
+
+  const selectIndex = useCallback(
+    (index: number) => {
+      const next = errors[Math.max(0, Math.min(index, errors.length - 1))]
+      if (next) setSelectedFile(next.file)
+    },
+    [errors],
+  )
+
+  const setFileDirty = useCallback((file: string, dirty: boolean) => {
+    setDirtyFiles((current) => {
+      if (current.has(file) === dirty) return current
+      const next = new Set(current)
+      if (dirty) next.add(file)
+      else next.delete(file)
+      return next
+    })
+  }, [])
+
+  const deleteSelected = useCallback(() => {
+    if (selectedError?.file.endsWith(".yml")) onDelete(selectedError.file)
+  }, [onDelete, selectedError])
+
+  const saveSelected = useCallback(() => {
+    editorRef.current?.save()
+  }, [])
+
+  const handleDirtyChange = useCallback(
+    (dirty: boolean) => {
+      if (selectedError) setFileDirty(selectedError.file, dirty)
+    },
+    [selectedError, setFileDirty],
+  )
+
+  useEffect(() => {
+    if (deleteActionRef) deleteActionRef.current = deleteSelected
+    if (saveActionRef) saveActionRef.current = saveSelected
+    return () => {
+      if (deleteActionRef) deleteActionRef.current = null
+      if (saveActionRef) saveActionRef.current = null
+    }
+  }, [deleteActionRef, deleteSelected, saveActionRef, saveSelected])
+
+  useKeyboard((key) => {
+    if (keymap.getData("app.overlay") !== "none") return
+    if (focus === "folder" && key.name === "escape") {
+      onPaneFocus("sidebar")
+      key.preventDefault()
+      return
+    }
+    if (focus !== "sidebar" || errors.length === 0) return
+    if (key.name === "up") selectIndex(selectedIndex - 1)
+    else if (key.name === "down") selectIndex(selectedIndex + 1)
+    else if (key.name === "home") selectIndex(0)
+    else if (key.name === "end") selectIndex(errors.length - 1)
+    else if (key.name === "return") onPaneFocus("folder")
+    else return
+    key.preventDefault()
+  })
+
+  const initialDraft = useMemo(
+    () => (selectedError ? drafts[selectedError.file] : undefined),
+    [drafts, selectedError],
+  )
+
+  return (
+    <box
+      style={{
+        flexDirection: "row",
+        flexGrow: 1,
+        gap: 1,
+        minHeight: 0,
+        minWidth: 0,
+        backgroundColor: theme.backgroundPanel,
+      }}
+    >
+      <Frame
+        style={{
+          width: sidebarWidth,
+          flexDirection: "column",
+          flexShrink: 0,
+          backgroundColor: theme.backgroundPanel,
+          paddingTop: 0,
+          paddingBottom: 0,
+          paddingLeft: 1,
+          paddingRight: 1,
+          gap: 1,
+        }}
+        border={[...FullBorder.border]}
+        customBorderChars={FullBorder.customBorderChars}
+        borderColor={focus === "sidebar" ? theme.primary : theme.borderSubtle}
+        titleRight={
+          <Badge
+            bg={theme.backgroundPanel}
+            fg={focus === "sidebar" ? theme.primary : theme.textMuted}
+          >
+            Requests
+          </Badge>
+        }
+        onPaneFocus={() => onPaneFocus("sidebar")}
+      >
+        <scrollbox
+          ref={scrollRef}
+          focusable={false}
+          scrollY
+          style={{ flexGrow: 1, minHeight: 0 }}
+          verticalScrollbarOptions={{
+            trackOptions: {
+              backgroundColor: theme.background,
+              foregroundColor: theme.borderActive,
+            },
+          }}
+        >
+          {errors.map((error, index) => {
+            const selected = index === selectedIndex
+            const hovered = hoveredFile === error.file
+            return (
+              <box
+                key={error.file}
+                id={`collection-error-${index}`}
+                style={{
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  paddingLeft: 1,
+                  backgroundColor:
+                    selected || hovered ? theme.backgroundElement : undefined,
+                }}
+                border={[...LeftBar.border]}
+                customBorderChars={LeftBar.customBorderChars}
+                borderColor={selected ? theme.primary : theme.backgroundPanel}
+                onMouseDown={(event) => {
+                  if (event.button !== MouseButton.LEFT) return
+                  setSelectedFile(error.file)
+                  onPaneFocus("sidebar")
+                  event.preventDefault()
+                  event.stopPropagation()
+                }}
+                onMouseOver={() => setHoveredFile(error.file)}
+                onMouseOut={() => setHoveredFile(null)}
+              >
+                <box
+                  style={{
+                    flexDirection: "row",
+                    flexGrow: 1,
+                    flexShrink: 1,
+                    minWidth: 0,
+                    paddingRight: 1,
+                  }}
+                >
+                  <text fg={theme.error} style={{ width: 7, flexShrink: 0 }}>
+                    ERR
+                  </text>
+                  <text
+                    fg={theme.text}
+                    wrapMode="none"
+                    truncate
+                    style={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}
+                  >
+                    {error.file}
+                  </text>
+                </box>
+                {dirtyFiles.has(error.file) && (
+                  <text fg={theme.accent}>{`● `}</text>
+                )}
+              </box>
+            )
+          })}
+        </scrollbox>
+      </Frame>
+
+      <Frame
+        style={{
+          flexDirection: "column",
+          flexGrow: 1,
+          minHeight: 0,
+          minWidth: 0,
+          backgroundColor: theme.backgroundPanel,
+        }}
+        border={[...FullBorder.border]}
+        customBorderChars={FullBorder.customBorderChars}
+        borderColor={focus === "folder" ? theme.primary : theme.borderSubtle}
+        onPaneFocus={() => onPaneFocus("folder")}
+      >
+        {selectedError && filePath ? (
+          <YamlFileEditor
+            ref={editorRef}
+            key={selectedError.file}
+            editorId="collection-error-editor"
+            filePath={filePath}
+            displayName={selectedError.file}
+            kind={basename(filePath) === "folder.yml" ? "folder" : "request"}
+            active={focus === "folder"}
+            activeEnv={activeEnv}
+            initialDraft={initialDraft}
+            onDraftChange={(content) =>
+              setDrafts((current) => ({
+                ...current,
+                [selectedError.file]: content,
+              }))
+            }
+            onDirtyChange={handleDirtyChange}
+            onSaved={onSaved}
+          />
+        ) : selectedError ? (
+          <box
+            style={{
+              flexGrow: 1,
+              alignItems: "center",
+              justifyContent: "center",
+              paddingLeft: 1,
+              paddingRight: 1,
+            }}
+          >
+            <text fg={theme.error}>{selectedError.message}</text>
+          </box>
+        ) : null}
+      </Frame>
+    </box>
+  )
+}

--- a/src/ui/MainView.tsx
+++ b/src/ui/MainView.tsx
@@ -15,6 +15,8 @@ import { EmptyState } from "./EmptyState"
 import { FullBorder } from "./borders"
 import type { RefObject } from "react"
 import type { ResponseQueryController } from "./responseQuery"
+import { extractFileErrors } from "../filestore/load"
+import { CollectionErrorView } from "./CollectionErrorView"
 
 interface MainViewProps {
   items: CollectionItem[]
@@ -53,6 +55,11 @@ interface MainViewProps {
   onResponseBodyEditorAvailableChange?: (available: boolean) => void
   onInitialize: () => void
   onCreateRequest: () => void
+  onCollectionErrorDelete?: (file: string) => void
+  onCollectionErrorDirtyChange?: (dirty: boolean) => void
+  collectionErrorDeleteRef?: RefObject<(() => void) | null>
+  collectionErrorSaveRef?: RefObject<(() => void) | null>
+  onCollectionErrorSaved: () => void
   onPaneFocus?: (focus: Focus) => void
   onUrlbarFocus?: (subFocus: UrlBarSubFocus) => void
   onSend?: () => void
@@ -100,6 +107,11 @@ export function MainView({
   onResponseBodyEditorAvailableChange,
   onInitialize,
   onCreateRequest,
+  onCollectionErrorDelete = () => {},
+  onCollectionErrorDirtyChange = () => {},
+  collectionErrorDeleteRef,
+  collectionErrorSaveRef,
+  onCollectionErrorSaved,
   onPaneFocus = () => {},
   onUrlbarFocus,
   onSend,
@@ -118,6 +130,23 @@ export function MainView({
         actionActive
         message="Initialize this collection"
         onAction={onInitialize}
+      />
+    )
+  }
+
+  if (error) {
+    return (
+      <CollectionErrorView
+        collectionDir={collectionDir}
+        errors={extractFileErrors(error)}
+        focus={focus}
+        activeEnv={activeEnv}
+        onPaneFocus={onPaneFocus}
+        onDelete={onCollectionErrorDelete}
+        onDirtyChange={onCollectionErrorDirtyChange}
+        deleteActionRef={collectionErrorDeleteRef}
+        saveActionRef={collectionErrorSaveRef}
+        onSaved={onCollectionErrorSaved}
       />
     )
   }

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -156,6 +156,7 @@ export function StatusBar(input: {
   globalHints: HintSegment[]
   footerHints: HintSegment[]
   collectionPath?: string
+  errorCount?: number
   sendCommand?: string
   cookieStatus?: CookieJarStatus
   onHintActivate?: (command: string) => void
@@ -176,9 +177,14 @@ export function StatusBar(input: {
     (collectionMode === "browse" || collectionMode === "empty") &&
     input.collectionPath !== undefined
   const collectionPath = showCollectionPath ? input.collectionPath! : ""
-  const collectionPathWidth = collectionPath
+  const errorLabel =
+    view === "main" && !transient && (input.errorCount ?? 0) > 0
+      ? `${input.errorCount} ${input.errorCount === 1 ? "error" : "errors"}`
+      : ""
+  const rightLabel = errorLabel || collectionPath
+  const rightLabelWidth = rightLabel
     ? Math.min(
-        stringWidth(collectionPath),
+        stringWidth(rightLabel),
         Math.floor(Math.max(0, termWidth - 2) / 2),
       )
     : 0
@@ -230,7 +236,7 @@ export function StatusBar(input: {
         cookieIndicatorWidth -
         (cookieIndicator ? HINT_ITEM_GAP : 0) -
         (expandSegment.length > 0 ? HINT_ITEM_GAP : 0) -
-        (collectionPathWidth > 0 ? collectionPathWidth + HINT_ITEM_GAP : 0),
+        (rightLabelWidth > 0 ? rightLabelWidth + HINT_ITEM_GAP : 0),
     )
       ? sendSegment
       : []
@@ -256,8 +262,8 @@ export function StatusBar(input: {
       (cookieIndicator ? HINT_ITEM_GAP : 0) -
       (expandSegment.length > 0 ? HINT_ITEM_GAP : 0) -
       (visibleSendSegment.length > 0 ? HINT_ITEM_GAP : 0) -
-      collectionPathWidth -
-      (collectionPathWidth > 0 &&
+      rightLabelWidth -
+      (rightLabelWidth > 0 &&
       (cookieIndicator !== "" || visibleSendSegment.length > 0)
         ? HINT_ITEM_GAP
         : 0),
@@ -374,18 +380,18 @@ export function StatusBar(input: {
         {visibleSendSegment.map((seg, i) =>
           renderSegment(seg, `send-${seg.command ?? seg.key}-${i}`),
         )}
-        {collectionPathWidth > 0 && (
+        {rightLabelWidth > 0 && (
           <text
-            fg={theme.textMuted}
+            fg={errorLabel ? theme.error : theme.textMuted}
             wrapMode="none"
             truncate
             style={{
-              width: collectionPathWidth,
+              width: rightLabelWidth,
               minWidth: 0,
               flexShrink: 1,
             }}
           >
-            {collectionPath}
+            {rightLabel}
           </text>
         )}
       </box>

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -15,6 +15,7 @@ import type { SendState } from "./sendState"
 import type { ResponseQueryController } from "./responseQuery"
 import type { ProxyPolicy } from "../proxy"
 import type { TlsPolicy } from "../tls"
+import type { CollectionMode } from "../collectionPath"
 import {
   saveRequest,
   saveFolder,
@@ -79,7 +80,7 @@ export interface CommandBuilderContext {
   folderDeletePathRef: RefObject<string | null>
   getKeymapFocus: () => string
   getView: () => string
-  getCollectionMode: () => "collection" | "browse" | "empty"
+  getCollectionMode: () => CollectionMode
   setLayout: (
     v:
       | "stacked"

--- a/src/ui/editor/ValidationNotice.tsx
+++ b/src/ui/editor/ValidationNotice.tsx
@@ -1,20 +1,25 @@
 import { LeftBar } from "../borders"
 import { useTheme } from "../theme"
+import type { YamlValidationNotice } from "./yamlValidation"
 
 interface Props {
+  notice?: YamlValidationNotice
   title?: string
   detail?: string | null
 }
 
-function truncateDetail(detail: string): string {
+function truncateText(detail: string): string {
   const max = 180
   if (detail.length <= max) return detail
   return `${detail.slice(0, max - 3)}...`
 }
 
-export function ValidationNotice({ title, detail }: Props) {
+export function ValidationNotice({ notice, title, detail }: Props) {
   const theme = useTheme()
-  const compactDetail = detail ? truncateDetail(detail) : null
+  const resolvedTitle = notice?.title ?? title
+  const resolvedDetail = notice?.detail ?? detail
+  const compactTitle = resolvedTitle ? truncateText(resolvedTitle) : null
+  const compactDetail = resolvedDetail ? truncateText(resolvedDetail) : null
 
   return (
     <box
@@ -24,15 +29,30 @@ export function ValidationNotice({ title, detail }: Props) {
       style={{
         flexDirection: "column",
         flexShrink: 0,
+        minWidth: 0,
         paddingLeft: 1,
         paddingRight: 1,
         backgroundColor: theme.backgroundElement,
       }}
     >
-      {title && <text fg={theme.error}>! {title}</text>}
+      {compactTitle && (
+        <text
+          fg={theme.error}
+          wrapMode="none"
+          truncate
+          style={{ minWidth: 0, width: "100%" }}
+        >
+          ! {compactTitle}
+        </text>
+      )}
       {compactDetail && (
-        <text fg={title ? theme.textMuted : theme.error}>
-          {title ? ` ${compactDetail}` : compactDetail}
+        <text
+          fg={compactTitle ? theme.textMuted : theme.error}
+          wrapMode="none"
+          truncate
+          style={{ minWidth: 0, width: "100%" }}
+        >
+          {compactTitle ? ` ${compactDetail}` : compactDetail}
         </text>
       )}
     </box>

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -1,23 +1,18 @@
-import { MouseButton, type LineNumberRenderable } from "@opentui/core"
-import { useEffect, useRef, useState, useCallback, useMemo } from "react"
-import { useKeymap } from "@opentui/keymap/react"
-import { basename, dirname } from "node:path"
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { MouseButton } from "@opentui/core"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useBindings, useKeymap } from "@opentui/keymap/react"
 import { useTheme } from "../theme"
 import { Overlay } from "../overlays/Overlay"
 import { EscapeClose } from "../overlays/EscapeClose"
-import type { CodeEditorRenderable } from "./CodeEditor"
-import { ValidationNotice } from "./ValidationNotice"
-import { lang } from "../../lang"
 import type { Environment } from "../../schema"
-import { CodeEditorCompletion } from "./CodeEditorCompletion"
-import { getEnvVarHighlights } from "../variable-completion/variableCompletion"
-import { RESERVED_FOLD_SIGN, syncCodeEditorGutter } from "./codeEditorGutter"
+import { YamlFileEditor, type YamlFileEditorHandle } from "./YamlFileEditor"
+import { displayKey } from "../keybind"
 
 export interface YamlEditorOverlayProps {
   visible: boolean
   filePath: string
   requestName: string
+  saveKey: string
   onSaved: () => void
   onClose: () => void
   activeEnv?: Environment | null
@@ -28,6 +23,7 @@ export function YamlEditorOverlay({
   visible,
   filePath,
   requestName,
+  saveKey,
   onSaved,
   onClose,
   activeEnv = null,
@@ -35,138 +31,26 @@ export function YamlEditorOverlay({
 }: YamlEditorOverlayProps) {
   const theme = useTheme()
   const keymap = useKeymap()
-  const editorRef = useRef<CodeEditorRenderable | null>(null)
-  const [editorInstance, setEditorInstance] =
-    useState<CodeEditorRenderable | null>(null)
-  const lineNumberRef = useRef<LineNumberRenderable | null>(null)
-  const hoveredFoldLineRef = useRef<number | null>(null)
-  const [content, setContent] = useState<string | null>(null)
-  const [draftContent, setDraftContent] = useState<string | null>(null)
-  const [validationError, setValidationError] = useState<string | null>(null)
-  const [readError, setReadError] = useState<string | null>(null)
-  const [saveError, setSaveError] = useState<string | null>(null)
+  const editorRef = useRef<YamlFileEditorHandle | null>(null)
   const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
     null,
   )
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!visible) {
-      setContent(null)
-      setDraftContent(null)
-      setValidationError(null)
-      return
-    }
-    setReadError(null)
-    setSaveError(null)
-
-    readFile(filePath, "utf8")
-      .then((v) => {
-        if (mountedRef.current) {
-          setContent(v)
-          setDraftContent(v)
-        }
-      })
-      .catch((e) => {
-        if (!mountedRef.current) return
-        if (kind === "folder" && (e as { code?: string }).code === "ENOENT") {
-          setContent("")
-          setDraftContent("")
-        } else {
-          setReadError(e instanceof Error ? e.message : String(e))
-        }
-      })
-  }, [visible, filePath])
-
   const handleSave = useCallback(() => {
-    const editor = editorRef.current
-    if (!editor) return
-    setSaveError(null)
-    const yamlText = editor.plainText
-    try {
-      if (kind === "folder") {
-        lang.parseFolder(yamlText)
-      } else {
-        lang.parseRequest(basename(filePath, ".yml"), yamlText)
-      }
-    } catch (e) {
-      if (!mountedRef.current) return
-      setSaveError(e instanceof Error ? e.message : String(e))
-      return
-    }
-
-    mkdir(dirname(filePath), { recursive: true })
-      .then(() => writeFile(filePath, yamlText, "utf8"))
-      .then(() => {
-        if (!mountedRef.current) return
-        onSaved()
-      })
-      .catch((e) => {
-        if (!mountedRef.current) return
-        setSaveError(e instanceof Error ? e.message : String(e))
-      })
-  }, [filePath, onSaved, kind])
-
-  const validateContent = useCallback(
-    (content: string): string | null => {
-      try {
-        if (kind === "folder") {
-          lang.parseFolder(content)
-        } else {
-          lang.parseRequest(basename(filePath, ".yml"), content)
-        }
-        return null
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        const prefix =
-          kind === "folder" ? "Invalid folder YAML" : "Invalid request YAML"
-        return `${prefix}: ${message}`
-      }
-    },
-    [filePath, kind],
-  )
-
-  const handleContentChange = useCallback(() => {
-    const editor = editorRef.current
-    if (editor) setDraftContent(editor.plainText)
+    editorRef.current?.save()
   }, [])
-
-  const extraHighlights = useCallback(
-    (value: string) => {
-      const editor = editorRef.current
-      if (!editor || !activeEnv) return []
-      return getEnvVarHighlights(
-        value,
-        activeEnv,
-        editor.envResolvedStyleId,
-        editor.envMissingStyleId,
-      )
-    },
-    [activeEnv],
-  )
-
-  const validationNotice = useMemo(() => {
-    if (!validationError) return null
-    const prefix =
-      kind === "folder" ? "Invalid folder YAML" : "Invalid request YAML"
-    return {
-      title: prefix,
-      detail: validationError.replace(
-        new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}: `),
-        "",
-      ),
-    }
-  }, [validationError, kind])
 
   const handleClose = useCallback(() => {
     onClose()
   }, [onClose])
+
+  useBindings(
+    () => ({
+      enabled: visible,
+      commands: [{ name: "yaml-editor.save", run: handleSave }],
+      bindings: [{ key: saveKey, cmd: "yaml-editor.save" }],
+    }),
+    [handleSave, saveKey, visible],
+  )
 
   useEffect(() => {
     if (!visible) return
@@ -177,56 +61,12 @@ export function YamlEditorOverlay({
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           handleClose()
-        } else if (ctx.event.name === "s" && ctx.event.ctrl) {
-          ctx.event.preventDefault()
-          ctx.event.stopPropagation()
-          handleSave()
         }
       },
       { priority: 100 },
     )
     return dispose
-  }, [visible, handleSave, handleClose, keymap])
-
-  useEffect(() => {
-    if (visible && content !== null && editorRef.current) {
-      editorRef.current.focus()
-    }
-  }, [visible, content])
-
-  const syncFoldSigns = useCallback(
-    (hoveredFoldLine?: number) => {
-      const ed = editorRef.current
-      const ln = lineNumberRef.current
-      if (!ed || !ln) return
-      syncCodeEditorGutter(ln, ed, hoveredFoldLine, theme.primary)
-    },
-    [theme.primary],
-  )
-
-  const handleFoldsChange = useCallback(() => {
-    hoveredFoldLineRef.current = null
-    syncFoldSigns()
-  }, [syncFoldSigns])
-
-  const updateFoldHover = useCallback(
-    (event: { x: number; y: number }) => {
-      const editor = editorRef.current
-      const lineNumbers = lineNumberRef.current
-      const displayLine =
-        editor && lineNumbers && event.x === lineNumbers.x
-          ? editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
-          : undefined
-      const hoveredFoldLine =
-        displayLine !== undefined && editor?.getFoldSigns().has(displayLine)
-          ? displayLine
-          : null
-      if (hoveredFoldLine === hoveredFoldLineRef.current) return
-      hoveredFoldLineRef.current = hoveredFoldLine
-      syncFoldSigns(hoveredFoldLine ?? undefined)
-    },
-    [syncFoldSigns],
-  )
+  }, [visible, handleClose, keymap])
 
   if (!visible) return null
 
@@ -247,93 +87,17 @@ export function YamlEditorOverlay({
         </text>
         <EscapeClose onClose={handleClose} />
       </box>
-      {readError ? (
-        <box
-          style={{
-            flexGrow: 1,
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          <text fg={theme.error}>Error: {readError}</text>
-        </box>
-      ) : content !== null ? (
-        <box
-          height={20}
-          style={{
-            paddingLeft: 4,
-            paddingRight: 4,
-            flexDirection: "column",
-            gap: 1,
-          }}
-        >
-          <line-number
-            ref={lineNumberRef}
-            minWidth={4}
-            paddingRight={1}
-            fg={theme.textMuted}
-            bg={theme.backgroundPanel}
-            lineSigns={RESERVED_FOLD_SIGN}
-            onMouseMove={updateFoldHover}
-            onMouseOut={() => {
-              if (hoveredFoldLineRef.current === null) return
-              hoveredFoldLineRef.current = null
-              syncFoldSigns()
-            }}
-            onMouseDown={(event) => {
-              const editor = editorRef.current
-              if (event.button !== MouseButton.LEFT || !editor) return
-              if (event.x >= editor.x) return
-              const displayLine =
-                editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
-              if (
-                displayLine === undefined ||
-                !editor.getFoldSigns().has(displayLine)
-              )
-                return
-              editor.toggleFold(displayLine)
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            style={{ flexGrow: 1, minHeight: 0 }}
-            width="100%"
-          >
-            <code-editor
-              ref={(editor) => {
-                editorRef.current = editor
-                setEditorInstance(editor)
-              }}
-              filetype="yaml"
-              theme={theme}
-              initialValue={content}
-              extraHighlights={activeEnv ? extraHighlights : undefined}
-              validateContent={validateContent}
-              onValidationChange={setValidationError}
-              onSourceChange={handleContentChange}
-              onFoldsChange={handleFoldsChange}
-              backgroundColor={theme.backgroundPanel}
-              focusedBackgroundColor={theme.backgroundPanel}
-              textColor={theme.text}
-              cursorColor={theme.primary}
-            />
-          </line-number>
-          <CodeEditorCompletion
-            editor={editorInstance}
-            env={activeEnv}
-            isEditing
-            value={draftContent ?? content ?? ""}
-          />
-          {validationNotice && (
-            <ValidationNotice
-              title={validationNotice.title}
-              detail={validationNotice.detail}
-            />
-          )}
-        </box>
-      ) : (
-        <text fg={theme.textMuted}>Loading...</text>
-      )}
-      {saveError && <text fg={theme.error}>Save error: {saveError}</text>}
+      <YamlFileEditor
+        ref={editorRef}
+        filePath={filePath}
+        displayName={
+          kind === "folder" ? `${requestName}/folder.yml` : `${requestName}.yml`
+        }
+        activeEnv={activeEnv}
+        kind={kind}
+        height={20}
+        onSaved={onSaved}
+      />
       <box
         style={{
           flexDirection: "row",
@@ -365,7 +129,7 @@ export function YamlEditorOverlay({
                 hoveredAction === "save" ? theme.backgroundElement : undefined,
             }}
           >
-            <text fg={theme.text}>^S</text>
+            <text fg={theme.text}>{displayKey(saveKey)}</text>
             <text fg={theme.textMuted}> save</text>
           </box>
           <box

--- a/src/ui/editor/YamlFileEditor.tsx
+++ b/src/ui/editor/YamlFileEditor.tsx
@@ -67,6 +67,7 @@ export const YamlFileEditor = forwardRef<
   const lineNumberRef = useRef<LineNumberRenderable | null>(null)
   const hoveredFoldLineRef = useRef<number | null>(null)
   const initialDraftRef = useRef(initialDraft)
+  const onDirtyChangeRef = useRef(onDirtyChange)
   const [content, setContent] = useState<string | null>(null)
   const [originalContent, setOriginalContent] = useState<string | null>(null)
   const [draftContent, setDraftContent] = useState<string | null>(null)
@@ -84,6 +85,10 @@ export const YamlFileEditor = forwardRef<
   }, [])
 
   useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange
+  }, [onDirtyChange])
+
+  useEffect(() => {
     setContent(null)
     setOriginalContent(null)
     setDraftContent(null)
@@ -99,7 +104,7 @@ export const YamlFileEditor = forwardRef<
         setOriginalContent(value)
         setContent(next)
         setDraftContent(next)
-        onDirtyChange?.(next !== value)
+        onDirtyChangeRef.current?.(next !== value)
       })
       .catch((error) => {
         if (!mountedRef.current) return
@@ -111,12 +116,12 @@ export const YamlFileEditor = forwardRef<
           setOriginalContent("")
           setContent(next)
           setDraftContent(next)
-          onDirtyChange?.(next !== "")
+          onDirtyChangeRef.current?.(next !== "")
         } else {
           setReadError(error instanceof Error ? error.message : String(error))
         }
       })
-  }, [filePath, kind, onDirtyChange])
+  }, [filePath, kind])
 
   const validateContent = useCallback(
     (value: string): string | null => {

--- a/src/ui/editor/YamlFileEditor.tsx
+++ b/src/ui/editor/YamlFileEditor.tsx
@@ -1,0 +1,338 @@
+import { MouseButton, type LineNumberRenderable } from "@opentui/core"
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { basename, dirname } from "node:path"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import type { Environment } from "../../schema"
+import { lang } from "../../lang"
+import { useTheme } from "../theme"
+import { CodeEditorCompletion } from "./CodeEditorCompletion"
+import type { CodeEditorRenderable } from "./CodeEditor"
+import { ValidationNotice } from "./ValidationNotice"
+import {
+  formatYamlValidationNotice,
+  type YamlValidationNotice,
+} from "./yamlValidation"
+import { getEnvVarHighlights } from "../variable-completion/variableCompletion"
+import { RESERVED_FOLD_SIGN, syncCodeEditorGutter } from "./codeEditorGutter"
+
+export interface YamlFileEditorHandle {
+  save: () => void
+}
+
+export interface YamlFileEditorProps {
+  filePath: string
+  displayName?: string
+  onSaved: () => void
+  onDirtyChange?: (dirty: boolean) => void
+  activeEnv?: Environment | null
+  kind?: "request" | "folder"
+  active?: boolean
+  height?: number
+  initialDraft?: string
+  onDraftChange?: (content: string) => void
+  editorId?: string
+}
+
+export const YamlFileEditor = forwardRef<
+  YamlFileEditorHandle,
+  YamlFileEditorProps
+>(function YamlFileEditor(
+  {
+    filePath,
+    displayName,
+    onSaved,
+    onDirtyChange,
+    activeEnv = null,
+    kind = "request",
+    active = true,
+    height,
+    initialDraft,
+    onDraftChange,
+    editorId,
+  },
+  ref,
+) {
+  const theme = useTheme()
+  const editorRef = useRef<CodeEditorRenderable | null>(null)
+  const [editorInstance, setEditorInstance] =
+    useState<CodeEditorRenderable | null>(null)
+  const lineNumberRef = useRef<LineNumberRenderable | null>(null)
+  const hoveredFoldLineRef = useRef<number | null>(null)
+  const initialDraftRef = useRef(initialDraft)
+  const [content, setContent] = useState<string | null>(null)
+  const [originalContent, setOriginalContent] = useState<string | null>(null)
+  const [draftContent, setDraftContent] = useState<string | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [saveValidationNotice, setSaveValidationNotice] =
+    useState<YamlValidationNotice | null>(null)
+  const [readError, setReadError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    setContent(null)
+    setOriginalContent(null)
+    setDraftContent(null)
+    setValidationError(null)
+    setSaveValidationNotice(null)
+    setReadError(null)
+    setSaveError(null)
+
+    readFile(filePath, "utf8")
+      .then((value) => {
+        if (!mountedRef.current) return
+        const next = initialDraftRef.current ?? value
+        setOriginalContent(value)
+        setContent(next)
+        setDraftContent(next)
+        onDirtyChange?.(next !== value)
+      })
+      .catch((error) => {
+        if (!mountedRef.current) return
+        if (
+          kind === "folder" &&
+          (error as { code?: string }).code === "ENOENT"
+        ) {
+          const next = initialDraftRef.current ?? ""
+          setOriginalContent("")
+          setContent(next)
+          setDraftContent(next)
+          onDirtyChange?.(next !== "")
+        } else {
+          setReadError(error instanceof Error ? error.message : String(error))
+        }
+      })
+  }, [filePath, kind, onDirtyChange])
+
+  const validateContent = useCallback(
+    (value: string): string | null => {
+      try {
+        if (kind === "folder") lang.parseFolder(value)
+        else lang.parseRequest(basename(filePath, ".yml"), value)
+        return null
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error)
+      }
+    },
+    [filePath, kind],
+  )
+
+  const handleSave = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    setSaveError(null)
+    setSaveValidationNotice(null)
+    const yamlText = editor.plainText
+
+    try {
+      if (kind === "folder") lang.parseFolder(yamlText)
+      else lang.parseRequest(basename(filePath, ".yml"), yamlText)
+    } catch (error) {
+      if (!mountedRef.current) return
+      setSaveValidationNotice(
+        formatYamlValidationNotice({
+          kind,
+          fileName: displayName ?? basename(filePath),
+          source: yamlText,
+          error,
+        }),
+      )
+      return
+    }
+
+    mkdir(dirname(filePath), { recursive: true })
+      .then(() => writeFile(filePath, yamlText, "utf8"))
+      .then(() => {
+        if (!mountedRef.current) return
+        setOriginalContent(yamlText)
+        setContent(yamlText)
+        setDraftContent(yamlText)
+        onDraftChange?.(yamlText)
+        onDirtyChange?.(false)
+        onSaved()
+      })
+      .catch((error) => {
+        if (!mountedRef.current) return
+        setSaveError(error instanceof Error ? error.message : String(error))
+      })
+  }, [displayName, filePath, kind, onDirtyChange, onDraftChange, onSaved])
+
+  useImperativeHandle(ref, () => ({ save: handleSave }), [handleSave])
+
+  useEffect(() => {
+    if (active && content !== null) editorRef.current?.focus()
+  }, [active, content])
+
+  const handleContentChange = useCallback(() => {
+    const editor = editorRef.current
+    if (!editor) return
+    const next = editor.plainText
+    setDraftContent(next)
+    setSaveValidationNotice(null)
+    onDraftChange?.(next)
+    onDirtyChange?.(originalContent !== null && next !== originalContent)
+  }, [onDraftChange, onDirtyChange, originalContent])
+
+  const extraHighlights = useCallback(
+    (value: string) => {
+      const editor = editorRef.current
+      if (!editor || !activeEnv) return []
+      return getEnvVarHighlights(
+        value,
+        activeEnv,
+        editor.envResolvedStyleId,
+        editor.envMissingStyleId,
+      )
+    },
+    [activeEnv],
+  )
+
+  const validationNotice = useMemo(() => {
+    if (!validationError) return null
+    return formatYamlValidationNotice({
+      kind,
+      fileName: displayName ?? basename(filePath),
+      source: draftContent ?? content ?? "",
+      error: validationError,
+    })
+  }, [content, displayName, draftContent, filePath, kind, validationError])
+
+  const activeValidationNotice = saveValidationNotice ?? validationNotice
+
+  const syncFoldSigns = useCallback(
+    (hoveredFoldLine?: number) => {
+      const editor = editorRef.current
+      const lineNumbers = lineNumberRef.current
+      if (!editor || !lineNumbers) return
+      syncCodeEditorGutter(lineNumbers, editor, hoveredFoldLine, theme.primary)
+    },
+    [theme.primary],
+  )
+
+  const updateFoldHover = useCallback(
+    (event: { x: number; y: number }) => {
+      const editor = editorRef.current
+      const lineNumbers = lineNumberRef.current
+      const displayLine =
+        editor && lineNumbers && event.x === lineNumbers.x
+          ? editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
+          : undefined
+      const hoveredFoldLine =
+        displayLine !== undefined && editor?.getFoldSigns().has(displayLine)
+          ? displayLine
+          : null
+      if (hoveredFoldLine === hoveredFoldLineRef.current) return
+      hoveredFoldLineRef.current = hoveredFoldLine
+      syncFoldSigns(hoveredFoldLine ?? undefined)
+    },
+    [syncFoldSigns],
+  )
+
+  return (
+    <box
+      style={{
+        flexDirection: "column",
+        gap: 1,
+        minHeight: 0,
+        paddingLeft: 1,
+        paddingRight: 1,
+        ...(height === undefined ? { flexGrow: 1 } : { height }),
+      }}
+    >
+      {readError ? (
+        <box
+          style={{
+            flexGrow: 1,
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <text fg={theme.error}>{readError}</text>
+        </box>
+      ) : content !== null ? (
+        <>
+          <line-number
+            ref={lineNumberRef}
+            minWidth={4}
+            paddingRight={1}
+            fg={theme.textMuted}
+            bg={theme.backgroundPanel}
+            lineSigns={RESERVED_FOLD_SIGN}
+            onMouseMove={updateFoldHover}
+            onMouseOut={() => {
+              if (hoveredFoldLineRef.current === null) return
+              hoveredFoldLineRef.current = null
+              syncFoldSigns()
+            }}
+            onMouseDown={(event) => {
+              const editor = editorRef.current
+              if (event.button !== MouseButton.LEFT || !editor) return
+              if (event.x >= editor.x) return
+              const displayLine =
+                editor.lineInfo.lineSources[event.y - editor.y + editor.scrollY]
+              if (
+                displayLine === undefined ||
+                !editor.getFoldSigns().has(displayLine)
+              )
+                return
+              editor.toggleFold(displayLine)
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            style={{ flexGrow: 1, minHeight: 0 }}
+            width="100%"
+          >
+            <code-editor
+              id={editorId}
+              ref={(editor) => {
+                editorRef.current = editor
+                setEditorInstance(editor)
+              }}
+              filetype="yaml"
+              theme={theme}
+              initialValue={content}
+              extraHighlights={activeEnv ? extraHighlights : undefined}
+              validateContent={validateContent}
+              onValidationChange={setValidationError}
+              onSourceChange={handleContentChange}
+              onFoldsChange={() => {
+                hoveredFoldLineRef.current = null
+                syncFoldSigns()
+              }}
+              backgroundColor={theme.backgroundPanel}
+              focusedBackgroundColor={theme.backgroundPanel}
+              textColor={theme.text}
+              cursorColor={theme.primary}
+            />
+          </line-number>
+          <CodeEditorCompletion
+            editor={editorInstance}
+            env={activeEnv}
+            isEditing={active}
+            value={draftContent ?? content}
+          />
+          {activeValidationNotice && (
+            <ValidationNotice notice={activeValidationNotice} />
+          )}
+        </>
+      ) : (
+        <text fg={theme.textMuted}>Loading...</text>
+      )}
+      {saveError && <text fg={theme.error}>Save error: {saveError}</text>}
+    </box>
+  )
+})

--- a/src/ui/editor/yamlValidation.ts
+++ b/src/ui/editor/yamlValidation.ts
@@ -1,0 +1,133 @@
+export interface YamlValidationNotice {
+  title: string
+  detail: string
+}
+
+export type YamlFileKind = "request" | "folder"
+
+interface FormatYamlValidationNoticeOptions {
+  kind: YamlFileKind
+  fileName: string
+  source: string
+  error: unknown
+}
+
+interface ErrorLocation {
+  line: number
+  column?: number
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function removeEditorPrefixes(message: string, kind: YamlFileKind): string {
+  const parserPrefix =
+    kind === "folder" ? "lang.parseFolder" : "lang.parseRequest"
+  const titlePrefix =
+    kind === "folder" ? "Invalid folder YAML" : "Invalid request YAML"
+
+  return message
+    .replace(
+      new RegExp(`^${escapeRegExp(titlePrefix)}(?::| for [^:]+:)?\\s*`),
+      "",
+    )
+    .replace(new RegExp(`^${escapeRegExp(parserPrefix)}:\\s*`), "")
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function extractLocation(message: string): {
+  detail: string
+  location?: ErrorLocation
+} {
+  const locationMatch = message.match(/\((\d+)(?::(\d+))?\)/)
+  const withoutLocation = locationMatch
+    ? `${message.slice(0, locationMatch.index)}${message.slice(
+        (locationMatch.index ?? 0) + locationMatch[0].length,
+      )}`
+    : message
+  const detail = withoutLocation.split(/\r?\n/, 1)[0]?.trim() ?? ""
+
+  if (!locationMatch) return { detail }
+  return {
+    detail,
+    location: {
+      line: Number(locationMatch[1]),
+      ...(locationMatch[2] !== undefined
+        ? { column: Number(locationMatch[2]) }
+        : {}),
+    },
+  }
+}
+
+function extractFieldName(detail: string): string | undefined {
+  const namedField = detail.match(/\b(?:field|key)\s+["']([^"']+)["']/i)?.[1]
+  if (namedField) return namedField
+
+  const quotedField = detail.match(/^["']([^"']+)["']\s+must\b/i)?.[1]
+  if (quotedField) return quotedField
+
+  return detail.match(
+    /^([A-Za-z_][\w.-]*(?:\[\d+\])?(?:\.[A-Za-z_][\w-]*)*)\s+must\b/i,
+  )?.[1]
+}
+
+function yamlKey(line: string): string | undefined {
+  const match = line.match(
+    /^\s*(?:-\s+)?(?:"((?:\\.|[^"])*)"|'((?:''|[^'])*)'|([^:#][^:]*?))\s*:/,
+  )
+  if (!match) return undefined
+  if (match[1] !== undefined) return match[1].replace(/\\(["\\])/g, "$1")
+  if (match[2] !== undefined) return match[2].replace(/''/g, "'")
+  return match[3]?.trim()
+}
+
+function inferLocation(
+  detail: string,
+  source: string,
+): ErrorLocation | undefined {
+  const fieldName = extractFieldName(detail)
+  if (!fieldName) return undefined
+
+  const candidates = new Set([fieldName])
+  const leaf = fieldName
+    .split(".")
+    .at(-1)
+    ?.replace(/\[\d+\]$/, "")
+  if (leaf) candidates.add(leaf)
+
+  const matches: number[] = []
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    const key = yamlKey(line)
+    if (key && candidates.has(key)) matches.push(index + 1)
+  }
+
+  return matches.length === 1 ? { line: matches[0]! } : undefined
+}
+
+export function formatYamlValidationNotice({
+  kind,
+  fileName,
+  source,
+  error,
+}: FormatYamlValidationNoticeOptions): YamlValidationNotice {
+  const titleBase =
+    kind === "folder" ? "Invalid folder YAML" : "Invalid request YAML"
+  const message = removeEditorPrefixes(
+    errorMessage(error).trim(),
+    kind,
+  ).replace(/^YAML syntax:\s*/, "")
+  const { detail, location: parserLocation } = extractLocation(message)
+  const location = parserLocation ?? inferLocation(detail, source)
+  const locationPrefix = location
+    ? `Line ${location.line}${location.column === undefined ? "" : `, Col ${location.column}`}: `
+    : ""
+
+  return {
+    title: `${titleBase} for ${fileName}`,
+    detail: `${locationPrefix}${detail}`,
+  }
+}

--- a/src/ui/keybindingHints.ts
+++ b/src/ui/keybindingHints.ts
@@ -12,6 +12,7 @@ export interface KeybindingHintsContext {
   focus: Focus
   paneMode: PaneMode
   collectionMode: CollectionMode
+  collectionError?: boolean
   overlayActive: boolean
   jumpMode: boolean
   tab?: string
@@ -61,6 +62,28 @@ function getFooterHints(ctx: KeybindingHintsContext): HintSegment[] {
 
   const { kb } = { kb: ctx.keybinds }
   const col = ctx.collectionMode === "collection"
+
+  if (ctx.collectionError) {
+    if (ctx.focus === "sidebar") {
+      return [
+        {
+          key: displayKey(kb.request_delete),
+          word: "delete",
+          command: "request.delete",
+        },
+      ]
+    }
+    if (ctx.focus === "folder") {
+      return [
+        {
+          key: displayKey(kb.request_save),
+          word: "save",
+          command: "folder.save",
+        },
+      ]
+    }
+    return []
+  }
 
   if (ctx.view === "env-editor") {
     if (!col) return []

--- a/src/ui/keymap/folderLayers.ts
+++ b/src/ui/keymap/folderLayers.ts
@@ -7,6 +7,7 @@ export function createFolderLayers(
 ): [UseBindingsLayer, UseBindingsLayer, UseBindingsLayer, UseBindingsLayer] {
   const { keymap, keybinds, global, request, folder, actions } = context
   const canEdit = () => global.modeRef.current === "collection"
+  const isCollectionError = () => global.modeRef.current === "invalid"
   const isFolder = () =>
     keymap.getData("app.focus") === "folder" &&
     keymap.getData("app.overlay") === "none" &&
@@ -64,8 +65,14 @@ export function createFolderLayers(
     commands: [
       {
         name: "folder.save",
-        enabled: canEdit,
-        run: () => saveFolder(actions),
+        enabled: () => canEdit() || isCollectionError(),
+        run: () => {
+          if (isCollectionError()) {
+            request.collectionErrorSaveRef.current?.()
+            return
+          }
+          saveFolder(actions)
+        },
       },
       {
         name: "folder.delete",
@@ -143,7 +150,8 @@ export function createFolderLayers(
   }
 
   const edit: UseBindingsLayer = {
-    enabled: () => isFolder() && keymap.getData("app.mode") === "edit",
+    enabled: () =>
+      isFolder() && keymap.getData("app.mode") === "edit" && canEdit(),
     commands: [
       {
         name: "folder-edit.commit",

--- a/src/ui/keymap/requestLayers.ts
+++ b/src/ui/keymap/requestLayers.ts
@@ -16,8 +16,9 @@ export function createRequestLayers(
 ): [UseBindingsLayer, UseBindingsLayer, UseBindingsLayer, UseBindingsLayer] {
   const { keymap, keybinds, global, request, folder, actions } = context
   const canEdit = () => global.modeRef.current === "collection"
+  const isCollectionError = () => global.modeRef.current === "invalid"
   const isMainBase = () =>
-    keymap.getData("app.mode") === "base" &&
+    (keymap.getData("app.mode") === "base" || isCollectionError()) &&
     keymap.getData("app.focus") !== "folder" &&
     keymap.getData("app.overlay") === "none" &&
     keymap.getData("app.view") === "main"
@@ -79,8 +80,12 @@ export function createRequestLayers(
       },
       {
         name: "request.delete",
-        enabled: canEdit,
+        enabled: () => canEdit() || isCollectionError(),
         run: () => {
+          if (isCollectionError()) {
+            request.collectionErrorDeleteRef.current?.()
+            return
+          }
           const targetFolder = deleteFolder(actions)
           if (targetFolder) {
             folder.folderDeletePathRef.current = targetFolder.folderPath
@@ -214,9 +219,10 @@ export function createRequestLayers(
   const edit: UseBindingsLayer = {
     enabled: () =>
       keymap.getData("app.mode") === "edit" &&
-      keymap.getData("app.focus") !== "folder" &&
+      keymap.getData("app.focus") === "request" &&
       keymap.getData("app.overlay") === "none" &&
-      keymap.getData("app.view") === "main",
+      keymap.getData("app.view") === "main" &&
+      canEdit(),
     commands: [
       {
         name: "edit.commit",

--- a/src/ui/keymap/types.ts
+++ b/src/ui/keymap/types.ts
@@ -90,6 +90,8 @@ export interface AppKeymapRequest {
   setRequestDeletePending: (
     s: string | null | ((prev: string | null) => string | null),
   ) => void
+  collectionErrorDeleteRef: RefObject<(() => void) | null>
+  collectionErrorSaveRef: RefObject<(() => void) | null>
 }
 
 export interface AppKeymapFolder {

--- a/src/ui/useCollectionFileActions.ts
+++ b/src/ui/useCollectionFileActions.ts
@@ -43,6 +43,7 @@ interface UseCollectionFileActionsOptions {
   setCloneRequestVisible: Dispatch<SetStateAction<boolean>>
   setNewFolderVisible: Dispatch<SetStateAction<boolean>>
   setEditRequestVisible: Dispatch<SetStateAction<boolean>>
+  requestDeleteFileRef: MutableRefObject<string | null>
   setRequestDeletePending: Dispatch<SetStateAction<string | null>>
   setFolderDeletePending: Dispatch<SetStateAction<string | null>>
   onCollectionBootstrapped: (dir: string) => void
@@ -70,6 +71,7 @@ export function useCollectionFileActions({
   setCloneRequestVisible,
   setNewFolderVisible,
   setEditRequestVisible,
+  requestDeleteFileRef,
   setRequestDeletePending,
   setFolderDeletePending,
   onCollectionBootstrapped,
@@ -411,6 +413,23 @@ export function useCollectionFileActions({
   )
 
   const handleRequestDeleteConfirm = useCallback(() => {
+    const errorFileId = requestDeleteFileRef.current
+    if (errorFileId) {
+      deleteRequest(collectionDir, errorFileId)
+        .then(() => {
+          requestDeleteFileRef.current = null
+          setCollectionReloadToken((n) => n + 1)
+          setRequestDeletePending(null)
+          setFocus("sidebar")
+          showSaveResult({
+            kind: "success",
+            message: `Successfully deleted ${errorFileId}.yml`,
+          })
+        })
+        .catch(showError)
+      return
+    }
+
     const req = selectedRequest
     if (!req) return
 
@@ -427,6 +446,7 @@ export function useCollectionFileActions({
       .catch(showError)
   }, [
     collectionDir,
+    requestDeleteFileRef,
     selectedRequest,
     setCollectionReloadToken,
     setFocus,

--- a/src/ui/useEditModeSync.ts
+++ b/src/ui/useEditModeSync.ts
@@ -14,6 +14,7 @@ interface UseEditModeSyncProps {
   eb: UseEditBrowseResult
   folderEb: UseFolderEditBrowseResult
   envEditor: UseEnvironmentEditorResult
+  repairEditor?: boolean
 }
 
 function toPaneMode(mode: "inactive" | "browsing" | "editing"): PaneMode {
@@ -28,9 +29,11 @@ export function useEditModeSync({
   eb,
   folderEb,
   envEditor,
+  repairEditor = false,
 }: UseEditModeSyncProps): PaneMode {
   const keymap = useKeymap()
   const paneMode = useMemo(() => {
+    if (repairEditor) return "edit"
     if (view === "env-editor" && focus === "env-vars") {
       return toPaneMode(envEditor.editState.mode)
     }
@@ -39,6 +42,7 @@ export function useEditModeSync({
   }, [
     view,
     focus,
+    repairEditor,
     envEditor.editState.mode,
     folderEb.editState.mode,
     eb.editState.mode,
@@ -54,7 +58,7 @@ export function useEditModeSync({
       if (state.mode === "editing") eb.cancelEdit()
       else if (state.mode === "browsing") eb.exitBrowse()
     }
-    if (focus !== "folder") {
+    if (focus !== "folder" || repairEditor) {
       const state = folderEb.editState
       if (state.mode === "editing") folderEb.cancelEdit()
       else if (state.mode === "browsing") folderEb.exitBrowse()
@@ -66,6 +70,7 @@ export function useEditModeSync({
     }
   }, [
     focus,
+    repairEditor,
     eb.editState.mode,
     eb.cancelEdit,
     eb.exitBrowse,
@@ -78,7 +83,11 @@ export function useEditModeSync({
   ])
 
   useEffect(() => {
-    if (focus === "folder" && folderEb.editState.mode === "inactive") {
+    if (
+      !repairEditor &&
+      focus === "folder" &&
+      folderEb.editState.mode === "inactive"
+    ) {
       folderEb.enterBrowse()
     }
     if (focus === "env-vars" && envEditor.editState.mode === "inactive") {
@@ -86,6 +95,7 @@ export function useEditModeSync({
     }
   }, [
     focus,
+    repairEditor,
     folderEb.editState.mode,
     folderEb.enterBrowse,
     envEditor.editState.mode,

--- a/tests/unit/CollectionErrorView.test.tsx
+++ b/tests/unit/CollectionErrorView.test.tsx
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { act } from "react"
+import { extend } from "@opentui/react"
+import type { BoxRenderable } from "@opentui/core"
+import { MouseButtons } from "@opentui/core/testing"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createTestRender } from "../testRender"
+import { setupKeymap } from "./_helpers"
+import { ThemeProvider } from "../../src/ui/theme"
+import {
+  CollectionErrorView,
+  resolveCollectionErrorFile,
+} from "../../src/ui/CollectionErrorView"
+import { CodeEditorRenderable } from "../../src/ui/editor/CodeEditor"
+import type { CollectionFileError } from "../../src/filestore/load"
+
+extend({ "code-editor": CodeEditorRenderable })
+
+const testRender = createTestRender()
+let collectionDir: string
+
+const errors: CollectionFileError[] = [
+  {
+    file: "first.yml",
+    message: 'missing required field "url"',
+    rawError: 'lang.parseRequest: missing required field "url"',
+  },
+  {
+    file: "second.yml",
+    message: '"timeout" must be a finite number',
+    rawError: 'lang.parseRequest: "timeout" must be a finite number',
+  },
+]
+
+async function settle(renderOnce: () => Promise<void>): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 30))
+  })
+  await renderOnce()
+}
+
+beforeEach(async () => {
+  collectionDir = await mkdtemp(join(tmpdir(), "noodle-errors-"))
+  await writeFile(
+    join(collectionDir, "first.yml"),
+    "name: first\nmethod: GET\n",
+  )
+  await writeFile(
+    join(collectionDir, "second.yml"),
+    "name: second\nmethod: GET\nurl: https://example.com\ntimeout: nope\n",
+  )
+})
+
+afterEach(async () => {
+  await rm(collectionDir, { recursive: true, force: true })
+})
+
+describe("CollectionErrorView", () => {
+  it("renders only error items on the left and the selected YAML on the right", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionErrorView
+            collectionDir={collectionDir}
+            errors={errors}
+            focus="sidebar"
+            activeEnv={null}
+            onPaneFocus={() => {}}
+            onSaved={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 28 },
+    )
+    await settle(renderOnce)
+
+    const frame = captureCharFrame()
+    const frameLines = frame.split("\n")
+    const firstFileLine = frameLines.findIndex((line) =>
+      line.includes("first.yml"),
+    )
+    const secondFileLine = frameLines.findIndex((line) =>
+      line.includes("second.yml"),
+    )
+    const firstFileColumn = frameLines[firstFileLine]!.indexOf("first.yml")
+    const secondFileColumn = frameLines[secondFileLine]!.indexOf("second.yml")
+    expect(frame).toContain("Requests")
+    expect(frame).toContain("ERR    first.yml")
+    expect(frame).toContain("first.yml")
+    expect(frame).toContain("second.yml")
+    expect(secondFileLine - firstFileLine).toBe(1)
+    expect(secondFileColumn).toBe(firstFileColumn)
+    expect(frame).toContain("name: first")
+    expect(frame).toContain("! Invalid request YAML for first.yml")
+    expect(frame).not.toContain("lang.parseRequest:")
+    expect(frame).not.toContain("Collection Errors")
+    expect(frame).not.toContain("Problems")
+    expect(frame).not.toContain("Collection needs attention")
+    expect(frame).not.toContain("Select a problem")
+    expect(frame).not.toContain("2 errors")
+    cleanup()
+  })
+
+  it("renders only truncated filenames in the sidebar", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const longErrors: CollectionFileError[] = [
+      {
+        file: "a-very-long-request-filename-that-does-not-fit.yml",
+        message:
+          "this is a very long validation message that must stay inside the sidebar",
+        rawError: "long error",
+      },
+    ]
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionErrorView
+            collectionDir={collectionDir}
+            errors={longErrors}
+            focus="sidebar"
+            activeEnv={null}
+            onPaneFocus={() => {}}
+            onSaved={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 12 },
+    )
+    await settle(renderOnce)
+
+    const frame = captureCharFrame()
+    const sidebarFrame = frame.split("\n").slice(0, 3).join("\n")
+    expect(sidebarFrame).toContain("...")
+    expect(sidebarFrame).not.toContain(
+      "a-very-long-request-filename-that-does-not-fit.yml",
+    )
+    expect(sidebarFrame).not.toContain(longErrors[0]!.message)
+    cleanup()
+  })
+
+  it("selects error files with the keyboard", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionErrorView
+            collectionDir={collectionDir}
+            errors={errors}
+            focus="sidebar"
+            activeEnv={null}
+            onPaneFocus={() => {}}
+            onSaved={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 28 },
+    )
+    await settle(renderOnce)
+
+    await act(async () => mockInput.pressKey("ARROW_DOWN"))
+    await settle(renderOnce)
+    expect(captureCharFrame()).toContain("name: second")
+    cleanup()
+  })
+
+  it("selects error files with the mouse", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, renderer, mockMouse } =
+      await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <CollectionErrorView
+              collectionDir={collectionDir}
+              errors={errors}
+              focus="sidebar"
+              activeEnv={null}
+              onPaneFocus={() => {}}
+              onSaved={() => {}}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 28 },
+      )
+    await settle(renderOnce)
+
+    const row = renderer.root.findDescendantById(
+      "collection-error-1",
+    ) as BoxRenderable
+    await act(async () => {
+      await mockMouse.click(row.screenX + 1, row.screenY, MouseButtons.LEFT)
+    })
+    await settle(renderOnce)
+    expect(captureCharFrame()).toContain("name: second")
+    cleanup()
+  })
+
+  it("tracks a dirty invalid draft until it is successfully saved", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let dirty = false
+    let saved = 0
+    const saveActionRef: { current: (() => void) | null } = { current: null }
+    const { renderOnce, captureCharFrame, renderer } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionErrorView
+            collectionDir={collectionDir}
+            errors={errors.slice(0, 1)}
+            focus="folder"
+            activeEnv={null}
+            onPaneFocus={() => {}}
+            onDirtyChange={(value) => (dirty = value)}
+            saveActionRef={saveActionRef}
+            onSaved={() => saved++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 28 },
+    )
+    await settle(renderOnce)
+
+    const editor = renderer.root.findDescendantById(
+      "collection-error-editor",
+    ) as CodeEditorRenderable
+    await act(async () => {
+      editor.value = "name: first\nmethod: GET\nunknown: true\n"
+      editor.onSourceChange?.()
+    })
+    await renderOnce()
+
+    expect(dirty).toBe(true)
+    expect(captureCharFrame()).toContain("●")
+    expect(captureCharFrame()).toContain("! Invalid request YAML for first.yml")
+    expect(captureCharFrame()).not.toContain("lang.parseRequest:")
+
+    await act(async () => {
+      saveActionRef.current?.()
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+    await renderOnce()
+    expect(dirty).toBe(true)
+    expect(captureCharFrame()).not.toContain("Save error:")
+
+    await act(async () => {
+      editor.value = "name: first\nmethod: GET\nurl: https://example.com\n"
+      editor.onSourceChange?.()
+      saveActionRef.current?.()
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+    await renderOnce()
+
+    expect(saved).toBe(1)
+    expect(dirty).toBe(false)
+    expect(captureCharFrame()).not.toContain("●")
+    cleanup()
+  })
+
+  it("keeps dirty drafts and markers when switching error files", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, renderer, mockMouse } =
+      await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <CollectionErrorView
+              collectionDir={collectionDir}
+              errors={errors}
+              focus="folder"
+              activeEnv={null}
+              onPaneFocus={() => {}}
+              onSaved={() => {}}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 28 },
+      )
+    await settle(renderOnce)
+
+    const editor = renderer.root.findDescendantById(
+      "collection-error-editor",
+    ) as CodeEditorRenderable
+    await act(async () => {
+      editor.value = "name: first\nmethod: GET\nunknown: true\n"
+      editor.onSourceChange?.()
+    })
+    await renderOnce()
+
+    const secondRow = renderer.root.findDescendantById(
+      "collection-error-1",
+    ) as BoxRenderable
+    await act(async () => {
+      await mockMouse.click(
+        secondRow.screenX + 1,
+        secondRow.screenY,
+        MouseButtons.LEFT,
+      )
+    })
+    await settle(renderOnce)
+    expect(captureCharFrame()).toContain("●")
+
+    const firstRow = renderer.root.findDescendantById(
+      "collection-error-0",
+    ) as BoxRenderable
+    await act(async () => {
+      await mockMouse.click(
+        firstRow.screenX + 1,
+        firstRow.screenY,
+        MouseButtons.LEFT,
+      )
+    })
+    await settle(renderOnce)
+    expect(captureCharFrame()).toContain("unknown: true")
+    cleanup()
+  })
+
+  it("does not intercept ctrl+s outside the configured command layer", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let saved = 0
+    const { renderOnce, renderer } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionErrorView
+            collectionDir={collectionDir}
+            errors={errors.slice(0, 1)}
+            focus="folder"
+            activeEnv={null}
+            onPaneFocus={() => {}}
+            onSaved={() => saved++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 28 },
+    )
+    await settle(renderOnce)
+
+    const editor = renderer.root.findDescendantById(
+      "collection-error-editor",
+    ) as CodeEditorRenderable
+    await act(async () => {
+      editor.value =
+        "name: first\nmethod: GET\nurl: https://example.com\ntimeout: 10000\n"
+    })
+    await act(async () => {
+      host.press("s", { ctrl: true })
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+
+    expect(saved).toBe(0)
+    cleanup()
+  })
+
+  it("activates the editor pane when the YAML content is clicked", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const focused: string[] = []
+    const { renderOnce, renderer, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <CollectionErrorView
+            collectionDir={collectionDir}
+            errors={errors.slice(0, 1)}
+            focus="sidebar"
+            activeEnv={null}
+            onPaneFocus={(next) => focused.push(next)}
+            onSaved={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 28 },
+    )
+    await settle(renderOnce)
+
+    const editor = renderer.root.findDescendantById(
+      "collection-error-editor",
+    ) as CodeEditorRenderable
+    await act(async () => {
+      await mockMouse.click(editor.x + 5, editor.y, MouseButtons.LEFT)
+    })
+
+    expect(focused).toContain("folder")
+    cleanup()
+  })
+})
+
+describe("resolveCollectionErrorFile", () => {
+  it("rejects files outside the collection", () => {
+    expect(
+      resolveCollectionErrorFile(collectionDir, "../outside.yml"),
+    ).toBeNull()
+    expect(
+      resolveCollectionErrorFile(collectionDir, "/tmp/outside.yml"),
+    ).toBeNull()
+    expect(resolveCollectionErrorFile(collectionDir, "collection")).toBeNull()
+  })
+})

--- a/tests/unit/CollectionErrorView.test.tsx
+++ b/tests/unit/CollectionErrorView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { extend } from "@opentui/react"
 import type { BoxRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
@@ -311,6 +311,55 @@ describe("CollectionErrorView", () => {
       )
     })
     await settle(renderOnce)
+    expect(captureCharFrame()).toContain("unknown: true")
+    cleanup()
+  })
+
+  it("keeps a dirty draft when refreshed errors recreate the selected item", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let refreshErrors = () => {}
+
+    function Harness() {
+      const [revision, setRevision] = useState(0)
+      refreshErrors = () => setRevision((current) => current + 1)
+      return (
+        <CollectionErrorView
+          collectionDir={collectionDir}
+          errors={errors.slice(0, 1).map((error) => ({
+            ...error,
+            message: `${error.message} (${revision})`,
+          }))}
+          focus="folder"
+          activeEnv={null}
+          onPaneFocus={() => {}}
+          onSaved={() => {}}
+        />
+      )
+    }
+
+    const { renderOnce, captureCharFrame, renderer } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 28 },
+    )
+    await settle(renderOnce)
+
+    const editor = renderer.root.findDescendantById(
+      "collection-error-editor",
+    ) as CodeEditorRenderable
+    await act(async () => {
+      editor.value = "name: first\nmethod: GET\nunknown: true\n"
+      editor.onSourceChange?.()
+    })
+    await renderOnce()
+    expect(captureCharFrame()).toContain("unknown: true")
+
+    await act(async () => refreshErrors())
+    await settle(renderOnce)
+
     expect(captureCharFrame()).toContain("unknown: true")
     cleanup()
   })

--- a/tests/unit/MainView.test.tsx
+++ b/tests/unit/MainView.test.tsx
@@ -144,4 +144,50 @@ describe("MainView", () => {
 
     cleanup()
   })
+
+  it("keeps collection errors in the repair view while reloading", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const error = new Error("collection failed") as Error & {
+      fileErrors: Array<{
+        file: string
+        message: string
+        rawError: string
+      }>
+    }
+    error.fileErrors = [
+      {
+        file: "collection",
+        message: "Could not read collection",
+        rawError: "Could not read collection",
+      },
+    ]
+    const props = {
+      items: [],
+      collectionDir: "/tmp/noodle-errors",
+      loading: true,
+      error,
+      focus: "sidebar" as const,
+      activeEnv: null,
+      mode: "collection" as const,
+      onInitialize: () => {},
+      onCreateRequest: () => {},
+      onCollectionErrorSaved: () => {},
+    } as unknown as Parameters<typeof MainView>[0]
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <MainView {...props} />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 80, height: 20 },
+    )
+    await renderOnce()
+
+    const frame = captureCharFrame()
+    expect(frame).toContain("Could not read collection")
+    expect(frame).not.toContain("Collection Error")
+    expect(frame).not.toContain("Problems")
+    expect(frame).not.toContain("No collection found")
+    cleanup()
+  })
 })

--- a/tests/unit/StatusBar.test.tsx
+++ b/tests/unit/StatusBar.test.tsx
@@ -417,6 +417,39 @@ describe("StatusBar component", () => {
     expect(narrowFrame.split("\n")[0]!.length).toBeLessThanOrEqual(30)
   })
 
+  it("shows the collection error count only on the footer right", async () => {
+    const errorHints = getKeybindingHints({
+      view: "main",
+      focus: "sidebar",
+      paneMode: "edit",
+      collectionMode: "collection",
+      collectionError: true,
+      overlayActive: false,
+      jumpMode: false,
+      sendState: { status: "idle" },
+      keybinds: kb,
+    }).footer
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <StatusBar
+          kb={kb}
+          view="main"
+          collectionMode="collection"
+          errorCount={13}
+          globalHints={emptyHints}
+          footerHints={errorHints}
+        />
+      </ThemeProvider>,
+      { width: 60, height: 1 },
+    )
+    await renderOnce()
+
+    const row = captureCharFrame().split("\n")[0]!
+    expect(row).toContain("13 errors")
+    expect(row).toContain("^w")
+    expect(row.indexOf("13 errors")).toBeGreaterThan(40)
+  })
+
   it("adds Commands when width fitting hides one of three actions", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>

--- a/tests/unit/ValidationNotice.test.tsx
+++ b/tests/unit/ValidationNotice.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test"
+import { createTestRender } from "../testRender"
+import { ThemeProvider } from "../../src/ui/theme"
+import { ValidationNotice } from "../../src/ui/editor/ValidationNotice"
+
+const testRender = createTestRender()
+
+describe("ValidationNotice", () => {
+  it("keeps the title and detail on single truncated lines", async () => {
+    const { renderOnce, captureCharFrame } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <box style={{ width: 48, height: 4 }}>
+          <ValidationNotice
+            notice={{
+              title:
+                "Invalid request YAML for a-very-long-request-filename-that-does-not-fit.yml",
+              detail:
+                'Line 42, Col 18: "timeout" must be a finite number and this detail is intentionally longer than the available editor width',
+            }}
+          />
+        </box>
+      </ThemeProvider>,
+      { width: 48, height: 6 },
+    )
+    await renderOnce()
+
+    const lines = captureCharFrame().split("\n")
+    const titleLine = lines.find((line) => line.includes("Invalid request"))
+    const detailLine = lines.find((line) => line.includes("Line 42"))
+    expect(titleLine).toBeDefined()
+    expect(detailLine).toBeDefined()
+    expect(titleLine!).toContain("! Invalid request")
+    expect(titleLine!).toContain("...")
+    expect(detailLine!).toContain("Line 42")
+    expect(detailLine!).toContain("...")
+    expect(
+      lines.filter((line) => line.includes("Invalid request")),
+    ).toHaveLength(1)
+    expect(
+      lines.filter((line) => line.includes("detail is intentionally")),
+    ).toHaveLength(0)
+  })
+})

--- a/tests/unit/YamlEditorOverlay.test.tsx
+++ b/tests/unit/YamlEditorOverlay.test.tsx
@@ -93,6 +93,7 @@ describe("YamlEditorOverlay", () => {
             visible
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -116,6 +117,7 @@ describe("YamlEditorOverlay", () => {
             visible
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -125,7 +127,7 @@ describe("YamlEditorOverlay", () => {
     )
     await loadEditor(renderOnce)
     const frame = captureCharFrame()
-    expect(frame).toContain("^S")
+    expect(frame).toContain("^s")
     expect(frame).toContain("save")
     expect(frame).toContain("esc")
     expect(frame).toContain("close")
@@ -147,6 +149,7 @@ describe("YamlEditorOverlay", () => {
             visible
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {
               saved++
               resolveSaved?.()
@@ -174,6 +177,40 @@ describe("YamlEditorOverlay", () => {
     cleanup()
   })
 
+  it("uses the configured save key instead of ctrl+s", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let saved = 0
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <YamlEditorOverlay
+            visible
+            filePath={filePath}
+            requestName="get-users"
+            saveKey="ctrl+x"
+            onSaved={() => saved++}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 30 },
+    )
+    await loadEditor(renderOnce)
+
+    await act(async () => {
+      host.press("s", { ctrl: true })
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+    expect(saved).toBe(0)
+
+    await act(async () => {
+      host.press("x", { ctrl: true })
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+    expect(saved).toBe(1)
+    cleanup()
+  })
+
   it("toggles a YAML fold from its gutter icon", async () => {
     await writeFile(
       filePath,
@@ -187,6 +224,7 @@ describe("YamlEditorOverlay", () => {
             visible
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -219,6 +257,7 @@ describe("YamlEditorOverlay", () => {
             visible={false}
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -241,6 +280,7 @@ describe("YamlEditorOverlay", () => {
             visible={false}
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -263,6 +303,7 @@ describe("YamlEditorOverlay", () => {
             visible
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -272,7 +313,7 @@ describe("YamlEditorOverlay", () => {
     )
     await loadEditor(renderOnce)
     const frame = captureCharFrame()
-    expect(frame).toMatch(/\^S.*save.*esc.*close/)
+    expect(frame).toMatch(/\^s.*save.*esc.*close/)
     cleanup()
   })
 
@@ -287,6 +328,7 @@ describe("YamlEditorOverlay", () => {
             visible
             filePath={filePath}
             requestName="get-users"
+            saveKey="ctrl+s"
             onSaved={() => {}}
             onClose={() => {}}
           />
@@ -303,8 +345,69 @@ describe("YamlEditorOverlay", () => {
     await renderOnce()
 
     const frame = captureCharFrame()
-    expect(frame).toContain("Save error:")
+    expect(frame).toContain("! Invalid request YAML for get-users.yml")
+    expect(frame).toContain("Line 4, Col 1:")
+    expect(frame).not.toContain("Save error:")
     expect(await readFile(filePath, "utf8")).toBe(invalidYaml)
+    cleanup()
+  })
+
+  it("shows the shared request validation notice with the filename", async () => {
+    await writeFile(
+      filePath,
+      "name: test\nmethod: GET\nurl: https://example.com\ntimeout: nope\n",
+    )
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <YamlEditorOverlay
+            visible
+            filePath={filePath}
+            requestName="get-users"
+            saveKey="ctrl+s"
+            onSaved={() => {}}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 30 },
+    )
+    await loadEditor(renderOnce)
+
+    const frame = captureCharFrame()
+    expect(frame).toContain("! Invalid request YAML for get-users.yml")
+    expect(frame).toContain('Line 4: "timeout" must be a finite number')
+    expect(frame).not.toContain("lang.parseRequest:")
+    cleanup()
+  })
+
+  it("shows the shared folder validation notice", async () => {
+    const folderPath = join(testDir, "folder.yml")
+    await writeFile(folderPath, "unknown: true\n")
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <YamlEditorOverlay
+            visible
+            filePath={folderPath}
+            requestName="auth"
+            kind="folder"
+            saveKey="ctrl+s"
+            onSaved={() => {}}
+            onClose={() => {}}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 100, height: 30 },
+    )
+    await loadEditor(renderOnce)
+
+    const frame = captureCharFrame()
+    expect(frame).toContain("! Invalid folder YAML for auth/folder.yml")
+    expect(frame).toContain('Line 1: unknown field "unknown"')
+    expect(frame).not.toContain("lang.parseFolder:")
     cleanup()
   })
 })

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -44,6 +44,8 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     jsonEnter: 0,
     jsonLeave: 0,
     jsonReturnToSelect: 0,
+    collectionErrorDelete: 0,
+    collectionErrorSave: 0,
     focus: "",
     view: "",
     jumpMode: false,
@@ -74,6 +76,12 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
       },
     },
     trySendRef: { current: () => calls.send++ },
+    collectionErrorDeleteRef: {
+      current: () => calls.collectionErrorDelete++,
+    },
+    collectionErrorSaveRef: {
+      current: () => calls.collectionErrorSave++,
+    },
   }
   const folder = {
     folderEbRef: {
@@ -349,6 +357,33 @@ describe("app keymap layers", () => {
     cleanup()
   })
 
+  it("routes collection error delete and save through the existing commands", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    context.keybinds = { ...context.keybinds, request_save: "ctrl+x" }
+    context.global.modeRef.current = "invalid"
+    keymap.setData("app.mode", "edit")
+    const disposers = register(context)
+
+    host.press("w", { ctrl: true })
+    expect(calls.collectionErrorDelete).toBe(1)
+    expect(keymap.dispatchCommand("request.delete")).toMatchObject({
+      ok: true,
+    })
+    expect(calls.collectionErrorDelete).toBe(2)
+
+    keymap.setData("app.focus", "folder")
+    host.press("s", { ctrl: true })
+    expect(calls.collectionErrorSave).toBe(0)
+    host.press("x", { ctrl: true })
+    expect(calls.collectionErrorSave).toBe(1)
+    expect(keymap.dispatchCommand("folder.save")).toMatchObject({ ok: true })
+    expect(calls.collectionErrorSave).toBe(2)
+
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
   it("opens the environment picker with e from the sidebar", () => {
     const { keymap, host, cleanup } = setup()
     const { context, calls } = createContext(keymap)
@@ -496,6 +531,22 @@ describe("app keymap layers", () => {
     expect(calls.envSave).toBe(0)
     expect(calls.editorOpened).toBe("")
 
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("moves from the collection error list to its YAML editor", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    context.folder.folderViewRef.current = true
+    context.global.focusRef.current = "sidebar"
+    keymap.setData("app.mode", "edit")
+    keymap.setData("app.focus", "sidebar")
+    const disposers = register(context)
+
+    host.press("tab")
+
+    expect(calls.focus).toBe("folder")
     disposers.forEach((dispose) => dispose())
     cleanup()
   })

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -540,6 +540,7 @@ describe("app keymap layers", () => {
     const { context, calls } = createContext(keymap)
     context.folder.folderViewRef.current = true
     context.global.focusRef.current = "sidebar"
+    context.global.modeRef.current = "invalid"
     keymap.setData("app.mode", "edit")
     keymap.setData("app.focus", "sidebar")
     const disposers = register(context)

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -775,6 +775,20 @@ describe("buildCommandPaletteCommands", () => {
     expect(envCmds).toHaveLength(0)
   })
 
+  it("excludes collection-only commands when mode is invalid", () => {
+    const ctx = minimalContext()
+    ctx.getCollectionMode = () => "invalid"
+
+    const commandIds = buildCommandPaletteCommands(ctx).map(
+      (command) => command.id,
+    )
+
+    expect(commandIds).not.toContain("request.new")
+    expect(commandIds).not.toContain("request.save")
+    expect(commandIds).not.toContain("folder.new")
+    expect(commandIds).not.toContain("collection.import")
+  })
+
   it("env editor view shows env commands only in collection mode", () => {
     const ctx = minimalContext()
     ctx.getCollectionMode = () => "collection"

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -784,6 +784,7 @@ describe("buildCommandPaletteCommands", () => {
     )
 
     expect(commandIds).not.toContain("request.new")
+    expect(commandIds).not.toContain("request.send")
     expect(commandIds).not.toContain("request.save")
     expect(commandIds).not.toContain("folder.new")
     expect(commandIds).not.toContain("collection.import")

--- a/tests/unit/getContextualSegments.test.ts
+++ b/tests/unit/getContextualSegments.test.ts
@@ -59,6 +59,25 @@ describe("getContextualSegments", () => {
     expect(r.footer).toMatchObject([])
   })
 
+  it("collection errors show delete on the focused sidebar", () => {
+    const r = base({ collectionError: true, focus: "sidebar" })
+    expect(r.footer).toMatchObject([seg("^w", "delete")])
+  })
+
+  it("collection errors show save on the focused YAML editor", () => {
+    const r = base({ collectionError: true, focus: "folder" })
+    expect(r.footer).toMatchObject([seg("^s", "save")])
+  })
+
+  it("collection error hints use configured request actions", () => {
+    const r = base({
+      collectionError: true,
+      focus: "folder",
+      keybinds: { ...kb, request_delete: "ctrl+d", request_save: "ctrl+x" },
+    })
+    expect(r.footer).toMatchObject([seg("^x", "save")])
+  })
+
   // ── urlbar ──────────────────────────────────────
 
   it("urlbar in collection mode", () => {

--- a/tests/unit/useCollectionFileActions.test.tsx
+++ b/tests/unit/useCollectionFileActions.test.tsx
@@ -44,6 +44,7 @@ function ActionsHarness({
   onEditSaved,
   onNewReady,
   onCreateFailed,
+  onDeleteReady,
 }: {
   collectionDir: string
   onSaveReady: (save: () => void) => void
@@ -67,6 +68,7 @@ function ActionsHarness({
     ) => void,
   ) => void
   onCreateFailed?: () => void
+  onDeleteReady?: (setFile: (id: string) => void, confirm: () => void) => void
 }) {
   const [collection, updateCollection] = useState<Collection | null>(null)
   const folderDraftRef = useRef<UseFolderDraftResult>({
@@ -75,6 +77,7 @@ function ActionsHarness({
   } as never)
   const savingRef = useRef(false)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const requestDeleteFileRef = useRef<string | null>(null)
   const actions = useCollectionFileActions({
     collectionDir,
     collection,
@@ -101,6 +104,7 @@ function ActionsHarness({
     setCloneRequestVisible: () => {},
     setNewFolderVisible: () => {},
     setEditRequestVisible: () => {},
+    requestDeleteFileRef,
     setRequestDeletePending: () => {},
     setFolderDeletePending: () => {},
     onCollectionBootstrapped: () => {},
@@ -121,6 +125,12 @@ function ActionsHarness({
   useEffect(() => {
     onNewReady?.(actions.handleNewRequestConfirm)
   }, [actions.handleNewRequestConfirm, onNewReady])
+
+  useEffect(() => {
+    onDeleteReady?.((id) => {
+      requestDeleteFileRef.current = id
+    }, actions.handleRequestDeleteConfirm)
+  }, [actions.handleRequestDeleteConfirm, onDeleteReady])
 
   return null
 }
@@ -294,5 +304,41 @@ describe("useCollectionFileActions", () => {
     )
     expect(request.name).toBe("Existing request")
     expect(request.method).toBe("GET")
+  })
+
+  it("deletes a request file that failed collection parsing", async () => {
+    const collectionDir = await mkdtemp(join(tmpdir(), "noodle-actions-"))
+    dirs.push(collectionDir)
+    await writeFile(join(collectionDir, "broken.yml"), "collection_id: nope\n")
+
+    let setDeleteFile: ((id: string) => void) | undefined
+    let confirmDelete: (() => void) | undefined
+    let resolveDeleted: (() => void) | undefined
+    const deleted = new Promise<void>((resolve) => {
+      resolveDeleted = resolve
+    })
+    const render = await testRender(
+      <ActionsHarness
+        collectionDir={collectionDir}
+        onSaveReady={() => {}}
+        onMarkSaved={() => {}}
+        onDeleteReady={(setFile, confirm) => {
+          setDeleteFile = setFile
+          confirmDelete = confirm
+        }}
+        onEditSaved={() => resolveDeleted?.()}
+      />,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await render.renderOnce()
+    await act(async () => {
+      setDeleteFile?.("broken")
+      confirmDelete?.()
+    })
+    await deleted
+
+    await expect(readFile(join(collectionDir, "broken.yml"))).rejects.toThrow()
   })
 })

--- a/tests/unit/useEditModeSync.test.tsx
+++ b/tests/unit/useEditModeSync.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { createTestRender } from "../testRender"
+import { setupKeymap } from "./_helpers"
+import { useEditModeSync } from "../../src/ui/useEditModeSync"
+import type { UseEditBrowseResult } from "../../src/hooks/useEditBrowse"
+import type { UseFolderEditBrowseResult } from "../../src/hooks/useFolderEditBrowse"
+import type { UseEnvironmentEditorResult } from "../../src/hooks/useEnvironmentEditor"
+
+const testRender = createTestRender()
+
+describe("useEditModeSync", () => {
+  it("keeps the repair YAML editor in edit mode without entering folder browse", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let folderBrowseCalls = 0
+    const inactive = {
+      editState: { mode: "inactive" },
+      cancelEdit: () => {},
+      exitBrowse: () => {},
+    }
+
+    function Harness() {
+      const mode = useEditModeSync({
+        focus: "folder",
+        view: "main",
+        eb: inactive as unknown as UseEditBrowseResult,
+        folderEb: {
+          ...inactive,
+          enterBrowse: () => folderBrowseCalls++,
+        } as unknown as UseFolderEditBrowseResult,
+        envEditor: {
+          ...inactive,
+          enterBrowse: () => {},
+        } as unknown as UseEnvironmentEditorResult,
+        repairEditor: true,
+      } as Parameters<typeof useEditModeSync>[0])
+      return <text>{mode}</text>
+    }
+
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <Harness />
+      </KeymapProvider>,
+      { width: 20, height: 2 },
+    )
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("edit")
+    expect(keymap.getData("app.mode")).toBe("edit")
+    expect(folderBrowseCalls).toBe(0)
+    cleanup()
+  })
+})

--- a/tests/unit/yamlValidation.test.ts
+++ b/tests/unit/yamlValidation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test"
+import { formatYamlValidationNotice } from "../../src/ui/editor/yamlValidation"
+
+describe("formatYamlValidationNotice", () => {
+  it("formats request validation with the filename and inferred field line", () => {
+    const notice = formatYamlValidationNotice({
+      kind: "request",
+      fileName: "google copy copy 2.yml",
+      source:
+        "name: Google\nmethod: GET\nurl: https://example.com\ntimeout: nope\n",
+      error: 'lang.parseRequest: "timeout" must be a finite number',
+    })
+
+    expect(notice).toEqual({
+      title: "Invalid request YAML for google copy copy 2.yml",
+      detail: 'Line 4: "timeout" must be a finite number',
+    })
+  })
+
+  it("uses the folder validation title", () => {
+    const notice = formatYamlValidationNotice({
+      kind: "folder",
+      fileName: "auth/folder.yml",
+      source: "unknown: true\n",
+      error: 'lang.parseFolder: unknown field "unknown"',
+    })
+
+    expect(notice.title).toBe("Invalid folder YAML for auth/folder.yml")
+    expect(notice.detail).toBe('Line 1: unknown field "unknown"')
+  })
+
+  it("preserves parser-provided line and column information", () => {
+    const notice = formatYamlValidationNotice({
+      kind: "request",
+      fileName: "broken.yml",
+      source: "name: broken\nmethod: GET\nurl: [broken\n",
+      error:
+        "lang.parseRequest: YAML syntax: unexpected end of the stream (4:1)\n\n 1 | url: [broken",
+    })
+
+    expect(notice.detail).toBe("Line 4, Col 1: unexpected end of the stream")
+  })
+
+  it("omits a line when the offending field is missing", () => {
+    const notice = formatYamlValidationNotice({
+      kind: "request",
+      fileName: "missing.yml",
+      source: "name: missing\nmethod: GET\n",
+      error: 'lang.parseRequest: missing required field "url"',
+    })
+
+    expect(notice.detail).toBe('missing required field "url"')
+  })
+
+  it("omits a line when a field match is ambiguous", () => {
+    const notice = formatYamlValidationNotice({
+      kind: "request",
+      fileName: "duplicate.yml",
+      source: "headers:\n  accept: json\nheaders:\n  content: text\n",
+      error: 'lang.parseRequest: "headers" must be a map',
+    })
+
+    expect(notice.detail).toBe('"headers" must be a map')
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a repair view that replaces the collection view when the collection contains invalid YAML request/folder files. It lists each broken file with its validation error, lets you edit and fix the YAML inline (with live validation), save or delete the file, and shows a live error count in the status bar. The view stays fully non-interactive-safe: edit mode and collection-only actions are gated to the invalid state.

Also extracts the shared YAML file editor from `YamlEditorOverlay` into a reusable `YamlFileEditor` component and adds a `yamlValidation` helper for formatting parse errors with line/column location.

### How did you verify your code works?

Added unit tests for the new `CollectionErrorView`, `YamlFileEditor`, `yamlValidation`, status bar error count, keymap layers, and file-delete flow (`bun test`). `bun run lint` and `bun run typecheck` pass.

### Screenshots / recordings

N/A (terminal UI; test coverage added)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a collection error view for finding, reviewing, editing, saving, or deleting malformed YAML files.
  - Added clearer YAML validation messages with relevant file, line, and field details.
  - Added repair-mode keyboard shortcuts, status indicators, and contextual save/delete hints.
  - Added configurable save-key support for YAML editing.

- **Bug Fixes**
  - Preserved collection errors during reloads and cleared them after successful recovery.
  - Blocked sending and folder editing while collection errors require repair.

- **Tests**
  - Added coverage for repair workflows, validation notices, status indicators, and keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->