### PR TITLE
refactor(ui): extract ActionButton component from overlays

### DIFF
--- a/src/ui/ActionButton.tsx
+++ b/src/ui/ActionButton.tsx
@@ -1,0 +1,88 @@
+import { MouseButton } from "@opentui/core"
+import { useState } from "react"
+import { contrastOnSecondary, useTheme } from "./theme"
+
+export function ActionButton({
+  id,
+  label,
+  shortcut,
+  shortcutPosition = "left",
+  paddingX = 1,
+  gap = 0,
+  active = true,
+  disabled = false,
+  onAction,
+  onHover,
+}: {
+  id?: string
+  label: string
+  shortcut?: string
+  shortcutPosition?: "left" | "right"
+  paddingX?: number
+  gap?: number
+  active?: boolean
+  disabled?: boolean
+  onAction: () => void
+  onHover?: () => void
+}) {
+  const theme = useTheme()
+  const [hovered, setHovered] = useState(false)
+  const enabled = !disabled
+  const highlighted = enabled && (hovered || active)
+  const shortcutColor = disabled
+    ? theme.border
+    : hovered
+      ? contrastOnSecondary(theme)
+      : active
+        ? theme.secondary
+        : theme.text
+  const labelColor = shortcut
+    ? disabled
+      ? theme.border
+      : hovered
+        ? contrastOnSecondary(theme)
+        : theme.textMuted
+    : shortcutColor
+
+  return (
+    <box
+      id={id}
+      onMouseDown={(event) => {
+        if (event.button !== MouseButton.LEFT || disabled) return
+        onAction()
+        event.preventDefault()
+        event.stopPropagation()
+      }}
+      onMouseOver={() => {
+        if (!enabled) return
+        setHovered(true)
+        onHover?.()
+      }}
+      onMouseOut={() => setHovered(false)}
+      style={{
+        flexDirection: "row",
+        paddingLeft: paddingX,
+        paddingRight: paddingX,
+        gap,
+        backgroundColor: highlighted
+          ? hovered
+            ? theme.secondary
+            : theme.backgroundElement
+          : undefined,
+      }}
+    >
+      {shortcutPosition === "right" ? (
+        <>
+          <text fg={labelColor}>{label}</text>
+          <box flexGrow={1} />
+          {shortcut && <text fg={shortcutColor}>{shortcut}</text>}
+        </>
+      ) : (
+        <>
+          {shortcut && <text fg={shortcutColor}>{shortcut}</text>}
+          <text fg={labelColor}>{shortcut ? ` ${label}` : label}</text>
+        </>
+      )}
+    </box>
+  )
+}

--- a/src/ui/EmptyState.tsx
+++ b/src/ui/EmptyState.tsx
@@ -1,9 +1,9 @@
-import { MouseButton, type ASCIIFontName } from "@opentui/core"
+import { type ASCIIFontName } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useKeymap } from "@opentui/keymap/react"
-import { useState } from "react"
 import type { BorderPreset } from "./borders"
