### PR TITLE
feat: declarative assertions foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
       - uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.ref }}
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: 1.4.0
       - name: Validate tag and package version
         shell: bash
         run: |

--- a/collections/assertions/create-post.yml
+++ b/collections/assertions/create-post.yml
@@ -1,0 +1,41 @@
+name: Assert Created Post
+method: POST
+url: $base_url/posts
+timeout: 0
+followRedirects: true
+maxRedirects: 5
+headers:
+  Content-Type: application/json
+body: |-
+  {
+    "title": "Assertion example",
+    "userId": 1,
+    "published": true,
+    "note": null,
+    "tags": ["noodle", "assertions"]
+  }
+body_type: json
+assert:
+  - expression: status
+    operator: equals
+    value: 201
+  - expression: headers.Content-Type
+    operator: contains
+    value: application/json
+  - expression: body
+    operator: isObject
+  - expression: body.id
+    operator: isNumber
+  - expression: body.title
+    operator: equals
+    value: Assertion example
+  - expression: body.published
+    operator: isBoolean
+  - expression: body.note
+    operator: isNull
+  - expression: body.tags
+    operator: contains
+    value: assertions
+  - expression: body.tags
+    operator: notContains
+    value: missing

--- a/collections/assertions/folder.yml
+++ b/collections/assertions/folder.yml
@@ -1,0 +1,5 @@
+meta:
+  name: Response Assertions
+  seq: 1
+auth:
+  type: none

--- a/collections/assertions/get-post.yml
+++ b/collections/assertions/get-post.yml
@@ -1,0 +1,27 @@
+name: Assert Post Response
+method: GET
+url: $base_url/posts/:postId
+timeout: 0
+followRedirects: true
+maxRedirects: 5
+path_params:
+  - name: postId
+    value: '1'
+body_type: none
+assert:
+  - expression: status
+    operator: equals
+    value: 200
+  - expression: body.id
+    operator: equals
+    value: 1
+  - expression: body.userId
+    operator: isNumber
+  - expression: body.title
+    operator: contains
+    value: sunt
+  - expression: body.deletedAt
+    operator: notExists
+  - expression: response.time
+    operator: lt
+    value: 30000

--- a/collections/assertions/get-users.yml
+++ b/collections/assertions/get-users.yml
@@ -1,0 +1,28 @@
+name: Assert Users Response
+method: GET
+url: $base_url/users
+timeout: 0
+followRedirects: true
+maxRedirects: 5
+body_type: none
+assert:
+  - expression: status
+    operator: equals
+    value: 200
+  - expression: body
+    operator: isArray
+  - expression: body[0].id
+    operator: isNumber
+  - expression: body[0].address
+    operator: isObject
+  - expression: body[0].address.geo.lat
+    operator: isString
+  - expression: body[0].name
+    operator: equals
+    value: Leanne Graham
+  - expression: body[0].phone
+    operator: matches
+    value: ^1-
+  - expression: body[0].name
+    operator: notContains
+    value: Noodle

--- a/src/app/humanOutput.ts
+++ b/src/app/humanOutput.ts
@@ -27,6 +27,22 @@ function statusLabel(result: RequestRunResult): string {
   return color(label, status < 400 ? "green" : "red")
 }
 
