### PR TITLE
feat(commands): add command palette entries for settings categories

### DIFF
--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -5,7 +5,12 @@ import type { Keybinds } from "./keybind"
 import { displayKey } from "./keybind"
 import type { Focus } from "./focus"
 import type { AppView, YamlEditorState } from "./appState"
-import type { SettingsCategory, SettingsScope } from "./settings/SettingsView"
+import {
+  COLLECTION_CATEGORIES,
+  GLOBAL_CATEGORIES,
+  type SettingsCategory,
+  type SettingsScope,
+} from "./settings/SettingsView"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
 import type { UseEnvironmentsResult } from "../hooks/useEnvironments"
@@ -557,6 +562,38 @@ export function buildCommandPaletteCommands(
     },
   ]
 
+  const openSettingsCategory = (
+    scope: SettingsScope,
+    category: SettingsCategory,
+  ): boolean => {
+    if (!openSettings(c, view)) return false
+    openSettingsView(scope, category)
+    return true
+  }
+
+  const applicationSettingsCommands: CommandItem[] = GLOBAL_CATEGORIES.map(
+    ({ id, label }) => ({
+      id: `app.settings-${id}`,
+      label,
+      section: "Application Settings",
+      run: () => openSettingsCategory("global", id),
+    }),
+  )
+
+  const collectionSettingsCommands: CommandItem[] = COLLECTION_CATEGORIES.map(
+    ({ id, label }) => ({
+      id: `collection.settings-${id}`,
+      label,
+      section: "Collection Settings",
+      run: () => openSettingsCategory("collection", id),
+    }),
+  )
+
+  const settingsCommands = [
+    ...applicationSettingsCommands,
+    ...(mode === "collection" ? collectionSettingsCommands : []),
+  ]
+
   const systemCommands: CommandItem[] = [
     {
       id: "app.settings-open",
@@ -683,20 +720,22 @@ export function buildCommandPaletteCommands(
     return [
       ...(mode === "collection" ? editorEnvCommands : readOnlyCommands),
       ...(mode === "collection" ? workspaceCommands : []),
+      ...settingsCommands,
       ...globalCommands,
       ...systemCommands,
     ]
   }
 
-  if (view === "cookie-jar") return systemCommands
+  if (view === "cookie-jar") return [...settingsCommands, ...systemCommands]
 
-  if (view === "settings") return systemCommands
+  if (view === "settings") return [...settingsCommands, ...systemCommands]
 
   return [
     ...(mode === "collection" ? visibleRequestCommands : []),
     ...(mode === "collection" ? mainEnvCommands : []),
     ...(mode === "collection" ? workspaceCommands : readOnlyCommands),
     ...mainOnlyCommands,
+    ...settingsCommands,
     ...globalCommands,
     ...systemCommands,
   ]

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -53,7 +53,7 @@ export type CollectionSettingsCategory = "general" | "network" | "tls"
 export type SettingsCategory =
   GlobalSettingsCategory | CollectionSettingsCategory
 
-const GLOBAL_CATEGORIES: readonly {
+export const GLOBAL_CATEGORIES: readonly {
   id: GlobalSettingsCategory
   label: string
 }[] = [
@@ -64,13 +64,13 @@ const GLOBAL_CATEGORIES: readonly {
   { id: "keyboard", label: "Keyboard" },
 ]
 
-const COLLECTION_CATEGORIES: readonly {
+export const COLLECTION_CATEGORIES: readonly {
   id: CollectionSettingsCategory
   label: string
 }[] = [
   { id: "general", label: "General" },
   { id: "network", label: "Proxy" },
-  { id: "tls", label: "TLS" },
+  { id: "tls", label: "Certificates" },
 ]
 
 const KEYBIND_CATEGORIES: readonly KeybindCategory[] = [
@@ -935,7 +935,7 @@ export function SettingsView({
             {scope === "collection" && category === "tls" && (
               <>
                 <SettingsSectionHeader
-                  title="TLS"
+                  title="Certificates"
                   description="Configure certificate verification, trust roots, and mutual TLS for this collection."
                 />
                 <TlsSettingsForm

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -313,6 +313,21 @@ describe("SettingsView", () => {
     cleanup()
   })
 
+  it("labels collection TLS settings as Certificates", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness initialScope="collection" initialCategory="tls" />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 24 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Certificates")
+    cleanup()
+  })
+
   it("commits collection name and multiline description when tabbing", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     const patches: Array<Partial<CollectionSettings>> = []

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -185,7 +185,14 @@ describe("buildCommandPaletteCommands", () => {
   it("sections appear in correct order", () => {
     const commands = buildCommandPaletteCommands(minimalContext())
     const sections = [...new Set(commands.map((c) => c.section))]
-    expect(sections).toEqual(["Request", "Environment", "Workspace", "System"])
+    expect(sections).toEqual([
+      "Request",
+      "Environment",
+      "Workspace",
+      "Application Settings",
+      "Collection Settings",
+      "System",
+    ])
   })
 
   it("shows only request commands for a request context menu", () => {
@@ -491,7 +498,7 @@ describe("buildCommandPaletteCommands", () => {
     expect(visible).toBe(true)
   })
 
-  it("exposes Open Settings without a duplicate proxy shortcut", () => {
+  it("opens generic and scoped settings commands", () => {
     const ctx = minimalContext()
     const opened: Array<[string | undefined, string | undefined]> = []
     ctx.openSettingsView = (scope, category) => {
@@ -500,13 +507,32 @@ describe("buildCommandPaletteCommands", () => {
 
     const commands = buildCommandPaletteCommands(ctx)
     const settings = commands.find((item) => item.id === "app.settings-open")!
+    const appearance = commands.find(
+      (item) => item.id === "app.settings-appearance",
+    )!
+    const certificates = commands.find(
+      (item) => item.id === "collection.settings-tls",
+    )!
 
     expect(settings.keybinding).toBe("f4")
     expect(settings.run()).toBe(true)
-    expect(commands.find((item) => item.id === "app.proxy-settings")).toBe(
-      undefined,
-    )
-    expect(opened).toEqual([[undefined, undefined]])
+    expect(appearance.section).toBe("Application Settings")
+    expect(appearance.run()).toBe(true)
+    expect(certificates.label).toBe("Certificates")
+    expect(certificates.section).toBe("Collection Settings")
+    expect(certificates.run()).toBe(true)
+    expect(opened).toEqual([
+      [undefined, undefined],
+      ["global", "appearance"],
+      ["collection", "tls"],
+    ])
+
+    ctx.getCollectionMode = () => "browse"
+    expect(
+      buildCommandPaletteCommands(ctx).some(
+        (item) => item.section === "Collection Settings",
+      ),
+    ).toBe(false)
   })
 
   it("blocks Settings from a dirty environment editor", () => {
@@ -763,7 +789,12 @@ describe("buildCommandPaletteCommands", () => {
     const commands = buildCommandPaletteCommands(ctx)
     const sections = [...new Set(commands.map((c) => c.section))]
     expect(sections).not.toContain("Environment")
-    expect(sections).toEqual(["Collection", "Workspace", "System"])
+    expect(sections).toEqual([
+      "Collection",
+      "Workspace",
+      "Application Settings",
+      "System",
+    ])
   })
 
   it("excludes environment commands when mode is empty", () => {


### PR DESCRIPTION
### Type of change

- [x] New feature
- [ ] Refactor / code improvement

### What does this PR do?

Adds per-category command palette entries that open the Settings view directly at a specific tab (Application Settings: Appearance, Themes, Network, Keyboard; Collection Settings: General, Proxy, Certificates). Also renames the TLS collection settings label from "TLS" to "Certificates" to match the tab title.

### How did you verify your code works?

- Ran `bun test tests/unit/commands.test.ts tests/unit/SettingsView.test.tsx` — 66 pass.
- Updated unit tests cover the new command entries, section ordering, browse-mode exclusion, and the Certificates label.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [ ] `bun run lint` passes
- [ ] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR