### PR TITLE
fix(keymap): apply shortcut settings immediately and toast save/reset feedback

### DIFF
--- a/src/ui/settings/SettingsView.tsx
+++ b/src/ui/settings/SettingsView.tsx
@@ -34,6 +34,7 @@ import {
 } from "../keybind"
 import { THEMES } from "../theme-data"
 import { useTheme } from "../theme"
+import { showToast } from "../Toast"
 import { FullBorder, LeftBar } from "../borders"
 import { Frame } from "../Frame"
 import { Checkbox } from "../Checkbox"
@@ -449,7 +450,8 @@ export function SettingsView({
         }
         if (onKeybindChange(captureName, binding)) {
           setCaptureName(null)
-          setMessage({ text: "Shortcut saved", kind: "success" })
+          setMessage(null)
+          showToast("Shortcut saved", "success")
         }
       },
       { priority: 220 },
@@ -573,17 +575,14 @@ export function SettingsView({
             const name = keybindNames[contentIndex]
             if (!name) return
             setCaptureName(name)
-            setMessage({
-              text: "Press a shortcut · Esc cancels",
-              kind: "success",
-            })
           } else if (keyEventToBinding(event) === keybinds.browse_delete) {
             event.preventDefault()
             event.stopPropagation()
             const name = keybindNames[contentIndex]
             if (name) {
               if (onKeybindChange(name, Definitions[name].default)) {
-                setMessage({ text: "Shortcut reset", kind: "success" })
+                setMessage(null)
+                showToast("Shortcut reset", "success")
               }
             }
           }
@@ -1452,7 +1451,7 @@ function KeyboardRows({
                   : `${displayKey(keybinds[name])}${keybinds[name] === definition.default ? "" : " · custom"}`}
               </text>
             </box>
-            {selected && message && (
+            {captureName === name && message && (
               <text
                 id="settings-key-message"
                 fg={message.kind === "success" ? theme.success : theme.error}

--- a/src/ui/useAppKeymap.ts
+++ b/src/ui/useAppKeymap.ts
@@ -58,21 +58,26 @@ export function useAppKeymap(args: UseAppKeymapArgs): void {
     actions: createActionsConfig(args, renderer),
   }
   const layers = createAppKeymapLayers(context)
+  const bindingDeps = [
+    args.runtime.keybinds,
+    args.runtime.collectionDir,
+    args.runtime.confirmUndoAll,
+  ]
 
-  useBindings(() => layers[0])
-  useBindings(() => layers[1])
-  useBindings(() => layers[2])
-  useBindings(() => layers[3])
-  useBindings(() => layers[4])
-  useBindings(() => layers[5])
-  useBindings(() => layers[6])
-  useBindings(() => layers[7])
-  useBindings(() => layers[8])
-  useBindings(() => layers[9])
-  useBindings(() => layers[10])
-  useBindings(() => layers[11])
-  useBindings(() => layers[12])
-  useBindings(() => layers[13])
-  useBindings(() => layers[14])
-  useBindings(() => layers[15])
+  useBindings(() => layers[0], bindingDeps)
+  useBindings(() => layers[1], bindingDeps)
+  useBindings(() => layers[2], bindingDeps)
+  useBindings(() => layers[3], bindingDeps)
+  useBindings(() => layers[4], bindingDeps)
+  useBindings(() => layers[5], bindingDeps)
+  useBindings(() => layers[6], bindingDeps)
+  useBindings(() => layers[7], bindingDeps)
+  useBindings(() => layers[8], bindingDeps)
+  useBindings(() => layers[9], bindingDeps)
+  useBindings(() => layers[10], bindingDeps)
+  useBindings(() => layers[11], bindingDeps)
+  useBindings(() => layers[12], bindingDeps)
+  useBindings(() => layers[13], bindingDeps)
+  useBindings(() => layers[14], bindingDeps)
+  useBindings(() => layers[15], bindingDeps)
 }

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -16,6 +16,7 @@ import type { KeymapProviderProps } from "@opentui/keymap/react"
 import { createTestRender } from "../testRender"
 import { ThemeProvider } from "../../src/ui/theme"
 import { bindingDefaults } from "../../src/ui/keybind"
+import { Toast } from "../../src/ui/Toast"
 import type { Focus } from "../../src/ui/focus"
 import type { AppProxySettings, CollectionSettings } from "../../src/schema"
 import {
@@ -817,6 +818,37 @@ describe("SettingsView", () => {
     await renderOnce()
 
     expect(captureCharFrame()).toContain("That key cannot be assigned")
+    cleanup()
+  })
+
+  it("shows successful shortcut changes in a toast", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame, renderer } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <>
+            <Harness
+              initialCategory="keyboard"
+              initialFocus="settings-content"
+            />
+            <Toast />
+          </>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 72, height: 12 },
+    )
+    await renderOnce()
+
+    await act(async () => host.press("return"))
+    await renderOnce()
+    expect(captureCharFrame()).not.toContain("Press a shortcut")
+    await act(async () => host.press("f7"))
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("Shortcut saved")
+    expect(
+      renderer.root.findDescendantById("settings-key-message"),
+    ).toBeUndefined()
     cleanup()
   })
 

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "bun:test"
+import { act, createElement, useState } from "react"
+import type { CliRenderer } from "@opentui/core"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
   registerDefaultKeys,
   registerEnabledFields,
 } from "@opentui/keymap/addons"
 import type { UseBindingsLayer } from "@opentui/keymap/react"
+import { KeymapProvider } from "@opentui/keymap/react"
+import type { KeymapProviderProps } from "@opentui/keymap/react"
+import { RendererProvider } from "../../src/ui/RendererContext"
 import { bindingDefaults } from "../../src/ui/keybind"
+import type { Keybinds } from "../../src/ui/keybind"
 import { createAppKeymapLayers } from "../../src/ui/keymap/layers"
 import type { AppKeymapContext } from "../../src/ui/keymap/types"
+import { useAppKeymap } from "../../src/ui/useAppKeymap"
+import { createTestRender } from "../testRender"
+
+const testRender = createTestRender()
 
 function setup() {
   const { keymap, host, cleanup: hostCleanup } = createTestKeymap()
@@ -191,6 +201,30 @@ function register(context: AppKeymapContext) {
   return createAppKeymapLayers(context).map((layer) =>
     context.keymap.registerLayer(layer),
   )
+}
+
+function KeymapHarness({
+  context,
+  onKeybindsChange,
+}: {
+  context: AppKeymapContext
+  onKeybindsChange: (update: (keybinds: Keybinds) => void) => void
+}) {
+  const [keybinds, setKeybinds] = useState(context.keybinds)
+  onKeybindsChange((next) => setKeybinds(next))
+  useAppKeymap({
+    runtime: {
+      keybinds,
+      collectionDir: context.collectionDir,
+      confirmUndoAll: context.confirmUndoAll,
+    },
+    global: context.global,
+    request: context.request,
+    folder: context.folder,
+    environment: context.environment,
+    cookies: context.cookies,
+  })
+  return null
 }
 
 function firstCommandName(layer: UseBindingsLayer): string | undefined {
@@ -455,6 +489,44 @@ describe("app keymap layers", () => {
     expect(calls.settingsOpened).toBe(true)
 
     disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("refreshes settings shortcuts without remounting the keymap", async () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    let updateKeybinds: ((keybinds: Keybinds) => void) | undefined
+    const render = await testRender(
+      createElement(RendererProvider, {
+        renderer: {} as CliRenderer,
+        children: createElement(KeymapProvider, {
+          keymap: keymap as unknown as KeymapProviderProps["keymap"],
+          children: createElement(KeymapHarness, {
+            context,
+            onKeybindsChange: (update) => {
+              updateKeybinds = update
+            },
+          }),
+        }),
+      }),
+      { width: 80, height: 24 },
+    )
+    await render.renderOnce()
+
+    host.press("f4")
+    expect(calls.settingsOpened).toBe(true)
+    calls.settingsOpened = false
+
+    await act(() => {
+      updateKeybinds!({ ...context.keybinds, settings_open: "f5" })
+    })
+    await render.renderOnce()
+
+    host.press("f4")
+    expect(calls.settingsOpened).toBe(false)
+    host.press("f5")
+    expect(calls.settingsOpened).toBe(true)
+
     cleanup()
   })
 

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { act, createElement, useState } from "react"
+import { act, createElement, useEffect, useState } from "react"
 import type { CliRenderer } from "@opentui/core"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import {
@@ -211,7 +211,9 @@ function KeymapHarness({
   onKeybindsChange: (update: (keybinds: Keybinds) => void) => void
 }) {
   const [keybinds, setKeybinds] = useState(context.keybinds)
-  onKeybindsChange((next) => setKeybinds(next))
+  useEffect(() => {
+    onKeybindsChange((next) => setKeybinds(next))
+  }, [onKeybindsChange])
   useAppKeymap({
     runtime: {
       keybinds,


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Saved shortcut changes now take effect immediately. `useBindings` is reactive to runtime keybinds instead of capturing a stale snapshot, so remounting the app is no longer required after editing keyboard shortcuts. Save and reset feedback moved from inline rows to toasts.

### How did you verify your code works?

- Added `tests/unit/appKeymapLayers.test.ts` — verifies an updated shortcut fires without a keymap remount.
- Added `tests/unit/SettingsView.test.tsx` — verifies save feedback renders as a toast and the inline message is gone.
- `bun test` passes (2766 pass, 0 fail).
- `bun run lint` passes.
- `bun run typecheck` passes.

### Screenshots / recordings

N/A — terminal UI change, no visual regression covered by existing snapshot tests.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toast notifications when keyboard shortcuts are saved or reset.
  * Shortcut feedback now appears inline only for the shortcut currently being captured.
  * Updated keyboard shortcuts take effect immediately without restarting the app.

* **Bug Fixes**
  * Prevented shortcut messages from appearing for unrelated selected shortcuts.
  * Improved reliability when changing keyboard shortcuts while the app is running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->