### PR TITLE
feat(agent): add --force flag with rollback on skill install failure

### DIFF
--- a/src/agentSkill.ts
+++ b/src/agentSkill.ts
@@ -52,6 +52,16 @@ interface SkillReplacement {
   inode: number
 }
 
+class SkillReplacementError extends Error {
+  constructor(
+    message: string,
+    readonly replacement: SkillReplacement,
+    cause: unknown,
+  ) {
+    super(message, { cause })
+  }
+}
+
 function userHome(home?: string): string {
   return home ?? process.env.HOME ?? homedir()
 }
@@ -144,6 +154,12 @@ async function replacePath(
   const parent = dirname(targetPath)
   const stagedInfo = await lstat(stagedPath)
   let backupPath: string | undefined
+  const replacement = (): SkillReplacement => ({
+    targetPath,
+    backupPath,
+    device: stagedInfo.dev,
+    inode: stagedInfo.ino,
+  })
   if (await exists(targetPath)) {
     await assertReplaceablePath(targetPath, force)
     backupPath = await mkdtemp(join(parent, ".noodle-use-backup-"))
@@ -155,9 +171,11 @@ async function replacePath(
       try {
         await rename(backupPath, targetPath)
       } catch (restoreError) {
-        throw new Error(`Failed to restore ${targetPath}`, {
-          cause: restoreError,
-        })
+        throw new SkillReplacementError(
+          `Failed to restore ${targetPath}`,
+          replacement(),
+          restoreError,
+        )
       }
       throw new Error(`Failed to validate backed-up skill path ${backupPath}`, {
         cause: error,
@@ -168,16 +186,49 @@ async function replacePath(
   try {
     await rename(stagedPath, targetPath)
   } catch (error) {
-    if (backupPath) await rename(backupPath, targetPath)
+    if (backupPath) {
+      try {
+        await rename(backupPath, targetPath)
+      } catch (restoreError) {
+        throw new SkillReplacementError(
+          `Failed to replace and restore ${targetPath}`,
+          replacement(),
+          restoreError,
+        )
+      }
+    }
     throw new Error(`Failed to replace ${targetPath}`, { cause: error })
   }
 
-  return {
-    targetPath,
-    backupPath,
-    device: stagedInfo.dev,
-    inode: stagedInfo.ino,
+  return replacement()
+}
+
+async function withStagingCleanup(
+  stagingRoot: string,
+  operation: () => Promise<SkillReplacement>,
+): Promise<SkillReplacement> {
+  let replacement: SkillReplacement
+  try {
+    replacement = await operation()
+  } catch (error) {
+    try {
+      await rm(stagingRoot, { recursive: true, force: true })
+    } catch {
+      // Preserve the installation error; the staging path is safe to leave.
+    }
+    throw error
   }
+
+  try {
+    await rm(stagingRoot, { recursive: true, force: true })
+  } catch (error) {
+    throw new SkillReplacementError(
+      `Failed to clean up staging path ${stagingRoot}`,
+      replacement,
+      error,
+    )
+  }
+  return replacement
 }
 
 async function discardBackups(replacements: SkillReplacement[]) {
@@ -216,7 +267,7 @@ async function writeCanonicalSkill(path: string, force = false) {
   await mkdir(parent, { recursive: true })
   const stagingRoot = await mkdtemp(join(parent, ".noodle-use-stage-"))
   const stagedPath = join(stagingRoot, "noodle-use")
-  try {
+  return withStagingCleanup(stagingRoot, async () => {
     for (const [relativePath, contents] of Object.entries(NOODLE_SKILL_FILES)) {
       const filePath = join(stagedPath, relativePath)
       await mkdir(dirname(filePath), { recursive: true })
@@ -227,9 +278,7 @@ async function writeCanonicalSkill(path: string, force = false) {
       NOODLE_SKILL_MARKER_CONTENT,
     )
     return await replacePath(stagedPath, path, force)
-  } finally {
-    await rm(stagingRoot, { recursive: true, force: true })
-  }
+  })
 }
 
 async function linkSkill(
@@ -241,12 +290,10 @@ async function linkSkill(
   await mkdir(parent, { recursive: true })
   const stagingRoot = await mkdtemp(join(parent, ".noodle-use-link-"))
   const stagedPath = join(stagingRoot, "noodle-use")
-  try {
+  return withStagingCleanup(stagingRoot, async () => {
     await symlink(canonicalPath, stagedPath, "dir")
     return await replacePath(stagedPath, targetPath, force)
-  } finally {
-    await rm(stagingRoot, { recursive: true, force: true })
-  }
+  })
 }
 
 async function detectedToolLinks(home: string): Promise<string[]> {
@@ -293,6 +340,9 @@ export async function installNoodleSkill(
       replacements.push(await linkSkill(target, canonical, force))
     }
   } catch (error) {
+    if (error instanceof SkillReplacementError) {
+      replacements.push(error.replacement)
+    }
     try {
       await rollbackReplacements(replacements)
     } catch (rollbackError) {

--- a/src/agentSkill.ts
+++ b/src/agentSkill.ts
@@ -45,6 +45,13 @@ export interface AgentSkillInstallResult {
   linked: string[]
 }
 
+interface SkillReplacement {
+  targetPath: string
+  backupPath?: string
+  device: number
+  inode: number
+}
+
 function userHome(home?: string): string {
   return home ?? process.env.HOME ?? homedir()
 }
@@ -91,20 +98,31 @@ async function hasManagedMarker(path: string): Promise<boolean> {
   }
 }
 
-async function assertReplaceablePath(targetPath: string): Promise<void> {
+async function isUnmanagedPath(targetPath: string): Promise<boolean> {
   let info
   try {
     info = await lstat(targetPath)
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
     throw new Error(`Failed to inspect skill path ${targetPath}`, {
       cause: error,
     })
   }
 
-  if (info.isSymbolicLink()) return
-  if (info.isDirectory() && (await hasManagedMarker(targetPath))) return
-  throw new Error(`Refusing to replace unmanaged skill path ${targetPath}`)
+  if (info.isSymbolicLink()) return false
+  return !(info.isDirectory() && (await hasManagedMarker(targetPath)))
+}
+
+function unmanagedPathsError(paths: string[]): Error {
+  return new Error(
+    `Refusing to replace unmanaged skill paths:\n${paths.map((path) => `- ${path}`).join("\n")}\nRetry with: noodle agent install --force`,
+  )
+}
+
+async function assertReplaceablePath(targetPath: string, force = false) {
+  if (!force && (await isUnmanagedPath(targetPath))) {
+    throw unmanagedPathsError([targetPath])
+  }
 }
 
 export async function isNoodleSkillInstalled(home?: string): Promise<boolean> {
@@ -118,16 +136,21 @@ export async function isNoodleSkillInstalled(home?: string): Promise<boolean> {
   return false
 }
 
-async function replacePath(stagedPath: string, targetPath: string) {
+async function replacePath(
+  stagedPath: string,
+  targetPath: string,
+  force = false,
+): Promise<SkillReplacement> {
   const parent = dirname(targetPath)
+  const stagedInfo = await lstat(stagedPath)
   let backupPath: string | undefined
   if (await exists(targetPath)) {
-    await assertReplaceablePath(targetPath)
+    await assertReplaceablePath(targetPath, force)
     backupPath = await mkdtemp(join(parent, ".noodle-use-backup-"))
     await rm(backupPath, { recursive: true, force: true })
     await rename(targetPath, backupPath)
     try {
-      await assertReplaceablePath(backupPath)
+      await assertReplaceablePath(backupPath, force)
     } catch (error) {
       try {
         await rename(backupPath, targetPath)
@@ -149,10 +172,46 @@ async function replacePath(stagedPath: string, targetPath: string) {
     throw new Error(`Failed to replace ${targetPath}`, { cause: error })
   }
 
-  if (backupPath) await rm(backupPath, { recursive: true, force: true })
+  return {
+    targetPath,
+    backupPath,
+    device: stagedInfo.dev,
+    inode: stagedInfo.ino,
+  }
 }
 
-async function writeCanonicalSkill(path: string) {
+async function discardBackups(replacements: SkillReplacement[]) {
+  for (const { backupPath } of replacements) {
+    if (backupPath) await rm(backupPath, { recursive: true, force: true })
+  }
+}
+
+async function rollbackReplacements(replacements: SkillReplacement[]) {
+  let firstError: unknown
+  for (const replacement of replacements.reverse()) {
+    const { targetPath, backupPath, device, inode } = replacement
+    try {
+      let current
+      try {
+        current = await lstat(targetPath)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      }
+      if (current && (current.dev !== device || current.ino !== inode)) {
+        throw new Error(
+          `Refusing to roll back changed skill path ${targetPath}${backupPath ? `; original preserved at ${backupPath}` : ""}`,
+        )
+      }
+      if (current) await rm(targetPath, { recursive: true, force: true })
+      if (backupPath) await rename(backupPath, targetPath)
+    } catch (error) {
+      firstError ??= error
+    }
+  }
+  if (firstError) throw firstError
+}
+
+async function writeCanonicalSkill(path: string, force = false) {
   const parent = dirname(path)
   await mkdir(parent, { recursive: true })
   const stagingRoot = await mkdtemp(join(parent, ".noodle-use-stage-"))
@@ -167,20 +226,24 @@ async function writeCanonicalSkill(path: string) {
       join(stagedPath, NOODLE_SKILL_MARKER),
       NOODLE_SKILL_MARKER_CONTENT,
     )
-    await replacePath(stagedPath, path)
+    return await replacePath(stagedPath, path, force)
   } finally {
     await rm(stagingRoot, { recursive: true, force: true })
   }
 }
 
-async function linkSkill(targetPath: string, canonicalPath: string) {
+async function linkSkill(
+  targetPath: string,
+  canonicalPath: string,
+  force = false,
+) {
   const parent = dirname(targetPath)
   await mkdir(parent, { recursive: true })
   const stagingRoot = await mkdtemp(join(parent, ".noodle-use-link-"))
   const stagedPath = join(stagingRoot, "noodle-use")
   try {
     await symlink(canonicalPath, stagedPath, "dir")
-    await replacePath(stagedPath, targetPath)
+    return await replacePath(stagedPath, targetPath, force)
   } finally {
     await rm(stagingRoot, { recursive: true, force: true })
   }
@@ -207,17 +270,40 @@ async function detectedToolLinks(home: string): Promise<string[]> {
 
 export async function installNoodleSkill(
   home?: string,
+  force = false,
 ): Promise<AgentSkillInstallResult> {
   const root = userHome(home)
   const { canonical } = getNoodleSkillPaths(root)
   const action = (await isNoodleSkillInstalled(root)) ? "updated" : "installed"
   const linked = await detectedToolLinks(root)
+  const targetPaths = [canonical, ...linked]
 
-  await assertReplaceablePath(canonical)
-  for (const target of linked) await assertReplaceablePath(target)
+  if (!force) {
+    const unmanaged: string[] = []
+    for (const target of targetPaths) {
+      if (await isUnmanagedPath(target)) unmanaged.push(target)
+    }
+    if (unmanaged.length) throw unmanagedPathsError(unmanaged)
+  }
 
-  await writeCanonicalSkill(canonical)
-  for (const target of linked) await linkSkill(target, canonical)
+  const replacements: SkillReplacement[] = []
+  try {
+    replacements.push(await writeCanonicalSkill(canonical, force))
+    for (const target of linked) {
+      replacements.push(await linkSkill(target, canonical, force))
+    }
+  } catch (error) {
+    try {
+      await rollbackReplacements(replacements)
+    } catch (rollbackError) {
+      throw new Error(
+        `Agent skill installation failed and rollback was incomplete: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+        { cause: rollbackError },
+      )
+    }
+    throw error
+  }
+  await discardBackups(replacements)
 
   return { action, path: canonical, linked }
 }

--- a/src/app/commands/agent.ts
+++ b/src/app/commands/agent.ts
@@ -16,11 +16,16 @@ const install = defineCommand({
       default: false,
       description: "Write one JSON result envelope to stdout",
     },
+    force: {
+      type: "boolean",
+      default: false,
+      description: "Replace all detected unmanaged skill paths",
+    },
   },
   async run({ args }) {
     await emitCommand(
       args.json === true,
-      async () => ({ data: await installNoodleSkill() }),
+      async () => ({ data: await installNoodleSkill(undefined, args.force) }),
       formatInstall,
     )
   },

--- a/tests/agentSkill.test.ts
+++ b/tests/agentSkill.test.ts
@@ -80,14 +80,37 @@ describe("Noodle agent skill installer", () => {
   })
 
   it("preserves an unmanaged tool skill directory", async () => {
+    const canonical = getNoodleSkillPaths(home).canonical
     const target = join(home, ".claude", "skills", "noodle-use")
+    await mkdir(canonical, { recursive: true })
     await mkdir(target, { recursive: true })
+    await writeFile(join(canonical, "local.md"), "keep me too")
     await writeFile(join(target, "local.md"), "keep me")
 
     await expect(installNoodleSkill(home)).rejects.toThrow(
-      `Refusing to replace unmanaged skill path ${target}`,
+      `Refusing to replace unmanaged skill paths:\n- ${canonical}\n- ${target}\nRetry with: noodle agent install --force`,
+    )
+    expect(await readFile(join(canonical, "local.md"), "utf8")).toBe(
+      "keep me too",
     )
     expect(await readFile(join(target, "local.md"), "utf8")).toBe("keep me")
+  })
+
+  it("replaces unmanaged skill paths with force", async () => {
+    const canonical = getNoodleSkillPaths(home).canonical
+    const target = join(home, ".claude", "skills", "noodle-use")
+    await mkdir(canonical, { recursive: true })
+    await mkdir(target, { recursive: true })
+    await writeFile(join(canonical, "local.md"), "replace me")
+    await writeFile(join(target, "local.md"), "replace me too")
+
+    const result = await installNoodleSkill(home, true)
+
+    expect(await filesBelow(canonical)).toEqual(
+      [...Object.keys(NOODLE_SKILL_FILES), NOODLE_SKILL_MARKER].sort(),
+    )
+    expect((await lstat(target)).isSymbolicLink()).toBe(true)
+    expect(await readlink(target)).toBe(result.path)
   })
 
   it("discovers Claude, Cursor, Codex, and OpenCode and links each one", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -94,7 +94,7 @@ describe("update command", () => {
 })
 
 describe("agent command", () => {
-  it("exposes the nested install command with JSON output", () => {
+  it("exposes the nested install command with JSON and force options", () => {
     expect(agentMeta?.name).toBe("agent")
     const subCommands = agentCommand.subCommands as Record<
       string,
@@ -103,6 +103,10 @@ describe("agent command", () => {
     const install = subCommands.install
     expect(install?.meta?.name).toBe("install")
     expect((install?.args as ArgsDef | undefined)?.json).toMatchObject({
+      type: "boolean",
+      default: false,
+    })
+    expect((install?.args as ArgsDef | undefined)?.force).toMatchObject({
       type: "boolean",
       default: false,
     })
@@ -356,6 +360,7 @@ describe("CLI integration", () => {
     const install = Bun.spawnSync(["bun", CLI, "agent", "install", "--help"])
     expect(install.exitCode).toBe(0)
     expect(install.stdout.toString()).toContain("json")
+    expect(install.stdout.toString()).toContain("force")
   })
 
   it("fails when import is called without source argument", () => {


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `--force` to `noodle agent install` to replace unmanaged skill paths (canonical + detected tool links) in one atomic operation with rollback on failure. Without `--force`, the installer now reports all unmanaged paths at once and suggests retrying with `--force`. Fixes partial-install state by tracking device/inode replacements and restoring backups if any step fails.

### How did you verify your code works?

Ran `bun test` (2785 pass), `bun run lint` (clean), `bun run typecheck` (clean). Verified `src/agentSkill.ts:120-340` force/rollback logic and CLI help exposes `--force`. Existing `tests/agentSkill.test.ts` and `tests/cli.test.ts` cover unmanaged-path error and force replacement.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--force` option to agent skill installation.
  - Forced installation replaces unmanaged skill directories and restores tool-specific links.
  - Added automatic backups, rollback on failure, and backup cleanup after successful installation.

- **Bug Fixes**
  - Prevented unmanaged skill contents from being overwritten during standard installation.
  - Preserved existing files when installation is rejected.
  - Prevented rollback from overwriting paths changed during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->