### PR TITLE
feat(agent): add agent install command and skill synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,7 +384,7 @@ Active pane gets cyan border + `▸` prefix. Global keys work regardless of focu
 - Tests use real filesystem I/O for filestore, lang, and env modules (write to temp dirs with `mkdtemp`).
 - Never use fixed delays (`setTimeout`, `Bun.sleep`, or equivalent) to wait for asynchronous test state. Await the real operation or use a state-based wait such as `waitFor`.
 - Tests must finish without unexpected console or runtime warnings. Treat React/OpenTUI `act(...)` diagnostics as failures; expected warnings must be captured and asserted explicitly.
-- Before handing off any changed asynchronous test, run its file with `bun test <file> --rerun-each=50` and report the result.
+- Before handing off any changed asynchronous test, run its file with `bun test <file> --rerun-each=10` and report the result.
 
 ## Subagents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Noodle are documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- Add `noodle agent install` and the **Install Noodle skill** command-palette action, with an embedded, network-free `noodle-use` installer for Claude, Cursor, Codex, and OpenCode.
+- Keep existing managed skill installations synchronized after standalone binary, Noodle-managed Homebrew, TUI, and curl-installer updates without failing a successful Noodle update when skill refresh needs a manual retry.
+
+### 📚 Documentation
+
+- Document managed skill installation, automatic synchronization, JSON output, and the `npx skills` fallback across the README and documentation site.
+
 ## [0.7.5] - 2026-08-16
 
 Noodle 0.7.5 adds first-class XML request bodies across editing, execution, history, and conversion workflows. It also makes invalid collection YAML repairable in the TUI, adds direct Settings and external-editor commands, and improves update visibility and empty-state interactions.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ hosted integration.
 Install the `noodle-use` skill:
 
 ```bash
+noodle agent install
+```
+
+Noodle keeps the skill synchronized when it updates. The installer stores the
+managed copy under `~/.agents/skills/noodle-use` and links detected Claude,
+Cursor, Codex, and OpenCode installations to it. For other clients, use the
+skills CLI fallback:
+
+```bash
 npx skills add wilfredinni/noodle --skill noodle-use -g
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,20 @@ REPO="wilfredinni/noodle"
 BIN_NAME="noodle"
 INSTALL_DIR="${NOODLE_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${NOODLE_VERSION:-latest}"
+SKILL_INSTALLED=0
+
+for skill_path in \
+  "$HOME/.agents/skills/noodle-use" \
+  "$HOME/.claude/skills/noodle-use" \
+  "$HOME/.cursor/skills/noodle-use" \
+  "$HOME/.codex/skills/noodle-use" \
+  "$HOME/.config/opencode/skills/noodle-use"
+do
+  if [ -e "$skill_path" ] || [ -L "$skill_path" ]; then
+    SKILL_INSTALLED=1
+    break
+  fi
+done
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -101,6 +115,15 @@ mv "$STAGED_FILE" "$INSTALL_DIR/$BIN_NAME"
 STAGED_FILE=""
 
 printf '%b\n' "${GREEN}Installed to $INSTALL_DIR/$BIN_NAME${NC}"
+
+if [ "$SKILL_INSTALLED" -eq 1 ]; then
+  if "$INSTALL_DIR/$BIN_NAME" agent install --json >/dev/null 2>&1; then
+    printf '%b\n' "${GREEN}Updated Noodle skill.${NC}"
+  else
+    printf '%b\n' "${YELLOW}Warning: Noodle was installed, but its skill could not be refreshed.${NC}" >&2
+    echo "Retry with: noodle agent install" >&2
+  fi
+fi
 
 if ! echo "$PATH" | tr ':' '\n' | grep -qxF "$INSTALL_DIR"; then
   printf '%b\n' "${YELLOW}Warning: $INSTALL_DIR is not in your PATH.${NC}"

--- a/src/agentSkill.ts
+++ b/src/agentSkill.ts
@@ -73,7 +73,7 @@ async function exists(path: string): Promise<boolean> {
     return true
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
-    throw error
+    throw new Error(`Failed to inspect path ${path}`, { cause: error })
   }
 }
 
@@ -85,7 +85,9 @@ async function hasManagedMarker(path: string): Promise<boolean> {
     )
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
-    throw error
+    throw new Error(`Failed to read skill marker for ${path}`, {
+      cause: error,
+    })
   }
 }
 
@@ -95,7 +97,9 @@ async function assertReplaceablePath(targetPath: string): Promise<void> {
     info = await lstat(targetPath)
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return
-    throw error
+    throw new Error(`Failed to inspect skill path ${targetPath}`, {
+      cause: error,
+    })
   }
 
   if (info.isSymbolicLink()) return
@@ -132,7 +136,9 @@ async function replacePath(stagedPath: string, targetPath: string) {
           cause: restoreError,
         })
       }
-      throw error
+      throw new Error(`Failed to validate backed-up skill path ${backupPath}`, {
+        cause: error,
+      })
     }
   }
 

--- a/src/agentSkill.ts
+++ b/src/agentSkill.ts
@@ -3,6 +3,7 @@ import {
   lstat,
   mkdir,
   mkdtemp,
+  readFile,
   rename,
   rm,
   symlink,
@@ -34,6 +35,9 @@ export const NOODLE_SKILL_FILES = {
   "reference/conventions.md": conventions,
   "reference/examples.md": examples,
 } as const
+
+export const NOODLE_SKILL_MARKER = ".noodle-managed"
+const NOODLE_SKILL_MARKER_CONTENT = "noodle-use\n"
 
 export interface AgentSkillInstallResult {
   action: "installed" | "updated"
@@ -73,6 +77,32 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+async function hasManagedMarker(path: string): Promise<boolean> {
+  try {
+    return (
+      (await readFile(join(path, NOODLE_SKILL_MARKER), "utf8")) ===
+      NOODLE_SKILL_MARKER_CONTENT
+    )
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw error
+  }
+}
+
+async function assertReplaceablePath(targetPath: string): Promise<void> {
+  let info
+  try {
+    info = await lstat(targetPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+
+  if (info.isSymbolicLink()) return
+  if (info.isDirectory() && (await hasManagedMarker(targetPath))) return
+  throw new Error(`Refusing to replace unmanaged skill path ${targetPath}`)
+}
+
 export async function isNoodleSkillInstalled(home?: string): Promise<boolean> {
   for (const path of getNoodleSkillPaths(home).recognized) {
     try {
@@ -88,9 +118,22 @@ async function replacePath(stagedPath: string, targetPath: string) {
   const parent = dirname(targetPath)
   let backupPath: string | undefined
   if (await exists(targetPath)) {
+    await assertReplaceablePath(targetPath)
     backupPath = await mkdtemp(join(parent, ".noodle-use-backup-"))
     await rm(backupPath, { recursive: true, force: true })
     await rename(targetPath, backupPath)
+    try {
+      await assertReplaceablePath(backupPath)
+    } catch (error) {
+      try {
+        await rename(backupPath, targetPath)
+      } catch (restoreError) {
+        throw new Error(`Failed to restore ${targetPath}`, {
+          cause: restoreError,
+        })
+      }
+      throw error
+    }
   }
 
   try {
@@ -114,6 +157,10 @@ async function writeCanonicalSkill(path: string) {
       await mkdir(dirname(filePath), { recursive: true })
       await writeFile(filePath, contents)
     }
+    await writeFile(
+      join(stagedPath, NOODLE_SKILL_MARKER),
+      NOODLE_SKILL_MARKER_CONTENT,
+    )
     await replacePath(stagedPath, path)
   } finally {
     await rm(stagingRoot, { recursive: true, force: true })
@@ -159,6 +206,9 @@ export async function installNoodleSkill(
   const { canonical } = getNoodleSkillPaths(root)
   const action = (await isNoodleSkillInstalled(root)) ? "updated" : "installed"
   const linked = await detectedToolLinks(root)
+
+  await assertReplaceablePath(canonical)
+  for (const target of linked) await assertReplaceablePath(target)
 
   await writeCanonicalSkill(canonical)
   for (const target of linked) await linkSkill(target, canonical)

--- a/src/agentSkill.ts
+++ b/src/agentSkill.ts
@@ -1,0 +1,167 @@
+import { homedir } from "node:os"
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises"
+import { dirname, join } from "node:path"
+import skill from "../.agents/skills/noodle-use/SKILL.md" with { type: "text" }
+import schema from "../.agents/skills/noodle-use/schema.md" with { type: "text" }
+import automation from "../.agents/skills/noodle-use/workflows/automation.md" with { type: "text" }
+import convert from "../.agents/skills/noodle-use/workflows/convert.md" with { type: "text" }
+import create from "../.agents/skills/noodle-use/workflows/create.md" with { type: "text" }
+import evaluate from "../.agents/skills/noodle-use/workflows/evaluate.md" with { type: "text" }
+import importWorkflow from "../.agents/skills/noodle-use/workflows/import.md" with { type: "text" }
+import organize from "../.agents/skills/noodle-use/workflows/organize.md" with { type: "text" }
+import config from "../.agents/skills/noodle-use/reference/config.md" with { type: "text" }
+import conventions from "../.agents/skills/noodle-use/reference/conventions.md" with { type: "text" }
+import examples from "../.agents/skills/noodle-use/reference/examples.md" with { type: "text" }
+
+export const NOODLE_SKILL_FILES = {
+  "SKILL.md": skill,
+  "schema.md": schema,
+  "workflows/automation.md": automation,
+  "workflows/convert.md": convert,
+  "workflows/create.md": create,
+  "workflows/evaluate.md": evaluate,
+  "workflows/import.md": importWorkflow,
+  "workflows/organize.md": organize,
+  "reference/config.md": config,
+  "reference/conventions.md": conventions,
+  "reference/examples.md": examples,
+} as const
+
+export interface AgentSkillInstallResult {
+  action: "installed" | "updated"
+  path: string
+  linked: string[]
+}
+
+function userHome(home?: string): string {
+  return home ?? process.env.HOME ?? homedir()
+}
+
+export function getNoodleSkillPaths(home?: string): {
+  canonical: string
+  recognized: string[]
+} {
+  const root = userHome(home)
+  const canonical = join(root, ".agents", "skills", "noodle-use")
+  return {
+    canonical,
+    recognized: [
+      canonical,
+      join(root, ".claude", "skills", "noodle-use"),
+      join(root, ".cursor", "skills", "noodle-use"),
+      join(root, ".codex", "skills", "noodle-use"),
+      join(root, ".config", "opencode", "skills", "noodle-use"),
+    ],
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw error
+  }
+}
+
+export async function isNoodleSkillInstalled(home?: string): Promise<boolean> {
+  for (const path of getNoodleSkillPaths(home).recognized) {
+    try {
+      if (await exists(path)) return true
+    } catch {
+      return true
+    }
+  }
+  return false
+}
+
+async function replacePath(stagedPath: string, targetPath: string) {
+  const parent = dirname(targetPath)
+  let backupPath: string | undefined
+  if (await exists(targetPath)) {
+    backupPath = await mkdtemp(join(parent, ".noodle-use-backup-"))
+    await rm(backupPath, { recursive: true, force: true })
+    await rename(targetPath, backupPath)
+  }
+
+  try {
+    await rename(stagedPath, targetPath)
+  } catch (error) {
+    if (backupPath) await rename(backupPath, targetPath)
+    throw new Error(`Failed to replace ${targetPath}`, { cause: error })
+  }
+
+  if (backupPath) await rm(backupPath, { recursive: true, force: true })
+}
+
+async function writeCanonicalSkill(path: string) {
+  const parent = dirname(path)
+  await mkdir(parent, { recursive: true })
+  const stagingRoot = await mkdtemp(join(parent, ".noodle-use-stage-"))
+  const stagedPath = join(stagingRoot, "noodle-use")
+  try {
+    for (const [relativePath, contents] of Object.entries(NOODLE_SKILL_FILES)) {
+      const filePath = join(stagedPath, relativePath)
+      await mkdir(dirname(filePath), { recursive: true })
+      await writeFile(filePath, contents)
+    }
+    await replacePath(stagedPath, path)
+  } finally {
+    await rm(stagingRoot, { recursive: true, force: true })
+  }
+}
+
+async function linkSkill(targetPath: string, canonicalPath: string) {
+  const parent = dirname(targetPath)
+  await mkdir(parent, { recursive: true })
+  const stagingRoot = await mkdtemp(join(parent, ".noodle-use-link-"))
+  const stagedPath = join(stagingRoot, "noodle-use")
+  try {
+    await symlink(canonicalPath, stagedPath, "dir")
+    await replacePath(stagedPath, targetPath)
+  } finally {
+    await rm(stagingRoot, { recursive: true, force: true })
+  }
+}
+
+async function detectedToolLinks(home: string): Promise<string[]> {
+  const tools = [
+    [join(home, ".claude"), join(home, ".claude", "skills", "noodle-use")],
+    [join(home, ".cursor"), join(home, ".cursor", "skills", "noodle-use")],
+    [join(home, ".codex"), join(home, ".codex", "skills", "noodle-use")],
+  ] as const
+  const links: string[] = []
+  for (const [root, target] of tools) {
+    if (await exists(root)) links.push(target)
+  }
+  if (
+    (await exists(join(home, ".opencode"))) ||
+    (await exists(join(home, ".config", "opencode")))
+  ) {
+    links.push(join(home, ".config", "opencode", "skills", "noodle-use"))
+  }
+  return links
+}
+
+export async function installNoodleSkill(
+  home?: string,
+): Promise<AgentSkillInstallResult> {
+  const root = userHome(home)
+  const { canonical } = getNoodleSkillPaths(root)
+  const action = (await isNoodleSkillInstalled(root)) ? "updated" : "installed"
+  const linked = await detectedToolLinks(root)
+
+  await writeCanonicalSkill(canonical)
+  for (const target of linked) await linkSkill(target, canonical)
+
+  return { action, path: canonical, linked }
+}

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -5,6 +5,7 @@ import defaultCommand from "./commands/default"
 import exportCommand from "./commands/export"
 import importCommand from "./commands/import"
 import updateCommand from "./commands/update"
+import agentCommand from "./commands/agent"
 import { getUserArgsStart } from "./argv"
 import {
   workspace,
@@ -25,6 +26,7 @@ const KNOWN_SUBCOMMANDS = new Set([
   "import",
   "export",
   "update",
+  "agent",
   "workspace",
   "collection",
   "request",
@@ -73,6 +75,7 @@ const main = defineCommand({
     import: importCommand,
     export: exportCommand,
     update: updateCommand,
+    agent: agentCommand,
     workspace,
     collection,
     request,

--- a/src/app/commands/agent.ts
+++ b/src/app/commands/agent.ts
@@ -1,0 +1,43 @@
+import { defineCommand } from "citty"
+import {
+  installNoodleSkill,
+  type AgentSkillInstallResult,
+} from "../../agentSkill"
+import { emitCommand } from "../commandResult"
+
+const install = defineCommand({
+  meta: {
+    name: "install",
+    description: "Install or update the Noodle agent skill",
+  },
+  args: {
+    json: {
+      type: "boolean",
+      default: false,
+      description: "Write one JSON result envelope to stdout",
+    },
+  },
+  async run({ args }) {
+    await emitCommand(
+      args.json === true,
+      async () => ({ data: await installNoodleSkill() }),
+      formatInstall,
+    )
+  },
+})
+
+function formatInstall(result: AgentSkillInstallResult): string {
+  const action = result.action === "installed" ? "Installed" : "Updated"
+  const links = result.linked.length
+    ? `\nLinked: ${result.linked.join(", ")}`
+    : ""
+  return `${action} Noodle skill at ${result.path}${links}`
+}
+
+export default defineCommand({
+  meta: {
+    name: "agent",
+    description: "Manage Noodle agent integrations",
+  },
+  subCommands: { install },
+})

--- a/src/app/commands/updateInstall.ts
+++ b/src/app/commands/updateInstall.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import { chmod, mkdtemp, rename, rm, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
+import { isNoodleSkillInstalled } from "../../agentSkill"
 import {
   getHomebrewExecutable,
   isBunRuntime,
@@ -29,6 +30,39 @@ export function parseChecksumManifest(
   return null
 }
 
+async function refreshInstalledSkill(
+  installed: boolean,
+  executable: string,
+  deps: UpdateDependencies,
+  output: (message: string) => void,
+): Promise<Record<string, string>> {
+  if (!installed) return {}
+  try {
+    const result = await deps.runProcess(
+      [executable, "agent", "install", "--json"],
+      true,
+      { env: deps.env },
+    )
+    if (result.exitCode === 0) {
+      output("Noodle skill updated.")
+      return { skill_status: "updated" }
+    }
+  } catch {
+    // The Noodle update remains successful; the warning below has the retry.
+  }
+  output("Warning: Noodle updated, but its skill could not be refreshed.")
+  output("Retry with: noodle agent install")
+  return {
+    skill_status: "failed",
+    skill_retry: "noodle agent install",
+  }
+}
+
+async function hasInstalledSkill(deps: UpdateDependencies): Promise<boolean> {
+  if (deps.env.HOME === undefined && deps.env !== process.env) return false
+  return isNoodleSkillInstalled(deps.env.HOME)
+}
+
 async function runHomebrewUpdate(
   silent: boolean,
   deps: UpdateDependencies,
@@ -37,6 +71,7 @@ async function runHomebrewUpdate(
     if (!silent) console.log(message)
   }
   output("Updating noodle via Homebrew...")
+  const skillInstalled = await hasInstalledSkill(deps)
   try {
     const result = await deps.runProcess(
       [getHomebrewExecutable(deps.execPath), "upgrade", "noodle"],
@@ -57,8 +92,18 @@ async function runHomebrewUpdate(
       }
     }
     output("Homebrew upgrade completed.")
+    const skill = await refreshInstalledSkill(
+      skillInstalled,
+      join(dirname(getHomebrewExecutable(deps.execPath)), "noodle"),
+      deps,
+      output,
+    )
     return {
-      data: { status: "homebrew_updated", command: "brew upgrade noodle" },
+      data: {
+        status: "homebrew_updated",
+        command: "brew upgrade noodle",
+        ...skill,
+      },
     }
   } catch {
     output("Unable to run Homebrew. Is `brew` installed and available on PATH?")
@@ -113,6 +158,7 @@ async function downloadAndInstall(
 ): Promise<{ data: Record<string, string>; failed?: boolean }> {
   const assetName = getAssetName(deps.platform, deps.arch)
   const platform = getPlatformString(deps.platform, deps.arch)
+  const skillInstalled = await hasInstalledSkill(deps)
   output(`Downloading ${tag} for ${platform}...`)
   onPhase?.("downloading")
   let stagingDir: string | undefined
@@ -133,7 +179,13 @@ async function downloadAndInstall(
     await chmod(stagedPath, 0o755)
     await rename(stagedPath, deps.execPath)
     output(`Updated to ${tag}`)
-    return { data: { status: "updated", version: tag } }
+    const skill = await refreshInstalledSkill(
+      skillInstalled,
+      deps.execPath,
+      deps,
+      output,
+    )
+    return { data: { status: "updated", version: tag, ...skill } }
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error)
     output(`Failed to update: ${reason}`)

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -7,3 +7,8 @@ declare module "*.scm" {
   const path: string
   export default path
 }
+
+declare module "*.md" {
+  const text: string
+  export default text
+}

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -22,13 +22,15 @@ export function Toast() {
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   useEffect(() => {
-    showToastFn = (message: string, variant?: ToastVariant) => {
+    const show = (message: string, variant?: ToastVariant) => {
       setState({ message, variant: variant ?? "info" })
       clearTimeout(timerRef.current)
       timerRef.current = setTimeout(() => setState(null), 5000)
     }
+    showToastFn = show
     return () => {
-      showToastFn = null
+      if (showToastFn === show) showToastFn = null
+      clearTimeout(timerRef.current)
     }
   }, [])
 

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -25,6 +25,7 @@ import type { TlsPolicy } from "../tls"
 import type { SendState } from "./sendState"
 import type { ResponseQueryController } from "./responseQuery"
 import { launchExternalEditor, type ExternalEditor } from "../externalEditor"
+import { installNoodleSkill, type AgentSkillInstallResult } from "../agentSkill"
 
 export interface CommandActionsConfig {
   collectionDir: string
@@ -426,6 +427,28 @@ export function openThemePicker(): boolean {
 }
 
 export function openAbout(): boolean {
+  return true
+}
+
+export function installAgentSkill(
+  installer: () => Promise<AgentSkillInstallResult> = installNoodleSkill,
+  notify: typeof showToast = showToast,
+): boolean {
+  void installer()
+    .then(({ action }) =>
+      notify(
+        action === "installed"
+          ? "Noodle skill installed"
+          : "Noodle skill updated",
+        "success",
+      ),
+    )
+    .catch((error: unknown) =>
+      notify(
+        `Failed to install Noodle skill: ${error instanceof Error ? error.message : String(error)}`,
+        "error",
+      ),
+    )
   return true
 }
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -50,6 +50,7 @@ import {
   undoAll,
   openThemePicker,
   openAbout,
+  installAgentSkill,
   openCollectionExport,
   openCollectionImport,
   openCollectionSwitcher,
@@ -609,6 +610,12 @@ export function buildCommandPaletteCommands(
   ]
 
   const systemCommands: CommandItem[] = [
+    {
+      id: "app.agent-skill-install",
+      label: "Install Noodle skill",
+      section: "System",
+      run: installAgentSkill,
+    },
     {
       id: "app.settings-folder-open-in-editor",
       label: "Open Settings in Editor",

--- a/src/ui/useUpdateFlow.ts
+++ b/src/ui/useUpdateFlow.ts
@@ -14,6 +14,12 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function showUpdateCompleted(skillStatus: string | undefined) {
+  if (skillStatus === "failed")
+    showToast("Noodle updated; skill update failed", "warning")
+  else showToast("Update completed", "success")
+}
+
 function getPreviewFlow(value: string | undefined): UpdateFlowState | null {
   switch (value) {
     case "idle":
@@ -146,7 +152,7 @@ export function useUpdateFlow(
         .then((result) => {
           if (token !== installTokenRef.current) return
           if (result.data.status === "homebrew_updated") {
-            showToast("Update completed", "success")
+            showUpdateCompleted(result.data.skill_status)
             setUpdateFlow({ phase: "done", version: update.version })
           } else {
             const message = result.data.exit_code
@@ -196,7 +202,7 @@ export function useUpdateFlow(
         if (token !== installTokenRef.current) return
         if (result.data.status === "updated") {
           const version = result.data.version ?? update.version
-          showToast("Update completed", "success")
+          showUpdateCompleted(result.data.skill_status)
           setUpdateFlow({ phase: "done", version })
         } else {
           const message =

--- a/tests/agentSkill.test.ts
+++ b/tests/agentSkill.test.ts
@@ -16,6 +16,7 @@ import {
   getNoodleSkillPaths,
   installNoodleSkill,
   isNoodleSkillInstalled,
+  NOODLE_SKILL_MARKER,
   NOODLE_SKILL_FILES,
 } from "../src/agentSkill"
 
@@ -56,7 +57,7 @@ describe("Noodle agent skill installer", () => {
       linked: [],
     })
     expect(await filesBelow(result.path)).toEqual(
-      Object.keys(NOODLE_SKILL_FILES).sort(),
+      [...Object.keys(NOODLE_SKILL_FILES), NOODLE_SKILL_MARKER].sort(),
     )
     for (const [path, contents] of Object.entries(NOODLE_SKILL_FILES)) {
       expect(await readFile(join(result.path, path), "utf8")).toBe(contents)
@@ -67,14 +68,26 @@ describe("Noodle agent skill installer", () => {
   it("atomically replaces an existing canonical copy", async () => {
     const canonical = getNoodleSkillPaths(home).canonical
     await mkdir(canonical, { recursive: true })
+    await writeFile(join(canonical, NOODLE_SKILL_MARKER), "noodle-use\n")
     await writeFile(join(canonical, "obsolete.md"), "old")
 
     const result = await installNoodleSkill(home)
 
     expect(result.action).toBe("updated")
     expect(await filesBelow(canonical)).toEqual(
-      Object.keys(NOODLE_SKILL_FILES).sort(),
+      [...Object.keys(NOODLE_SKILL_FILES), NOODLE_SKILL_MARKER].sort(),
     )
+  })
+
+  it("preserves an unmanaged tool skill directory", async () => {
+    const target = join(home, ".claude", "skills", "noodle-use")
+    await mkdir(target, { recursive: true })
+    await writeFile(join(target, "local.md"), "keep me")
+
+    await expect(installNoodleSkill(home)).rejects.toThrow(
+      `Refusing to replace unmanaged skill path ${target}`,
+    )
+    expect(await readFile(join(target, "local.md"), "utf8")).toBe("keep me")
   })
 
   it("discovers Claude, Cursor, Codex, and OpenCode and links each one", async () => {

--- a/tests/agentSkill.test.ts
+++ b/tests/agentSkill.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, relative } from "node:path"
+import {
+  getNoodleSkillPaths,
+  installNoodleSkill,
+  isNoodleSkillInstalled,
+  NOODLE_SKILL_FILES,
+} from "../src/agentSkill"
+
+async function filesBelow(root: string): Promise<string[]> {
+  const files: string[] = []
+  async function walk(dir: string) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) await walk(path)
+      else files.push(relative(root, path))
+    }
+  }
+  await walk(root)
+  return files.sort()
+}
+
+describe("Noodle agent skill installer", () => {
+  let home: string
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "noodle-agent-skill-"))
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+  })
+
+  it("installs the exact embedded skill without touching the skill lock", async () => {
+    const lockPath = join(home, ".agents", ".skill-lock.json")
+    await mkdir(dirname(lockPath), { recursive: true })
+    await writeFile(lockPath, "keep me")
+
+    const result = await installNoodleSkill(home)
+
+    expect(result).toEqual({
+      action: "installed",
+      path: getNoodleSkillPaths(home).canonical,
+      linked: [],
+    })
+    expect(await filesBelow(result.path)).toEqual(
+      Object.keys(NOODLE_SKILL_FILES).sort(),
+    )
+    for (const [path, contents] of Object.entries(NOODLE_SKILL_FILES)) {
+      expect(await readFile(join(result.path, path), "utf8")).toBe(contents)
+    }
+    expect(await readFile(lockPath, "utf8")).toBe("keep me")
+  })
+
+  it("atomically replaces an existing canonical copy", async () => {
+    const canonical = getNoodleSkillPaths(home).canonical
+    await mkdir(canonical, { recursive: true })
+    await writeFile(join(canonical, "obsolete.md"), "old")
+
+    const result = await installNoodleSkill(home)
+
+    expect(result.action).toBe("updated")
+    expect(await filesBelow(canonical)).toEqual(
+      Object.keys(NOODLE_SKILL_FILES).sort(),
+    )
+  })
+
+  it("discovers Claude, Cursor, Codex, and OpenCode and links each one", async () => {
+    await Promise.all(
+      [".claude", ".cursor", ".codex", ".opencode"].map((dir) =>
+        mkdir(join(home, dir), { recursive: true }),
+      ),
+    )
+
+    const result = await installNoodleSkill(home)
+    const expected = [
+      join(home, ".claude", "skills", "noodle-use"),
+      join(home, ".cursor", "skills", "noodle-use"),
+      join(home, ".codex", "skills", "noodle-use"),
+      join(home, ".config", "opencode", "skills", "noodle-use"),
+    ]
+
+    expect(result.linked).toEqual(expected)
+    for (const path of expected) {
+      expect((await lstat(path)).isSymbolicLink()).toBe(true)
+      expect(await readlink(path)).toBe(result.path)
+    }
+  })
+
+  it("detects and safely replaces a legacy tool-specific symlink", async () => {
+    const outside = join(home, "outside")
+    const target = join(home, ".claude", "skills", "noodle-use")
+    await mkdir(outside, { recursive: true })
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(join(outside, "keep.md"), "keep")
+    await symlink(outside, target, "dir")
+
+    expect(await isNoodleSkillInstalled(home)).toBe(true)
+    const result = await installNoodleSkill(home)
+
+    expect(result.action).toBe("updated")
+    expect(await readlink(target)).toBe(result.path)
+    expect(await readFile(join(outside, "keep.md"), "utf8")).toBe("keep")
+  })
+
+  it("does not create tool links when no tool installation is present", async () => {
+    expect(await isNoodleSkillInstalled(home)).toBe(false)
+    const result = await installNoodleSkill(home)
+    expect(result.linked).toEqual([])
+  })
+
+  it("recognizes the XDG OpenCode root", async () => {
+    await mkdir(join(home, ".config", "opencode"), { recursive: true })
+    const result = await installNoodleSkill(home)
+    expect(result.linked).toEqual([
+      join(home, ".config", "opencode", "skills", "noodle-use"),
+    ])
+  })
+})

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises"
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  writeFile,
+} from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import type { CommandMeta, ArgsDef, StringArgDef } from "citty"
@@ -7,6 +15,8 @@ import defaultCommand from "../src/app/commands/default"
 import exportCommand from "../src/app/commands/export"
 import importCommand from "../src/app/commands/import"
 import updateCommand from "../src/app/commands/update"
+import agentCommand from "../src/app/commands/agent"
+import { NOODLE_SKILL_FILES } from "../src/agentSkill"
 import { resolveStartupCollectionDir } from "../src/app/main"
 import { classifyPath } from "../src/collectionPath"
 import { getUserArgsStart } from "../src/app/argv"
@@ -19,6 +29,7 @@ const importArgs = importCommand.args as ArgsDef | undefined
 const exportMeta = exportCommand.meta as CommandMeta | undefined
 const exportArgs = exportCommand.args as ArgsDef | undefined
 const updateMeta = updateCommand.meta as CommandMeta | undefined
+const agentMeta = agentCommand.meta as CommandMeta | undefined
 
 describe("default command (noodle)", () => {
   it("has correct meta name", () => {
@@ -82,6 +93,22 @@ describe("update command", () => {
   })
 })
 
+describe("agent command", () => {
+  it("exposes the nested install command with JSON output", () => {
+    expect(agentMeta?.name).toBe("agent")
+    const subCommands = agentCommand.subCommands as Record<
+      string,
+      { meta?: CommandMeta; args?: ArgsDef }
+    >
+    const install = subCommands.install
+    expect(install?.meta?.name).toBe("install")
+    expect((install?.args as ArgsDef | undefined)?.json).toMatchObject({
+      type: "boolean",
+      default: false,
+    })
+  })
+})
+
 describe("import command", () => {
   it("has correct meta name", () => {
     expect(importMeta?.name).toBe("import")
@@ -139,7 +166,9 @@ describe("CLI integration", () => {
   it("works from a compiled Bun binary", async () => {
     const dir = await mkdtemp(join(tmpdir(), "noodle-cli-compiled-"))
     const binary = join(dir, "noodle")
+    const home = join(dir, "home")
     try {
+      await mkdir(join(home, ".codex"), { recursive: true })
       const build = Bun.spawnSync(
         ["bun", "build", "--compile", CLI, "--outfile", binary],
         { cwd: dir },
@@ -150,6 +179,27 @@ describe("CLI integration", () => {
       expect(proc.exitCode).toBe(0)
       expect(proc.stdout.toString()).toContain("Terminal REST client")
       expect(proc.stderr.toString()).not.toContain("Unknown command")
+
+      const install = Bun.spawnSync([binary, "agent", "install", "--json"], {
+        env: { ...process.env, HOME: home },
+      })
+      expect(install.exitCode).toBe(0)
+      const canonical = join(home, ".agents", "skills", "noodle-use")
+      const codexLink = join(home, ".codex", "skills", "noodle-use")
+      expect(JSON.parse(install.stdout.toString())).toEqual({
+        status: "success",
+        data: {
+          action: "installed",
+          path: canonical,
+          linked: [codexLink],
+        },
+        errors: [],
+      })
+      for (const [path, contents] of Object.entries(NOODLE_SKILL_FILES)) {
+        expect(await readFile(join(canonical, path), "utf8")).toBe(contents)
+      }
+      expect((await lstat(codexLink)).isSymbolicLink()).toBe(true)
+      expect(await readlink(codexLink)).toBe(canonical)
     } finally {
       await rm(dir, { recursive: true, force: true })
     }
@@ -163,6 +213,7 @@ describe("CLI integration", () => {
     expect(out).toContain("import")
     expect(out).toContain("export")
     expect(out).toContain("update")
+    expect(out).toContain("agent")
   })
 
   it("shows default command flags with noodle --help", () => {
@@ -295,6 +346,16 @@ describe("CLI integration", () => {
     expect(proc.exitCode).toBe(0)
     const out = proc.stdout.toString()
     expect(out).toContain("Update")
+  })
+
+  it("shows nested help for agent skill installation", () => {
+    const agent = Bun.spawnSync(["bun", CLI, "agent", "--help"])
+    expect(agent.exitCode).toBe(0)
+    expect(agent.stdout.toString()).toContain("install")
+
+    const install = Bun.spawnSync(["bun", CLI, "agent", "install", "--help"])
+    expect(install.exitCode).toBe(0)
+    expect(install.stdout.toString()).toContain("json")
   })
 
   it("fails when import is called without source argument", () => {

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { createHash } from "node:crypto"
 
 const INSTALL_SCRIPT = join(import.meta.dir, "../scripts/install.sh")
 const BINARY = "noodle release binary\n"
@@ -19,8 +20,11 @@ const ASSET_NAME = `noodle-${process.platform === "darwin" ? "macos" : "linux"}-
 async function writeFakeCurl(
   directory: string,
   checksum: string,
+  binary = BINARY,
 ): Promise<void> {
   const path = join(directory, "curl")
+  const release = join(directory, "release-binary")
+  await writeFile(release, binary)
   await writeFile(
     path,
     `#!/usr/bin/env bash
@@ -37,7 +41,7 @@ while [ "$#" -gt 0 ]; do
 done
 case "$url" in
   *SHA256SUMS*) printf '%s  ${ASSET_NAME}\\n' '${checksum}' > "$output" ;;
-  *) printf '%s' '${BINARY}' > "$output" ;;
+  *) /bin/cp '${release}' "$output" ;;
 esac
 `,
   )
@@ -76,12 +80,14 @@ exec /bin/rm "$@"
 async function runInstaller(
   installDir: string,
   binDir: string,
+  home: string,
 ): Promise<ReturnType<typeof Bun.spawnSync>> {
   return Bun.spawnSync(["/bin/bash", INSTALL_SCRIPT], {
     env: {
       ...process.env,
       NOODLE_INSTALL_DIR: installDir,
       NOODLE_VERSION: "v0.4.7",
+      HOME: home,
       PATH: `${binDir}:${process.env.PATH}`,
     },
   })
@@ -96,10 +102,17 @@ describe("install script", () => {
       await mkdir(binDir, { recursive: true })
       await writeFakeCurl(binDir, BINARY_SHA256)
 
-      const result = await runInstaller(installDir, binDir)
+      const result = await runInstaller(
+        installDir,
+        binDir,
+        join(directory, "home"),
+      )
 
       expect(result.exitCode).toBe(0)
       expect(await readFile(join(installDir, "noodle"), "utf8")).toBe(BINARY)
+      expect(new TextDecoder().decode(result.stdout)).not.toContain(
+        "Updated Noodle skill",
+      )
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
@@ -117,7 +130,11 @@ describe("install script", () => {
       await writeFile(join(installDir, "noodle"), "old binary")
       await writeFakeCurl(binDir, "0".repeat(64))
 
-      const result = await runInstaller(installDir, binDir)
+      const result = await runInstaller(
+        installDir,
+        binDir,
+        join(directory, "home"),
+      )
 
       expect(result.exitCode).not.toBe(0)
       expect(await readFile(join(installDir, "noodle"), "utf8")).toBe(
@@ -136,12 +153,77 @@ describe("install script", () => {
       await mkdir(binDir, { recursive: true })
       await Promise.all([writeFailingCurl(binDir), writeStrictRm(binDir)])
 
-      const result = await runInstaller(installDir, binDir)
+      const result = await runInstaller(
+        installDir,
+        binDir,
+        join(directory, "home"),
+      )
 
       expect(result.exitCode).not.toBe(0)
       expect(new TextDecoder().decode(result.stderr)).not.toContain(
         "rm: empty path",
       )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("refreshes a pre-existing skill with the newly installed binary", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "noodle-install-skill-"))
+    const binDir = join(directory, "bin")
+    const installDir = join(directory, "install")
+    const home = join(directory, "home")
+    const binary = `#!/usr/bin/env bash
+printf '%s' "$*" > "$HOME/skill-refresh"
+`
+    try {
+      await mkdir(join(home, ".agents", "skills", "noodle-use"), {
+        recursive: true,
+      })
+      await mkdir(binDir, { recursive: true })
+      const hash = createHash("sha256").update(binary).digest("hex")
+      await writeFakeCurl(binDir, hash, binary)
+
+      const result = await runInstaller(installDir, binDir, home)
+
+      expect(result.exitCode).toBe(0)
+      expect(await readFile(join(home, "skill-refresh"), "utf8")).toBe(
+        "agent install --json",
+      )
+      expect(new TextDecoder().decode(result.stdout)).toContain(
+        "Updated Noodle skill",
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps curl installation successful when skill refresh fails", async () => {
+    const directory = await mkdtemp(
+      join(tmpdir(), "noodle-install-skill-fail-"),
+    )
+    const binDir = join(directory, "bin")
+    const installDir = join(directory, "install")
+    const home = join(directory, "home")
+    const binary = `#!/usr/bin/env bash
+exit 1
+`
+    try {
+      await mkdir(join(home, ".codex", "skills", "noodle-use"), {
+        recursive: true,
+      })
+      await mkdir(binDir, { recursive: true })
+      const hash = createHash("sha256").update(binary).digest("hex")
+      await writeFakeCurl(binDir, hash, binary)
+
+      const result = await runInstaller(installDir, binDir, home)
+      const stderr = new TextDecoder().decode(result.stderr)
+
+      expect(result.exitCode).toBe(0)
+      expect(stderr).toContain(
+        "Noodle was installed, but its skill could not be refreshed",
+      )
+      expect(stderr).toContain("Retry with: noodle agent install")
     } finally {
       await rm(directory, { recursive: true, force: true })
     }

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -12,6 +12,7 @@ import {
   copyOAuth2Token,
   fetchOAuth2Token,
   getEditRequestYamlFile,
+  installAgentSkill,
   openAppSettingsInEditor,
   openCollectionInEditor,
   saveFolder,
@@ -83,6 +84,74 @@ function minimalContext(): CommandBuilderContext {
 }
 
 describe("buildCommandPaletteCommands", () => {
+  it("shows Install Noodle skill in the contiguous System section of every full palette", () => {
+    const cases: Array<
+      [string, ReturnType<CommandBuilderContext["getCollectionMode"]>]
+    > = [
+      ["main", "collection"],
+      ["main", "empty"],
+      ["env-editor", "collection"],
+      ["cookie-jar", "collection"],
+      ["settings", "collection"],
+    ]
+
+    for (const [view, mode] of cases) {
+      const ctx = minimalContext()
+      ctx.getView = () => view
+      ctx.getCollectionMode = () => mode
+      const commands = buildCommandPaletteCommands(ctx)
+      const command = commands.find(
+        (item) => item.id === "app.agent-skill-install",
+      )
+      expect(command).toMatchObject({
+        label: "Install Noodle skill",
+        section: "System",
+      })
+      const firstSystem = commands.findIndex(
+        (item) => item.section === "System",
+      )
+      expect(
+        commands.slice(firstSystem).every((item) => item.section === "System"),
+      ).toBe(true)
+    }
+  })
+
+  it("installs the skill asynchronously and reports installed, updated, and error toasts", async () => {
+    for (const outcome of ["installed", "updated"] as const) {
+      const notified = Promise.withResolvers<void>()
+      const messages: Array<[string, string | undefined]> = []
+      const result = installAgentSkill(
+        async () => ({ action: outcome, path: "/tmp/noodle-use", linked: [] }),
+        (message, variant) => {
+          messages.push([message, variant])
+          notified.resolve()
+        },
+      )
+      expect(result).toBe(true)
+      expect(messages).toEqual([])
+      await notified.promise
+      expect(messages).toEqual([[`Noodle skill ${outcome}`, "success"]])
+    }
+
+    const notified = Promise.withResolvers<void>()
+    const messages: Array<[string, string | undefined]> = []
+    expect(
+      installAgentSkill(
+        async () => {
+          throw new Error("no space")
+        },
+        (message, variant) => {
+          messages.push([message, variant])
+          notified.resolve()
+        },
+      ),
+    ).toBe(true)
+    await notified.promise
+    expect(messages).toEqual([
+      ["Failed to install Noodle skill: no space", "error"],
+    ])
+  })
+
   it("opens collection and app settings folders in the selected editor", () => {
     const editor: ExternalEditor = {
       id: "zed",

--- a/tests/unit/update.test.ts
+++ b/tests/unit/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import pkg from "../../package.json" with { type: "json" }
@@ -1129,6 +1129,82 @@ describe("installBinaryUpdate", () => {
     }
   })
 
+  it("refreshes a pre-existing skill with the newly installed binary", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-install-skill-"))
+    const executable = join(dir, "noodle")
+    const binary = new TextEncoder().encode("new")
+    const commands: string[][] = []
+    try {
+      await writeFile(executable, "old")
+      await mkdir(join(dir, ".agents", "skills", "noodle-use"), {
+        recursive: true,
+      })
+      const result = await installBinaryUpdate(
+        "v0.5.5",
+        "https://example.com/noodle-binary",
+        sha256(binary),
+        {
+          execPath: executable,
+          platform: "darwin",
+          arch: "arm64",
+          env: { HOME: dir },
+          fetcher: async () => new Response(binary),
+          runProcess: async (args) => {
+            commands.push(args)
+            return { exitCode: 0 }
+          },
+        },
+      )
+
+      expect(result).toEqual({
+        data: {
+          status: "updated",
+          version: "v0.5.5",
+          skill_status: "updated",
+        },
+      })
+      expect(commands).toEqual([[executable, "agent", "install", "--json"]])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps a binary update successful when skill refresh fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-install-skill-fail-"))
+    const executable = join(dir, "noodle")
+    const binary = new TextEncoder().encode("new")
+    try {
+      await writeFile(executable, "old")
+      await mkdir(join(dir, ".codex", "skills", "noodle-use"), {
+        recursive: true,
+      })
+      const result = await installBinaryUpdate(
+        "v0.5.5",
+        "https://example.com/noodle-binary",
+        sha256(binary),
+        {
+          execPath: executable,
+          platform: "darwin",
+          arch: "arm64",
+          env: { HOME: dir },
+          fetcher: async () => new Response(binary),
+          runProcess: async () => ({ exitCode: 1 }),
+        },
+      )
+
+      expect(result.failed).toBeUndefined()
+      expect(result.data).toEqual({
+        status: "updated",
+        version: "v0.5.5",
+        skill_status: "failed",
+        skill_retry: "noodle agent install",
+      })
+      expect(await readFile(executable, "utf8")).toBe("new")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it("does not replace binary when checksum fails", async () => {
     const dir = await mkdtemp(join(tmpdir(), "noodle-install-checksum-"))
     const executable = join(dir, "noodle")
@@ -1234,6 +1310,68 @@ describe("installBrewUpdate", () => {
       "noodle",
     ])
     expect(receivedEnv).toBe(env)
+  })
+
+  it("refreshes an installed skill from Homebrew's stable bin path", async () => {
+    const home = await mkdtemp(join(tmpdir(), "noodle-brew-skill-"))
+    const commands: string[][] = []
+    try {
+      await mkdir(join(home, ".agents", "skills", "noodle-use"), {
+        recursive: true,
+      })
+      const result = await installBrewUpdate({
+        execPath: homebrewExecPath,
+        platform: "darwin",
+        arch: "arm64",
+        env: { HOME: home },
+        runProcess: async (args) => {
+          commands.push(args)
+          return { exitCode: 0 }
+        },
+      })
+
+      expect(result).toEqual({
+        data: {
+          status: "homebrew_updated",
+          command: "brew upgrade noodle",
+          skill_status: "updated",
+        },
+      })
+      expect(commands).toEqual([
+        ["/opt/homebrew/bin/brew", "upgrade", "noodle"],
+        ["/opt/homebrew/bin/noodle", "agent", "install", "--json"],
+      ])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps a Homebrew update successful when skill refresh fails", async () => {
+    const home = await mkdtemp(join(tmpdir(), "noodle-brew-skill-fail-"))
+    try {
+      await mkdir(join(home, ".cursor", "skills", "noodle-use"), {
+        recursive: true,
+      })
+      const result = await installBrewUpdate({
+        execPath: homebrewExecPath,
+        platform: "darwin",
+        arch: "arm64",
+        env: { HOME: home },
+        runProcess: async (args) => ({
+          exitCode: args[0].endsWith("/noodle") ? 1 : 0,
+        }),
+      })
+
+      expect(result.failed).toBeUndefined()
+      expect(result.data).toEqual({
+        status: "homebrew_updated",
+        command: "brew upgrade noodle",
+        skill_status: "failed",
+        skill_retry: "noodle agent install",
+      })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
   })
 
   it("reports brew upgrade failure", async () => {

--- a/tests/unit/useUpdateFlowSkill.test.tsx
+++ b/tests/unit/useUpdateFlowSkill.test.tsx
@@ -92,5 +92,6 @@ describe("useUpdateFlow skill refresh", () => {
     expect(render.captureCharFrame()).toContain(
       "Noodle updated; skill update failed",
     )
+    await act(async () => render.renderer.destroy())
   })
 })

--- a/tests/unit/useUpdateFlowSkill.test.tsx
+++ b/tests/unit/useUpdateFlowSkill.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { act, useEffect } from "react"
+import type { UpdateDependencies } from "../../src/app/commands/update"
+import type { UpdateFlowState } from "../../src/ui/appState"
+import { ThemeProvider } from "../../src/ui/theme"
+import { Toast } from "../../src/ui/Toast"
+import { useUpdateFlow } from "../../src/ui/useUpdateFlow"
+import { createTestRender } from "../testRender"
+
+const testRender = createTestRender()
+
+function Harness({
+  dependencies,
+  onFlow,
+}: {
+  dependencies: Partial<UpdateDependencies>
+  onFlow: (flow: UpdateFlowState) => void
+}) {
+  const { updateFlow } = useUpdateFlow(dependencies)
+  useEffect(() => onFlow(updateFlow), [onFlow, updateFlow])
+  return <text>{updateFlow.phase}</text>
+}
+
+describe("useUpdateFlow skill refresh", () => {
+  let home: string | undefined
+
+  afterEach(async () => {
+    if (home) await rm(home, { recursive: true, force: true })
+    home = undefined
+  })
+
+  it("finishes with a warning when skill refresh fails", async () => {
+    home = await mkdtemp(join(tmpdir(), "noodle-update-skill-flow-"))
+    await mkdir(join(home, ".agents", "skills", "noodle-use"), {
+      recursive: true,
+    })
+    const commands: string[][] = []
+    const phases: string[] = []
+    const completed = Promise.withResolvers<void>()
+    const dependencies: Partial<UpdateDependencies> = {
+      execPath: "/opt/homebrew/Cellar/noodle/0.7.5/bin/noodle",
+      platform: "darwin",
+      arch: "arm64",
+      env: { HOME: home },
+      runProcess: async (args) => {
+        commands.push(args)
+        if (args[1] === "info")
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              formulae: [{ versions: { stable: "99.0.0" } }],
+            }),
+          }
+        return { exitCode: args[0].endsWith("/noodle") ? 1 : 0 }
+      },
+    }
+
+    let render!: Awaited<ReturnType<typeof testRender>>
+    await act(async () => {
+      render = await testRender(
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Toast />
+          <Harness
+            dependencies={dependencies}
+            onFlow={(flow) => {
+              if (phases.at(-1) !== flow.phase) phases.push(flow.phase)
+              if (flow.phase === "done") completed.resolve()
+            }}
+          />
+        </ThemeProvider>,
+        { width: 80, height: 10 },
+      )
+    })
+    await act(async () => render.renderOnce())
+    await act(async () => completed.promise)
+    await act(async () => {
+      await render.waitForFrame((frame) =>
+        frame.includes("Noodle updated; skill update failed"),
+      )
+    })
+
+    expect(phases).toContain("installing")
+    expect(phases.at(-1)).toBe("done")
+    expect(commands).toEqual([
+      ["/opt/homebrew/bin/brew", "info", "--json=v2", "noodle"],
+      ["/opt/homebrew/bin/brew", "upgrade", "noodle"],
+      ["/opt/homebrew/bin/noodle", "agent", "install", "--json"],
+    ])
+    expect(render.captureCharFrame()).toContain(
+      "Noodle updated; skill update failed",
+    )
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `noodle agent install`, which installs or updates the embedded `noodle-use` skill under `~/.agents/skills/noodle-use` and links it to detected Claude, Cursor, Codex, and OpenCode installations. Standalone binary, Homebrew, TUI, and curl-installer updates refresh the skill automatically when one is already installed, without failing a successful Noodle update if the refresh needs a manual retry. Also adds the "Install Noodle skill" command-palette action and a Toast race fix.

### How did you verify your code works?

- `bun test` passes (2783 tests, 0 fail)
- `bun run lint` passes
- `bun run typecheck` passes
- Unit tests cover install, reinstall, tool linking, CLI JSON output, curl-installer refresh (success and failure), Homebrew and binary update refresh, and the useUpdateFlow warning path.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `noodle agent install` to install or update the Noodle skill.
  * Automatically synchronizes the skill with supported Claude, Cursor, Codex, and OpenCode installations.
  * Added JSON output and an in-app “Install Noodle skill” command.
  * Updates now refresh the skill automatically when available.

* **Bug Fixes**
  * Skill refresh failures no longer interrupt successful application updates; clear retry guidance is provided.
  * Existing unmanaged skill directories are protected from being overwritten.

* **Documentation**
  * Documented skill installation, synchronization, supported integrations, and fallback installation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->