+function formatAssertions(result: RequestRunResult): string[] {
+  if (!result.assertions) return []
+  if (!result.assertions.evaluated) return ["  Assertions: not evaluated"]
+  const passed = result.assertions.results.filter(
+    (assertion) => assertion.passed,
+  ).length
+  const failed = result.assertions.results.length - passed
+  return [
+    `  Assertions: ${passed} passed, ${failed} failed`,
+    ...result.assertions.results.map(
+      (assertion) =>
+        `    ${assertion.passed ? color("✓", "green") : color("✗", "red")} ${assertion.expression} ${assertion.operator}${assertion.passed ? "" : `: ${assertion.message}`}`,
+    ),
+  ]
+}
+
 function formatTree(items: CollectionTreeItem[], prefix = ""): string[] {
   return items.flatMap((item, index) => {
     const last = index === items.length - 1
@@ -135,6 +151,7 @@ export function formatRunResult(result: RequestRunResult): string {
   return [
     `${result.ok ? color("✓", "green") : color("✗", "red")} ${color(result.method, "cyan")} ${result.id}  ${statusLabel(result)}${duration}`,
     `  ${result.url}${result.error ? `\n  ${color(result.error, "red")}` : ""}`,
+    ...formatAssertions(result),
     ...(result.warnings ?? []).map(
       (warning) => `  ${color("warning", "yellow")}: ${warning}`,
     ),

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -55,6 +55,8 @@ import {
   setStoredSecret,
 } from "../secrets"
 import { environmentSecretValues, redactKnownSecrets } from "../secrets/redact"
+import { evaluateAssertions, type AssertionResult } from "../assertions"
+import type { AssertionValue } from "../schema"
 
 const CONFIG_DIR = join(process.env.HOME ?? "~", ".config/noodle")
 const SKIP_DIRS = new Set([".noodle", ".timeline", ".git", "node_modules"])
@@ -532,6 +534,10 @@ export interface RequestRunResult {
   }
   error?: string
   warnings?: string[]
+  assertions?: {
+    evaluated: boolean
+    results: AssertionResult[]
+  }
 }
 export interface CollectionRunResult {
   results: RequestRunResult[]
@@ -558,6 +564,7 @@ async function runRequest(
   ].filter((value): value is string => Boolean(value))
   const redact = (value: string) => redactKnownSecrets(value, secretValues)
   try {
+    const effective = environment ? substitute(request, environment) : request
     const response = await executor.send(request, {
       environment,
       collection,
@@ -577,7 +584,15 @@ async function runRequest(
           ),
       )
       .map((event) => event.message)
-    const effective = environment ? substitute(request, environment) : request
+    const assertionResults = effective.assertions?.length
+      ? evaluateAssertions(effective.assertions, response).map((result) => ({
+          ...result,
+          ...(Object.hasOwn(result, "expected")
+            ? { expected: redactAssertionValue(result.expected!, redact) }
+            : {}),
+          message: redact(result.message),
+        }))
+      : undefined
     return {
       id: request.id,
       method: request.method,
@@ -589,7 +604,12 @@ async function runRequest(
         body: response.body,
         timeMs: response.timeMs,
       },
-      ok: response.status < 400,
+      ok:
+        response.status < 400 &&
+        (assertionResults?.every((result) => result.passed) ?? true),
+      ...(assertionResults
+        ? { assertions: { evaluated: true, results: assertionResults } }
+        : {}),
       ...(authWarnings.length > 0
         ? { warnings: [...new Set(authWarnings)] }
         : {}),
@@ -601,8 +621,30 @@ async function runRequest(
       url: redact(request.url),
       error: redact(errorMessage(error)),
       ok: false,
+      ...(request.assertions?.length
+        ? { assertions: { evaluated: false, results: [] } }
+        : {}),
     }
   }
+}
+
+function redactAssertionValue(
+  value: AssertionValue,
+  redact: (value: string) => string,
+): AssertionValue {
+  if (typeof value === "string") return redact(value)
+  if (Array.isArray(value)) {
+    return value.map((item) => redactAssertionValue(item, redact))
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        redactAssertionValue(item, redact),
+      ]),
+    )
+  }
+  return value
 }
 export async function collectionRun(
   path: string,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,0 +1,225 @@
+import { isDeepStrictEqual } from "node:util"
+import type {
+  AssertionOperator,
+  AssertionValue,
+  Response,
+  ResponseAssertion,
+} from "./schema"
+import { createResponseResolver } from "./response"
+
+export interface AssertionResult {
+  expression: string
+  operator: AssertionOperator
+  expected?: AssertionValue
+  actual?: AssertionValue
+  passed: boolean
+  message: string
+}
+
+type CompiledAssertionRegex =
+  { kind: "success"; regex: RegExp } | { kind: "error"; message: string }
+
+export function compileAssertionRegex(source: string): CompiledAssertionRegex {
+  if (source.length > 1000) {
+    return { kind: "error", message: "Regular expression is too long" }
+  }
+  let regex: RegExp
+  try {
+    regex = new RegExp(source)
+  } catch {
+    return { kind: "error", message: "Invalid regular expression" }
+  }
+
+  let canQuantify = false
+  let escaped = false
+  let inClass = false
+  let quantifiers = 0
+  for (const character of source) {
+    if (escaped) {
+      if (!inClass && /[1-9k]/.test(character)) {
+        return {
+          kind: "error",
+          message: "Regular expression uses unsupported syntax",
+        }
+      }
+      escaped = false
+      canQuantify = true
+      continue
+    }
+    if (character === "\\") {
+      escaped = true
+      continue
+    }
+    if (inClass) {
+      if (character === "]") {
+        inClass = false
+        canQuantify = true
+      }
+      continue
+    }
+    if (character === "[") {
+      inClass = true
+      canQuantify = false
+      continue
+    }
+    if ("()|{}".includes(character)) {
+      return {
+        kind: "error",
+        message: "Regular expression uses unsupported syntax",
+      }
+    }
+    if ("*+?".includes(character)) {
+      quantifiers++
+      if (
+        !canQuantify ||
+        quantifiers > 1 ||
+        ((character === "*" || character === "+") && !source.startsWith("^"))
+      ) {
+        return {
+          kind: "error",
+          message: "Regular expression uses unsupported syntax",
+        }
+      }
+      canQuantify = false
+      continue
+    }
+    canQuantify = character !== "^" && character !== "$"
+  }
+  return { kind: "success", regex }
+}
+
+export function evaluateAssertions(
+  assertions: ResponseAssertion[],
+  response: Response,
+): AssertionResult[] {
+  const resolve = createResponseResolver(response)
+  return assertions.map((assertion) => {
+    const resolution = resolve(assertion.expression)
+    const expected = Object.hasOwn(assertion, "value")
+      ? { expected: assertion.value }
+      : {}
+    const base = {
+      expression: assertion.expression,
+      operator: assertion.operator,
+      ...expected,
+    }
+
+    if (resolution.kind === "error") {
+      return {
+        ...base,
+        passed: false,
+        message: resolution.message,
+      }
+    }
+    if (resolution.kind === "missing") {
+      const passed = assertion.operator === "notExists"
+      return {
+        ...base,
+        passed,
+        message: passed
+          ? "Assertion passed"
+          : `Expression "${assertion.expression}" is missing`,
+      }
+    }
+
+    const actual = resolution.value
+    const result = evaluateValue(assertion, actual)
+    return { ...base, actual, ...result }
+  })
+}
+
+function evaluateValue(
+  assertion: ResponseAssertion,
+  actual: AssertionValue,
+): Pick<AssertionResult, "passed" | "message"> {
+  const pass = (passed: boolean, failure: string) => ({
+    passed,
+    message: passed ? "Assertion passed" : failure,
+  })
+
+  switch (assertion.operator) {
+    case "exists":
+      return pass(true, "")
+    case "notExists":
+      return pass(false, `Expression "${assertion.expression}" exists`)
+    case "isString":
+      return pass(typeof actual === "string", "Expected a string")
+    case "isNumber":
+      return pass(
+        typeof actual === "number" && Number.isFinite(actual),
+        "Expected a number",
+      )
+    case "isBoolean":
+      return pass(typeof actual === "boolean", "Expected a boolean")
+    case "isArray":
+      return pass(Array.isArray(actual), "Expected an array")
+    case "isObject":
+      return pass(
+        actual !== null && typeof actual === "object" && !Array.isArray(actual),
+        "Expected an object",
+      )
+    case "isNull":
+      return pass(actual === null, "Expected null")
+    case "notNull":
+      return pass(actual !== null, "Expected a non-null value")
+    case "equals":
+      return pass(
+        isDeepStrictEqual(actual, assertion.value),
+        "Expected values to be equal",
+      )
+    case "notEquals":
+      return pass(
+        !isDeepStrictEqual(actual, assertion.value),
+        "Expected values to be different",
+      )
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte": {
+      if (
+        typeof actual !== "number" ||
+        !Number.isFinite(actual) ||
+        typeof assertion.value !== "number" ||
+        !Number.isFinite(assertion.value)
+      ) {
+        return pass(false, `Operator "${assertion.operator}" requires numbers`)
+      }
+      const passed =
+        assertion.operator === "gt"
+          ? actual > assertion.value
+          : assertion.operator === "gte"
+            ? actual >= assertion.value
+            : assertion.operator === "lt"
+              ? actual < assertion.value
+              : actual <= assertion.value
+      return pass(passed, `Numeric comparison "${assertion.operator}" failed`)
+    }
+    case "contains":
+    case "notContains": {
+      let contains: boolean
+      if (typeof actual === "string" && typeof assertion.value === "string") {
+        contains = actual.includes(assertion.value)
+      } else if (Array.isArray(actual)) {
+        contains = actual.some((item) =>
+          isDeepStrictEqual(item, assertion.value),
+        )
+      } else {
+        return pass(
+          false,
+          `Operator "${assertion.operator}" requires a string or array`,
+        )
+      }
+      const passed = assertion.operator === "contains" ? contains : !contains
+      return pass(passed, `Containment check "${assertion.operator}" failed`)
+    }
+    case "matches": {
+      if (typeof actual !== "string" || typeof assertion.value !== "string") {
+        return pass(false, 'Operator "matches" requires strings')
+      }
+      const compiled = compileAssertionRegex(assertion.value)
+      return compiled.kind === "error"
+        ? pass(false, compiled.message)
+        : pass(compiled.regex.test(actual), "Regex did not match")
+    }
+  }
+}

--- a/src/lang/parse.ts
+++ b/src/lang/parse.ts
@@ -1,13 +1,20 @@
 import yaml from "js-yaml"
 import type {
+  AssertionOperator,
+  AssertionValue,
+  AssertionWithoutValueOperator,
+  AssertionWithValueOperator,
   BodyType,
   FormEntry,
   KvEntry,
   Method,
   ParamEntry,
   Request,
+  ResponseAssertion,
   RequestTlsSettings,
 } from "../schema"
+import { parseResponseExpression } from "../response"
+import { compileAssertionRegex } from "../assertions"
 import { parseAuth } from "./auth"
 
 const METHODS: readonly Method[] = [
@@ -28,6 +35,35 @@ const BODY_TYPES = [
   "urlencoded",
   "binary",
 ] as const
+
+const ASSERTION_WITHOUT_VALUE_OPERATORS = [
+  "exists",
+  "notExists",
+  "isString",
+  "isNumber",
+  "isBoolean",
+  "isArray",
+  "isObject",
+  "isNull",
+  "notNull",
+] as const satisfies readonly AssertionWithoutValueOperator[]
+
+const ASSERTION_WITH_VALUE_OPERATORS = [
+  "equals",
+  "notEquals",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "contains",
+  "notContains",
+  "matches",
+] as const satisfies readonly AssertionWithValueOperator[]
+
+const ASSERTION_OPERATORS: readonly AssertionOperator[] = [
+  ...ASSERTION_WITHOUT_VALUE_OPERATORS,
+  ...ASSERTION_WITH_VALUE_OPERATORS,
+]
 
 function isBodyType(s: string): s is BodyType {
   return (BODY_TYPES as readonly string[]).includes(s as BodyType)
@@ -76,6 +112,7 @@ export function parseRequest(id: string, yamlText: string): Request {
     "form_data",
     "file_path",
     "tls",
+    "assert",
   ])
   for (const key of Object.keys(raw)) {
     if (!knownKeys.has(key)) {
@@ -167,6 +204,7 @@ export function parseRequest(id: string, yamlText: string): Request {
 
   const auth = parseAuth(raw.auth, "lang.parseRequest", true)
   const tls = parseRequestTls(raw.tls)
+  const assertions = parseAssertions(raw.assert)
 
   let timeout = 0
   if (raw.timeout !== undefined) {
@@ -222,12 +260,148 @@ export function parseRequest(id: string, yamlText: string): Request {
     formData,
     filePath,
     auth,
+    ...(assertions ? { assertions } : {}),
   }
   const requestWithTls = tls === undefined ? request : { ...request, tls }
   if (Object.hasOwn(raw, "path_params") && pathParams.length > 0) {
     return { ...requestWithTls, pathParams }
   }
   return requestWithTls as Request
+}
+
+function parseAssertions(value: unknown): ResponseAssertion[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw new Error('lang.parseRequest: "assert" must be an array')
+  }
+  const assertions = value.map((item, index): ResponseAssertion => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new Error(`lang.parseRequest: assert[${index}] must be an object`)
+    }
+    const raw = item as Record<string, unknown>
+    for (const key of Object.keys(raw)) {
+      if (key !== "expression" && key !== "operator" && key !== "value") {
+        throw new Error(
+          `lang.parseRequest: unknown assert[${index}] field "${key}"`,
+        )
+      }
+    }
+    if (typeof raw.expression !== "string") {
+      throw new Error(
+        `lang.parseRequest: assert[${index}].expression must be a string`,
+      )
+    }
+    try {
+      parseResponseExpression(raw.expression)
+    } catch (error) {
+      throw new Error(
+        `lang.parseRequest: assert[${index}].expression: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      )
+    }
+    if (
+      typeof raw.operator !== "string" ||
+      !ASSERTION_OPERATORS.includes(raw.operator as AssertionOperator)
+    ) {
+      throw new Error(
+        `lang.parseRequest: invalid assert[${index}].operator "${String(raw.operator)}"`,
+      )
+    }
+
+    const hasValue = Object.hasOwn(raw, "value")
+    if (
+      ASSERTION_WITHOUT_VALUE_OPERATORS.includes(
+        raw.operator as AssertionWithoutValueOperator,
+      )
+    ) {
+      if (hasValue) {
+        throw new Error(
+          `lang.parseRequest: assert[${index}].operator "${raw.operator}" does not accept value`,
+        )
+      }
+      return {
+        expression: raw.expression,
+        operator: raw.operator as AssertionWithoutValueOperator,
+      }
+    }
+    if (!hasValue) {
+      throw new Error(
+        `lang.parseRequest: assert[${index}].operator "${raw.operator}" requires value`,
+      )
+    }
+
+    assertJsonValue(raw.value, `assert[${index}].value`, new Set())
+    if (
+      ["gt", "gte", "lt", "lte"].includes(raw.operator) &&
+      (typeof raw.value !== "number" || !Number.isFinite(raw.value))
+    ) {
+      throw new Error(
+        `lang.parseRequest: assert[${index}].operator "${raw.operator}" requires a finite numeric value`,
+      )
+    }
+    if (raw.operator === "matches") {
+      if (typeof raw.value !== "string") {
+        throw new Error(
+          `lang.parseRequest: assert[${index}].operator "matches" requires a string value`,
+        )
+      }
+      const compiled = compileAssertionRegex(raw.value)
+      if (compiled.kind === "error") {
+        throw new Error(
+          `lang.parseRequest: assert[${index}].operator "matches": ${compiled.message}`,
+        )
+      }
+    }
+    return {
+      expression: raw.expression,
+      operator: raw.operator as AssertionWithValueOperator,
+      value: raw.value as AssertionValue,
+    }
+  })
+  return assertions.length > 0 ? assertions : undefined
+}
+
+function assertJsonValue(
+  value: unknown,
+  path: string,
+  ancestors: Set<object>,
+): asserts value is AssertionValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return
+  }
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return
+    throw new Error(`lang.parseRequest: ${path} must contain finite numbers`)
+  }
+  if (typeof value !== "object") {
+    throw new Error(
+      `lang.parseRequest: ${path} must be a JSON-compatible value`,
+    )
+  }
+  if (ancestors.has(value)) {
+    throw new Error(`lang.parseRequest: ${path} must not contain cycles`)
+  }
+  ancestors.add(value)
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertJsonValue(item, `${path}[${index}]`, ancestors),
+    )
+  } else {
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error(
+        `lang.parseRequest: ${path} must be a JSON-compatible value`,
+      )
+    }
+    for (const [key, item] of Object.entries(value)) {
+      assertJsonValue(item, `${path}.${key}`, ancestors)
+    }
+  }
+  ancestors.delete(value)
 }
 
 function parseRequestTls(value: unknown): RequestTlsSettings | undefined {

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -89,6 +89,15 @@ export function serializeRequest(req: Request): string {
     out += `file_path: ${yamlVal(req.filePath)}\n`
   }
 
+  if (req.assertions && req.assertions.length > 0) {
+    out += yaml.dump(
+      {
+        assert: req.assertions.map((assertion) => ({ ...assertion })),
+      },
+      { lineWidth: -1, noRefs: true },
+    )
+  }
+
   if (req.auth && req.auth.type !== "none") {
     out += yaml.dump(
       { auth: authToObj(req.auth) },

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -1,4 +1,11 @@
-import type { Auth, Environment, ParamEntry, Request } from "../schema"
+import type {
+  AssertionValue,
+  Auth,
+  Environment,
+  ParamEntry,
+  Request,
+  ResponseAssertion,
+} from "../schema"
 
 const VAR_RE = /\$(\w+)/g
 
@@ -62,6 +69,18 @@ export function substitute(req: Request, env: Environment): SubstitutedRequest {
       ? resolve(req.filePath, "filePath")
       : req.filePath
 
+  const assertions = req.assertions?.map((assertion, index) => {
+    if (assertion.value === undefined) return assertion
+    return {
+      ...assertion,
+      value: substituteAssertionValue(
+        assertion.value,
+        resolve,
+        `assertions[${index}].value`,
+      ),
+    } as ResponseAssertion
+  })
+
   return {
     id: req.id,
     name: req.name,
@@ -80,7 +99,30 @@ export function substitute(req: Request, env: Environment): SubstitutedRequest {
     filePath,
     auth,
     tls: req.tls,
+    assertions,
   }
+}
+
+function substituteAssertionValue(
+  value: AssertionValue,
+  resolve: (value: string, field: string) => string,
+  field: string,
+): AssertionValue {
+  if (typeof value === "string") return resolve(value, field)
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      substituteAssertionValue(item, resolve, `${field}[${index}]`),
+    )
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        substituteAssertionValue(item, resolve, `${field}.${key}`),
+      ]),
+    )
+  }
+  return value
 }
 
 function substituteAuth(

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,0 +1,140 @@
+import type { JsonValue, Response } from "./schema"
+
+export type ParsedResponseBody =
+  | { kind: "success"; value: unknown }
+  | { kind: "invalid-json"; message: string }
+
+export type ResponsePathPart =
+  { kind: "property"; name: string } | { kind: "index"; index: number }
+
+export type ResponseExpression =
+  | { kind: "status" }
+  | { kind: "response-time" }
+  | { kind: "header"; name: string }
+  | { kind: "body"; path: ResponsePathPart[] }
+
+export type ResponseExpressionResult =
+  | { kind: "value"; value: JsonValue }
+  | { kind: "missing" }
+  | { kind: "error"; message: string }
+
+const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
+const PROPERTY_RE = /^[A-Za-z_][A-Za-z0-9_-]*/
+
+export function parseResponseBody(body: string): ParsedResponseBody {
+  try {
+    return { kind: "success", value: JSON.parse(body) }
+  } catch {
+    return {
+      kind: "invalid-json",
+      message: "Response body is not valid JSON",
+    }
+  }
+}
+
+export function parseResponseExpression(
+  expression: string,
+): ResponseExpression {
+  if (expression === "status") return { kind: "status" }
+  if (expression === "response.time") return { kind: "response-time" }
+  if (expression.startsWith("headers.")) {
+    const name = expression.slice("headers.".length)
+    if (HEADER_NAME_RE.test(name)) return { kind: "header", name }
+    throw invalidExpression(expression)
+  }
+  if (!expression.startsWith("body")) throw invalidExpression(expression)
+
+  const path: ResponsePathPart[] = []
+  let offset = "body".length
+  while (offset < expression.length) {
+    if (expression[offset] === ".") {
+      const match = PROPERTY_RE.exec(expression.slice(offset + 1))
+      if (!match) throw invalidExpression(expression)
+      path.push({ kind: "property", name: match[0] })
+      offset += match[0].length + 1
+      continue
+    }
+    if (expression[offset] === "[") {
+      const end = expression.indexOf("]", offset + 1)
+      if (end === -1) throw invalidExpression(expression)
+      const rawIndex = expression.slice(offset + 1, end)
+      if (!/^(0|[1-9]\d*)$/.test(rawIndex)) throw invalidExpression(expression)
+      const index = Number(rawIndex)
+      if (!Number.isSafeInteger(index)) throw invalidExpression(expression)
+      path.push({ kind: "index", index })
+      offset = end + 1
+      continue
+    }
+    throw invalidExpression(expression)
+  }
+  return { kind: "body", path }
+}
+
+export function createResponseResolver(
+  response: Pick<Response, "status" | "headers" | "body" | "timeMs">,
+): (expression: string) => ResponseExpressionResult {
+  let parsedBody: ParsedResponseBody | undefined
+  const headers = new Map(
+    Object.entries(response.headers).map(([name, value]) => [
+      name.toLowerCase(),
+      value,
+    ]),
+  )
+
+  return (expression) => {
+    let parsedExpression: ResponseExpression
+    try {
+      parsedExpression = parseResponseExpression(expression)
+    } catch (error) {
+      return {
+        kind: "error",
+        message: error instanceof Error ? error.message : String(error),
+      }
+    }
+
+    if (parsedExpression.kind === "status") {
+      return { kind: "value", value: response.status }
+    }
+    if (parsedExpression.kind === "response-time") {
+      return { kind: "value", value: response.timeMs }
+    }
+    if (parsedExpression.kind === "header") {
+      const value = headers.get(parsedExpression.name.toLowerCase())
+      return value === undefined
+        ? { kind: "missing" }
+        : { kind: "value", value }
+    }
+
+    parsedBody ??= parseResponseBody(response.body)
+    if (parsedBody.kind === "invalid-json") {
+      return { kind: "error", message: parsedBody.message }
+    }
+    let value = parsedBody.value
+    for (const part of parsedExpression.path) {
+      if (part.kind === "index") {
+        if (!Array.isArray(value)) {
+          return {
+            kind: "error",
+            message: `Cannot access index ${part.index} on a non-array value`,
+          }
+        }
+        if (!Object.hasOwn(value, part.index)) return { kind: "missing" }
+        value = value[part.index]
+        continue
+      }
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        return {
+          kind: "error",
+          message: `Cannot access property "${part.name}" on a non-object value`,
+        }
+      }
+      if (!Object.hasOwn(value, part.name)) return { kind: "missing" }
+      value = (value as Record<string, unknown>)[part.name]
+    }
+    return { kind: "value", value: value as JsonValue }
+  }
+}
+
+function invalidExpression(expression: string): Error {
+  return new Error(`Invalid response expression "${expression}"`)
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -4,6 +4,48 @@ export type Method =
 export type BodyType =
   "none" | "json" | "xml" | "multipart" | "urlencoded" | "binary"
 
+export type JsonValue =
+  null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
+
+export type AssertionValue = JsonValue
+
+export type AssertionWithoutValueOperator =
+  | "exists"
+  | "notExists"
+  | "isString"
+  | "isNumber"
+  | "isBoolean"
+  | "isArray"
+  | "isObject"
+  | "isNull"
+  | "notNull"
+
+export type AssertionWithValueOperator =
+  | "equals"
+  | "notEquals"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "contains"
+  | "notContains"
+  | "matches"
+
+export type AssertionOperator =
+  AssertionWithoutValueOperator | AssertionWithValueOperator
+
+export type ResponseAssertion =
+  | {
+      expression: string
+      operator: AssertionWithoutValueOperator
+      value?: never
+    }
+  | {
+      expression: string
+      operator: AssertionWithValueOperator
+      value: AssertionValue
+    }
+
 export interface FormEntry {
   name: string
   value: string
@@ -186,6 +228,7 @@ export interface Request {
   filePath?: string
   auth?: Auth
   tls?: RequestTlsSettings
+  assertions?: ResponseAssertion[]
 }
 
 export interface Collection {

--- a/src/ui/responseQuery.ts
+++ b/src/ui/responseQuery.ts
@@ -1,13 +1,10 @@
 import { JSONPath } from "jsonpath-plus"
+import { parseResponseBody } from "../response"
 
 export type ResponseQueryResult =
   | { kind: "success"; body: string; matchCount: number }
   | { kind: "invalid-json"; message: string }
   | { kind: "invalid-expression"; message: string }
-
-export type ParsedResponseBody =
-  | { kind: "success"; value: unknown }
-  | { kind: "invalid-json"; message: string }
 
 export interface ResponseQueryController {
   canOpen: () => boolean
@@ -24,16 +21,7 @@ export function queryResponseBody(
   return queryParsedResponseBody(parsed.value, expression)
 }
 
-export function parseResponseBody(body: string): ParsedResponseBody {
-  try {
-    return { kind: "success", value: JSON.parse(body) }
-  } catch {
-    return {
-      kind: "invalid-json",
-      message: "Response body is not valid JSON",
-    }
-  }
-}
+export { parseResponseBody }
 
 export function queryParsedResponseBody(
   value: unknown,

--- a/tests/humanOutput.test.ts
+++ b/tests/humanOutput.test.ts
@@ -123,6 +123,68 @@ describe("human CLI output", () => {
     expect(output).not.toContain('{"users":[]}')
   })
 
+  it("summarizes assertions without printing raw actual values", () => {
+    const output = plain(
+      formatRequestRun({
+        result: {
+          id: "users/get",
+          method: "GET",
+          url: "https://example.com/users/1",
+          ok: false,
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: '{"token":"raw-server-secret"}',
+            timeMs: 2,
+          },
+          assertions: {
+            evaluated: true,
+            results: [
+              {
+                expression: "status",
+                operator: "equals",
+                expected: 200,
+                actual: 200,
+                passed: true,
+                message: "Assertion passed",
+              },
+              {
+                expression: "body.token",
+                operator: "equals",
+                expected: "[REDACTED]",
+                actual: "raw-server-secret",
+                passed: false,
+                message: "Expected values to be equal",
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    expect(output).toContain("Assertions: 1 passed, 1 failed")
+    expect(output).toContain("✗ body.token equals: Expected values to be equal")
+    expect(output).not.toContain("raw-server-secret")
+  })
+
+  it("reports assertions that could not be evaluated", () => {
+    expect(
+      plain(
+        formatRequestRun({
+          result: {
+            id: "users/get",
+            method: "GET",
+            url: "https://example.com/users/1",
+            ok: false,
+            error: "unresolved variable",
+            assertions: { evaluated: false, results: [] },
+          },
+        }),
+      ),
+    ).toContain("Assertions: not evaluated")
+  })
+
   it("prints cookie warnings, storage state, and recovery backups", () => {
     const listed = plain(
       formatCookieList({

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -324,6 +324,214 @@ describe("automation services", () => {
     }
   })
 
+  it("evaluates passing assertions for request run", async () => {
+    await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\nassert:\n  - expression: status\n    operator: equals\n    value: 201\n  - expression: body.id\n    operator: isNumber\n  - expression: headers.X-Trace\n    operator: equals\n    value: abc\n  - expression: response.time\n    operator: lt\n    value: 500\n",
+    )
+    const send = executor.send
+    executor.send = async () => ({
+      status: 201,
+      statusText: "Created",
+      headers: { "x-trace": "abc" },
+      body: '{"id":42}',
+      timeMs: 12,
+    })
+    try {
+      const result = await requestRun("request", dir)
+      expect(result.failed).toBe(false)
+      expect(result.result.ok).toBe(true)
+      expect(result.result.assertions).toMatchObject({
+        evaluated: true,
+        results: [
+          { expression: "status", passed: true, actual: 201 },
+          { expression: "body.id", passed: true, actual: 42 },
+          { expression: "headers.X-Trace", passed: true, actual: "abc" },
+          { expression: "response.time", passed: true, actual: 12 },
+        ],
+      })
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("marks collection run failed when any assertion fails", async () => {
+    await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
+    await writeFile(
+      join(dir, "passing.yml"),
+      "name: Passing\nmethod: GET\nurl: https://example.com/pass\nassert:\n  - expression: status\n    operator: equals\n    value: 200\n",
+    )
+    await writeFile(
+      join(dir, "failing.yml"),
+      "name: Failing\nmethod: GET\nurl: https://example.com/fail\nassert:\n  - expression: body.id\n    operator: equals\n    value: 99\n",
+    )
+    const send = executor.send
+    executor.send = async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: '{"id":42}',
+      timeMs: 1,
+    })
+    try {
+      const result = await collectionRun(dir)
+      expect(result.failed).toBe(true)
+      expect(
+        result.results.find((item) => item.id === "passing"),
+      ).toMatchObject({ ok: true, assertions: { evaluated: true } })
+      const failed = result.results.find((item) => item.id === "failing")!
+      expect(failed).toMatchObject({
+        ok: false,
+        response: { body: '{"id":42}' },
+        assertions: {
+          evaluated: true,
+          results: [
+            {
+              expected: 99,
+              actual: 42,
+              passed: false,
+              message: "Expected values to be equal",
+            },
+          ],
+        },
+      })
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("reports declared assertions as not evaluated when substitution fails", async () => {
+    await writeFile(
+      join(dir, "settings.yml"),
+      "environment: development\ncookies:\n  enabled: false\n",
+    )
+    await env.saveEnvironment(join(dir, ".environments"), {
+      name: "development",
+      vars: {},
+    })
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\nassert:\n  - expression: body.id\n    operator: equals\n    value: $MISSING\n",
+    )
+    const send = executor.send
+    let calls = 0
+    executor.send = async () => {
+      calls++
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "{}",
+        timeMs: 1,
+      }
+    }
+    try {
+      const result = await requestRun("request", dir)
+      expect(calls).toBe(0)
+      expect(result.result).toMatchObject({
+        ok: false,
+        assertions: { evaluated: false, results: [] },
+      })
+      expect(result.result.error).toContain('unresolved variable "MISSING"')
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("omits assertion output for legacy requests", async () => {
+    await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\n",
+    )
+    const send = executor.send
+    executor.send = async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: "{}",
+      timeMs: 1,
+    })
+    try {
+      const result = await requestRun("request", dir)
+      expect(result.result.ok).toBe(true)
+      expect(result.result).not.toHaveProperty("assertions")
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("keeps HTTP failure in the aggregate result when assertions pass", async () => {
+    await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
+    await writeFile(
+      join(dir, "request.yml"),
+      "name: Request\nmethod: GET\nurl: https://example.com\nassert:\n  - expression: status\n    operator: equals\n    value: 500\n",
+    )
+    const send = executor.send
+    executor.send = async () => ({
+      status: 500,
+      statusText: "Error",
+      headers: {},
+      body: "{}",
+      timeMs: 1,
+    })
+    try {
+      const result = await requestRun("request", dir)
+      expect(result).toMatchObject({
+        failed: true,
+        result: {
+          ok: false,
+          assertions: { evaluated: true, results: [{ passed: true }] },
+        },
+      })
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("redacts secret expected values but preserves raw actual response values", async () => {
+    const key = "NOODLE_ASSERTION_SECRET"
+    const originalValue = process.env[key]
+    const send = executor.send
+    try {
+      process.env[key] = "assertion-secret"
+      await writeFile(
+        join(dir, "settings.yml"),
+        "environment: development\ncookies:\n  enabled: false\n",
+      )
+      await env.saveEnvironment(join(dir, ".environments"), {
+        name: "development",
+        vars: {},
+        secretVars: { [key]: "process" },
+      })
+      await writeFile(
+        join(dir, "request.yml"),
+        `name: Request\nmethod: GET\nurl: https://example.com\nassert:\n  - expression: body.token\n    operator: equals\n    value: $${key}\n`,
+      )
+      executor.send = async () => ({
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: '{"token":"assertion-secret"}',
+        timeMs: 1,
+      })
+      const result = await requestRun("request", dir)
+      expect(result.result.assertions?.results[0]).toMatchObject({
+        expected: "[REDACTED]",
+        actual: "assertion-secret",
+        passed: true,
+      })
+      expect(result.result.assertions?.results[0]?.message).not.toContain(
+        "assertion-secret",
+      )
+    } finally {
+      executor.send = send
+      if (originalValue === undefined) delete process.env[key]
+      else process.env[key] = originalValue
+    }
+  })
+
   it("reports run progress before and after each collection request", async () => {
     await writeFile(join(dir, "settings.yml"), "{}\n")
     await writeFile(

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -1115,3 +1115,153 @@ describe("lang.serializeFolder — multiline values", () => {
     })
   })
 })
+
+describe("lang.parseRequest — response assertions", () => {
+  const prefix = "name: Assertions\nmethod: GET\nurl: https://example.com\n"
+
+  it("parses and canonically round-trips typed assertions", () => {
+    const request = lang.parseRequest(
+      "assertions",
+      `${prefix}assert:\n  - expression: status\n    operator: equals\n    value: 201\n  - expression: body.users[0].id\n    operator: isNumber\n  - expression: body\n    operator: equals\n    value:\n      ok: true\n      values: [1, null]\n`,
+    )
+
+    expect(request.assertions).toEqual([
+      { expression: "status", operator: "equals", value: 201 },
+      { expression: "body.users[0].id", operator: "isNumber" },
+      {
+        expression: "body",
+        operator: "equals",
+        value: { ok: true, values: [1, null] },
+      },
+    ])
+    const serialized = lang.serializeRequest(request)
+    expect(serialized).toContain(
+      "assert:\n  - expression: status\n    operator: equals\n    value: 201\n",
+    )
+    expect(lang.parseRequest("assertions", serialized).assertions).toEqual(
+      request.assertions,
+    )
+  })
+
+  it("accepts an empty assertion list as no declarations", () => {
+    const request = lang.parseRequest("assertions", `${prefix}assert: []\n`)
+    expect(request.assertions).toBeUndefined()
+    expect(lang.serializeRequest(request)).not.toContain("assert:")
+  })
+
+  it("rejects malformed assertion containers and items", () => {
+    expect(() =>
+      lang.parseRequest("assertions", `${prefix}assert: {}\n`),
+    ).toThrow('lang.parseRequest: "assert" must be an array')
+    expect(() =>
+      lang.parseRequest("assertions", `${prefix}assert:\n  - nope\n`),
+    ).toThrow("lang.parseRequest: assert[0] must be an object")
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: status\n    operator: exists\n    extra: true\n`,
+      ),
+    ).toThrow('lang.parseRequest: unknown assert[0] field "extra"')
+  })
+
+  it("rejects malformed expressions and invalid operators", () => {
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body..id\n    operator: exists\n`,
+      ),
+    ).toThrow(
+      'lang.parseRequest: assert[0].expression: Invalid response expression "body..id"',
+    )
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: status\n    operator: equalz\n    value: 200\n`,
+      ),
+    ).toThrow('lang.parseRequest: invalid assert[0].operator "equalz"')
+  })
+
+  it("enforces value presence and absence by operator", () => {
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: status\n    operator: equals\n`,
+      ),
+    ).toThrow('assert[0].operator "equals" requires value')
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: status\n    operator: exists\n    value: 200\n`,
+      ),
+    ).toThrow('assert[0].operator "exists" does not accept value')
+  })
+
+  it("rejects incompatible numeric and regex definitions", () => {
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: response.time\n    operator: lt\n    value: $MAX_TIME\n`,
+      ),
+    ).toThrow('operator "lt" requires a finite numeric value')
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: 42\n`,
+      ),
+    ).toThrow('operator "matches" requires a string value')
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: '['\n`,
+      ),
+    ).toThrow('operator "matches": Invalid regular expression')
+  })
+
+  it("accepts safe regex repetition and rejects backtracking syntax", () => {
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: '^user-\\d+$'\n`,
+      ),
+    ).not.toThrow()
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: '^(a+)+$'\n`,
+      ),
+    ).toThrow('operator "matches": Regular expression uses unsupported syntax')
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: '.*a'\n`,
+      ),
+    ).toThrow('operator "matches": Regular expression uses unsupported syntax')
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: '[ab]+c'\n`,
+      ),
+    ).toThrow('operator "matches": Regular expression uses unsupported syntax')
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.name\n    operator: matches\n    value: '^.*a'\n`,
+      ),
+    ).not.toThrow()
+  })
+
+  it("rejects non-JSON-compatible values and non-finite numbers", () => {
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.value\n    operator: equals\n    value: .nan\n`,
+      ),
+    ).toThrow("assert[0].value must contain finite numbers")
+    expect(() =>
+      lang.parseRequest(
+        "assertions",
+        `${prefix}assert:\n  - expression: body.value\n    operator: equals\n    value: 2026-08-24\n`,
+      ),
+    ).toThrow("assert[0].value must be a JSON-compatible value")
+  })
+})

