### PR TITLE
fix(ui): preserve URL input width while sending

### DIFF
--- a/src/ui/UrlBar.tsx
+++ b/src/ui/UrlBar.tsx
@@ -202,16 +202,24 @@ export function UrlBar({
               }
               style={{
                 flexShrink: 0,
-                paddingLeft: 1,
-                paddingRight: 1,
-                backgroundColor: sendHovered
-                  ? theme.backgroundElement
-                  : undefined,
+                width: 8,
+                alignItems: "flex-end",
               }}
             >
-              <text fg={theme.primary} selectable={false}>
-                {sending ? `${SPINNER_FRAMES[spinnerIdx]} Send` : "Send"}
-              </text>
+              <box
+                id="urlbar-send-button"
+                style={{
+                  paddingLeft: 1,
+                  paddingRight: 1,
+                  backgroundColor: sendHovered
+                    ? theme.backgroundElement
+                    : undefined,
+                }}
+              >
+                <text fg={theme.primary} selectable={false}>
+                  {sending ? `${SPINNER_FRAMES[spinnerIdx]} Send` : "Send"}
+                </text>
+              </box>
             </box>
           )}
         </box>

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -129,14 +129,18 @@ describe("UrlBar", () => {
       }
     }
     const width = findInput(renderer.root)!.width
-    expect(renderer.root.findDescendantById("urlbar-send-button")!.width).toBe(
-      6,
-    )
+    const button = renderer.root.findDescendantById("urlbar-send-button")!
+    const sendSlotWidth = button.parent!.width
+    expect(button.width).toBe(6)
+    expect(sendSlotWidth).toBe(8)
 
     act(() => startSending())
     await renderOnce()
 
     expect(findInput(renderer.root)!.width).toBe(width)
+    expect(
+      renderer.root.findDescendantById("urlbar-send-button")!.parent!.width,
+    ).toBe(sendSlotWidth)
     cleanup()
   })
 

--- a/tests/unit/UrlBar.test.tsx
+++ b/tests/unit/UrlBar.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { act, useState } from "react"
 import { createTestRender } from "../testRender"
 import { MouseButtons } from "@opentui/core/testing"
+import { InputRenderable, type BaseRenderable } from "@opentui/core"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
 import { UrlBar } from "../../src/ui/UrlBar"
@@ -21,6 +22,7 @@ function UrlBarHarness({
   onSubFocus,
   onSend,
   sending = false,
+  initialUrl = "https://example.com",
 }: {
   subFocus?: "select" | "text"
   focused?: boolean
@@ -32,8 +34,9 @@ function UrlBarHarness({
   onSubFocus?: (subFocus: "select" | "text") => void
   onSend?: () => void
   sending?: boolean
+  initialUrl?: string
 }) {
-  const [url, setUrl] = useState("https://example.com")
+  const [url, setUrl] = useState(initialUrl)
   const [method, setMethod] = useState<Method>(initialMethod)
   return (
     <UrlBar
@@ -89,6 +92,51 @@ describe("UrlBar", () => {
     await mockMouse.click(sendX, sendY, MouseButtons.LEFT)
     expect(sends).toBe(1)
     expect(focusCount).toBe(0)
+    cleanup()
+  })
+
+  it("keeps the URL width stable while sending a long URL", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    let startSending = () => {}
+
+    function TestContainer() {
+      const [sending, setSending] = useState(false)
+      startSending = () => setSending(true)
+      return (
+        <UrlBarHarness
+          initialUrl={`https://example.com/${"long-path/".repeat(20)}`}
+          onSend={() => {}}
+          sending={sending}
+        />
+      )
+    }
+
+    const { renderOnce, renderer } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <TestContainer />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 40, height: 12 },
+    )
+    await renderOnce()
+
+    const findInput = (node: BaseRenderable): InputRenderable | undefined => {
+      if (node instanceof InputRenderable) return node
+      for (const child of node.getChildren()) {
+        const input = findInput(child)
+        if (input) return input
+      }
+    }
+    const width = findInput(renderer.root)!.width
+    expect(renderer.root.findDescendantById("urlbar-send-button")!.width).toBe(
+      6,
+    )
+
+    act(() => startSending())
+    await renderOnce()
+
+    expect(findInput(renderer.root)!.width).toBe(width)
     cleanup()
   })
 


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the URL bar shrinking the URL input when sending a request. The spinner + "Send" text changes width while sending, which resized the URL field. This wraps the label in a fixed-width inner box so the URL input keeps a stable width during a request.

### How did you verify your code works?

Added a unit test that renders a long URL, snapshots the input width, flips to `sending`, and asserts the input width and send button width stay stable.

- `bun test` passes (2764 tests)
- `bun run lint` passes
- `bun run typecheck` passes

### Screenshots / recordings

N/A (terminal UI width fix)

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented long URLs from changing the URL input width while a request is being sent.
  * Standardized the Send button width for a more consistent layout.
  * Preserved existing Send text and loading spinner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->