-import { contrastOnSecondary, useTheme } from "./theme"
+import { useTheme } from "./theme"
+import { ActionButton } from "./ActionButton"
 
 export interface EmptyStateProps {
   title?: string
@@ -28,17 +28,6 @@ export function EmptyState({
 }: EmptyStateProps) {
   const theme = useTheme()
   const keymap = useKeymap()
-  const [hovered, setHovered] = useState(false)
-  const actionTextColor = hovered
-    ? contrastOnSecondary(theme)
-    : actionActive
-      ? theme.secondary
-      : theme.text
-  const actionBackgroundColor = hovered
-    ? theme.secondary
-    : actionActive
-      ? theme.backgroundElement
-      : undefined
 
   useKeyboard((key) => {
     if (keymap.getData("app.overlay") !== "none") return
@@ -83,24 +72,12 @@ export function EmptyState({
             {subtitle}
           </text>
         )}
-        <box
+        <ActionButton
           id="empty-state-action"
-          paddingLeft={1}
-          paddingRight={1}
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onAction()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHovered(true)}
-          onMouseOut={() => setHovered(false)}
-          style={{
-            backgroundColor: actionBackgroundColor,
-          }}
-        >
-          <text fg={actionTextColor}>{actionLabel}</text>
-        </box>
+          label={actionLabel}
+          active={actionActive}
+          onAction={onAction}
+        />
       </box>
     </box>
   )

--- a/src/ui/editor/YamlEditorOverlay.tsx
+++ b/src/ui/editor/YamlEditorOverlay.tsx
@@ -1,6 +1,6 @@
-import { MouseButton } from "@opentui/core"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { useBindings, useKeymap } from "@opentui/keymap/react"
+import { ActionButton } from "../ActionButton"
 import { useTheme } from "../theme"
 import { Overlay } from "../overlays/Overlay"
 import { EscapeClose } from "../overlays/EscapeClose"
@@ -32,9 +32,6 @@ export function YamlEditorOverlay({
   const theme = useTheme()
   const keymap = useKeymap()
   const editorRef = useRef<YamlFileEditorHandle | null>(null)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
   const handleSave = useCallback(() => {
     editorRef.current?.save()
   }, [])
@@ -113,44 +110,12 @@ export function YamlEditorOverlay({
             gap: 1,
           }}
         >
-          <box
-            onMouseDown={(event) => {
-              if (event.button !== MouseButton.LEFT) return
-              handleSave()
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            onMouseOver={() => setHoveredAction("save")}
-            onMouseOut={() => setHoveredAction(null)}
-            style={{
-              flexDirection: "row",
-              paddingX: 1,
-              backgroundColor:
-                hoveredAction === "save" ? theme.backgroundElement : undefined,
-            }}
-          >
-            <text fg={theme.text}>{displayKey(saveKey)}</text>
-            <text fg={theme.textMuted}> save</text>
-          </box>
-          <box
-            onMouseDown={(event) => {
-              if (event.button !== MouseButton.LEFT) return
-              handleClose()
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            onMouseOver={() => setHoveredAction("close")}
-            onMouseOut={() => setHoveredAction(null)}
-            style={{
-              flexDirection: "row",
-              paddingX: 1,
-              backgroundColor:
-                hoveredAction === "close" ? theme.backgroundElement : undefined,
-            }}
-          >
-            <text fg={theme.text}>esc</text>
-            <text fg={theme.textMuted}> close</text>
-          </box>
+          <ActionButton
+            shortcut={displayKey(saveKey)}
+            label="save"
+            onAction={handleSave}
+          />
+          <ActionButton shortcut="esc" label="close" onAction={handleClose} />
         </box>
       </box>
     </Overlay>

--- a/src/ui/overlays/CloneRequestOverlay.tsx
+++ b/src/ui/overlays/CloneRequestOverlay.tsx
@@ -5,7 +5,8 @@ import {
   useRef,
   useState,
 } from "react"
-import { MouseButton, type InputRenderable } from "@opentui/core"
+import { type InputRenderable } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
 import { useTheme } from "../theme"
@@ -31,9 +32,6 @@ export const CloneRequestOverlay = forwardRef<
   const theme = useTheme()
   const [name, setName] = useState(initialName)
   const [errorText, setErrorText] = useState<string | null>(null)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
   const nameRef = useRef<InputRenderable | null>(null)
 
   useEffect(() => {
@@ -99,46 +97,16 @@ export const CloneRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="save"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/CodeGeneratorOverlay.tsx
+++ b/src/ui/overlays/CodeGeneratorOverlay.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useKeymap } from "@opentui/keymap/react"
-import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
+import { type ScrollBoxRenderable } from "@opentui/core"
 import type { Collection, Environment, Request } from "../../schema"
 import { generateCode, getCodeTarget } from "../../codegen"
 import { CODE_LANGUAGES } from "../../codegen/targets"
 import { copyToClipboard } from "../clipboard"
+import { ActionButton } from "../ActionButton"
 import { useRenderer } from "../RendererContext"
 import { showToast } from "../Toast"
 import { useTheme } from "../theme"
@@ -52,9 +53,6 @@ export function CodeGeneratorOverlay({
   const [clientId, setClientId] = useState(DEFAULT_LANG.defaultClientId)
   const [focus, setFocus] = useState<"language" | "library">("language")
   const [interpolate, setInterpolate] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<
-    "interpolate" | "copy" | "close" | null
-  >(null)
 
   const clientItems = buildClientItems(languageKey)
   const hasClients = clientItems.length > 0
@@ -255,83 +253,19 @@ export function CodeGeneratorOverlay({
             gap: 1,
           }}
         >
-          <box
-            onMouseDown={(event) => {
-              if (event.button !== MouseButton.LEFT || !env) return
-              toggleInterpolate()
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            onMouseOver={
-              env ? () => setHoveredAction("interpolate") : undefined
-            }
-            onMouseOut={() => setHoveredAction(null)}
-            style={{
-              flexDirection: "row",
-              paddingLeft: 1,
-              paddingRight: 1,
-              backgroundColor:
-                hoveredAction === "interpolate"
-                  ? theme.backgroundElement
-                  : undefined,
-            }}
-          >
-            <text fg={theme.text}>i</text>
-            <text
-              fg={
-                !env
-                  ? theme.border
-                  : interpolate
-                    ? theme.primary
-                    : theme.textMuted
-              }
-            >
-              {" "}
-              interpolate{!env ? " (no env)" : ""}{" "}
-            </text>
-          </box>
-          <box
-            onMouseDown={(event) => {
-              if (event.button !== MouseButton.LEFT || !result.generated) return
-              copyCode()
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            onMouseOver={
-              result.generated ? () => setHoveredAction("copy") : undefined
-            }
-            onMouseOut={() => setHoveredAction(null)}
-            style={{
-              flexDirection: "row",
-              paddingLeft: 1,
-              paddingRight: 1,
-              backgroundColor:
-                hoveredAction === "copy" ? theme.backgroundElement : undefined,
-            }}
-          >
-            <text fg={theme.text}>c</text>
-            <text fg={theme.textMuted}> copy </text>
-          </box>
-          <box
-            onMouseDown={(event) => {
-              if (event.button !== MouseButton.LEFT) return
-              onClose()
-              event.preventDefault()
-              event.stopPropagation()
-            }}
-            onMouseOver={() => setHoveredAction("close")}
-            onMouseOut={() => setHoveredAction(null)}
-            style={{
-              flexDirection: "row",
-              paddingLeft: 1,
-              paddingRight: 1,
-              backgroundColor:
-                hoveredAction === "close" ? theme.backgroundElement : undefined,
-            }}
-          >
-            <text fg={theme.text}>esc</text>
-            <text fg={theme.textMuted}> close</text>
-          </box>
+          <ActionButton
+            shortcut="i"
+            label={`interpolate${!env ? " (no env)" : ""}`}
+            disabled={!env}
+            onAction={toggleInterpolate}
+          />
+          <ActionButton
+            shortcut="c"
+            label="copy"
+            disabled={!result.generated}
+            onAction={copyCode}
+          />
+          <ActionButton shortcut="esc" label="close" onAction={onClose} />
         </box>
       </box>
     </Overlay>

--- a/src/ui/overlays/ConfirmOverlay.tsx
+++ b/src/ui/overlays/ConfirmOverlay.tsx
@@ -1,5 +1,4 @@
-import { MouseButton } from "@opentui/core"
-import { useState } from "react"
+import { ActionButton } from "../ActionButton"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
@@ -18,9 +17,6 @@ export function ConfirmOverlay({
   onCancel,
 }: ConfirmOverlayProps) {
   const theme = useTheme()
-  const [hoveredAction, setHoveredAction] = useState<
-    "confirm" | "cancel" | null
-  >(null)
 
   return (
     <Overlay visible={visible} width={50} gap={1} padding={1}>
@@ -46,46 +42,16 @@ export function ConfirmOverlay({
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("confirm")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "confirm" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>y</text>
-          <text fg={theme.textMuted}> confirm</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onCancel?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("cancel")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "cancel" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>n</text>
-          <text fg={theme.textMuted}> cancel</text>
-        </box>
+        <ActionButton
+          shortcut="y"
+          label="confirm"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="n"
+          label="cancel"
+          onAction={() => onCancel?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/CookieFormOverlay.tsx
+++ b/src/ui/overlays/CookieFormOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react"
 import { MouseButton, type InputRenderable } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import { Checkbox } from "../Checkbox"
 import { Select } from "../Select"
 import { useTheme } from "../theme"
@@ -93,9 +94,6 @@ export const CookieFormOverlay = forwardRef<
   const [focus, setFocus] = useState<CookieFormFocus>("name")
   const [errorText, setErrorText] = useState<string | null>(null)
   const [selectOpen, setSelectOpen] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
   const inputRefs = useRef<
     Partial<Record<CookieFormFocus, InputRenderable | null>>
   >({})
@@ -368,46 +366,16 @@ export const CookieFormOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="save"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/ExportCollectionOverlay.tsx
+++ b/src/ui/overlays/ExportCollectionOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react"
 import { MouseButton } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import {
   getExportTargetPath,
   type ExportCollectionValues,
@@ -51,9 +52,6 @@ export const ExportCollectionOverlay = forwardRef<
   const [focus, setFocus] = useState<"format" | "output">("format")
   const [errorText, setErrorText] = useState<string | null>(null)
   const [selectOpen, setSelectOpen] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<"export" | "close" | null>(
-    null,
-  )
   const outputRef = useRef<VarInputHandle | null>(null)
 
   useImperativeHandle(ref, () => ({
@@ -194,46 +192,16 @@ export const ExportCollectionOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("export")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "export" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> export</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="export"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/ImportCollectionOverlay.tsx
+++ b/src/ui/overlays/ImportCollectionOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react"
 import { MouseButton } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import { Select, type SelectItem } from "../Select"
 import { useTheme } from "../theme"
 import { VarInput, type VarInputHandle } from "../VarInput"
@@ -54,9 +55,6 @@ export const ImportCollectionOverlay = forwardRef<
   const [focus, setFocus] = useState<ImportFocus>("source")
   const [destinationOpen, setDestinationOpen] = useState(false)
   const [errorText, setErrorText] = useState<string | null>(null)
-  const [hoveredAction, setHoveredAction] = useState<"import" | "close" | null>(
-    null,
-  )
   const sourceRef = useRef<VarInputHandle | null>(null)
   const parentRef = useRef<VarInputHandle | null>(null)
 
@@ -234,48 +232,18 @@ export const ImportCollectionOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT || pending) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("import")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "import" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}>
-            {pending ? " importing..." : " import"}
-          </text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT || pending) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label={pending ? "importing..." : "import"}
+          disabled={pending}
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          disabled={pending}
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/ImportCurlOverlay.tsx
+++ b/src/ui/overlays/ImportCurlOverlay.tsx
@@ -5,11 +5,8 @@ import {
   useRef,
   useState,
 } from "react"
-import {
-  MouseButton,
-  type InputRenderable,
-  type TextareaRenderable,
-} from "@opentui/core"
+import { type InputRenderable, type TextareaRenderable } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import type { SelectItem } from "../Select"
 import { Select } from "../Select"
 import { useTheme } from "../theme"
@@ -51,9 +48,6 @@ export const ImportCurlOverlay = forwardRef<
   const [focus, setFocus] = useState<"folder" | "name" | "curl">("folder")
   const [errorText, setErrorText] = useState<string | null>(null)
   const [folderSelectOpen, setFolderSelectOpen] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
   const curlRef = useRef<TextareaRenderable | null>(null)
   const nameRef = useRef<InputRenderable | null>(null)
 
@@ -184,46 +178,16 @@ export const ImportCurlOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="save"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/NewEnvironmentOverlay.tsx
+++ b/src/ui/overlays/NewEnvironmentOverlay.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react"
 import { MouseButton, type InputRenderable } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import { VALID_COLORS } from "../../env/constants"
 import { Select, type SelectItem } from "../Select"
 import { useTheme } from "../theme"
@@ -42,9 +43,6 @@ export const NewEnvironmentOverlay = forwardRef<
   const [focus, setFocus] = useState<"name" | "color">("name")
   const [errorText, setErrorText] = useState<string | null>(null)
   const [selectOpen, setSelectOpen] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
   const nameRef = useRef<InputRenderable | null>(null)
 
   const colorItems = useMemo<SelectItem[]>(() => {
@@ -174,46 +172,16 @@ export const NewEnvironmentOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="save"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/NewFolderOverlay.tsx
+++ b/src/ui/overlays/NewFolderOverlay.tsx
@@ -5,7 +5,8 @@ import {
   useRef,
   useState,
 } from "react"
-import { MouseButton, type InputRenderable } from "@opentui/core"
+import { type InputRenderable } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
 import { useTheme } from "../theme"
@@ -27,9 +28,6 @@ export const NewFolderOverlay = forwardRef<
   const theme = useTheme()
   const [name, setName] = useState("")
   const [errorText, setErrorText] = useState<string | null>(null)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
   const nameRef = useRef<InputRenderable | null>(null)
 
   useEffect(() => {
@@ -95,46 +93,16 @@ export const NewFolderOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="save"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/NewRequestOverlay.tsx
+++ b/src/ui/overlays/NewRequestOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react"
 import { MouseButton, type InputRenderable } from "@opentui/core"
+import { ActionButton } from "../ActionButton"
 import { VarInput, type VarInputHandle } from "../VarInput"
 import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
@@ -81,9 +82,6 @@ export const NewRequestOverlay = forwardRef<
   )
   const [errorText, setErrorText] = useState<string | null>(null)
   const [folderSelectOpen, setFolderSelectOpen] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<"save" | "close" | null>(
-    null,
-  )
 
   const nameRef = useRef<InputRenderable | null>(null)
   const urlRef = useRef<VarInputHandle | null>(null)
@@ -264,46 +262,16 @@ export const NewRequestOverlay = forwardRef<
           paddingX: 2,
         }}
       >
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onConfirm?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("save")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "save" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>^S</text>
-          <text fg={theme.textMuted}> save</text>
-        </box>
-        <box
-          onMouseDown={(event) => {
-            if (event.button !== MouseButton.LEFT) return
-            onClose?.()
-            event.preventDefault()
-            event.stopPropagation()
-          }}
-          onMouseOver={() => setHoveredAction("close")}
-          onMouseOut={() => setHoveredAction(null)}
-          style={{
-            flexDirection: "row",
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor:
-              hoveredAction === "close" ? theme.backgroundElement : undefined,
-          }}
-        >
-          <text fg={theme.text}>esc</text>
-          <text fg={theme.textMuted}> close</text>
-        </box>
+        <ActionButton
+          shortcut="^S"
+          label="save"
+          onAction={() => onConfirm?.()}
+        />
+        <ActionButton
+          shortcut="esc"
+          label="close"
+          onAction={() => onClose?.()}
+        />
       </box>
     </Overlay>
   )

--- a/src/ui/overlays/PickerOverlay.tsx
+++ b/src/ui/overlays/PickerOverlay.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import type { ReactNode } from "react"
 import { MouseButton, type ScrollBoxRenderable } from "@opentui/core"
 import { useKeymap } from "@opentui/keymap/react"
+import { ActionButton } from "../ActionButton"
 import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
 import { useTheme } from "../theme"
@@ -255,38 +256,20 @@ export function PickerOverlay<T>({
   )
 
   const action = firstAction && (
-    <box paddingLeft={1} paddingRight={1}>
-      <box
-        onMouseDown={(event) => {
-          if (event.button !== MouseButton.LEFT) return
-          firstAction.onSelect()
-          event.preventDefault()
-          event.stopPropagation()
-        }}
-        onMouseOver={() => {
+    <box paddingLeft={3} paddingRight={1}>
+      <ActionButton
+        label={firstAction.label}
+        shortcut={firstAction.shortcut}
+        shortcutPosition="right"
+        paddingX={3}
+        gap={1}
+        onAction={firstAction.onSelect}
+        onHover={() => {
           actionHighlightedRef.current = true
           setActionHighlighted(true)
           onHighlightChange?.(null)
         }}
-        style={{
-          flexDirection: "row",
-          paddingLeft: 3,
-          paddingRight: 3,
-          gap: 1,
-          backgroundColor: isActionHighlighted ? theme.primary : undefined,
-        }}
-      >
-        <box width={1} />
-        <text fg={isActionHighlighted ? "#1a1a1a" : theme.text}>
-          {firstAction.label}
-        </text>
-        <box flexGrow={1} />
-        {firstAction.shortcut && (
-          <text fg={isActionHighlighted ? "#1a1a1a" : theme.textMuted}>
-            {firstAction.shortcut}
-          </text>
-        )}
-      </box>
+      />
     </box>
   )
 

--- a/src/ui/overlays/PickerOverlay.tsx
+++ b/src/ui/overlays/PickerOverlay.tsx
@@ -263,6 +263,7 @@ export function PickerOverlay<T>({
         shortcutPosition="right"
         paddingX={3}
         gap={1}
+        active={isActionHighlighted}
         onAction={firstAction.onSelect}
         onHover={() => {
           actionHighlightedRef.current = true

--- a/src/ui/overlays/TimelineDetailOverlay.tsx
+++ b/src/ui/overlays/TimelineDetailOverlay.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useKeymap } from "@opentui/keymap/react"
-import { MouseButton, t, fg, type ScrollBoxRenderable } from "@opentui/core"
+import { t, fg, type ScrollBoxRenderable } from "@opentui/core"
 import type { TimelineBodyRef, TimelineEntry } from "../../schema"
 import { formatJson } from "../../lang/formatJson"
+import { ActionButton } from "../ActionButton"
 import { useTheme } from "../theme"
 import { Overlay } from "./Overlay"
 import { EscapeClose } from "./EscapeClose"
@@ -97,15 +98,6 @@ export function TimelineDetailOverlay({
   const [bodyError, setBodyError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [showLargeBody, setShowLargeBody] = useState(false)
-  const [hoveredAction, setHoveredAction] = useState<
-    | "view"
-    | "large-copy"
-    | "large-export"
-    | "headers"
-    | "body"
-    | "export"
-    | null
-  >(null)
   const bodyScrollRef = useRef<ScrollBoxRenderable | null>(null)
   const bodyEditorRef = useRef<CodeEditorRenderable | null>(null)
   const [bodyEditor, setBodyEditor] = useState<CodeEditorRenderable | null>(
@@ -434,72 +426,21 @@ export function TimelineDetailOverlay({
                     fg={theme.warning}
                   >{`Body is ${formatSize(info!.size)}. It was not rendered automatically.`}</text>
                   <box style={{ flexDirection: "row", gap: 1 }}>
-                    <box
-                      onMouseDown={(event) => {
-                        if (event.button !== MouseButton.LEFT) return
-                        setShowLargeBody(true)
-                        event.preventDefault()
-                        event.stopPropagation()
-                      }}
-                      onMouseOver={() => setHoveredAction("view")}
-                      onMouseOut={() => setHoveredAction(null)}
-                      style={{
-                        flexDirection: "row",
-                        paddingLeft: 1,
-                        paddingRight: 1,
-                        backgroundColor:
-                          hoveredAction === "view"
-                            ? theme.backgroundElement
-                            : undefined,
-                      }}
-                    >
-                      <text fg={theme.text}>v</text>
-                      <text fg={theme.textMuted}> view raw </text>
-                    </box>
-                    <box
-                      onMouseDown={(event) => {
-                        if (event.button !== MouseButton.LEFT) return
-                        copyBody()
-                        event.preventDefault()
-                        event.stopPropagation()
-                      }}
-                      onMouseOver={() => setHoveredAction("large-copy")}
-                      onMouseOut={() => setHoveredAction(null)}
-                      style={{
-                        flexDirection: "row",
-                        paddingLeft: 1,
-                        paddingRight: 1,
-                        backgroundColor:
-                          hoveredAction === "large-copy"
-                            ? theme.backgroundElement
-                            : undefined,
-                      }}
-                    >
-                      <text fg={theme.text}>b</text>
-                      <text fg={theme.textMuted}> copy </text>
-                    </box>
-                    <box
-                      onMouseDown={(event) => {
-                        if (event.button !== MouseButton.LEFT) return
-                        exportBody()
-                        event.preventDefault()
-                        event.stopPropagation()
-                      }}
-                      onMouseOver={() => setHoveredAction("large-export")}
-                      onMouseOut={() => setHoveredAction(null)}
-                      style={{
-                        flexDirection: "row",
-                        paddingLeft: 1,
-                        paddingRight: 1,
-                        backgroundColor:
-                          hoveredAction === "large-export"
-                            ? theme.backgroundElement
-                            : undefined,
-                      }}
-                    >
-                      <text fg={theme.text}>e</text>
-                      <text fg={theme.textMuted}> export</text>
-                    </box>
+                    <ActionButton
+                      shortcut="v"
+                      label="view raw"
+                      onAction={() => setShowLargeBody(true)}
+                    />
+                    <ActionButton
+                      shortcut="b"
+                      label="copy"
+                      onAction={copyBody}
+                    />
+                    <ActionButton
+                      shortcut="e"
+                      label="export"
+                      onAction={exportBody}
+                    />
                   </box>
                 </box>
               ) : renderedBody ? (
@@ -571,72 +512,13 @@ export function TimelineDetailOverlay({
               gap: 1,
             }}
           >
-            <box
-              onMouseDown={(event) => {
-                if (event.button !== MouseButton.LEFT) return
-                copyHeaders()
-                event.preventDefault()
-                event.stopPropagation()
-              }}
-              onMouseOver={() => setHoveredAction("headers")}
-              onMouseOut={() => setHoveredAction(null)}
-              style={{
-                flexDirection: "row",
-                paddingLeft: 1,
-                paddingRight: 1,
-                backgroundColor:
-                  hoveredAction === "headers"
-                    ? theme.backgroundElement
-                    : undefined,
-              }}
-            >
-              <text fg={theme.text}>h</text>
-              <text fg={theme.textMuted}> copy headers </text>
-            </box>
-            <box
-              onMouseDown={(event) => {
-                if (event.button !== MouseButton.LEFT) return
-                copyBody()
-                event.preventDefault()
-                event.stopPropagation()
-              }}
-              onMouseOver={() => setHoveredAction("body")}
-              onMouseOut={() => setHoveredAction(null)}
-              style={{
-                flexDirection: "row",
-                paddingLeft: 1,
-                paddingRight: 1,
-                backgroundColor:
-                  hoveredAction === "body"
-                    ? theme.backgroundElement
-                    : undefined,
-              }}
-            >
-              <text fg={theme.text}>b</text>
-              <text fg={theme.textMuted}> copy body </text>
-            </box>
-            <box
-              onMouseDown={(event) => {
-                if (event.button !== MouseButton.LEFT) return
-                exportBody()
-                event.preventDefault()
-                event.stopPropagation()
-              }}
-              onMouseOver={() => setHoveredAction("export")}
-              onMouseOut={() => setHoveredAction(null)}
-              style={{
-                flexDirection: "row",
-                paddingLeft: 1,
-                paddingRight: 1,
-                backgroundColor:
-                  hoveredAction === "export"
-                    ? theme.backgroundElement
-                    : undefined,
-              }}
-            >
-              <text fg={theme.text}>e</text>
-              <text fg={theme.textMuted}> export</text>
-            </box>
+            <ActionButton
+              shortcut="h"
+              label="copy headers"
+              onAction={copyHeaders}
+            />
+            <ActionButton shortcut="b" label="copy body" onAction={copyBody} />
+            <ActionButton shortcut="e" label="export" onAction={exportBody} />
           </box>
         )}
       </box>

--- a/tests/unit/ActionButton.test.tsx
+++ b/tests/unit/ActionButton.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test"
+import { RGBA, type BoxRenderable } from "@opentui/core"
+import { act } from "react"
+import { createTestRender } from "../testRender"
+import { ActionButton } from "../../src/ui/ActionButton"
+import { contrastOnSecondary, THEMES, ThemeProvider } from "../../src/ui/theme"
+
+const testRender = createTestRender()
+const theme = THEMES[0]!
+
+describe("ActionButton", () => {
+  it("keeps the shortcut accented and the description muted until hover", async () => {
+    const { renderOnce, renderer, captureSpans, mockMouse } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <ActionButton
+          id="action-button"
+          label="Save"
+          shortcut="enter"
+          onAction={() => {}}
+        />
+      </ThemeProvider>,
+      { width: 30, height: 3 },
+    )
+    await renderOnce()
+
+    const action = renderer.root.findDescendantById(
+      "action-button",
+    ) as BoxRenderable
+    const spans = () => captureSpans().lines.flatMap((line) => line.spans)
+    const shortcut = () => spans().find((span) => span.text.includes("enter"))
+    const label = () => spans().find((span) => span.text.includes("Save"))
+
+    expect(shortcut()?.fg.equals(RGBA.fromHex(theme.secondary))).toBe(true)
+    expect(label()?.fg.equals(RGBA.fromHex(theme.textMuted))).toBe(true)
+
+    await act(async () => {
+      await mockMouse.moveTo(action.screenX + 1, action.screenY)
+      await renderOnce()
+    })
+
+    const hoverColor = RGBA.fromHex(contrastOnSecondary(theme))
+    expect(shortcut()?.fg.equals(hoverColor)).toBe(true)
+    expect(label()?.fg.equals(hoverColor)).toBe(true)
+  })
+})

--- a/tests/unit/PickerOverlay.test.tsx
+++ b/tests/unit/PickerOverlay.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
+import { RGBA } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestRender } from "../testRender"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -9,7 +10,7 @@ import {
 } from "@opentui/keymap/addons"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { KeymapProviderProps } from "@opentui/keymap/react"
-import { ThemeProvider } from "../../src/ui/theme"
+import { THEMES, ThemeProvider } from "../../src/ui/theme"
 import { PickerOverlay } from "../../src/ui/overlays/PickerOverlay"
 
 const testRender = createTestRender()
@@ -515,6 +516,50 @@ describe("PickerOverlay", () => {
 
     expect(actionCount).toBe(1)
     expect(selected).toEqual([])
+    cleanup()
+  })
+
+  it("reflects first-action selection in its active styling", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const { renderOnce, captureSpans } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <PickerOverlay
+            visible
+            title="Test"
+            items={testItems}
+            keyExtractor={(item) => item.id}
+            filter={() => true}
+            renderItem={(item) => <text>{item.label}</text>}
+            highlightedItem={testItems[2]}
+            firstAction={{
+              label: "Manage items",
+              shortcut: "f3",
+              onSelect: noop,
+            }}
+            onHighlightChange={noop}
+            onSelect={noop}
+            onClose={noop}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 20 },
+    )
+    await renderOnce()
+
+    const actionShortcut = () =>
+      captureSpans()
+        .lines.flatMap((line) => line.spans)
+        .find((span) => span.text.includes("f3"))?.fg
+
+    expect(actionShortcut()?.equals(RGBA.fromHex(THEMES[0]!.text))).toBe(true)
+
+    act(() => host.press("down"))
+    await renderOnce()
+
+    expect(actionShortcut()?.equals(RGBA.fromHex(THEMES[0]!.secondary))).toBe(
+      true,
+    )
     cleanup()
   })
 

--- a/tests/unit/PickerOverlay.test.tsx
+++ b/tests/unit/PickerOverlay.test.tsx
@@ -521,46 +521,49 @@ describe("PickerOverlay", () => {
 
   it("reflects first-action selection in its active styling", async () => {
     const { keymap, host, cleanup } = setupKeymap()
-    const { renderOnce, captureSpans } = await testRender(
-      <KeymapProvider keymap={keymap}>
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <PickerOverlay
-            visible
-            title="Test"
-            items={testItems}
-            keyExtractor={(item) => item.id}
-            filter={() => true}
-            renderItem={(item) => <text>{item.label}</text>}
-            highlightedItem={testItems[2]}
-            firstAction={{
-              label: "Manage items",
-              shortcut: "f3",
-              onSelect: noop,
-            }}
-            onHighlightChange={noop}
-            onSelect={noop}
-            onClose={noop}
-          />
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 60, height: 20 },
-    )
-    await renderOnce()
+    try {
+      const { renderOnce, captureSpans } = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <PickerOverlay
+              visible
+              title="Test"
+              items={testItems}
+              keyExtractor={(item) => item.id}
+              filter={() => true}
+              renderItem={(item) => <text>{item.label}</text>}
+              highlightedItem={testItems[2]}
+              firstAction={{
+                label: "Manage items",
+                shortcut: "f3",
+                onSelect: noop,
+              }}
+              onHighlightChange={noop}
+              onSelect={noop}
+              onClose={noop}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 60, height: 20 },
+      )
+      await renderOnce()
 
-    const actionShortcut = () =>
-      captureSpans()
-        .lines.flatMap((line) => line.spans)
-        .find((span) => span.text.includes("f3"))?.fg
+      const actionShortcut = () =>
+        captureSpans()
+          .lines.flatMap((line) => line.spans)
+          .find((span) => span.text.includes("f3"))?.fg
 
-    expect(actionShortcut()?.equals(RGBA.fromHex(THEMES[0]!.text))).toBe(true)
+      expect(actionShortcut()?.equals(RGBA.fromHex(THEMES[0]!.text))).toBe(true)
 
-    act(() => host.press("down"))
-    await renderOnce()
+      act(() => host.press("down"))
+      await renderOnce()
 
-    expect(actionShortcut()?.equals(RGBA.fromHex(THEMES[0]!.secondary))).toBe(
-      true,
-    )
-    cleanup()
+      expect(actionShortcut()?.equals(RGBA.fromHex(THEMES[0]!.secondary))).toBe(
+        true,
+      )
+    } finally {
+      cleanup()
+    }
   })
 
   it("wraps keyboard navigation through the first action", async () => {


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extracts the duplicated overlay footer buttons into a shared `ActionButton` component. Every overlay previously repeated the same `box` + mouse handlers + hovered-state `useState` block; this consolidates that into one component with `label`, `shortcut`, `shortcutPosition`, `disabled`, `active`, and hover styling. Applied across EmptyState, YamlEditorOverlay, and 12 overlays (Clone, CodeGenerator, Confirm, CookieForm, Export, ImportCollection, ImportCurl, NewEnvironment, NewFolder, NewRequest, Picker, TimelineDetail).

### How did you verify your code works?

- Added `tests/unit/ActionButton.test.tsx` covering shortcut/label colors and hover state
- Ran `bun test` (2761 pass, 0 fail), `bun run lint`, `bun run typecheck`, and `bunx prettier --check ./src ./tests` — all pass
- Stress-tested the affected overlay/UI test files 50x with no failures

### Screenshots / recordings

Terminal UI refactor; no visual change intended.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent themed action buttons with labels, keyboard shortcuts, hover feedback, active states, and disabled states.
  - Updated editor and overlay actions—including save, close, confirm, cancel, import, export, copy, and other commands—to use the unified button experience.
  - Preserved existing shortcuts and action behavior across dialogs and workflows.

- **Tests**
  - Added coverage for button rendering, hover-state styling, and selection-dependent colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->