--- a/tests/requests.test.ts
+++ b/tests/requests.test.ts
@@ -208,6 +208,81 @@ describe("substitute — auth", () => {
   })
 })
 
+describe("substitute — response assertions", () => {
+  it("recursively substitutes assertion string values without coercion", () => {
+    const result = substitute(
+      makeReq({
+        assertions: [
+          {
+            expression: "body.user",
+            operator: "equals",
+            value: {
+              name: "$NAME",
+              roles: ["$ROLE", 2, null],
+              $KEY: "$VALUE",
+            },
+          },
+          { expression: "status", operator: "equals", value: "$STATUS" },
+        ],
+      }),
+      {
+        name: "dev",
+        vars: {
+          NAME: "Noodle",
+          ROLE: "admin",
+          KEY: "ignored-key",
+          VALUE: "resolved",
+          STATUS: "200",
+        },
+      },
+    )
+
+    expect(result.assertions).toEqual([
+      {
+        expression: "body.user",
+        operator: "equals",
+        value: {
+          name: "Noodle",
+          roles: ["admin", 2, null],
+          $KEY: "resolved",
+        },
+      },
+      { expression: "status", operator: "equals", value: "200" },
+    ])
+  })
+
+  it("reports unresolved variables with the assertion value path", () => {
+    expect(() =>
+      substitute(
+        makeReq({
+          assertions: [
+            {
+              expression: "body.user",
+              operator: "equals",
+              value: { roles: ["$MISSING"] },
+            },
+          ],
+        }),
+        { name: "dev", vars: {} },
+      ),
+    ).toThrow(
+      'requests.substitute: unresolved variable "MISSING" in assertions[0].value.roles[0]',
+    )
+  })
+
+  it("does not substitute assertion expressions or operators", () => {
+    const result = substitute(
+      makeReq({
+        assertions: [{ expression: "body.$FIELD", operator: "exists" }],
+      }),
+      { name: "dev", vars: { FIELD: "id" } },
+    )
+    expect(result.assertions).toEqual([
+      { expression: "body.$FIELD", operator: "exists" },
+    ])
+  })
+})
+
 describe("substitute — AWS SigV4", () => {
   it("substitutes every credential and scope field", () => {
     const result = substitute(

--- a/tests/unit/assertions.test.ts
+++ b/tests/unit/assertions.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "bun:test"
+import { compileAssertionRegex, evaluateAssertions } from "../../src/assertions"
+import type { Response, ResponseAssertion } from "../../src/schema"
+
+function response(body: unknown): Response {
+  return {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    timeMs: 25,
+  }
+}
+
+const body = {
+  string: "hello noodle",
+  number: 5,
+  boolean: true,
+  array: [1, { id: 2 }],
+  object: { id: 2 },
+  null: null,
+}
+
+describe("response assertions", () => {
+  const cases: Array<{
+    operator: ResponseAssertion["operator"]
+    passing: ResponseAssertion
+    failing: ResponseAssertion
+  }> = [
+    {
+      operator: "equals",
+      passing: {
+        expression: "body.object",
+        operator: "equals",
+        value: { id: 2 },
+      },
+      failing: {
+        expression: "body.object",
+        operator: "equals",
+        value: { id: 3 },
+      },
+    },
+    {
+      operator: "notEquals",
+      passing: { expression: "body.number", operator: "notEquals", value: 4 },
+      failing: { expression: "body.number", operator: "notEquals", value: 5 },
+    },
+    {
+      operator: "exists",
+      passing: { expression: "body.string", operator: "exists" },
+      failing: { expression: "body.missing", operator: "exists" },
+    },
+    {
+      operator: "notExists",
+      passing: { expression: "body.missing", operator: "notExists" },
+      failing: { expression: "body.string", operator: "notExists" },
+    },
+    {
+      operator: "isString",
+      passing: { expression: "body.string", operator: "isString" },
+      failing: { expression: "body.number", operator: "isString" },
+    },
+    {
+      operator: "isNumber",
+      passing: { expression: "body.number", operator: "isNumber" },
+      failing: { expression: "body.string", operator: "isNumber" },
+    },
+    {
+      operator: "isBoolean",
+      passing: { expression: "body.boolean", operator: "isBoolean" },
+      failing: { expression: "body.number", operator: "isBoolean" },
+    },
+    {
+      operator: "isArray",
+      passing: { expression: "body.array", operator: "isArray" },
+      failing: { expression: "body.object", operator: "isArray" },
+    },
+    {
+      operator: "isObject",
+      passing: { expression: "body.object", operator: "isObject" },
+      failing: { expression: "body.array", operator: "isObject" },
+    },
+    {
+      operator: "isNull",
+      passing: { expression: "body.null", operator: "isNull" },
+      failing: { expression: "body.missing", operator: "isNull" },
+    },
+    {
+      operator: "notNull",
+      passing: { expression: "body.number", operator: "notNull" },
+      failing: { expression: "body.null", operator: "notNull" },
+    },
+    {
+      operator: "gt",
+      passing: { expression: "body.number", operator: "gt", value: 4 },
+      failing: { expression: "body.number", operator: "gt", value: 5 },
+    },
+    {
+      operator: "gte",
+      passing: { expression: "body.number", operator: "gte", value: 5 },
+      failing: { expression: "body.number", operator: "gte", value: 6 },
+    },
+    {
+      operator: "lt",
+      passing: { expression: "body.number", operator: "lt", value: 6 },
+      failing: { expression: "body.number", operator: "lt", value: 5 },
+    },
+    {
+      operator: "lte",
+      passing: { expression: "body.number", operator: "lte", value: 5 },
+      failing: { expression: "body.number", operator: "lte", value: 4 },
+    },
+    {
+      operator: "contains",
+      passing: {
+        expression: "body.string",
+        operator: "contains",
+        value: "noodle",
+      },
+      failing: {
+        expression: "body.string",
+        operator: "contains",
+        value: "pasta",
+      },
+    },
+    {
+      operator: "notContains",
+      passing: {
+        expression: "body.string",
+        operator: "notContains",
+        value: "pasta",
+      },
+      failing: {
+        expression: "body.string",
+        operator: "notContains",
+        value: "noodle",
+      },
+    },
+    {
+      operator: "matches",
+      passing: {
+        expression: "body.string",
+        operator: "matches",
+        value: "^hello",
+      },
+      failing: {
+        expression: "body.string",
+        operator: "matches",
+        value: "world$",
+      },
+    },
+  ]
+
+  for (const testCase of cases) {
+    it(`evaluates passing and failing ${testCase.operator} assertions`, () => {
+      const [passing, failing] = evaluateAssertions(
+        [testCase.passing, testCase.failing],
+        response(body),
+      )
+      expect(passing!.passed).toBe(true)
+      expect(failing!.passed).toBe(false)
+      expect(failing!.message.length).toBeGreaterThan(0)
+    })
+  }
+
+  it("uses deep element equality for array containment", () => {
+    expect(
+      evaluateAssertions(
+        [{ expression: "body.array", operator: "contains", value: { id: 2 } }],
+        response(body),
+      )[0],
+    ).toMatchObject({ passed: true, actual: [1, { id: 2 }] })
+  })
+
+  it("preserves an actual null and omits actual for missing or errors", () => {
+    const results = evaluateAssertions(
+      [
+        { expression: "body.null", operator: "isNull" },
+        { expression: "body.missing", operator: "exists" },
+        { expression: "body.null.value", operator: "exists" },
+      ],
+      response(body),
+    )
+    expect(results[0]).toMatchObject({ actual: null, passed: true })
+    expect(results[1]).not.toHaveProperty("actual")
+    expect(results[2]).not.toHaveProperty("actual")
+    expect(results[2]!.message).toContain("Cannot access property")
+  })
+
+  it("fails type mismatches without coercion", () => {
+    const results = evaluateAssertions(
+      [
+        { expression: "body.string", operator: "gt", value: 1 },
+        { expression: "body.number", operator: "contains", value: 5 },
+        { expression: "body.string", operator: "contains", value: 5 },
+        { expression: "body.number", operator: "matches", value: "5" },
+      ],
+      response(body),
+    )
+    expect(results.every((result) => !result.passed)).toBe(true)
+    expect(results.map((result) => result.message)).toEqual([
+      'Operator "gt" requires numbers',
+      'Operator "contains" requires a string or array',
+      'Operator "contains" requires a string or array',
+      'Operator "matches" requires strings',
+    ])
+  })
+
+  it("turns an invalid substituted regex into a failed result", () => {
+    expect(
+      evaluateAssertions(
+        [{ expression: "body.string", operator: "matches", value: "[" }],
+        response(body),
+      )[0],
+    ).toMatchObject({ passed: false, message: "Invalid regular expression" })
+  })
+
+  it("supports one safe repetition and rejects backtracking regexes", () => {
+    expect(compileAssertionRegex("^user-\\d+$").kind).toBe("success")
+    expect(compileAssertionRegex("^(a+)+$")).toEqual({
+      kind: "error",
+      message: "Regular expression uses unsupported syntax",
+    })
+    expect(compileAssertionRegex(".*a")).toEqual({
+      kind: "error",
+      message: "Regular expression uses unsupported syntax",
+    })
+    expect(compileAssertionRegex("[ab]+c")).toEqual({
+      kind: "error",
+      message: "Regular expression uses unsupported syntax",
+    })
+    expect(compileAssertionRegex("^.*a").kind).toBe("success")
+    expect(
+      evaluateAssertions(
+        [
+          {
+            expression: "body.string",
+            operator: "matches",
+            value: "^(a+)+$",
+          },
+        ],
+        response(body),
+      )[0],
+    ).toMatchObject({
+      passed: false,
+      message: "Regular expression uses unsupported syntax",
+    })
+    expect(
+      evaluateAssertions(
+        [
+          {
+            expression: "body.string",
+            operator: "matches",
+            value: ".*a",
+          },
+        ],
+        response(body),
+      )[0],
+    ).toMatchObject({
+      passed: false,
+      message: "Regular expression uses unsupported syntax",
+    })
+  })
+
+  it("does not treat expression errors as notExists", () => {
+    expect(
+      evaluateAssertions(
+        [{ expression: "body.null.value", operator: "notExists" }],
+        response(body),
+      )[0],
+    ).toMatchObject({ passed: false })
+  })
+})

--- a/tests/unit/responseExpression.test.ts
+++ b/tests/unit/responseExpression.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test"
+import {
+  createResponseResolver,
+  parseResponseExpression,
+} from "../../src/response"
+import type { Response } from "../../src/schema"
+
+function response(overrides: Partial<Response> = {}): Response {
+  return {
+    status: 201,
+    statusText: "Created",
+    headers: { "Content-Type": "application/json", "X-Trace": "abc" },
+    body: JSON.stringify({
+      id: null,
+      user: { profile: { name: "Noodle" } },
+      users: [{ id: 42 }],
+    }),
+    timeMs: 12.5,
+    ...overrides,
+  }
+}
+
+describe("response expressions", () => {
+  it("parses the supported grammar", () => {
+    expect(parseResponseExpression("status")).toEqual({ kind: "status" })
+    expect(parseResponseExpression("response.time")).toEqual({
+      kind: "response-time",
+    })
+    expect(parseResponseExpression("headers.Content-Type")).toEqual({
+      kind: "header",
+      name: "Content-Type",
+    })
+    expect(parseResponseExpression("body")).toEqual({ kind: "body", path: [] })
+    expect(parseResponseExpression("body.users[0].id")).toEqual({
+      kind: "body",
+      path: [
+        { kind: "property", name: "users" },
+        { kind: "index", index: 0 },
+        { kind: "property", name: "id" },
+      ],
+    })
+    expect(parseResponseExpression("body[0].id")).toEqual({
+      kind: "body",
+      path: [
+        { kind: "index", index: 0 },
+        { kind: "property", name: "id" },
+      ],
+    })
+  })
+
+  it("resolves status, timing, headers, nested JSON, arrays, and the root body", () => {
+    const resolve = createResponseResolver(response())
+    expect(resolve("status")).toEqual({ kind: "value", value: 201 })
+    expect(resolve("response.time")).toEqual({ kind: "value", value: 12.5 })
+    expect(resolve("headers.content-type")).toEqual({
+      kind: "value",
+      value: "application/json",
+    })
+    expect(resolve("headers.X-TRACE")).toEqual({
+      kind: "value",
+      value: "abc",
+    })
+    expect(resolve("body.user.profile.name")).toEqual({
+      kind: "value",
+      value: "Noodle",
+    })
+    expect(resolve("body.users[0].id")).toEqual({
+      kind: "value",
+      value: 42,
+    })
+    expect(resolve("body")).toEqual({
+      kind: "value",
+      value: {
+        id: null,
+        user: { profile: { name: "Noodle" } },
+        users: [{ id: 42 }],
+      },
+    })
+    expect(
+      createResponseResolver(response({ body: '[{"id":7}]' }))("body[0].id"),
+    ).toEqual({ kind: "value", value: 7 })
+  })
+
+  it("distinguishes JSON null, missing values, and traversal errors", () => {
+    const resolve = createResponseResolver(response())
+    expect(resolve("body.id")).toEqual({ kind: "value", value: null })
+    expect(resolve("body.missing")).toEqual({ kind: "missing" })
+    expect(resolve("body.users[1]")).toEqual({ kind: "missing" })
+    expect(resolve("headers.missing")).toEqual({ kind: "missing" })
+    expect(resolve("body.id.value")).toEqual({
+      kind: "error",
+      message: 'Cannot access property "value" on a non-object value',
+    })
+    expect(resolve("body.user[0]")).toEqual({
+      kind: "error",
+      message: "Cannot access index 0 on a non-array value",
+    })
+  })
+
+  it("reports invalid JSON only for body expressions and parses it once", () => {
+    let bodyReads = 0
+    const value = response({ body: "{" })
+    Object.defineProperty(value, "body", {
+      get() {
+        bodyReads++
+        return "{"
+      },
+    })
+    const resolve = createResponseResolver(value)
+
+    expect(resolve("status")).toEqual({ kind: "value", value: 201 })
+    expect(resolve("body.id")).toEqual({
+      kind: "error",
+      message: "Response body is not valid JSON",
+    })
+    expect(resolve("body.other")).toEqual({
+      kind: "error",
+      message: "Response body is not valid JSON",
+    })
+    expect(bodyReads).toBe(1)
+  })
+
+  it("rejects malformed or unsupported expressions", () => {
+    for (const expression of [
+      "",
+      "response",
+      "response.status",
+      "headers",
+      "headers.",
+      "headers.Content Type",
+      "body.",
+      "body..id",
+      "body.*",
+      "body.$.id",
+      "body[-1]",
+      "body[01]",
+      "body['id']",
+      "body[0",
+      "body.users[*]",
+      "body.users[?(@.id)]",
+    ]) {
+      expect(() => parseResponseExpression(expression)).toThrow(
+        `Invalid response expression "${expression}"`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Declarative assertions foundation for collection request YAML (`assert` blocks).

- Add response assertion schema types and `createResponseResolver` / `parseResponseExpression` (`src/schema/index.ts`, `src/response.ts`)
- Add safe assertion evaluator with hardened regex validation and 18 operators (`exists`, `notExists`, type checks, `equals`/`notEquals`, numeric comparisons, `contains`/`notContains`, `matches`) (`src/assertions.ts`)
- Parse and serialize `assert` blocks in request YAML with strict validation and regex checks at parse time (`src/lang/parse.ts`, `src/lang/serialize.ts`)
- Integrate variable substitution and assertion evaluation in run pipeline: effective request resolved before send, assertion results redacted and factored into `ok`/human output (`src/requests/substitute.ts`, `src/app/services.ts`, `src/app/humanOutput.ts`, `src/ui/responseQuery.ts`)
- Wire `request run` / `collection run` assertion reporting and sample collection (`collections/assertions/`)
- Bump `bun` to `1.4.0` in CI/release workflows

### How did you verify your code works?

- Manual local testing of parsing/serialization and run pipeline with assertion samples
- `bun test` — 2839 pass, 0 fail across 186 files
- `bun run lint` — passes (no output)
- `bun run typecheck` — passes (`tsc --noEmit`)

### Screenshots / recordings

N/A — no UI change requiring screenshots (human output adds assertion summary lines; automation JSON adds `assertions` envelope).

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added response assertions for status, timing, headers, body fields, types, comparisons, containment, nullability, and regular expressions.
  - Assertions can use variables, nested values, and JSON request configuration.
  - Request results now show assertion pass/fail details and mark runs unsuccessful when assertions fail.
  - Added safeguards to redact sensitive expected values.

- **Bug Fixes**
  - Improved response parsing, including case-insensitive headers and nested JSON paths.

- **Tests**
  - Added comprehensive coverage for assertion parsing, evaluation, substitution, output, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->