### PR TITLE
feat: detect and launch external editors for collection and settings folders

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path"
 import * as yaml from "js-yaml"
 import type { AppProxySettings } from "../schema"
 import { parseAppProxyStrict } from "../proxy"
+import { isExternalEditorId, type ExternalEditorId } from "../externalEditor"
 
 export const CONFIG_FILE_NAME = "config.yml"
 export interface NoodleConfig {
@@ -10,6 +11,7 @@ export interface NoodleConfig {
   layout: "stacked" | "side-by-side"
   confirm_undo_all: boolean
   collections: string[]
+  external_editor?: ExternalEditorId
   proxy?: AppProxySettings
 }
 export const DEFAULT_CONFIG: NoodleConfig = {
@@ -75,6 +77,9 @@ export function loadConfig(configDir: string): NoodleConfig {
     collections: Array.isArray(obj.collections)
       ? obj.collections.filter((v): v is string => typeof v === "string")
       : [],
+    ...(isExternalEditorId(obj.external_editor)
+      ? { external_editor: obj.external_editor }
+      : {}),
     proxy: obj.proxy === undefined ? undefined : parseAppProxyStrict(obj.proxy),
   })
 }

--- a/src/externalEditor.ts
+++ b/src/externalEditor.ts
@@ -1,0 +1,113 @@
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const EDITORS = [
+  { id: "zed", label: "Zed", command: "zed", macApp: "Zed.app" },
+  {
+    id: "vscode",
+    label: "Visual Studio Code",
+    command: "code",
+    macApp: "Visual Studio Code.app",
+  },
+  {
+    id: "sublime",
+    label: "Sublime Text",
+    command: "subl",
+    macApp: "Sublime Text.app",
+  },
+  { id: "cursor", label: "Cursor", command: "cursor", macApp: "Cursor.app" },
+  {
+    id: "windsurf",
+    label: "Windsurf",
+    command: "windsurf",
+    macApp: "Windsurf.app",
+  },
+  {
+    id: "vscodium",
+    label: "VSCodium",
+    command: "codium",
+    macApp: "VSCodium.app",
+  },
+] as const
+
+export type ExternalEditorId = (typeof EDITORS)[number]["id"]
+
+export interface ExternalEditor {
+  id: ExternalEditorId
+  label: string
+  command: string[]
+}
+
+export function isExternalEditorId(value: unknown): value is ExternalEditorId {
+  return EDITORS.some((editor) => editor.id === value)
+}
+
+export function detectExternalEditors({
+  platform = process.platform,
+  homeDir = homedir(),
+  which = Bun.which,
+  exists = existsSync,
+}: {
+  platform?: NodeJS.Platform
+  homeDir?: string
+  which?: (command: string) => string | null
+  exists?: (path: string) => boolean
+} = {}): ExternalEditor[] {
+  return EDITORS.flatMap((editor) => {
+    const executable = which(editor.command)
+    if (executable) {
+      return [{ id: editor.id, label: editor.label, command: [executable] }]
+    }
+    if (platform !== "darwin") return []
+
+    const appPath = [
+      join("/Applications", editor.macApp),
+      join(homeDir, "Applications", editor.macApp),
+    ].find(exists)
+    return appPath
+      ? [
+          {
+            id: editor.id,
+            label: editor.label,
+            command: ["open", "-a", appPath],
+          },
+        ]
+      : []
+  })
+}
+
+export function resolveExternalEditor(
+  preferred: ExternalEditorId | undefined,
+  installed: ExternalEditor[],
+): ExternalEditor | undefined {
+  return installed.find((editor) => editor.id === preferred) ?? installed[0]
+}
+
+export function launchExternalEditor(
+  editor: ExternalEditor,
+  target: string,
+  spawn: (
+    command: string[],
+    options: { stdin: "ignore"; stdout: "ignore"; stderr: "ignore" },
+  ) => { exited: Promise<number> } = (command, options) =>
+    Bun.spawn(command, options),
+): Promise<void> {
+  let processHandle: { exited: Promise<number> }
+  try {
+    processHandle = spawn([...editor.command, target], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    })
+  } catch (error) {
+    throw new Error(`Unable to open folder in ${editor.label}`, {
+      cause: error,
+    })
+  }
+  return processHandle.exited.then((exitCode) => {
+    if (exitCode !== 0) {
+      throw new Error(`Unable to open folder in ${editor.label}`)
+    }
+  })
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -50,6 +50,11 @@ import {
   setCollectionSettingSecret,
   type SecretMutation,
 } from "../secrets"
