### PR TITLE
fix(timeline): XML syntax highlighting in timeline detail view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,6 +380,8 @@ Active pane gets cyan border + `▸` prefix. Global keys work regardless of focu
 - `bun test` runs all tests. No external services needed.
 - Pure helpers in `tests/unit/`, integration tests in `tests/integration/`.
 - Tests use real filesystem I/O for filestore, lang, and env modules (write to temp dirs with `mkdtemp`).
+- Never use fixed delays (`setTimeout`, `Bun.sleep`, or equivalent) to wait for asynchronous test state. Await the real operation or use a state-based wait such as `waitFor`.
+- Before handing off any changed asynchronous test, run its file with `bun test <file> --rerun-each=50` and report the result.
 
 ## Subagents
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -266,6 +266,7 @@ export interface TimelineEntry {
     params: ParamEntry[]
     pathParams?: ParamEntry[]
     body?: string
+    bodyType?: BodyType
     bodyRef?: TimelineBodyRef
     bodyTruncated?: boolean
     auth?: Auth

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -9,13 +9,14 @@ import {
 } from "@opentui/core"
 import type { RefObject } from "react"
 import type { SendState } from "./sendState"
-import type {
-  NetworkError,
-  Response,
-  ResponseCookie,
-  TimelineEntry,
-} from "../schema"
-import { formatHeaders, formatBody, formatSize, statusColor } from "./format"
+import type { NetworkError, ResponseCookie, TimelineEntry } from "../schema"
+import {
+  bodyFiletype,
+  formatHeaders,
+  formatBody,
+  formatSize,
+  statusColor,
+} from "./format"
 import { Tabs, type TabDef } from "./Tabs"
 import { useTheme } from "./theme"
 import { RESPONSE_TAB_HINT_ORDER } from "./useJumpMode"
@@ -49,18 +50,6 @@ const TAB_DEFS: TabDef[] = [
   { id: "timeline", label: "Timeline" },
   { id: "cookies", label: "Cookies" },
 ]
-
-function responseBodyFiletype(response: Response): "json" | "xml" {
-  const contentType = Object.entries(response.headers).find(
-    ([name]) => name.toLowerCase() === "content-type",
-  )?.[1]
-  const mimeType = contentType?.split(";", 1)[0]?.trim().toLowerCase()
-  return mimeType === "application/xml" ||
-    mimeType === "text/xml" ||
-    mimeType?.endsWith("+xml")
-    ? "xml"
-    : "json"
-}
 
 function isDeletedCookie(cookie: ResponseCookie): boolean {
   if (cookie.expires === null) return false
@@ -455,7 +444,7 @@ export function ResponsePane({
     queryResult?.kind === "success"
       ? "json"
       : isDone
-        ? responseBodyFiletype(state.response)
+        ? bodyFiletype(state.response.headers)
         : "json"
 
   useEffect(() => {

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -1,4 +1,4 @@
-import type { Response } from "../schema"
+import type { BodyType, KvEntry, Response } from "../schema"
 import { formatJson } from "../lang/formatJson"
 import type { Theme } from "./theme"
 
@@ -37,6 +37,28 @@ export function formatBody(res: Response): string {
   const jsonParseError = formatJsonParseErrorBody(res.body)
   if (jsonParseError !== null) return jsonParseError
   return formatJson(res.body)
+}
+
+export function bodyFiletype(
+  headers: Record<string, string | KvEntry>,
+  bodyType?: BodyType,
+): "json" | "xml" {
+  const contentType = Object.entries(headers).find(
+    ([name]) => name.toLowerCase() === "content-type",
+  )?.[1]
+  const value =
+    typeof contentType === "string"
+      ? contentType
+      : contentType?.enabled
+        ? contentType.value
+        : undefined
+  const mimeType = value?.split(";", 1)[0]?.trim().toLowerCase()
+  return bodyType === "xml" ||
+    mimeType === "application/xml" ||
+    mimeType === "text/xml" ||
+    mimeType?.endsWith("+xml")
+    ? "xml"
+    : "json"
 }
 
 function formatJsonParseErrorBody(body: string): string | null {

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -8,9 +8,9 @@ import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
 import { Tabs, type TabDef } from "../Tabs"
 import { Badge } from "../Badge"
-import { formatSize, statusColor } from "../format"
+import { bodyFiletype, formatSize, statusColor } from "../format"
 import { methodColor } from "../formatRequest"
-import { JsonBodyViewer } from "../editor/JsonBodyViewer"
+import { CodeEditorRenderable } from "../editor/CodeEditor"
 import { HeaderTable } from "../HeaderTable"
 import { NetworkTab } from "../NetworkTab"
 import {
@@ -106,10 +106,11 @@ export function TimelineDetailOverlay({
     | "export"
     | null
   >(null)
-  const [highlightPriority, setHighlightPriority] = useState<"start" | "end">(
-    "start",
-  )
   const bodyScrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const bodyEditorRef = useRef<CodeEditorRenderable | null>(null)
+  const [bodyEditor, setBodyEditor] = useState<CodeEditorRenderable | null>(
+    null,
+  )
 
   const hasNetwork = (entry?.network?.length ?? 0) > 0
   const tabs = hasNetwork
@@ -174,8 +175,8 @@ export function TimelineDetailOverlay({
     setBodyError(null)
     setLoading(false)
     setShowLargeBody(false)
-    setHighlightPriority("start")
     bodyScrollRef.current?.scrollTo(0)
+    bodyEditorRef.current?.scrollTo(0)
   }, [visible, entry])
 
   useEffect(() => {
@@ -205,8 +206,8 @@ export function TimelineDetailOverlay({
   }, [loadedBody, info?.body, isLarge])
 
   useEffect(() => {
-    setHighlightPriority("start")
     bodyScrollRef.current?.scrollTo(0)
+    bodyEditorRef.current?.scrollTo(0)
   }, [renderedBody])
 
   useEffect(() => {
@@ -229,22 +230,31 @@ export function TimelineDetailOverlay({
         else if (key.name === "h") copyHeaders()
         else if (key.name === "b") copyBody()
         else if (key.name === "e") exportBody()
-        else if (key.name === "up") bodyScrollRef.current?.scrollBy(-1)
-        else if (key.name === "down") bodyScrollRef.current?.scrollBy(1)
-        else if (key.name === "pageup")
-          bodyScrollRef.current?.scrollBy(-1, "viewport")
-        else if (key.name === "pagedown")
-          bodyScrollRef.current?.scrollBy(1, "viewport")
-        else if (key.name === "home") {
-          setHighlightPriority("start")
-          bodyScrollRef.current?.scrollTo(0)
+        else if (key.name === "up") {
+          if (activeTab === "network") bodyScrollRef.current?.scrollBy(-1)
+          else bodyEditorRef.current?.scrollBy(-1)
+        } else if (key.name === "down") {
+          if (activeTab === "network") bodyScrollRef.current?.scrollBy(1)
+          else bodyEditorRef.current?.scrollBy(1)
+        } else if (key.name === "pageup") {
+          if (activeTab === "network")
+            bodyScrollRef.current?.scrollBy(-1, "viewport")
+          else bodyEditorRef.current?.scrollByViewport(-1)
+        } else if (key.name === "pagedown") {
+          if (activeTab === "network")
+            bodyScrollRef.current?.scrollBy(1, "viewport")
+          else bodyEditorRef.current?.scrollByViewport(1)
+        } else if (key.name === "home") {
+          if (activeTab === "network") bodyScrollRef.current?.scrollTo(0)
+          else bodyEditorRef.current?.scrollTo(0)
         } else if (key.name === "end") {
-          setHighlightPriority("end")
-          const bodyScroll = bodyScrollRef.current
-          if (bodyScroll)
-            bodyScroll.scrollTo(
-              Math.max(0, bodyScroll.scrollHeight - bodyScroll.height),
-            )
+          if (activeTab === "network") {
+            const bodyScroll = bodyScrollRef.current
+            if (bodyScroll)
+              bodyScroll.scrollTo(
+                Math.max(0, bodyScroll.scrollHeight - bodyScroll.height),
+              )
+          } else bodyEditorRef.current?.scrollTo(Number.MAX_SAFE_INTEGER)
         }
       },
       { priority: 100 },
@@ -279,6 +289,10 @@ export function TimelineDetailOverlay({
         .map(([key, value]) => ({ key, value }))
     : []
   const headers = activeTab === "request" ? requestHeaders : responseHeaders
+  const renderedBodyFiletype =
+    activeTab === "request"
+      ? bodyFiletype(entry.request.headers, entry.request.bodyType)
+      : bodyFiletype(entry.response?.headers ?? {})
   const headerHeight = 5
 
   return (
@@ -482,33 +496,60 @@ export function TimelineDetailOverlay({
                   </box>
                 </box>
               ) : renderedBody ? (
-                <scrollbox
-                  ref={bodyScrollRef}
-                  scrollY
+                <box
                   onMouseScroll={(event) => {
                     const direction = event.scroll?.direction
                     if (!direction) return
                     const amount = event.scroll?.delta || 1
-                    bodyScrollRef.current?.scrollBy(
+                    bodyEditorRef.current?.scrollBy(
                       (direction === "up" ? -1 : 1) * amount,
                     )
                     event.preventDefault()
                     event.stopPropagation()
                   }}
-                  verticalScrollbarOptions={{
-                    trackOptions: {
+                  style={{
+                    flexDirection: "row",
+                    flexGrow: 1,
+                    flexBasis: 0,
+                    minHeight: 0,
+                  }}
+                >
+                  <line-number
+                    minWidth={3}
+                    paddingRight={1}
+                    fg={theme.textMuted}
+                    bg={theme.backgroundPanel}
+                    style={{ flexGrow: 1, minHeight: 0, minWidth: 0 }}
+                  >
+                    <code-editor
+                      id="timeline-body-editor"
+                      ref={(editor) => {
+                        bodyEditorRef.current = editor
+                        setBodyEditor(editor)
+                      }}
+                      filetype={renderedBodyFiletype}
+                      theme={theme}
+                      value={renderedBody}
+                      readOnly
+                      foldable={false}
+                      backgroundColor={theme.backgroundPanel}
+                      focusedBackgroundColor={theme.backgroundPanel}
+                      textColor={theme.text}
+                      focusedTextColor={theme.text}
+                      cursorColor={theme.primary}
+                      scrollMargin={0}
+                      style={{ flexGrow: 1, minHeight: 0 }}
+                    />
+                  </line-number>
+                  <code-editor-scrollbar
+                    target={bodyEditor}
+                    trackOptions={{
                       backgroundColor: theme.background,
                       foregroundColor: theme.borderActive,
-                    },
-                  }}
-                  style={{ flexGrow: 1, flexBasis: 0, minHeight: 0 }}
-                >
-                  <JsonBodyViewer
-                    body={renderedBody}
-                    theme={theme}
-                    highlightPriority={highlightPriority}
+                    }}
+                    style={{ width: 1, flexShrink: 0, zIndex: 1 }}
                   />
-                </scrollbox>
+                </box>
               ) : (
                 <text fg={theme.textMuted}>
                   {entry.response ? "(empty body)" : "No response"}

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -111,6 +111,13 @@ export function TimelineDetailOverlay({
   const [bodyEditor, setBodyEditor] = useState<CodeEditorRenderable | null>(
     null,
   )
+  const setBodyEditorRef = useCallback(
+    (editor: CodeEditorRenderable | null) => {
+      bodyEditorRef.current = editor
+      setBodyEditor(editor)
+    },
+    [],
+  )
 
   const hasNetwork = (entry?.network?.length ?? 0) > 0
   const tabs = hasNetwork
@@ -523,10 +530,7 @@ export function TimelineDetailOverlay({
                   >
                     <code-editor
                       id="timeline-body-editor"
-                      ref={(editor) => {
-                        bodyEditorRef.current = editor
-                        setBodyEditor(editor)
-                      }}
+                      ref={setBodyEditorRef}
                       filetype={renderedBodyFiletype}
                       theme={theme}
                       value={renderedBody}

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -198,6 +198,7 @@ export function buildTimelineEntry(
         req.body === undefined
           ? undefined
           : redact(resolvePublicVars(req.body)),
+      bodyType: req.bodyType,
       auth: redactAuth(req.auth),
     },
     response:

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -652,9 +652,10 @@ describe("buildTimelineEntry", () => {
       name: "Test",
       method: "POST" as const,
       url: "https://api.example.com",
-      headers: { "content-type": { value: "application/json", enabled: true } },
+      headers: { "content-type": { value: "application/xml", enabled: true } },
       params: [],
-      body: '{"key":"val"}',
+      body: "<key>val</key>",
+      bodyType: "xml" as const,
       auth: undefined,
       timeout: 0,
     }
@@ -673,6 +674,7 @@ describe("buildTimelineEntry", () => {
     const entry = buildTimelineEntry(req, result, "dev")
     expect(entry.request.method).toBe("POST")
     expect(entry.request.url).toBe("https://api.example.com")
+    expect(entry.request.bodyType).toBe("xml")
     expect(entry.response?.status).toBe(201)
     expect(entry.response?.timeMs).toBe(42)
     expect(entry.response?.size).toBe(0)

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test"
 import { act, useState, type ComponentProps } from "react"
+import { extend } from "@opentui/react"
 import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
+import { addDefaultParsers } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider } from "../../src/ui/theme"
 import {
@@ -9,7 +11,18 @@ import {
   formatHeaderEntries,
 } from "../../src/ui/overlays/TimelineDetailOverlay"
 import type { TimelineEntry } from "../../src/schema"
-import { setupKeymap } from "./_helpers"
+import { getHighlightCount, setupKeymap } from "./_helpers"
+import {
+  CodeEditorRenderable,
+  CodeEditorScrollBarRenderable,
+} from "../../src/ui/editor/CodeEditor"
+import { codeEditorParsers } from "../../src/ui/editor/codeEditorParsers"
+
+extend({
+  "code-editor": CodeEditorRenderable,
+  "code-editor-scrollbar": CodeEditorScrollBarRenderable,
+})
+addDefaultParsers([...codeEditorParsers])
 
 const testRender = createTestRender()
 
@@ -72,6 +85,53 @@ async function renderOverlay(
 }
 
 describe("TimelineDetailOverlay", () => {
+  it("uses XML highlighting for XML request and response bodies", async () => {
+    const { renderer, renderOnce, host, cleanup } = await renderOverlay(
+      makeEntry({
+        request: {
+          id: "request-1",
+          name: "XML request",
+          method: "POST",
+          url: "https://example.com",
+          headers: {
+            "Content-Type": { value: "application/xml", enabled: true },
+          },
+          params: [],
+          body: "<request><value>ok</value></request>",
+        },
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/soap+xml" },
+          body: "<response><value>ok</value></response>",
+          timeMs: 12,
+          size: 39,
+        },
+      }),
+      () => {},
+    )
+
+    await renderOnce()
+    const requestEditor = renderer.root.findDescendantById(
+      "timeline-body-editor",
+    ) as CodeEditorRenderable
+    expect(requestEditor.filetype).toBe("xml")
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    await renderOnce()
+    expect(getHighlightCount(requestEditor)).toBeGreaterThan(0)
+
+    await act(async () => host.press("right"))
+    await renderOnce()
+    const responseEditor = renderer.root.findDescendantById(
+      "timeline-body-editor",
+    ) as CodeEditorRenderable
+    expect(responseEditor.filetype).toBe("xml")
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    await renderOnce()
+    expect(getHighlightCount(responseEditor)).toBeGreaterThan(0)
+    cleanup()
+  })
+
   it("renders response details", async () => {
     const { renderOnce, captureCharFrame, host, cleanup } = await renderOverlay(
       makeEntry({

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -116,8 +116,7 @@ describe("TimelineDetailOverlay", () => {
       "timeline-body-editor",
     ) as CodeEditorRenderable
     expect(requestEditor.filetype).toBe("xml")
-    await new Promise((resolve) => setTimeout(resolve, 30))
-    await renderOnce()
+    await requestEditor.refreshHighlights()
     expect(getHighlightCount(requestEditor)).toBeGreaterThan(0)
 
     await act(async () => host.press("right"))
@@ -126,8 +125,7 @@ describe("TimelineDetailOverlay", () => {
       "timeline-body-editor",
     ) as CodeEditorRenderable
     expect(responseEditor.filetype).toBe("xml")
-    await new Promise((resolve) => setTimeout(resolve, 30))
-    await renderOnce()
+    await responseEditor.refreshHighlights()
     expect(getHighlightCount(responseEditor)).toBeGreaterThan(0)
     cleanup()
   })


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The timeline detail view rendered request/response bodies through `JsonBodyViewer`, which mangled XML content. This PR switches it to the `CodeEditorRenderable` and highlights XML bodies as XML instead of JSON.

It also:
- persists `bodyType` on timeline request snapshots so request bodies are detected as XML even without a `Content-Type` header
- extracts `responseBodyFiletype` into a shared `bodyFiletype(headers, bodyType)` helper in `format.ts`, now used by both `ResponsePane` and the timeline overlay
- reworks the timeline body scroll keybindings and mouse scroll to drive the code editor instead of the old scrollbox

### How did you verify your code works?

- Added a unit test in `tests/unit/TimelineDetailOverlay.test.tsx` asserting XML filetype detection and actual syntax highlighting for both request and response bodies
- Updated `tests/timeline-format.test.ts` to cover `bodyType` persistence
- Ran `bun test tests/timeline-format.test.ts tests/unit/TimelineDetailOverlay.test.tsx` (82 pass, 0 fail)

### Screenshots / recordings

<!-- If this is a UI change, include a screenshot or recording. -->

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added syntax-aware viewing for XML and JSON request and response bodies.
  - XML and SOAP responses now receive appropriate syntax highlighting in timeline details.
  - Added improved scrolling and keyboard navigation within formatted response content.

- **Bug Fixes**
  - Body formatting now correctly recognizes explicit body types and structured content-type headers.
  - Timeline entries now preserve the request body format for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->