+import {
+  detectExternalEditors,
+  resolveExternalEditor,
+  type ExternalEditorId,
+} from "../externalEditor"
 
 const CONFIG_DIR = `${process.env.HOME ?? "~"}/.config/noodle`
 
@@ -164,6 +169,11 @@ export function App({
   mode?: CollectionMode
 }) {
   const { config, updateConfig } = useConfig(CONFIG_DIR)
+  const externalEditors = useMemo(() => detectExternalEditors(), [])
+  const externalEditor = resolveExternalEditor(
+    config.external_editor,
+    externalEditors,
+  )
   const collectionPaths = config.collections
   const [liveKeybinds, setLiveKeybinds] = useState(keybinds)
   const switchingRef = useRef(false)
@@ -333,6 +343,16 @@ export function App({
       updateGlobalConfig(
         { confirm_undo_all: value },
         "Failed to save behavior settings",
+      )
+    },
+    [updateGlobalConfig],
+  )
+
+  const handleExternalEditorChange = useCallback(
+    (externalEditor: ExternalEditorId) => {
+      updateGlobalConfig(
+        { external_editor: externalEditor },
+        "Failed to save external editor",
       )
     },
     [updateGlobalConfig],
@@ -994,6 +1014,7 @@ export function App({
     <ThemeProvider activeIndex={activeIndex} previewIndex={previewIndex}>
       <Toast />
       <AppInner
+        appConfigDir={CONFIG_DIR}
         key={`${activeCollectionDir}__${reloadKey}__${mode}`}
         collectionDir={activeCollectionDir}
         environmentsDir={activeEnvironmentsDir}
@@ -1015,6 +1036,9 @@ export function App({
         initialLayout={config.layout}
         confirmUndoAll={config.confirm_undo_all}
         onConfirmUndoAllChange={handleConfirmUndoAllChange}
+        externalEditors={externalEditors}
+        externalEditor={externalEditor}
+        onExternalEditorChange={handleExternalEditorChange}
         onLayoutChange={handleLayoutChange}
         onEnvChange={handleEnvChange}
         onEnvListChanged={handleEnvListChanged}

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -114,8 +114,10 @@ import {
   type CollectionImportValues,
 } from "./collectionImport"
 import { extractFileErrors } from "../filestore/load"
+import type { ExternalEditor, ExternalEditorId } from "../externalEditor"
 
 export function AppInner({
+  appConfigDir,
   collectionDir,
   environmentsDir,
   envNames,
@@ -136,6 +138,9 @@ export function AppInner({
   initialLayout,
   confirmUndoAll,
   onConfirmUndoAllChange,
+  externalEditors,
+  externalEditor,
+  onExternalEditorChange,
   onLayoutChange,
   onEnvChange,
   onEnvListChanged,
@@ -173,6 +178,7 @@ export function AppInner({
   onCollectionImported,
   mode = "empty",
 }: {
+  appConfigDir: string
   collectionDir: string
   environmentsDir: string
   envNames: string[]
@@ -195,6 +201,9 @@ export function AppInner({
   initialLayout: "stacked" | "side-by-side"
   confirmUndoAll: boolean
   onConfirmUndoAllChange: (value: boolean) => void
+  externalEditors: ExternalEditor[]
+  externalEditor?: ExternalEditor
+  onExternalEditorChange: (editor: ExternalEditorId) => void
   onLayoutChange: (layout: "stacked" | "side-by-side") => boolean
   onEnvChange: (name: string | null) => void
   onEnvListChanged: () => Promise<void>
@@ -1437,6 +1446,8 @@ export function AppInner({
       buildCommandPaletteCommands({
         keybinds,
         collectionDir,
+        appConfigDir,
+        externalEditor,
         confirmUndoAll,
         renderer,
         proxyPolicy,
@@ -1495,6 +1506,8 @@ export function AppInner({
     [
       keybinds,
       collectionDir,
+      appConfigDir,
+      externalEditor,
       confirmUndoAll,
       onLayoutChange,
       setCollectionSwitcherVisible,
@@ -1677,6 +1690,8 @@ export function AppInner({
             activeThemeIndex={activeIndex}
             layout={layout}
             confirmUndoAll={confirmUndoAll}
+            externalEditors={externalEditors}
+            externalEditor={externalEditor}
             appProxy={appProxy}
             appProxyCredentials={appProxyCredentials}
             collectionProxy={collectionProxy}
@@ -1709,6 +1724,7 @@ export function AppInner({
               return true
             }}
             onConfirmUndoAllChange={onConfirmUndoAllChange}
+            onExternalEditorChange={onExternalEditorChange}
             onAppProxyChange={onAppProxyChange}
             onCollectionProxyChange={onCollectionProxyChange}
             onAppProxyCredentialsChange={onAppProxyCredentialsChange}

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path"
+import { mkdirSync } from "node:fs"
 import type { RefObject } from "react"
 import type { CliRenderer } from "@opentui/core"
 import type { Focus } from "./focus"
@@ -23,6 +24,7 @@ import type { ProxyPolicy } from "../proxy"
 import type { TlsPolicy } from "../tls"
 import type { SendState } from "./sendState"
 import type { ResponseQueryController } from "./responseQuery"
+import { launchExternalEditor, type ExternalEditor } from "../externalEditor"
 
 export interface CommandActionsConfig {
   collectionDir: string
@@ -425,6 +427,58 @@ export function openThemePicker(): boolean {
 
 export function openAbout(): boolean {
   return true
+}
+
+type EditorLauncher = typeof launchExternalEditor
+
+function openFolderInEditor(
+  editor: ExternalEditor | undefined,
+  target: string,
+  launch: EditorLauncher,
+): boolean {
+  if (!editor) {
+    showToast("No supported external editor found", "warning")
+    return false
+  }
+  try {
+    void launch(editor, target)
+      .then(() => showToast(`Opened folder in ${editor.label}`, "success"))
+      .catch((error: unknown) =>
+        showToast(
+          error instanceof Error ? error.message : String(error),
+          "error",
+        ),
+      )
+    return true
+  } catch (error) {
+    showToast(error instanceof Error ? error.message : String(error), "error")
+    return false
+  }
+}
+
+export function openCollectionInEditor(
+  editor: ExternalEditor | undefined,
+  collectionDir: string,
+  launch: EditorLauncher = launchExternalEditor,
+): boolean {
+  return openFolderInEditor(editor, collectionDir, launch)
+}
+
+export function openAppSettingsInEditor(
+  editor: ExternalEditor | undefined,
+  configDir: string,
+  launch: EditorLauncher = launchExternalEditor,
+  ensureDir: (path: string) => void = (path) =>
+    mkdirSync(path, { recursive: true }),
+): boolean {
+  if (!editor) return openFolderInEditor(editor, configDir, launch)
+  try {
+    ensureDir(configDir)
+  } catch (error) {
+    showToast(error instanceof Error ? error.message : String(error), "error")
+    return false
+  }
+  return openFolderInEditor(editor, configDir, launch)
 }
 
 export function openCollectionExport(

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -21,6 +21,7 @@ import type { ResponseQueryController } from "./responseQuery"
 import type { ProxyPolicy } from "../proxy"
 import type { TlsPolicy } from "../tls"
 import type { CollectionMode } from "../collectionPath"
+import type { ExternalEditor } from "../externalEditor"
 import {
   saveRequest,
   saveFolder,
@@ -53,6 +54,8 @@ import {
   openCollectionImport,
   openCollectionSwitcher,
   openSettings,
+  openCollectionInEditor,
+  openAppSettingsInEditor,
   type CommandActionsConfig,
 } from "./commandActions"
 
@@ -61,6 +64,8 @@ export type CommandPaletteTarget = "request" | "folder" | "environment"
 export interface CommandBuilderContext {
   keybinds: Keybinds
   collectionDir: string
+  appConfigDir: string
+  externalEditor?: ExternalEditor
   confirmUndoAll: boolean
   renderer: CliRenderer
   proxyPolicy?: ProxyPolicy
@@ -594,7 +599,22 @@ export function buildCommandPaletteCommands(
     ...(mode === "collection" ? collectionSettingsCommands : []),
   ]
 
+  const externalEditorCommands: CommandItem[] = [
+    {
+      id: "collection.open-in-editor",
+      label: "Open Collection in Editor",
+      section: "Workspace",
+      run: () => openCollectionInEditor(ctx.externalEditor, ctx.collectionDir),
+    },
+  ]
+
   const systemCommands: CommandItem[] = [
+    {
+      id: "app.settings-folder-open-in-editor",
+      label: "Open Settings in Editor",
+      section: "System",
+      run: () => openAppSettingsInEditor(ctx.externalEditor, ctx.appConfigDir),
+    },
     {
       id: "app.settings-open",
       label: "Open Settings",
@@ -720,21 +740,25 @@ export function buildCommandPaletteCommands(
     return [
       ...(mode === "collection" ? editorEnvCommands : readOnlyCommands),
       ...(mode === "collection" ? workspaceCommands : []),
+      ...externalEditorCommands,
       ...settingsCommands,
       ...globalCommands,
       ...systemCommands,
     ]
   }
 
-  if (view === "cookie-jar") return [...settingsCommands, ...systemCommands]
+  if (view === "cookie-jar")
+    return [...externalEditorCommands, ...settingsCommands, ...systemCommands]
 
-  if (view === "settings") return [...settingsCommands, ...systemCommands]
+  if (view === "settings")
+    return [...externalEditorCommands, ...settingsCommands, ...systemCommands]
 
   return [
     ...(mode === "collection" ? visibleRequestCommands : []),
     ...(mode === "collection" ? mainEnvCommands : []),
     ...(mode === "collection" ? workspaceCommands : readOnlyCommands),
     ...mainOnlyCommands,
+    ...externalEditorCommands,
     ...settingsCommands,
     ...globalCommands,
     ...systemCommands,

--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -45,6 +45,7 @@ import { ProxySettingsForm } from "./ProxySettingsForm"
 import { SettingsField } from "./SettingsField"
 import { TlsSettingsForm } from "./TlsSettingsForm"
 import { moveRegisteredCollection } from "./collectionRegistry"
+import type { ExternalEditor, ExternalEditorId } from "../../externalEditor"
 
 export type SettingsScope = "global" | "collection"
 export type GlobalSettingsCategory =
@@ -107,6 +108,8 @@ export function SettingsView({
   activeThemeIndex,
   layout,
   confirmUndoAll,
+  externalEditors = [],
+  externalEditor,
   appProxy,
   appProxyCredentials = {},
   collectionProxy,
@@ -131,6 +134,7 @@ export function SettingsView({
   onThemeChange,
   onLayoutChange,
   onConfirmUndoAllChange,
+  onExternalEditorChange = () => {},
   onAppProxyChange,
   onCollectionProxyChange,
   onAppProxyCredentialsChange = async () => false,
@@ -153,6 +157,8 @@ export function SettingsView({
   activeThemeIndex: number
   layout: "stacked" | "side-by-side"
   confirmUndoAll: boolean
+  externalEditors?: ExternalEditor[]
+  externalEditor?: ExternalEditor
   appProxy?: AppProxySettings
   appProxyCredentials?: ProxyCredentials
   collectionProxy?: CollectionProxySettings
@@ -177,6 +183,7 @@ export function SettingsView({
   onThemeChange: (index: number) => void
   onLayoutChange: (layout: "stacked" | "side-by-side") => boolean
   onConfirmUndoAllChange: (value: boolean) => void
+  onExternalEditorChange?: (editor: ExternalEditorId) => void
   onAppProxyChange: (proxy: AppProxySettings) => boolean
   onCollectionProxyChange: (proxy: CollectionProxySettings) => boolean
   onAppProxyCredentialsChange?: (
@@ -634,7 +641,8 @@ export function SettingsView({
           return
         }
 
-        const fieldCount = category === "appearance" ? 2 : 1
+        const fieldCount =
+          category === "appearance" || category === "behavior" ? 2 : 1
         if (["up", "down", "home", "end"].includes(event.name)) {
           event.preventDefault()
           event.stopPropagation()
@@ -658,7 +666,11 @@ export function SettingsView({
           } else {
             setContentIndex(next)
           }
-        } else if (event.name === "space" && category === "behavior") {
+        } else if (
+          event.name === "space" &&
+          category === "behavior" &&
+          contentIndex === 0
+        ) {
           event.preventDefault()
           event.stopPropagation()
           onConfirmUndoAllChange(!confirmUndoAll)
@@ -874,7 +886,7 @@ export function SettingsView({
               <>
                 <SettingsSectionHeader
                   title="Behavior"
-                  description="Control confirmation prompts for destructive changes."
+                  description="Control confirmation prompts and external tools."
                 />
                 <SettingLabel
                   title="Confirm undo all"
@@ -886,6 +898,29 @@ export function SettingsView({
                   }}
                 >
                   <Checkbox checked={confirmUndoAll} theme={theme} />
+                </SettingLabel>
+                <SettingLabel
+                  id="settings-behavior-external-editor"
+                  title="External editor"
+                  description="Editor used to open collection and application settings folders."
+                  active={focus === "settings-content" && contentIndex === 1}
+                >
+                  <Select
+                    items={externalEditors.map((editor) => ({
+                      id: editor.id,
+                      label: editor.label,
+                    }))}
+                    value={externalEditor?.id}
+                    placeholder="No supported editors found"
+                    fitContent
+                    interactive={externalEditors.length > 0}
+                    focused={focus === "settings-content" && contentIndex === 1}
+                    onActivate={() => setContentIndex(1)}
+                    onOpenChange={setSelectOpen}
+                    onChange={(value) =>
+                      onExternalEditorChange(value as ExternalEditorId)
+                    }
+                  />
                 </SettingLabel>
               </>
             )}

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -25,6 +25,7 @@ import {
   type SettingsScope,
 } from "../../src/ui/settings/SettingsView"
 import { SIDEBAR_WIDTH } from "../../src/ui/Sidebar"
+import type { ExternalEditor, ExternalEditorId } from "../../src/externalEditor"
 
 const testRender = createTestRender()
 
@@ -56,6 +57,9 @@ function Harness({
   onKeybindChange = () => true,
   onCollectionSettingsChange = () => true,
   onThemeChange = () => {},
+  externalEditors = [],
+  externalEditor,
+  onExternalEditorChange = () => {},
   appProxy = { mode: "system" },
   initialCollectionSettings = {},
 }: {
@@ -75,6 +79,9 @@ function Harness({
     >,
   ) => boolean
   onThemeChange?: (index: number) => void
+  externalEditors?: ExternalEditor[]
+  externalEditor?: ExternalEditor
+  onExternalEditorChange?: (editor: ExternalEditorId) => void
   appProxy?: AppProxySettings
   initialCollectionSettings?: CollectionSettings
 }) {
@@ -93,6 +100,8 @@ function Harness({
       activeThemeIndex={0}
       layout="stacked"
       confirmUndoAll
+      externalEditors={externalEditors}
+      externalEditor={externalEditor}
       appProxy={appProxy}
       appProxyCredentials={{ username: "alice", password: "secret" }}
       collectionProxy={{ mode: "inherit" }}
@@ -118,6 +127,7 @@ function Harness({
       onThemeChange={onThemeChange}
       onLayoutChange={() => true}
       onConfirmUndoAllChange={() => {}}
+      onExternalEditorChange={onExternalEditorChange}
       onAppProxyChange={() => true}
       onCollectionProxyChange={() => true}
       onCollectionSettingsChange={(patch) => {
@@ -292,6 +302,40 @@ describe("SettingsView", () => {
     await renderOnce()
     await act(async () => host.press("down"))
     expect(captureCharFrame()).toContain("Confirm undo all")
+    expect(captureCharFrame()).toContain("No supported editors found")
+    cleanup()
+  })
+
+  it("selects from installed external editors in Behavior settings", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const editors: ExternalEditor[] = [
+      { id: "zed", label: "Zed", command: ["zed"] },
+      { id: "vscode", label: "Visual Studio Code", command: ["code"] },
+    ]
+    const selected: ExternalEditorId[] = []
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Harness
+            initialCategory="behavior"
+            initialFocus="settings-content"
+            externalEditors={editors}
+            externalEditor={editors[0]}
+            onExternalEditorChange={(editor) => selected.push(editor)}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 90, height: 22 },
+    )
+    await renderOnce()
+    expect(captureCharFrame()).toContain("External editor")
+    expect(captureCharFrame()).toContain("Zed")
+
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    await act(async () => host.press("down"))
+    await act(async () => host.press("return"))
+    expect(selected).toEqual(["vscode"])
     cleanup()
   })
 

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -12,17 +12,21 @@ import {
   copyOAuth2Token,
   fetchOAuth2Token,
   getEditRequestYamlFile,
+  openAppSettingsInEditor,
+  openCollectionInEditor,
   saveFolder,
   saveRequest,
   sendRequest,
   undoAll,
 } from "../../src/ui/commandActions"
+import type { ExternalEditor } from "../../src/externalEditor"
 
 function minimalContext(): CommandBuilderContext {
   const keybinds = bindingDefaults()
   return {
     keybinds,
     collectionDir: "/tmp/collections",
+    appConfigDir: "/tmp/noodle-config",
     confirmUndoAll: false,
     renderer: { copyToClipboardOSC52: () => {} } as unknown as CliRenderer,
     trySendRef: { current: undefined } as never,
@@ -79,6 +83,49 @@ function minimalContext(): CommandBuilderContext {
 }
 
 describe("buildCommandPaletteCommands", () => {
+  it("opens collection and app settings folders in the selected editor", () => {
+    const editor: ExternalEditor = {
+      id: "zed",
+      label: "Zed",
+      command: ["zed"],
+    }
+    const opened: string[] = []
+    const launch = (_editor: ExternalEditor, path: string) => {
+      opened.push(path)
+      return Promise.resolve()
+    }
+
+    expect(openCollectionInEditor(editor, "/tmp/collection", launch)).toBe(true)
+    expect(
+      openAppSettingsInEditor(editor, "/tmp/noodle-config", launch, () => {}),
+    ).toBe(true)
+    expect(opened).toEqual(["/tmp/collection", "/tmp/noodle-config"])
+    expect(
+      openCollectionInEditor(editor, "/tmp/collection", () => {
+        throw new Error("Unable to launch")
+      }),
+    ).toBe(false)
+  })
+
+  it("keeps editor commands visible when no editor is installed", () => {
+    for (const view of ["main", "env-editor", "cookie-jar", "settings"]) {
+      const ctx = minimalContext()
+      ctx.getView = () => view
+      const commands = buildCommandPaletteCommands(ctx)
+      const collection = commands.find(
+        (command) => command.id === "collection.open-in-editor",
+      )
+      const settings = commands.find(
+        (command) => command.id === "app.settings-folder-open-in-editor",
+      )
+
+      expect(collection?.section).toBe("Workspace")
+      expect(settings?.section).toBe("System")
+      expect(collection?.run()).toBe(false)
+      expect(settings?.run()).toBe(false)
+    }
+  })
+
   it("keeps collection export open while an export is pending", () => {
     let visible = true
     const setVisible = (value: boolean) => {

--- a/tests/unit/externalEditor.test.ts
+++ b/tests/unit/externalEditor.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test"
+import {
+  detectExternalEditors,
+  launchExternalEditor,
+  resolveExternalEditor,
+  type ExternalEditor,
+} from "../../src/externalEditor"
+
+describe("external editors", () => {
+  it("detects launchers in priority order", () => {
+    const editors = detectExternalEditors({
+      platform: "linux",
+      which: (command) =>
+        command === "zed" || command === "code" ? `/bin/${command}` : null,
+    })
+
+    expect(editors.map((editor) => editor.id)).toEqual(["zed", "vscode"])
+    expect(editors[1]?.command).toEqual(["/bin/code"])
+  })
+
+  it("detects macOS application bundles without CLI launchers", () => {
+    const editors = detectExternalEditors({
+      platform: "darwin",
+      homeDir: "/Users/test",
+      which: () => null,
+      exists: (path) => path === "/Applications/Zed.app",
+    })
+
+    expect(editors).toEqual([
+      {
+        id: "zed",
+        label: "Zed",
+        command: ["open", "-a", "/Applications/Zed.app"],
+      },
+    ])
+  })
+
+  it("falls back to the first installed editor", () => {
+    const installed = detectExternalEditors({
+      platform: "linux",
+      which: (command) => (command === "code" ? "/bin/code" : null),
+    })
+
+    expect(resolveExternalEditor("zed", installed)?.id).toBe("vscode")
+  })
+
+  it("launches a folder as one argument and reports failures", async () => {
+    const editor: ExternalEditor = {
+      id: "zed",
+      label: "Zed",
+      command: ["/bin/zed"],
+    }
+    let command: string[] = []
+    await launchExternalEditor(editor, "/tmp/folder with spaces", (args) => {
+      command = args
+      return { exited: Promise.resolve(0) }
+    })
+    expect(command).toEqual(["/bin/zed", "/tmp/folder with spaces"])
+
+    expect(
+      launchExternalEditor(editor, "/tmp/folder", () => ({
+        exited: Promise.resolve(1),
+      })),
+    ).rejects.toThrow("Unable to open folder in Zed")
+    expect(() =>
+      launchExternalEditor(editor, "/tmp/folder", () => {
+        throw new Error("spawn failed")
+      }),
+    ).toThrow("Unable to open folder in Zed")
+  })
+})

--- a/tests/unit/useConfig.test.ts
+++ b/tests/unit/useConfig.test.ts
@@ -101,6 +101,18 @@ describe("loadConfig", () => {
     expect(result.confirm_undo_all).toBe(false)
   })
 
+  it("loads supported external editors and ignores unknown values", () => {
+    writeFileSync(join(dir, CONFIG_FILE_NAME), "external_editor: zed\n", "utf8")
+    expect(loadConfig(dir).external_editor).toBe("zed")
+
+    writeFileSync(
+      join(dir, CONFIG_FILE_NAME),
+      "external_editor: arbitrary-command\n",
+      "utf8",
+    )
+    expect(loadConfig(dir).external_editor).toBeUndefined()
+  })
+
   it("normalizes and deduplicates collections", () => {
     writeFileSync(
       join(dir, CONFIG_FILE_NAME),
@@ -185,6 +197,15 @@ describe("saveConfig", () => {
     const input: NoodleConfig = {
       ...DEFAULTS,
       proxy: { mode: "off" },
+    }
+    saveConfig(dir, input)
+    expect(loadConfig(dir)).toEqual(input)
+  })
+
+  it("round-trips the external editor", () => {
+    const input: NoodleConfig = {
+      ...DEFAULTS,
+      external_editor: "vscode",
     }
     saveConfig(dir, input)
     expect(loadConfig(dir)).toEqual(input)


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an "external editor" setting so users can open their collection folder or the app settings folder (`~/.config/noodle`) in an installed editor. The Settings > Behavior panel gains a select populated with detected editors (Zed, VS Code, Sublime, Cursor, Windsurf, VSCodium), found via CLI on PATH or macOS app bundles. The selection persists in `config.yml` as `external_editor`. Two new command palette entries — **Open Collection in Editor** (Workspace) and **Open Settings in Editor** (System) — launch the editor with the target folder; when no editor is installed they show a warning and stay visible.

### How did you verify your code works?

- New unit tests for editor detection (CLI + macOS bundles, priority fallback), launching with paths containing spaces, and failure reporting
- Tests for the palette commands (folder opened, no-editor warning) and the Settings Behavior select
- `loadConfig`/`saveConfig` round-trip and unknown-value rejection tests in `useConfig.test.ts`
- Ran `bun test` (full suite green), `bun run lint`, `bun run typecheck`, and `bunx prettier --check ./src ./tests` — all pass
- Reran the changed test files 50x with no failures

### Screenshots / recordings

Terminal TUI change; no screenshots.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and selecting an external editor.
  * Added commands to open collection and application settings folders in the selected editor.
  * Added external-editor settings under Behavior, including cases where no editor is available.
  * Editor preferences are saved and restored automatically.
  * Added success and error notifications when opening folders.

* **Bug Fixes**
  * Invalid editor configuration values are safely ignored.
  * Improved handling of unavailable editors and launch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->