### PR TITLE
refactor(ui): pass overlay state as one object

### DIFF
--- a/.agents/skills/noodle-dev/recipes.md
+++ b/.agents/skills/noodle-dev/recipes.md
@@ -64,6 +64,8 @@ Each recipe follows: **Locate → Follow → Implement → Test → Verify**
 
 **Follow:** For picker-style overlays, reuse `PickerOverlay<T>`. Add other overlays to `useOverlayState` and `AppOverlays`; do not create a direct OpenTUI modal or local `AppInner` state path. Classify every overlay in `EDITABLE_OVERLAYS` or `HARD_BLOCKING_OVERLAYS` in `useModalKeyboardShield`; add a modal-specific interceptor only when its controls need custom key handling.
 
+`useOverlayState` is the single owner of overlay visibility, pending values, and handles. `AppInner` passes the whole `OverlayState` object to `AppOverlays` and `useOverlayIntercepts`, so a new overlay never widens a mirrored prop list — declare it once in `useOverlayState`, then read it off `overlays` wherever it is needed. Keep behavior callbacks and state owned elsewhere (`useReloadGuard`, `useCollectionSwitcher`) as explicit props.
+
 **Implement (picker-style):**
 1. Define item type and use `PickerOverlay<T>` with `keyExtractor`, `filter`, `renderItem` props
 2. Wire `onSelect`, `onClose`, `onHighlightChange` to parent state
@@ -72,13 +74,13 @@ Each recipe follows: **Locate → Follow → Implement → Test → Verify**
 
 **Implement (modal):**
 1. Create component in `src/ui/YourOverlay.tsx`
-2. Add overlay type and state to `useOverlayState.ts`
-3. Add a render branch in `AppOverlays.tsx`
+2. Add overlay type and state to `useOverlayState.ts`, and its default to `tests/unit/_overlayState.ts`
+3. Add a render branch in `AppOverlays.tsx`, reading state off `overlays`
 4. Sync it with `app.overlay`; add opening/close keys in the owning layer or interceptor
 5. Add the overlay to `EDITABLE_OVERLAYS` or `HARD_BLOCKING_OVERLAYS`; editable overlays install no shield, while hard-blocking overlays prevent and stop background keys
 6. If overlay writes to collection (e.g., new request), call `filestore.saveRequest` then reload collection
 
-**Test:** Component test verifying overlay renders, form submission works, cancel dismisses, and a lower-priority background key handler does not receive an overlay shortcut or an unused printable key.
+**Test:** Component test verifying overlay renders, form submission works, cancel dismisses, and a lower-priority background key handler does not receive an overlay shortcut or an unused printable key. Add a routing case to `tests/unit/AppOverlays.test.tsx` so the overlay is proven to render from its own state field.
 
 **Verify:** `bun test && bun run lint && bun run typecheck`
 

--- a/.agents/skills/noodle-dev/testing.md
+++ b/.agents/skills/noodle-dev/testing.md
@@ -5,7 +5,7 @@
 `bun test` (NOT jest/vitest). Uses `describe`, `it`, `expect` from `bun:test`.
 
 ```bash
-bun test                                    # all 2876 tests across 187 files
+bun test                                    # all 2910 tests across 188 files
 bun test tests/lang.test.ts                 # single file
 bun test --test-name-pattern "parseFolder"  # by name
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Terminal REST client. Inspect, send, and iterate on HTTP requests from YAML file
 ```bash
 bun install
 bun run dev -- --collection ./collections --env development
-bun test                              # all tests (2876 across 187 files)
+bun test                              # all tests (2910 across 188 files)
 bun test tests/lang.test.ts           # single file
 bun run lint                          # eslint
 bun run typecheck                     # tsc --noEmit
@@ -218,6 +218,7 @@ tests/integration/ # Integration tests
 - **Resizable main layout:** `AppInner.tsx` owns the current sidebar width plus separate stacked and side-by-side request/response ratios. `MainView.tsx` handles drag state, responsive minimums, and double-click reset; `RequestResponseView.tsx` renders the layout-specific resize handles. Keep sizing session-only unless persistence is explicitly requested.
 - **UI features require loading the `opentui` skill**. The skill lives at `.agents/skills/opentui/SKILL.md`.
 - **Command actions are centralized** in `commandActions.ts`. Both `useAppKeymap.ts` and `commands.ts` import from it. Never duplicate command logic.
+- **Overlay state travels as one object.** `useOverlayState` owns every overlay's visibility, pending value, and handle, and `AppInner` passes the whole `OverlayState` to `AppOverlays` and `useOverlayIntercepts` rather than re-declaring fields at each consumer. Adding an overlay means declaring it in `useOverlayState` (state, `activeOverlay` branch, return), handling its keys in the intercepts, and rendering it in `AppOverlays` — never widening a mirrored prop list. State owned elsewhere (`useReloadGuard`, `useCollectionSwitcher`) and behavior callbacks stay explicit props. `tests/unit/_overlayState.ts` builds a default `OverlayState` for tests.
 - **Command palette commands return boolean**: `run()` returns `true` (close palette) or `false` (stay open).
 - **PickerOverlay isNavigable**: Pass to skip non-selectable items (section headers) during up/down/return navigation.
 - **Environment controls:** `e` opens the searchable picker from the main view; `F3` opens the full editor. New environments are created through `NewEnvironmentOverlay`, then persisted by `useEnvironmentEditor.createEnv()`. In environment browse mode, configurable `env_secret` (`s`) toggles secure storage and `env_reveal` (`r`) reveals the selected secret for the session.

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -348,18 +348,6 @@ export function AppInner({
   )
 
   const requests = useMemo(() => flattenRequests(items), [items])
-  const findRequest = useCallback(
-    (item: FinderItem) => {
-      if (item.type === "request") {
-        revealRequest(item.id)
-      } else {
-        revealFolder(item.id)
-      }
-      setFocus("sidebar")
-      setRequestFinderVisible(false)
-    },
-    [revealRequest, revealFolder],
-  )
 
   const focusedFolder = useMemo(
     () =>
@@ -720,85 +708,22 @@ export function AppInner({
   const overlayActiveRef = useRef(false)
   const { updateFlow, triggerAboutUpdateCheck } =
     useUpdateFlow(updateDependencies)
-  const {
-    activeOverlay,
-    helpVisible,
-    setHelpVisible,
-    aboutVisible,
-    setAboutVisible,
-    environmentPickerVisible,
-    setEnvironmentPickerVisible,
-    yamlEditor,
-    setYamlEditor,
-    envDeletePending,
-    setEnvDeletePending,
-    envDeletePendingRef,
-    collectionUnregisterPending,
-    setCollectionUnregisterPending,
-    newEnvironmentVisible,
-    setNewEnvironmentVisible,
-    newEnvironmentRef,
-    cookieFormVisible,
-    setCookieFormVisible,
-    cookieFormRef,
-    cookieFormInitial,
-    setCookieFormInitial,
-    cookieDeletePending,
-    setCookieDeletePending,
-    newRequestVisible,
-    setNewRequestVisible,
-    newRequestRef,
-    importCurlVisible,
-    setImportCurlVisible,
-    importCurlRef,
-    editRequestVisible,
-    setEditRequestVisible,
-    editRequestRef,
-    cloneRequestVisible,
-    setCloneRequestVisible,
-    cloneRequestRef,
-    requestDeletePending,
-    setRequestDeletePending,
-    newFolderVisible,
-    setNewFolderVisible,
-    newFolderRef,
-    folderDeletePending,
-    setFolderDeletePending,
-    undoAllPending,
-    setUndoAllPending,
-    initPending,
-    setInitPending,
-    commandPaletteVisible,
-    setCommandPaletteVisible,
-    codeGeneratorVisible,
-    setCodeGeneratorVisible,
-    exportCollectionVisible,
-    setExportCollectionVisible,
-    exportCollectionRef,
-    importCollectionVisible,
-    setImportCollectionVisible,
-    importCollectionRef,
-    importCollectionPending,
-    setImportCollectionPending,
-    importOpenPending,
-    setImportOpenPending,
-    requestFinderVisible,
-    setRequestFinderVisible,
-    timelineDetailEntry,
-    setTimelineDetailEntry,
-  } = useOverlayState({
+  // Overlay visibility, pending values, and handles stay in one object so
+  // adding an overlay does not mean re-declaring it at every consumer.
+  const overlays = useOverlayState({
     previewIndex,
     collectionSwitcherVisible,
     collectionSwitchPending,
     reloadPending,
   })
+  const { activeOverlay } = overlays
 
   useEffect(() => {
-    if (aboutVisible) triggerAboutUpdateCheck()
-  }, [aboutVisible, triggerAboutUpdateCheck])
+    if (overlays.aboutVisible) triggerAboutUpdateCheck()
+  }, [overlays.aboutVisible, triggerAboutUpdateCheck])
   useEffect(() => {
-    if (!commandPaletteVisible) setPaletteTarget(null)
-  }, [commandPaletteVisible])
+    if (!overlays.commandPaletteVisible) setPaletteTarget(null)
+  }, [overlays.commandPaletteVisible])
   const overlayActive = useKeymapSync({
     focus,
     view,
@@ -809,6 +734,19 @@ export function AppInner({
     pendingHeaderFieldRef,
     overlayActiveRef,
   })
+
+  const findRequest = useCallback(
+    (item: FinderItem) => {
+      if (item.type === "request") {
+        revealRequest(item.id)
+      } else {
+        revealFolder(item.id)
+      }
+      setFocus("sidebar")
+      overlays.setRequestFinderVisible(false)
+    },
+    [revealRequest, revealFolder, overlays.setRequestFinderVisible],
+  )
 
   const {
     handleFolderSave,
@@ -837,14 +775,14 @@ export function AppInner({
     saveTimerRef,
     setSelectedId,
     expandFolder,
-    setNewRequestVisible,
-    setImportCurlVisible,
-    setCloneRequestVisible,
-    setNewFolderVisible,
-    setEditRequestVisible,
+    setNewRequestVisible: overlays.setNewRequestVisible,
+    setImportCurlVisible: overlays.setImportCurlVisible,
+    setCloneRequestVisible: overlays.setCloneRequestVisible,
+    setNewFolderVisible: overlays.setNewFolderVisible,
+    setEditRequestVisible: overlays.setEditRequestVisible,
     requestDeleteFileRef,
-    setRequestDeletePending,
-    setFolderDeletePending,
+    setRequestDeletePending: overlays.setRequestDeletePending,
+    setFolderDeletePending: overlays.setFolderDeletePending,
     onCollectionBootstrapped,
   })
   folderSaveRef.current = handleFolderSave
@@ -862,18 +800,16 @@ export function AppInner({
     (file: string) => {
       if (!file.endsWith(".yml")) return
       requestDeleteFileRef.current = file.slice(0, -4)
-      setRequestDeletePending(file)
+      overlays.setRequestDeletePending(file)
     },
-    [setRequestDeletePending],
+    [overlays.setRequestDeletePending],
   )
 
-  const clearRequestDeletePending = useCallback(
-    (value: string | null) => {
-      if (value === null) requestDeleteFileRef.current = null
-      setRequestDeletePending(value)
-    },
-    [setRequestDeletePending],
-  )
+  /** Clears the pending id and the repair file it was opened for. */
+  const cancelRequestDelete = useCallback(() => {
+    requestDeleteFileRef.current = null
+    overlays.setRequestDeletePending(null)
+  }, [overlays.setRequestDeletePending])
 
   const displayTab = useMemo((): string | undefined => {
     if (focus === "request") return eb.activeTab
@@ -944,23 +880,23 @@ export function AppInner({
   )
 
   const handleAboutActivate = useCallback(() => {
-    setAboutVisible(true)
-  }, [setAboutVisible])
+    overlays.setAboutVisible(true)
+  }, [overlays.setAboutVisible])
 
   const handleCollectionActivate = useCallback(() => {
     setCollectionSwitcherVisible(true)
   }, [setCollectionSwitcherVisible])
 
   const handleEnvironmentActivate = useCallback(() => {
-    openEnvironmentPicker(setEnvironmentPickerVisible)
-  }, [setEnvironmentPickerVisible])
+    openEnvironmentPicker(overlays.setEnvironmentPickerVisible)
+  }, [overlays.setEnvironmentPickerVisible])
 
   const handleEnvironmentSelect = useCallback(
     (name: string) => {
       envState.select(name)
-      setEnvironmentPickerVisible(false)
+      overlays.setEnvironmentPickerVisible(false)
     },
-    [envState.select, setEnvironmentPickerVisible],
+    [envState.select, overlays.setEnvironmentPickerVisible],
   )
 
   // ── Refs for keymap/intercepts ─────────────────────────────────────
@@ -1034,11 +970,11 @@ export function AppInner({
   )
 
   const handleOpenEnvironmentEditor = useCallback(() => {
-    setEnvironmentPickerVisible(false)
+    overlays.setEnvironmentPickerVisible(false)
     openEnvironmentEditor({ envStateRef, envEditorRef })
     setView("env-editor")
     setFocus("env-sidebar")
-  }, [setEnvironmentPickerVisible, setView, setFocus])
+  }, [overlays.setEnvironmentPickerVisible, setView, setFocus])
 
   const envHeaderRef = useRef<EnvHeaderPaneHandle>(null)
 
@@ -1063,8 +999,8 @@ export function AppInner({
   }, [cookieJar, cookieStorage.flush, cookieStorage.retry])
 
   const requestCookieStorageReset = useCallback(() => {
-    setCookieDeletePending({ kind: "reset" })
-  }, [setCookieDeletePending])
+    overlays.setCookieDeletePending({ kind: "reset" })
+  }, [overlays.setCookieDeletePending])
 
   const activeIndexRef = useRef(activeIndex)
   activeIndexRef.current = activeIndex
@@ -1104,16 +1040,16 @@ export function AppInner({
       setFocus,
       setUrlbarSubFocus,
       setView,
-      setHelpVisible,
+      setHelpVisible: overlays.setHelpVisible,
       setLayout,
       setExpanded,
-      setYamlEditor,
+      setYamlEditor: overlays.setYamlEditor,
       setPreviewIndex: setPreviewIndexProp,
       setCollectionSwitcherVisible,
-      setEnvironmentPickerVisible,
-      setCommandPaletteVisible,
-      setRequestFinderVisible,
-      setUndoAllPending,
+      setEnvironmentPickerVisible: overlays.setEnvironmentPickerVisible,
+      setCommandPaletteVisible: overlays.setCommandPaletteVisible,
+      setRequestFinderVisible: overlays.setRequestFinderVisible,
+      setUndoAllPending: overlays.setUndoAllPending,
       setJumpMode,
       openSettingsView: handleOpenSettings,
       onLayoutChange,
@@ -1126,10 +1062,10 @@ export function AppInner({
       trySendRef,
       doSaveRef,
       savingRef,
-      setNewRequestVisible,
-      setEditRequestVisible,
-      setCloneRequestVisible,
-      setRequestDeletePending,
+      setNewRequestVisible: overlays.setNewRequestVisible,
+      setEditRequestVisible: overlays.setEditRequestVisible,
+      setCloneRequestVisible: overlays.setCloneRequestVisible,
+      setRequestDeletePending: overlays.setRequestDeletePending,
       collectionErrorDeleteRef,
       collectionErrorSaveRef,
     },
@@ -1141,20 +1077,20 @@ export function AppInner({
       focusedFolderPathRef,
       focusedFolderNameRef,
       folderDeletePathRef,
-      setNewFolderVisible,
-      setFolderDeletePending,
+      setNewFolderVisible: overlays.setNewFolderVisible,
+      setFolderDeletePending: overlays.setFolderDeletePending,
     },
     environment: {
       envStateRef,
       envEditorRef,
-      setNewEnvironmentVisible,
-      setEnvDeletePending,
+      setNewEnvironmentVisible: overlays.setNewEnvironmentVisible,
+      setEnvDeletePending: overlays.setEnvDeletePending,
     },
     cookies: {
       cookieJarViewRef,
-      setCookieFormVisible,
-      setCookieFormInitial,
-      setCookieDeletePending,
+      setCookieFormVisible: overlays.setCookieFormVisible,
+      setCookieFormInitial: overlays.setCookieFormInitial,
+      setCookieDeletePending: overlays.setCookieDeletePending,
       retryCookieStorage,
     },
   })
@@ -1178,7 +1114,7 @@ export function AppInner({
   const handleImportCollectionConfirm = useCallback(
     (values: CollectionImportValues) => {
       if (importCollectionPendingRef.current) return
-      setImportCollectionPending(true)
+      overlays.setImportCollectionPending(true)
       void runCollectionImport({
         values,
         collectionDir,
@@ -1189,7 +1125,7 @@ export function AppInner({
           if (!result) return
           if (values.destination === "current") {
             await onEnvListChanged().catch(() => {})
-            setImportCollectionVisible(false)
+            overlays.setImportCollectionVisible(false)
             onReloadCollection()
             showToast("Collection imported", "success")
             return
@@ -1205,15 +1141,18 @@ export function AppInner({
               { cause: error },
             )
           }
-          setImportCollectionVisible(false)
-          setImportOpenPending({ path: result.path, name: result.name })
+          overlays.setImportCollectionVisible(false)
+          overlays.setImportOpenPending({
+            path: result.path,
+            name: result.name,
+          })
         })
         .catch((error: unknown) => {
-          importCollectionRef.current?.setError(
+          overlays.importCollectionRef.current?.setError(
             error instanceof Error ? error.message : String(error),
           )
         })
-        .finally(() => setImportCollectionPending(false))
+        .finally(() => overlays.setImportCollectionPending(false))
     },
     [
       collectionDir,
@@ -1221,22 +1160,17 @@ export function AppInner({
       onCollectionImported,
       onEnvListChanged,
       onReloadCollection,
-      setImportCollectionPending,
-      setImportCollectionVisible,
-      setImportOpenPending,
+      overlays.setImportCollectionPending,
+      overlays.setImportCollectionVisible,
+      overlays.setImportOpenPending,
     ],
   )
 
   // ── Overlay intercepts ────────────────────────────────────────────
   const overlayActions = useOverlayIntercepts({
-    activeOverlay,
+    overlays,
     cancelSendRef,
     setSaveState,
-    envDeletePending,
-    envDeletePendingRef,
-    setEnvDeletePending,
-    collectionUnregisterPending,
-    setCollectionUnregisterPending,
     onCollectionUnregisterConfirm: (path) => {
       const next = unregisterCollection(
         collectionPaths,
@@ -1249,39 +1183,29 @@ export function AppInner({
     envEditorRef,
     clearSaveTimer,
     saveTimerRef,
-    helpVisible,
-    setHelpVisible,
-    aboutVisible,
-    setAboutVisible,
     view,
     setView,
     focusRef,
     setFocus,
     envHeaderRef,
     headerFieldRef,
-    newEnvironmentVisible,
-    newEnvironmentRef,
-    setNewEnvironmentVisible,
     onNewEnvironmentConfirm: (values) => {
       envEditor
         .createEnv(values)
         .then(() => {
-          setNewEnvironmentVisible(false)
+          overlays.setNewEnvironmentVisible(false)
           focusPane("env-vars")
         })
         .catch((e: unknown) => {
-          newEnvironmentRef.current?.setError(
+          overlays.newEnvironmentRef.current?.setError(
             e instanceof Error ? e.message : String(e),
           )
         })
     },
-    cookieFormVisible,
-    cookieFormRef,
-    setCookieFormVisible,
     onCookieFormConfirm: (values) => {
       const jar = cookieJar
       if (!jar) return
-      const initial = cookieFormInitial
+      const initial = overlays.cookieFormInitial
       const expiresText = values.expires.trim()
       const input = {
         name: values.name,
@@ -1297,7 +1221,7 @@ export function AppInner({
       try {
         jar.put(input)
       } catch (error) {
-        cookieFormRef.current?.setError(
+        overlays.cookieFormRef.current?.setError(
           error instanceof Error ? error.message : String(error),
         )
         return
@@ -1317,10 +1241,8 @@ export function AppInner({
             ),
           )
       }
-      setCookieFormVisible(false)
+      overlays.setCookieFormVisible(false)
     },
-    cookieDeletePending,
-    setCookieDeletePending,
     onCookieDeleteConfirm: (pending) => {
       const jar = cookieJar
       void (async () => {
@@ -1354,27 +1276,22 @@ export function AppInner({
         }
       })()
     },
-    newRequestVisible,
-    newRequestRef,
-    setNewRequestVisible,
     onNewRequestConfirm: (v) =>
       handleNewRequestConfirm(v.name, v.method as Method, v.url, v.folderPath),
-    importCurlVisible,
-    importCurlRef,
-    setImportCurlVisible,
     onImportCurlConfirm: (v) => {
       try {
         handleImportCurlConfirm(v.name, v.folderPath, parseCurl(v.command))
       } catch (e: unknown) {
-        importCurlRef.current?.setError(
+        overlays.importCurlRef.current?.setError(
           e instanceof Error ? e.message : String(e),
         )
       }
     },
-    exportCollectionVisible,
-    exportCollectionRef,
     onExportCollectionCancel: () =>
-      closeCollectionExport(exportPendingRef, setExportCollectionVisible),
+      closeCollectionExport(
+        exportPendingRef,
+        overlays.setExportCollectionVisible,
+      ),
     onExportCollectionConfirm: (values) => {
       const collectionName =
         collection?.name ?? (basename(collectionDir) || "collection")
@@ -1387,52 +1304,30 @@ export function AppInner({
       })
         .then((result) => {
           if (!result) return
-          setExportCollectionVisible(false)
+          overlays.setExportCollectionVisible(false)
           showToast("Collection exported", "success")
         })
         .catch((error: unknown) => {
-          exportCollectionRef.current?.setError(
+          overlays.exportCollectionRef.current?.setError(
             error instanceof Error ? error.message : String(error),
           )
         })
     },
-    importCollectionVisible,
-    importCollectionRef,
     importCollectionPendingRef,
-    setImportCollectionVisible,
     onImportCollectionConfirm: handleImportCollectionConfirm,
-    importOpenPending,
-    setImportOpenPending,
     onImportOpenConfirm: (pending) => requestCollectionSwitch(pending.path),
-    editRequestVisible,
-    editRequestRef,
-    setEditRequestVisible,
     onEditRequestConfirm: (v) =>
       handleEditRequestConfirm(v.name, v.method as Method, v.url, v.folderPath),
-    cloneRequestVisible,
-    cloneRequestRef,
-    setCloneRequestVisible,
     onCloneRequestConfirm: handleCloneRequestConfirm,
-    requestDeletePending,
-    setRequestDeletePending: clearRequestDeletePending,
     onRequestDeleteConfirm: handleRequestDeleteConfirm,
-    newFolderVisible,
-    newFolderRef,
-    setNewFolderVisible,
+    onRequestDeleteCancel: cancelRequestDelete,
     onNewFolderConfirm: handleNewFolderConfirm,
-    folderDeletePending,
-    setFolderDeletePending,
     onFolderDeleteConfirm: handleFolderDeleteConfirm,
     collectionSwitchPending,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm: confirmCollectionSwitch,
-    reloadPending,
-    setReloadPending: cancelReload,
     onReloadConfirm: confirmReload,
-    undoAllPending,
-    setUndoAllPending,
-    initPending,
-    setInitPending,
+    onReloadCancel: cancelReload,
     onInitConfirm: () => executeInitPending(),
     draftRef,
     folderDraftRef,
@@ -1480,31 +1375,31 @@ export function AppInner({
         getCollectionMode: () => effectiveCollectionMode,
         setLayout,
         onLayoutChange,
-        setHelpVisible,
-        setAboutVisible,
-        setNewEnvironmentVisible,
-        setEnvironmentPickerVisible,
-        setNewRequestVisible,
-        setImportCurlVisible,
-        setNewFolderVisible,
+        setHelpVisible: overlays.setHelpVisible,
+        setAboutVisible: overlays.setAboutVisible,
+        setNewEnvironmentVisible: overlays.setNewEnvironmentVisible,
+        setEnvironmentPickerVisible: overlays.setEnvironmentPickerVisible,
+        setNewRequestVisible: overlays.setNewRequestVisible,
+        setImportCurlVisible: overlays.setImportCurlVisible,
+        setNewFolderVisible: overlays.setNewFolderVisible,
         openSettingsView: handleOpenSettings,
-        setCloneRequestVisible,
-        setEditRequestVisible,
-        setRequestDeletePending,
-        setFolderDeletePending,
+        setCloneRequestVisible: overlays.setCloneRequestVisible,
+        setEditRequestVisible: overlays.setEditRequestVisible,
+        setRequestDeletePending: overlays.setRequestDeletePending,
+        setFolderDeletePending: overlays.setFolderDeletePending,
         setCollectionSwitcherVisible,
-        setRequestFinderVisible,
-        setCodeGeneratorVisible,
-        setExportCollectionVisible,
-        setImportCollectionVisible,
-        setYamlEditor,
+        setRequestFinderVisible: overlays.setRequestFinderVisible,
+        setCodeGeneratorVisible: overlays.setCodeGeneratorVisible,
+        setExportCollectionVisible: overlays.setExportCollectionVisible,
+        setImportCollectionVisible: overlays.setImportCollectionVisible,
+        setYamlEditor: overlays.setYamlEditor,
         setView,
         setFocus,
-        setUndoAllPending,
-        setInitPending,
+        setUndoAllPending: overlays.setUndoAllPending,
+        setInitPending: overlays.setInitPending,
         setExpanded,
         setPreviewIndexProp,
-        setEnvDeletePending,
+        setEnvDeletePending: overlays.setEnvDeletePending,
         onReloadCollection: requestReload,
         paletteTarget,
       }),
@@ -1517,7 +1412,7 @@ export function AppInner({
       onLayoutChange,
       setCollectionSwitcherVisible,
       handleOpenSettings,
-      setImportCollectionVisible,
+      overlays.setImportCollectionVisible,
       requestReload,
       view,
       effectiveCollectionMode,
@@ -1606,7 +1501,9 @@ export function AppInner({
             timelineEntries={timeline.entries}
             initialResponseTab={initialResponseTab}
             onResponseTabChange={onResponseTabChange}
-            onOpenTimelineEntry={(entry) => setTimelineDetailEntry(entry)}
+            onOpenTimelineEntry={(entry) =>
+              overlays.setTimelineDetailEntry(entry)
+            }
             setSelectOpen={setSelectOpen}
             urlbarSubFocus={urlbarSubFocus}
             urlbarInteractive={activeOverlay === "none" && !isReadOnly}
@@ -1614,8 +1511,8 @@ export function AppInner({
             responseBodyForCopyRef={responseBodyForCopyRef}
             onQueryVisibleChange={setQueryVisible}
             onResponseBodyEditorAvailableChange={setResponseBodyEditorAvailable}
-            onInitialize={() => setInitPending(true)}
-            onCreateRequest={() => setNewRequestVisible(true)}
+            onInitialize={() => overlays.setInitPending(true)}
+            onCreateRequest={() => overlays.setNewRequestVisible(true)}
             onCollectionErrorDelete={deleteCollectionErrorFile}
             onCollectionErrorDirtyChange={setCollectionErrorDirty}
             collectionErrorDeleteRef={collectionErrorDeleteRef}
@@ -1648,14 +1545,14 @@ export function AppInner({
               focusPane("sidebar")
               revealRequest(id)
               setPaletteTarget("request")
-              setCommandPaletteVisible(true)
+              overlays.setCommandPaletteVisible(true)
             }}
             onFolderContextMenu={(path) => {
               if (!isCollection) return
               focusPane("sidebar")
               revealFolder(path)
               setPaletteTarget("folder")
-              setCommandPaletteVisible(true)
+              overlays.setCommandPaletteVisible(true)
             }}
           />
         ) : view === "env-editor" && mode === "collection" ? (
@@ -1670,14 +1567,14 @@ export function AppInner({
               headerFieldRef.current = field
             }}
             onPaneFocus={focusPane}
-            onCreateEnvironment={() => setNewEnvironmentVisible(true)}
+            onCreateEnvironment={() => overlays.setNewEnvironmentVisible(true)}
             onEnvironmentContextMenu={async (name) => {
               focusPane("env-sidebar")
               if (!(await envEditor.selectEnv(name))) return
               setPaletteTarget("environment")
-              setCommandPaletteVisible(true)
+              overlays.setCommandPaletteVisible(true)
             }}
-            setEnvDeletePending={setEnvDeletePending}
+            setEnvDeletePending={overlays.setEnvDeletePending}
           />
         ) : view === "cookie-jar" && mode === "collection" ? (
           <CookieJarView
@@ -1687,8 +1584,8 @@ export function AppInner({
             jumpMode={jumpMode}
             onPaneFocus={focusPane}
             onAddCookie={() => {
-              setCookieFormInitial(null)
-              setCookieFormVisible(true)
+              overlays.setCookieFormInitial(null)
+              overlays.setCookieFormVisible(true)
             }}
             onRetry={retryCookieStorage}
             onReset={requestCookieStorageReset}
@@ -1752,67 +1649,43 @@ export function AppInner({
             onEnvironmentChange={envState.select}
             onKeybindChange={onKeybindChange}
             onCollectionsChange={onCollectionsChange}
-            onCollectionUnregister={setCollectionUnregisterPending}
+            onCollectionUnregister={overlays.setCollectionUnregisterPending}
             onRegisterCollection={onRegisterCollection}
           />
         ) : null}
         <AppOverlays
+          overlays={overlays}
           keybinds={keybinds}
-          activeOverlay={activeOverlay}
-          helpVisible={helpVisible}
-          setHelpVisible={setHelpVisible}
-          aboutVisible={aboutVisible}
-          setAboutVisible={setAboutVisible}
-          envDeletePending={envDeletePending}
-          collectionUnregisterPending={collectionUnregisterPending}
-          undoAllPending={undoAllPending}
           reloadPending={reloadPending}
-          initPending={initPending}
           collectionSwitchPending={collectionSwitchPending}
           onConfirmDialog={overlayActions.onConfirm}
           onCancelDialog={overlayActions.onCancel}
-          commandPaletteVisible={commandPaletteVisible}
           commandPaletteCommands={commandPaletteCommands}
-          setCommandPaletteVisible={setCommandPaletteVisible}
-          codeGeneratorVisible={codeGeneratorVisible}
-          setCodeGeneratorVisible={setCodeGeneratorVisible}
-          exportCollectionVisible={exportCollectionVisible}
-          exportCollectionRef={exportCollectionRef}
           exportCollectionActions={overlayActions.exportCollection}
-          importCollectionVisible={importCollectionVisible}
-          importCollectionRef={importCollectionRef}
-          importCollectionPending={importCollectionPending}
           importCollectionActions={overlayActions.importCollection}
           importCollectionInitialParent={collapseUserPath(
             dirname(collectionDir),
           )}
-          importOpenPending={importOpenPending}
           codeGeneratorRequest={draft.draft}
           codeGeneratorEnv={envState.activeEnv}
           codeGeneratorEnvName={envState.activeEnv?.name}
           collection={collection}
-          requestFinderVisible={requestFinderVisible}
           requests={requests}
           onFindRequest={findRequest}
-          setRequestFinderVisible={setRequestFinderVisible}
           collectionSwitcherVisible={collectionSwitcherVisible}
           collectionPaths={collectionPaths}
           collectionSettingsByPath={collectionSettingsByPath}
           collectionDir={collectionDir}
           requestCollectionSwitch={requestCollectionSwitch}
           setCollectionSwitcherVisible={setCollectionSwitcherVisible}
-          environmentPickerVisible={environmentPickerVisible}
           environmentNames={envState.names}
           activeEnvironmentName={envState.activeName}
           onSelectEnvironment={handleEnvironmentSelect}
           onOpenEnvironmentEditor={handleOpenEnvironmentEditor}
-          setEnvironmentPickerVisible={setEnvironmentPickerVisible}
           previewIndex={previewIndex}
           activeIndex={activeIndex}
           setPreviewIndex={setPreviewIndexProp}
           onThemeChange={onThemeChange}
-          yamlEditor={yamlEditor}
-          setYamlEditor={setYamlEditor}
           setCollectionReloadToken={setCollectionReloadToken}
           resetRequestDraft={draft.resetRequestDraft}
           resetFolderDraftByPath={folderDraft.clearFolderDraft}
@@ -1820,39 +1693,19 @@ export function AppInner({
           setSaveState={setSaveState}
           clearSaveTimer={clearSaveTimer}
           saveTimerRef={saveTimerRef}
-          newEnvironmentVisible={newEnvironmentVisible}
-          newEnvironmentRef={newEnvironmentRef}
           newEnvironmentActions={overlayActions.newEnvironment}
-          cookieFormVisible={cookieFormVisible}
-          cookieFormRef={cookieFormRef}
-          cookieFormInitial={cookieFormInitial}
           cookieFormActions={overlayActions.cookieForm}
-          cookieDeletePending={cookieDeletePending}
-          newRequestVisible={newRequestVisible}
-          newRequestRef={newRequestRef}
           newRequestActions={overlayActions.newRequest}
           newRequestInitialFolder={requestParentFolder ?? ""}
-          importCurlVisible={importCurlVisible}
-          importCurlRef={importCurlRef}
           importCurlActions={overlayActions.importCurl}
           importCurlInitialFolder={requestParentFolder ?? ""}
           activeEnv={envState.activeEnv}
-          editRequestVisible={editRequestVisible}
           selectedRequest={selectedRequest}
           folderPaths={folderPaths}
           editRequestInitialFolder={editRequestInitialFolder}
-          editRequestRef={editRequestRef}
           editRequestActions={overlayActions.editRequest}
-          cloneRequestVisible={cloneRequestVisible}
-          cloneRequestRef={cloneRequestRef}
           cloneRequestActions={overlayActions.cloneRequest}
-          newFolderVisible={newFolderVisible}
-          newFolderRef={newFolderRef}
           newFolderActions={overlayActions.newFolder}
-          folderDeletePending={folderDeletePending}
-          requestDeletePending={requestDeletePending}
-          timelineDetailEntry={timelineDetailEntry}
-          setTimelineDetailEntry={setTimelineDetailEntry}
           updateFlow={updateFlow}
           envColors={envColors}
           onLoadTimelineBody={onLoadTimelineBody}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -12,40 +12,14 @@ import { EnvironmentPickerOverlay } from "./overlays/EnvironmentPickerOverlay"
 import { RequestFinderOverlay } from "./overlays/RequestFinderOverlay"
 import { ThemePickerOverlay } from "./theme"
 import { YamlEditorOverlay } from "./editor/YamlEditorOverlay"
-import {
-  NewRequestOverlay,
-  type NewRequestOverlayHandle,
-} from "./overlays/NewRequestOverlay"
-import {
-  NewEnvironmentOverlay,
-  type NewEnvironmentOverlayHandle,
-} from "./overlays/NewEnvironmentOverlay"
-import {
-  CookieFormOverlay,
-  type CookieFormOverlayHandle,
-} from "./overlays/CookieFormOverlay"
-import type { CookieDeletePending } from "./useOverlayState"
-import type { JarCookie } from "../cookies"
-import {
-  CloneRequestOverlay,
-  type CloneRequestOverlayHandle,
-} from "./overlays/CloneRequestOverlay"
-import {
-  NewFolderOverlay,
-  type NewFolderOverlayHandle,
-} from "./overlays/NewFolderOverlay"
-import {
-  ImportCurlOverlay,
-  type ImportCurlOverlayHandle,
-} from "./overlays/ImportCurlOverlay"
-import {
-  ExportCollectionOverlay,
-  type ExportCollectionOverlayHandle,
-} from "./overlays/ExportCollectionOverlay"
-import {
-  ImportCollectionOverlay,
-  type ImportCollectionOverlayHandle,
-} from "./overlays/ImportCollectionOverlay"
+import { NewRequestOverlay } from "./overlays/NewRequestOverlay"
+import { NewEnvironmentOverlay } from "./overlays/NewEnvironmentOverlay"
+import { CookieFormOverlay } from "./overlays/CookieFormOverlay"
+import { CloneRequestOverlay } from "./overlays/CloneRequestOverlay"
+import { NewFolderOverlay } from "./overlays/NewFolderOverlay"
+import { ImportCurlOverlay } from "./overlays/ImportCurlOverlay"
+import { ExportCollectionOverlay } from "./overlays/ExportCollectionOverlay"
+import { ImportCollectionOverlay } from "./overlays/ImportCollectionOverlay"
 import type {
   Collection,
   CollectionSettings,
@@ -60,12 +34,8 @@ import { CodeGeneratorOverlay } from "./overlays/CodeGeneratorOverlay"
 import { displayKey, type Keybinds } from "./keybind"
 import type { Focus } from "./focus"
 import type { SaveState } from "./saveState"
-import {
-  initialYamlEditorState,
-  type UpdateFlowState,
-  type YamlEditorState,
-} from "./appState"
-import type { ActiveOverlay } from "./useOverlayState"
+import { initialYamlEditorState, type UpdateFlowState } from "./appState"
+import type { OverlayState } from "./useOverlayState"
 import { buildDisplayUrl } from "./urlParams"
 import { collectionDisplayName } from "./settings/collectionRegistry"
 
@@ -75,51 +45,40 @@ interface FolderPathOption {
 }
 
 interface AppOverlaysProps {
+  /**
+   * Overlay visibility, pending values, and handles owned by
+   * `useOverlayState`. Passed whole so a new overlay only needs declaring
+   * there and rendering here.
+   */
+  overlays: OverlayState
   keybinds: Keybinds
-  helpVisible: boolean
-  setHelpVisible: (visible: boolean) => void
-  aboutVisible: boolean
-  setAboutVisible: (visible: boolean) => void
-  activeOverlay: ActiveOverlay
-  envDeletePending: string | null
-  collectionUnregisterPending: string | null
-  undoAllPending: boolean
+  /** Owned by `useReloadGuard`, not by the overlay state. */
   reloadPending: boolean
-  initPending: boolean
+  /** Owned by `useCollectionSwitcher`, not by the overlay state. */
   collectionSwitchPending: string | null
+  collectionSwitcherVisible: boolean
+  requestCollectionSwitch: (nextDir: string) => void
+  setCollectionSwitcherVisible: (visible: boolean) => void
   onConfirmDialog: () => void
   onCancelDialog: () => void
-  commandPaletteVisible: boolean
   commandPaletteCommands: CommandItem[]
-  setCommandPaletteVisible: (visible: boolean) => void
-  codeGeneratorVisible: boolean
-  setCodeGeneratorVisible: (visible: boolean) => void
   codeGeneratorRequest: NoodleRequest | null
   codeGeneratorEnv?: Environment | null
   codeGeneratorEnvName?: string
   collection: Collection | null
-  requestFinderVisible: boolean
   requests: NoodleRequest[]
   onFindRequest: (item: FinderItem) => void
-  setRequestFinderVisible: (visible: boolean) => void
-  collectionSwitcherVisible: boolean
   collectionPaths: string[]
   collectionSettingsByPath: Record<string, CollectionSettings>
   collectionDir: string
-  requestCollectionSwitch: (nextDir: string) => void
-  setCollectionSwitcherVisible: (visible: boolean) => void
-  environmentPickerVisible: boolean
   environmentNames: string[]
   activeEnvironmentName: string | null
   onSelectEnvironment: (name: string) => void
   onOpenEnvironmentEditor: () => void
-  setEnvironmentPickerVisible: (visible: boolean) => void
   previewIndex: number | null
   activeIndex: number
   setPreviewIndex: (value: number | null) => void
   onThemeChange: (index: number) => void
-  yamlEditor: YamlEditorState
-  setYamlEditor: (state: YamlEditorState) => void
   setCollectionReloadToken: (fn: (n: number) => number) => void
   resetRequestDraft: (id: string) => void
   resetFolderDraftByPath: (path: string) => void
@@ -127,48 +86,22 @@ interface AppOverlaysProps {
   setSaveState: (state: SaveState) => void
   clearSaveTimer: () => void
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
-  newEnvironmentVisible: boolean
-  newEnvironmentRef: RefObject<NewEnvironmentOverlayHandle | null>
   newEnvironmentActions: { confirm: () => void; cancel: () => void }
-  cookieFormVisible: boolean
-  cookieFormRef: RefObject<CookieFormOverlayHandle | null>
-  cookieFormInitial: JarCookie | null
   cookieFormActions: { confirm: () => void; cancel: () => void }
-  cookieDeletePending: CookieDeletePending | null
-  newRequestVisible: boolean
-  newRequestRef: RefObject<NewRequestOverlayHandle | null>
   newRequestActions: { confirm: () => void; cancel: () => void }
   newRequestInitialFolder: string
-  importCurlVisible: boolean
-  importCurlRef: RefObject<ImportCurlOverlayHandle | null>
   importCurlActions: { confirm: () => void; cancel: () => void }
   importCurlInitialFolder: string
-  exportCollectionVisible: boolean
-  exportCollectionRef: RefObject<ExportCollectionOverlayHandle | null>
   exportCollectionActions: { confirm: () => void; cancel: () => void }
-  importCollectionVisible: boolean
-  importCollectionRef: RefObject<ImportCollectionOverlayHandle | null>
-  importCollectionPending: boolean
   importCollectionActions: { confirm: () => void; cancel: () => void }
   importCollectionInitialParent: string
-  importOpenPending: { path: string; name: string } | null
   activeEnv: Environment | null
-  editRequestVisible: boolean
   selectedRequest: NoodleRequest | null
   folderPaths: FolderPathOption[]
   editRequestInitialFolder: string
-  editRequestRef: RefObject<NewRequestOverlayHandle | null>
   editRequestActions: { confirm: () => void; cancel: () => void }
-  cloneRequestVisible: boolean
-  cloneRequestRef: RefObject<CloneRequestOverlayHandle | null>
   cloneRequestActions: { confirm: () => void; cancel: () => void }
-  newFolderVisible: boolean
-  newFolderRef: RefObject<NewFolderOverlayHandle | null>
   newFolderActions: { confirm: () => void; cancel: () => void }
-  folderDeletePending: string | null
-  requestDeletePending: string | null
-  timelineDetailEntry: TimelineEntry | null
-  setTimelineDetailEntry: (entry: TimelineEntry | null) => void
   updateFlow: UpdateFlowState
   envColors: Record<string, string | undefined>
   onLoadTimelineBody: (
@@ -185,51 +118,33 @@ interface AppOverlaysProps {
 }
 
 export function AppOverlays({
+  overlays,
   keybinds,
-  helpVisible,
-  setHelpVisible,
-  aboutVisible,
-  setAboutVisible,
-  activeOverlay,
-  envDeletePending,
-  collectionUnregisterPending,
-  undoAllPending,
   reloadPending,
-  initPending,
   collectionSwitchPending,
   onConfirmDialog,
   onCancelDialog,
-  commandPaletteVisible,
   commandPaletteCommands,
-  setCommandPaletteVisible,
-  codeGeneratorVisible,
-  setCodeGeneratorVisible,
   codeGeneratorRequest,
   codeGeneratorEnv,
   codeGeneratorEnvName,
   collection,
-  requestFinderVisible,
   requests,
   onFindRequest,
-  setRequestFinderVisible,
   collectionSwitcherVisible,
   collectionPaths,
   collectionSettingsByPath,
   collectionDir,
   requestCollectionSwitch,
   setCollectionSwitcherVisible,
-  environmentPickerVisible,
   environmentNames,
   activeEnvironmentName,
   onSelectEnvironment,
   onOpenEnvironmentEditor,
-  setEnvironmentPickerVisible,
   previewIndex,
   activeIndex,
   setPreviewIndex,
   onThemeChange,
-  yamlEditor,
-  setYamlEditor,
   setCollectionReloadToken,
   resetRequestDraft,
   resetFolderDraftByPath,
@@ -237,48 +152,22 @@ export function AppOverlays({
   setSaveState,
   clearSaveTimer,
   saveTimerRef,
-  newEnvironmentVisible,
-  newEnvironmentRef,
   newEnvironmentActions,
-  cookieFormVisible,
-  cookieFormRef,
-  cookieFormInitial,
   cookieFormActions,
-  cookieDeletePending,
-  newRequestVisible,
-  newRequestRef,
   newRequestActions,
   newRequestInitialFolder,
-  importCurlVisible,
-  importCurlRef,
   importCurlActions,
   importCurlInitialFolder,
-  exportCollectionVisible,
-  exportCollectionRef,
   exportCollectionActions,
-  importCollectionVisible,
-  importCollectionRef,
-  importCollectionPending,
   importCollectionActions,
   importCollectionInitialParent,
-  importOpenPending,
   activeEnv,
-  editRequestVisible,
   selectedRequest,
   folderPaths,
   editRequestInitialFolder,
-  editRequestRef,
   editRequestActions,
-  cloneRequestVisible,
-  cloneRequestRef,
   cloneRequestActions,
-  newFolderVisible,
-  newFolderRef,
   newFolderActions,
-  folderDeletePending,
-  requestDeletePending,
-  timelineDetailEntry,
-  setTimelineDetailEntry,
   updateFlow,
   envColors,
   onLoadTimelineBody,
@@ -286,6 +175,54 @@ export function AppOverlays({
   onCopyTimelineBody,
   onExportTimelineBody,
 }: AppOverlaysProps) {
+  const {
+    activeOverlay,
+    helpVisible,
+    setHelpVisible,
+    aboutVisible,
+    setAboutVisible,
+    envDeletePending,
+    collectionUnregisterPending,
+    undoAllPending,
+    initPending,
+    importOpenPending,
+    commandPaletteVisible,
+    setCommandPaletteVisible,
+    codeGeneratorVisible,
+    setCodeGeneratorVisible,
+    requestFinderVisible,
+    setRequestFinderVisible,
+    environmentPickerVisible,
+    setEnvironmentPickerVisible,
+    yamlEditor,
+    setYamlEditor,
+    newEnvironmentVisible,
+    newEnvironmentRef,
+    cookieFormVisible,
+    cookieFormRef,
+    cookieFormInitial,
+    cookieDeletePending,
+    newRequestVisible,
+    newRequestRef,
+    importCurlVisible,
+    importCurlRef,
+    exportCollectionVisible,
+    exportCollectionRef,
+    importCollectionVisible,
+    importCollectionRef,
+    importCollectionPending,
+    editRequestVisible,
+    editRequestRef,
+    cloneRequestVisible,
+    cloneRequestRef,
+    newFolderVisible,
+    newFolderRef,
+    folderDeletePending,
+    requestDeletePending,
+    timelineDetailEntry,
+    setTimelineDetailEntry,
+  } = overlays
+
   return (
     <>
       {helpVisible && (

--- a/src/ui/intercepts/useDialogIntercepts.ts
+++ b/src/ui/intercepts/useDialogIntercepts.ts
@@ -3,55 +3,38 @@ import type { RefObject } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 import type { SaveState } from "../saveState"
 import type { UseEnvironmentEditorResult } from "../../hooks/useEnvironmentEditor"
-import type { ActiveOverlay } from "../useOverlayState"
-import type { ImportedCollectionPending } from "../useOverlayState"
 import type { CookieDeletePending } from "../useOverlayState"
+import type { ImportedCollectionPending } from "../useOverlayState"
+import type { OverlayState } from "../useOverlayState"
 
 export function useDialogIntercepts(opts: {
-  activeOverlay: ActiveOverlay
+  overlays: OverlayState
   setSaveState: (s: SaveState) => void
-  envDeletePending: string | null
-  setEnvDeletePending: (s: string | null) => void
-  collectionUnregisterPending: string | null
-  setCollectionUnregisterPending: (s: string | null) => void
   onCollectionUnregisterConfirm: (path: string) => void
   envEditorRef: RefObject<UseEnvironmentEditorResult>
   clearSaveTimer: () => void
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
+  /** Owned by `useCollectionSwitcher`, not by the overlay state. */
   collectionSwitchPending: string | null
   setCollectionSwitchPending: (s: string | null) => void
   onCollectionSwitchConfirm: (collectionDir: string) => void
-  importOpenPending: ImportedCollectionPending | null
-  setImportOpenPending: (pending: ImportedCollectionPending | null) => void
   onImportOpenConfirm: (pending: ImportedCollectionPending) => void
-  reloadPending: boolean
-  setReloadPending: (v: boolean) => void
+  /** Owned by `useReloadGuard`, not by the overlay state. */
   onReloadConfirm: () => void
-  requestDeletePending: string | null
-  setRequestDeletePending: (s: string | null) => void
+  onReloadCancel: () => void
   onRequestDeleteConfirm: () => void
-  folderDeletePending: string | null
-  setFolderDeletePending: (s: string | null) => void
+  /** Clears the pending id and the companion file ref in `AppInner`. */
+  onRequestDeleteCancel: () => void
   onFolderDeleteConfirm: () => void
-  cookieDeletePending: CookieDeletePending | null
-  setCookieDeletePending: (pending: CookieDeletePending | null) => void
   onCookieDeleteConfirm: (pending: CookieDeletePending) => void
-  undoAllPending: boolean
-  setUndoAllPending: (v: boolean) => void
   draftRef: RefObject<{ revertAllRequests: () => void }>
   folderDraftRef: RefObject<{ revertAllFolders: () => void }>
-  initPending: boolean
-  setInitPending: (v: boolean) => void
   onInitConfirm: () => void
 }): { onConfirm: () => void; onCancel: () => void } {
   const keymap = useKeymap()
   const {
-    activeOverlay,
+    overlays,
     setSaveState,
-    envDeletePending,
-    setEnvDeletePending,
-    collectionUnregisterPending,
-    setCollectionUnregisterPending,
     onCollectionUnregisterConfirm,
     envEditorRef,
     clearSaveTimer,
@@ -59,24 +42,31 @@ export function useDialogIntercepts(opts: {
     collectionSwitchPending,
     setCollectionSwitchPending,
     onCollectionSwitchConfirm,
-    importOpenPending,
-    setImportOpenPending,
     onImportOpenConfirm,
-    setReloadPending,
     onReloadConfirm,
-    setRequestDeletePending,
+    onReloadCancel,
     onRequestDeleteConfirm,
-    setFolderDeletePending,
+    onRequestDeleteCancel,
     onFolderDeleteConfirm,
-    cookieDeletePending,
-    setCookieDeletePending,
     onCookieDeleteConfirm,
-    setUndoAllPending,
     draftRef,
     folderDraftRef,
-    setInitPending,
     onInitConfirm,
   } = opts
+  const {
+    activeOverlay,
+    envDeletePending,
+    setEnvDeletePending,
+    collectionUnregisterPending,
+    setCollectionUnregisterPending,
+    importOpenPending,
+    setImportOpenPending,
+    setFolderDeletePending,
+    cookieDeletePending,
+    setCookieDeletePending,
+    setUndoAllPending,
+    setInitPending,
+  } = overlays
 
   const confirmEnvDelete = useCallback(() => {
     if (!envDeletePending) return
@@ -190,9 +180,9 @@ export function useDialogIntercepts(opts: {
     else if (activeOverlay === "collection-switch-confirm")
       setCollectionSwitchPending(null)
     else if (activeOverlay === "import-open-confirm") setImportOpenPending(null)
-    else if (activeOverlay === "reload-confirm") setReloadPending(false)
+    else if (activeOverlay === "reload-confirm") onReloadCancel()
     else if (activeOverlay === "delete-folder") setFolderDeletePending(null)
-    else if (activeOverlay === "request-delete") setRequestDeletePending(null)
+    else if (activeOverlay === "request-delete") onRequestDeleteCancel()
     else if (activeOverlay === "cookie-delete") setCookieDeletePending(null)
   }, [
     activeOverlay,
@@ -202,9 +192,9 @@ export function useDialogIntercepts(opts: {
     setInitPending,
     setCollectionSwitchPending,
     setImportOpenPending,
-    setReloadPending,
+    onReloadCancel,
     setFolderDeletePending,
-    setRequestDeletePending,
+    onRequestDeleteCancel,
     setCookieDeletePending,
   ])
 

--- a/src/ui/intercepts/useEnvEditorIntercept.ts
+++ b/src/ui/intercepts/useEnvEditorIntercept.ts
@@ -5,8 +5,10 @@ import type { Focus } from "../focus"
 import type { UseEnvironmentEditorResult } from "../../hooks/useEnvironmentEditor"
 import type { EnvHeaderPaneHandle } from "../env-editor/EnvHeaderPane"
 import type { AppView } from "../appState"
+import type { OverlayState } from "../useOverlayState"
 
 export function useEnvEditorIntercept(opts: {
+  overlays: OverlayState
   view: AppView
   setView: (v: AppView) => void
   focusRef: RefObject<Focus>
@@ -14,10 +16,10 @@ export function useEnvEditorIntercept(opts: {
   envEditorRef: RefObject<UseEnvironmentEditorResult>
   envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
   headerFieldRef: RefObject<"name" | "color">
-  envDeletePendingRef: RefObject<string | null>
 }): void {
   const keymap = useKeymap()
   const {
+    overlays,
     view,
     setView,
     focusRef,
@@ -25,8 +27,8 @@ export function useEnvEditorIntercept(opts: {
     envEditorRef,
     envHeaderRef,
     headerFieldRef,
-    envDeletePendingRef,
   } = opts
+  const { envDeletePendingRef } = overlays
 
   useEffect(() => {
     if (view !== "env-editor") return

--- a/src/ui/intercepts/useGlobalIntercepts.ts
+++ b/src/ui/intercepts/useGlobalIntercepts.ts
@@ -2,26 +2,22 @@ import { useEffect } from "react"
 import type { RefObject } from "react"
 import { useKeymap } from "@opentui/keymap/react"
 import type { AppView } from "../appState"
+import type { OverlayState } from "../useOverlayState"
 
 export function useGlobalIntercepts(opts: {
-  activeOverlay: string
+  overlays: OverlayState
   view: AppView
   cancelSendRef: RefObject<() => void>
-  helpVisible: boolean
-  setHelpVisible: (v: boolean) => void
-  aboutVisible: boolean
-  setAboutVisible: (v: boolean) => void
 }): void {
   const keymap = useKeymap()
+  const { overlays, view, cancelSendRef } = opts
   const {
     activeOverlay,
-    view,
-    cancelSendRef,
     helpVisible,
     setHelpVisible,
     aboutVisible,
     setAboutVisible,
-  } = opts
+  } = overlays
 
   // ── Cancel send on ESC ──────────────────────────────────────────────
   useEffect(() => {

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -4,27 +4,15 @@ import type { Focus } from "./focus"
 import type { AppView } from "./appState"
 import type { UseEnvironmentEditorResult } from "../hooks/useEnvironmentEditor"
 import type { EnvHeaderPaneHandle } from "./env-editor/EnvHeaderPane"
-import type { NewRequestOverlayHandle } from "./overlays/NewRequestOverlay"
-import type { CloneRequestOverlayHandle } from "./overlays/CloneRequestOverlay"
-import type { NewFolderOverlayHandle } from "./overlays/NewFolderOverlay"
-import type { ImportCurlOverlayHandle } from "./overlays/ImportCurlOverlay"
-import type { ExportCollectionOverlayHandle } from "./overlays/ExportCollectionOverlay"
-import type { ImportCollectionOverlayHandle } from "./overlays/ImportCollectionOverlay"
 import type { ExportCollectionValues } from "./collectionExport"
 import type { CollectionImportValues } from "./collectionImport"
 import type { ImportedCollectionPending } from "./useOverlayState"
-import type {
-  NewEnvironmentOverlayHandle,
-  NewEnvironmentValues,
-} from "./overlays/NewEnvironmentOverlay"
-import type {
-  CookieFormOverlayHandle,
-  CookieFormValues,
-} from "./overlays/CookieFormOverlay"
+import type { NewEnvironmentValues } from "./overlays/NewEnvironmentOverlay"
+import type { CookieFormValues } from "./overlays/CookieFormOverlay"
 import type { CookieDeletePending } from "./useOverlayState"
+import type { OverlayState } from "./useOverlayState"
 import type { UseRequestDraftResult } from "../hooks/useRequestDraft"
 import type { UseFolderDraftResult } from "../hooks/useFolderDraft"
-import type { ActiveOverlay } from "./useOverlayState"
 import { useGlobalIntercepts } from "./intercepts/useGlobalIntercepts"
 import { useDialogIntercepts } from "./intercepts/useDialogIntercepts"
 import {
@@ -44,182 +32,145 @@ export function shouldCancelSend(
   )
 }
 
+/**
+ * Wires keyboard intercepts for every overlay.
+ *
+ * Overlay visibility, pending values, and handles travel as the single
+ * `overlays` object owned by `useOverlayState`; only behavior callbacks and
+ * state owned elsewhere (the reload guard, the collection switcher) are
+ * separate props.
+ */
 export function useOverlayIntercepts(opts: {
-  activeOverlay: ActiveOverlay
+  overlays: OverlayState
   cancelSendRef: RefObject<() => void>
   setSaveState: (s: SaveState) => void
-  envDeletePending: string | null
-  envDeletePendingRef: RefObject<string | null>
-  setEnvDeletePending: (s: string | null) => void
-  collectionUnregisterPending: string | null
-  setCollectionUnregisterPending: (s: string | null) => void
   onCollectionUnregisterConfirm: (path: string) => void
   envEditorRef: RefObject<UseEnvironmentEditorResult>
   clearSaveTimer: () => void
   saveTimerRef: RefObject<ReturnType<typeof setTimeout> | null>
-  helpVisible: boolean
-  setHelpVisible: (v: boolean) => void
-  aboutVisible: boolean
-  setAboutVisible: (v: boolean) => void
   view: AppView
   setView: (v: AppView) => void
   focusRef: RefObject<Focus>
   setFocus: (f: Focus) => void
   envHeaderRef: RefObject<EnvHeaderPaneHandle | null>
   headerFieldRef: RefObject<"name" | "color">
-  newEnvironmentVisible: boolean
-  newEnvironmentRef: RefObject<NewEnvironmentOverlayHandle | null>
-  setNewEnvironmentVisible: (v: boolean) => void
   onNewEnvironmentConfirm: (values: NewEnvironmentValues) => void
-  cookieFormVisible: boolean
-  cookieFormRef: RefObject<CookieFormOverlayHandle | null>
-  setCookieFormVisible: (v: boolean) => void
   onCookieFormConfirm: (values: CookieFormValues) => void
-  cookieDeletePending: CookieDeletePending | null
-  setCookieDeletePending: (pending: CookieDeletePending | null) => void
   onCookieDeleteConfirm: (pending: CookieDeletePending) => void
-  newRequestVisible: boolean
-  newRequestRef: RefObject<NewRequestOverlayHandle | null>
-  setNewRequestVisible: (v: boolean) => void
   onNewRequestConfirm: (values: {
     name: string
     method: string
     url: string
     folderPath?: string
   }) => void
-  importCurlVisible: boolean
-  importCurlRef: RefObject<ImportCurlOverlayHandle | null>
-  setImportCurlVisible: (v: boolean) => void
   onImportCurlConfirm: (values: {
     command: string
     name: string
     folderPath: string
   }) => void
-  exportCollectionVisible: boolean
-  exportCollectionRef: RefObject<ExportCollectionOverlayHandle | null>
   onExportCollectionCancel: () => void
   onExportCollectionConfirm: (values: ExportCollectionValues) => void
-  importCollectionVisible: boolean
-  importCollectionRef: RefObject<ImportCollectionOverlayHandle | null>
   importCollectionPendingRef: RefObject<boolean>
-  setImportCollectionVisible: (v: boolean) => void
   onImportCollectionConfirm: (values: CollectionImportValues) => void
-  importOpenPending: ImportedCollectionPending | null
-  setImportOpenPending: (pending: ImportedCollectionPending | null) => void
   onImportOpenConfirm: (pending: ImportedCollectionPending) => void
-  editRequestVisible: boolean
-  editRequestRef: RefObject<NewRequestOverlayHandle | null>
-  setEditRequestVisible: (v: boolean) => void
   onEditRequestConfirm: (values: {
     name: string
     method: string
     url: string
     folderPath?: string
   }) => void
-  cloneRequestVisible: boolean
-  cloneRequestRef: RefObject<CloneRequestOverlayHandle | null>
-  setCloneRequestVisible: (v: boolean) => void
   onCloneRequestConfirm: (newName: string) => void
-  requestDeletePending: string | null
-  setRequestDeletePending: (s: string | null) => void
   onRequestDeleteConfirm: () => void
-  newFolderVisible: boolean
-  newFolderRef: RefObject<NewFolderOverlayHandle | null>
-  setNewFolderVisible: (v: boolean) => void
+  onRequestDeleteCancel: () => void
   onNewFolderConfirm: (name: string) => void
-  folderDeletePending: string | null
-  setFolderDeletePending: (s: string | null) => void
   onFolderDeleteConfirm: () => void
   collectionSwitchPending: string | null
   setCollectionSwitchPending: (s: string | null) => void
   onCollectionSwitchConfirm: (collectionDir: string) => void
-  reloadPending: boolean
-  setReloadPending: (v: boolean) => void
   onReloadConfirm: () => void
-  undoAllPending: boolean
-  setUndoAllPending: (v: boolean) => void
-  initPending: boolean
-  setInitPending: (v: boolean) => void
+  onReloadCancel: () => void
   onInitConfirm: () => void
   draftRef: RefObject<UseRequestDraftResult>
   folderDraftRef: RefObject<UseFolderDraftResult>
 }) {
+  const { overlays } = opts
+
   useGlobalIntercepts(opts)
 
   const dialogActions = useDialogIntercepts(opts)
 
   const newEnvironmentActions = useFormOverlayIntercept({
-    visible: opts.newEnvironmentVisible,
-    handleRef: opts.newEnvironmentRef,
+    visible: overlays.newEnvironmentVisible,
+    handleRef: overlays.newEnvironmentRef,
     onConfirm: opts.onNewEnvironmentConfirm,
-    onCancel: () => opts.setNewEnvironmentVisible(false),
+    onCancel: () => overlays.setNewEnvironmentVisible(false),
     passThroughFocuses: ["color"],
   })
 
   const cookieFormActions = useFormOverlayIntercept({
-    visible: opts.cookieFormVisible,
-    handleRef: opts.cookieFormRef,
+    visible: overlays.cookieFormVisible,
+    handleRef: overlays.cookieFormRef,
     onConfirm: opts.onCookieFormConfirm,
-    onCancel: () => opts.setCookieFormVisible(false),
+    onCancel: () => overlays.setCookieFormVisible(false),
     passThroughFocuses: ["sameSite"],
     toggleFocuses: ["secure", "httpOnly", "hostOnly"],
   })
 
   const newRequestActions = useFormOverlayIntercept({
-    visible: opts.newRequestVisible,
-    handleRef: opts.newRequestRef,
+    visible: overlays.newRequestVisible,
+    handleRef: overlays.newRequestRef,
     onConfirm: opts.onNewRequestConfirm,
-    onCancel: () => opts.setNewRequestVisible(false),
+    onCancel: () => overlays.setNewRequestVisible(false),
     passThroughFocuses: ["method", "folder"],
   })
 
   const importCurlActions = useFormOverlayIntercept({
-    visible: opts.importCurlVisible,
-    handleRef: opts.importCurlRef,
+    visible: overlays.importCurlVisible,
+    handleRef: overlays.importCurlRef,
     onConfirm: opts.onImportCurlConfirm,
-    onCancel: () => opts.setImportCurlVisible(false),
+    onCancel: () => overlays.setImportCurlVisible(false),
   })
 
   const exportCollectionActions = useFormOverlayIntercept({
-    visible: opts.exportCollectionVisible,
-    handleRef: opts.exportCollectionRef,
+    visible: overlays.exportCollectionVisible,
+    handleRef: overlays.exportCollectionRef,
     onConfirm: opts.onExportCollectionConfirm,
     onCancel: opts.onExportCollectionCancel,
     passThroughFocuses: ["format"],
   })
 
   const importCollectionActions = useFormOverlayIntercept({
-    visible: opts.importCollectionVisible,
-    handleRef: opts.importCollectionRef,
+    visible: overlays.importCollectionVisible,
+    handleRef: overlays.importCollectionRef,
     onConfirm: opts.onImportCollectionConfirm,
     onCancel: () => {
       if (!opts.importCollectionPendingRef.current) {
-        opts.setImportCollectionVisible(false)
+        overlays.setImportCollectionVisible(false)
       }
     },
     passThroughFocuses: ["destination"],
   })
 
   const editRequestActions = useFormOverlayIntercept({
-    visible: opts.editRequestVisible,
-    handleRef: opts.editRequestRef,
+    visible: overlays.editRequestVisible,
+    handleRef: overlays.editRequestRef,
     onConfirm: opts.onEditRequestConfirm,
-    onCancel: () => opts.setEditRequestVisible(false),
+    onCancel: () => overlays.setEditRequestVisible(false),
     passThroughFocuses: ["method", "folder"],
   })
 
   const cloneRequestActions = useSingleFieldFormOverlayIntercept({
-    visible: opts.cloneRequestVisible,
-    handleRef: opts.cloneRequestRef,
+    visible: overlays.cloneRequestVisible,
+    handleRef: overlays.cloneRequestRef,
     onConfirm: opts.onCloneRequestConfirm,
-    onCancel: () => opts.setCloneRequestVisible(false),
+    onCancel: () => overlays.setCloneRequestVisible(false),
   })
 
   const newFolderActions = useSingleFieldFormOverlayIntercept({
-    visible: opts.newFolderVisible,
-    handleRef: opts.newFolderRef,
+    visible: overlays.newFolderVisible,
+    handleRef: overlays.newFolderRef,
     onConfirm: opts.onNewFolderConfirm,
-    onCancel: () => opts.setNewFolderVisible(false),
+    onCancel: () => overlays.setNewFolderVisible(false),
   })
 
   useEnvEditorIntercept(opts)

--- a/tests/unit/AppOverlays.test.tsx
+++ b/tests/unit/AppOverlays.test.tsx
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "bun:test"
+import { act, createRef } from "react"
+import { KeymapProvider } from "@opentui/keymap/react"
+import { createTestRender } from "../testRender"
+import { setupKeymap } from "./_helpers"
+import { makeOverlayState } from "./_overlayState"
+import { ThemeProvider } from "../../src/ui/theme"
+import { AppOverlays } from "../../src/ui/AppOverlays"
+import { bindingDefaults } from "../../src/ui/keybind"
+import type { OverlayState } from "../../src/ui/useOverlayState"
+
+const testRender = createTestRender()
+
+const noop = () => {}
+const actions = { confirm: noop, cancel: noop }
+
+/** Props outside the overlay bag, with nothing visible. */
+function baseProps() {
+  return {
+    keybinds: bindingDefaults(),
+    reloadPending: false,
+    collectionSwitchPending: null,
+    collectionSwitcherVisible: false,
+    requestCollectionSwitch: noop,
+    setCollectionSwitcherVisible: noop,
+    onConfirmDialog: noop,
+    onCancelDialog: noop,
+    commandPaletteCommands: [],
+    codeGeneratorRequest: null,
+    collection: null,
+    requests: [],
+    onFindRequest: noop,
+    collectionPaths: [],
+    collectionSettingsByPath: {},
+    collectionDir: "/tmp/collection",
+    environmentNames: [],
+    activeEnvironmentName: null,
+    onSelectEnvironment: noop,
+    onOpenEnvironmentEditor: noop,
+    previewIndex: null,
+    activeIndex: 0,
+    setPreviewIndex: noop,
+    onThemeChange: noop,
+    setCollectionReloadToken: noop,
+    resetRequestDraft: noop,
+    resetFolderDraftByPath: noop,
+    setFocus: noop,
+    setSaveState: noop,
+    clearSaveTimer: noop,
+    saveTimerRef: createRef<ReturnType<typeof setTimeout> | null>(),
+    newEnvironmentActions: actions,
+    cookieFormActions: actions,
+    newRequestActions: actions,
+    newRequestInitialFolder: "",
+    importCurlActions: actions,
+    importCurlInitialFolder: "",
+    exportCollectionActions: actions,
+    importCollectionActions: actions,
+    importCollectionInitialParent: "~/",
+    activeEnv: null,
+    selectedRequest: null,
+    folderPaths: [],
+    editRequestInitialFolder: "",
+    editRequestActions: actions,
+    cloneRequestActions: actions,
+    newFolderActions: actions,
+    updateFlow: { phase: "idle" as const },
+    envColors: {},
+    onLoadTimelineBody: async () => "",
+    onCopyTimelineHeaders: noop,
+    onCopyTimelineBody: noop,
+    onExportTimelineBody: async () => {},
+  } as unknown as Omit<Parameters<typeof AppOverlays>[0], "overlays">
+}
+
+/**
+ * Renders the overlay layer with one overlay enabled, so a field wired to the
+ * wrong overlay shows up as the wrong text on screen.
+ */
+async function renderOverlays(
+  overlayState: Partial<OverlayState>,
+  extraProps: Partial<Parameters<typeof AppOverlays>[0]> = {},
+) {
+  const { keymap, cleanup } = setupKeymap()
+  const props = {
+    ...baseProps(),
+    overlays: makeOverlayState(overlayState),
+    ...extraProps,
+  } as Parameters<typeof AppOverlays>[0]
+  const { renderOnce, captureCharFrame } = await testRender(
+    <KeymapProvider keymap={keymap}>
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <AppOverlays {...props} />
+      </ThemeProvider>
+    </KeymapProvider>,
+    { width: 100, height: 32 },
+  )
+  await act(async () => {
+    await renderOnce()
+    await renderOnce()
+  })
+  // Overlay text wraps to the frame width, so compare against a
+  // whitespace-normalized frame instead of the raw character grid.
+  const frame = captureCharFrame().replace(/\s+/g, " ").trim()
+  return { frame, cleanup }
+}
+
+describe("AppOverlays routing", () => {
+  it("should render no overlay when every overlay is hidden", async () => {
+    const { frame, cleanup } = await renderOverlays({})
+    expect(frame).toBe("")
+    cleanup()
+  })
+
+  /**
+   * The confirmation dialogs share one component and are distinguished only by
+   * `activeOverlay` plus a pending value, so a swapped field is invisible to
+   * the type checker. Each case pins one field to one message.
+   */
+  const confirmCases: {
+    name: string
+    overrides: Partial<OverlayState>
+    expected: string
+  }[] = [
+    {
+      name: "env-delete",
+      overrides: { activeOverlay: "env-delete", envDeletePending: "staging" },
+      expected: 'Delete environment "staging"?',
+    },
+    {
+      name: "collection-unregister",
+      overrides: {
+        activeOverlay: "collection-unregister",
+        collectionUnregisterPending: "/tmp/other",
+      },
+      expected: "Unregister collection",
+    },
+    {
+      name: "undo-all",
+      overrides: { activeOverlay: "undo-all", undoAllPending: true },
+      expected: "Discard all unsaved changes?",
+    },
+    {
+      name: "init-confirm",
+      overrides: { activeOverlay: "init-confirm", initPending: true },
+      expected: "Initialize collection in",
+    },
+    {
+      name: "import-open-confirm",
+      overrides: {
+        activeOverlay: "import-open-confirm",
+        importOpenPending: { path: "/tmp/imported", name: "Imported API" },
+      },
+      expected: "Open it now?",
+    },
+    {
+      name: "delete-folder",
+      overrides: {
+        activeOverlay: "delete-folder",
+        folderDeletePending: "auth",
+      },
+      expected: 'Delete folder "auth" and all requests inside?',
+    },
+    {
+      name: "request-delete",
+      overrides: {
+        activeOverlay: "request-delete",
+        requestDeletePending: "users/get",
+      },
+      expected: 'Delete "users/get"?',
+    },
+    {
+      name: "cookie-delete",
+      overrides: {
+        activeOverlay: "cookie-delete",
+        cookieDeletePending: {
+          kind: "cookie",
+          name: "session",
+          domain: "example.com",
+          path: "/",
+        },
+      },
+      expected: 'Delete cookie "session" from example.com?',
+    },
+  ]
+
+  for (const testCase of confirmCases) {
+    it(`should render the ${testCase.name} confirmation`, async () => {
+      const { frame, cleanup } = await renderOverlays(testCase.overrides)
+      expect(frame).toContain(testCase.expected)
+      cleanup()
+    })
+  }
+
+  it("should render only the pending confirmation that matches activeOverlay", async () => {
+    const { frame, cleanup } = await renderOverlays({
+      activeOverlay: "request-delete",
+      requestDeletePending: "users/get",
+      folderDeletePending: "auth",
+      envDeletePending: "staging",
+    })
+    expect(frame).toContain('Delete "users/get"?')
+    expect(frame).not.toContain("Delete folder")
+    expect(frame).not.toContain("Delete environment")
+    cleanup()
+  })
+
+  const visibilityCases: {
+    name: string
+    overrides: Partial<OverlayState>
+    expected: string
+  }[] = [
+    {
+      name: "help",
+      overrides: { activeOverlay: "help", helpVisible: true },
+      expected: "Keybindings",
+    },
+    {
+      name: "about",
+      overrides: { activeOverlay: "about", aboutVisible: true },
+      expected: "Noodle",
+    },
+    {
+      name: "new request",
+      overrides: { activeOverlay: "new-request", newRequestVisible: true },
+      expected: "New Request",
+    },
+    {
+      name: "clone request",
+      overrides: { activeOverlay: "clone-request", cloneRequestVisible: true },
+      expected: "Clone Request",
+    },
+    {
+      name: "new folder",
+      overrides: { activeOverlay: "new-folder", newFolderVisible: true },
+      expected: "New Folder",
+    },
+    {
+      name: "new environment",
+      overrides: {
+        activeOverlay: "new-environment",
+        newEnvironmentVisible: true,
+      },
+      expected: "New Environment",
+    },
+    {
+      name: "import curl",
+      overrides: { activeOverlay: "import-curl", importCurlVisible: true },
+      expected: "Import cURL",
+    },
+    {
+      name: "cookie form",
+      overrides: { activeOverlay: "cookie-form", cookieFormVisible: true },
+      expected: "Cookie",
+    },
+  ]
+
+  for (const testCase of visibilityCases) {
+    it(`should render the ${testCase.name} overlay`, async () => {
+      const { frame, cleanup } = await renderOverlays(testCase.overrides)
+      expect(frame).toContain(testCase.expected)
+      cleanup()
+    })
+  }
+
+  it("should render the environment picker with its environments", async () => {
+    const { frame, cleanup } = await renderOverlays(
+      { activeOverlay: "environment-picker", environmentPickerVisible: true },
+      {
+        environmentNames: ["development", "staging"],
+        activeEnvironmentName: "development",
+      },
+    )
+    expect(frame).toContain("development")
+    expect(frame).toContain("staging")
+    cleanup()
+  })
+
+  it("should render the collection switcher with registered collections", async () => {
+    const { frame, cleanup } = await renderOverlays(
+      { activeOverlay: "collection-switcher" },
+      {
+        collectionSwitcherVisible: true,
+        collectionPaths: ["/tmp/alpha", "/tmp/beta"],
+      },
+    )
+    expect(frame).toContain("alpha")
+    expect(frame).toContain("beta")
+    cleanup()
+  })
+
+  /**
+   * The reload guard and the collection switcher own their own pending state,
+   * so they stay separate props rather than joining the overlay bag.
+   */
+  it("should render the reload confirmation from its own prop", async () => {
+    const { frame, cleanup } = await renderOverlays(
+      { activeOverlay: "reload-confirm" },
+      { reloadPending: true },
+    )
+    expect(frame).toContain("Reload collection and discard unsaved changes?")
+    cleanup()
+  })
+
+  it("should render the collection switch confirmation from its own prop", async () => {
+    const { frame, cleanup } = await renderOverlays(
+      { activeOverlay: "collection-switch-confirm" },
+      { collectionSwitchPending: "/tmp/next" },
+    )
+    expect(frame).toContain("and discard unsaved changes?")
+    cleanup()
+  })
+})

--- a/tests/unit/_overlayState.ts
+++ b/tests/unit/_overlayState.ts
@@ -1,0 +1,89 @@
+import { createRef } from "react"
+import { initialYamlEditorState } from "../../src/ui/appState"
+import type { OverlayState } from "../../src/ui/useOverlayState"
+
+const noop = () => {}
+
+/**
+ * Builds an `OverlayState` with every overlay hidden.
+ *
+ * `useOverlayState` owns this shape, so adding an overlay there makes this
+ * factory fail to type-check until the default is declared here too. That is
+ * the only test-side edit a new overlay needs.
+ */
+export function makeOverlayState(
+  overrides: Partial<OverlayState> = {},
+): OverlayState {
+  const state: OverlayState = {
+    activeOverlay: "none",
+    helpVisible: false,
+    setHelpVisible: noop,
+    aboutVisible: false,
+    setAboutVisible: noop,
+    environmentPickerVisible: false,
+    setEnvironmentPickerVisible: noop,
+    yamlEditor: initialYamlEditorState,
+    setYamlEditor: noop,
+    envDeletePending: null,
+    setEnvDeletePending: noop,
+    envDeletePendingRef: createRef<
+      string | null
+    >() as OverlayState["envDeletePendingRef"],
+    collectionUnregisterPending: null,
+    setCollectionUnregisterPending: noop,
+    newEnvironmentVisible: false,
+    setNewEnvironmentVisible: noop,
+    newEnvironmentRef: createRef() as OverlayState["newEnvironmentRef"],
+    cookieFormVisible: false,
+    setCookieFormVisible: noop,
+    cookieFormRef: createRef() as OverlayState["cookieFormRef"],
+    cookieFormInitial: null,
+    setCookieFormInitial: noop,
+    cookieDeletePending: null,
+    setCookieDeletePending: noop,
+    cookieDeletePendingRef:
+      createRef() as OverlayState["cookieDeletePendingRef"],
+    newRequestVisible: false,
+    setNewRequestVisible: noop,
+    newRequestRef: createRef() as OverlayState["newRequestRef"],
+    importCurlVisible: false,
+    setImportCurlVisible: noop,
+    importCurlRef: createRef() as OverlayState["importCurlRef"],
+    editRequestVisible: false,
+    setEditRequestVisible: noop,
+    editRequestRef: createRef() as OverlayState["editRequestRef"],
+    cloneRequestVisible: false,
+    setCloneRequestVisible: noop,
+    cloneRequestRef: createRef() as OverlayState["cloneRequestRef"],
+    requestDeletePending: null,
+    setRequestDeletePending: noop,
+    newFolderVisible: false,
+    setNewFolderVisible: noop,
+    newFolderRef: createRef() as OverlayState["newFolderRef"],
+    folderDeletePending: null,
+    setFolderDeletePending: noop,
+    undoAllPending: false,
+    setUndoAllPending: noop,
+    initPending: false,
+    setInitPending: noop,
+    commandPaletteVisible: false,
+    setCommandPaletteVisible: noop,
+    codeGeneratorVisible: false,
+    setCodeGeneratorVisible: noop,
+    exportCollectionVisible: false,
+    setExportCollectionVisible: noop,
+    exportCollectionRef: createRef() as OverlayState["exportCollectionRef"],
+    importCollectionVisible: false,
+    setImportCollectionVisible: noop,
+    importCollectionRef: createRef() as OverlayState["importCollectionRef"],
+    importCollectionPending: false,
+    setImportCollectionPending: noop,
+    importOpenPending: null,
+    setImportOpenPending: noop,
+    requestFinderVisible: false,
+    setRequestFinderVisible: noop,
+    timelineDetailEntry: null,
+    setTimelineDetailEntry: noop,
+  }
+  return { ...state, ...overrides }
+}

--- a/tests/unit/useDialogIntercepts.test.tsx
+++ b/tests/unit/useDialogIntercepts.test.tsx
@@ -1,13 +1,28 @@
 import { describe, expect, it } from "bun:test"
 import { act, useRef } from "react"
+import type { Dispatch, SetStateAction } from "react"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { UseEnvironmentEditorResult } from "../../src/hooks/useEnvironmentEditor"
 import { useDialogIntercepts } from "../../src/ui/intercepts/useDialogIntercepts"
 import type { CookieDeletePending } from "../../src/ui/useOverlayState"
 import { createTestRender } from "../testRender"
 import { setupKeymap } from "./_helpers"
+import { makeOverlayState } from "./_overlayState"
 
 const testRender = createTestRender()
+
+/**
+ * The dialog intercepts only ever clear pending state with a direct value, so
+ * tests observe plain values instead of `SetStateAction` updaters.
+ */
+function settledValue<T>(
+  observe: (value: T) => void,
+): Dispatch<SetStateAction<T>> {
+  return (value) => {
+    if (typeof value === "function") throw new Error("unexpected updater")
+    observe(value)
+  }
+}
 
 function DialogHarness({
   onPendingChange,
@@ -22,12 +37,12 @@ function DialogHarness({
   const folderDraftRef = useRef({ revertAllFolders: () => {} })
 
   useDialogIntercepts({
-    activeOverlay: "collection-unregister",
+    overlays: makeOverlayState({
+      activeOverlay: "collection-unregister",
+      collectionUnregisterPending: "/tmp/one",
+      setCollectionUnregisterPending: settledValue(onPendingChange),
+    }),
     setSaveState: () => {},
-    envDeletePending: null,
-    setEnvDeletePending: () => {},
-    collectionUnregisterPending: "/tmp/one",
-    setCollectionUnregisterPending: onPendingChange,
     onCollectionUnregisterConfirm: onConfirm,
     envEditorRef,
     clearSaveTimer: () => {},
@@ -35,27 +50,15 @@ function DialogHarness({
     collectionSwitchPending: null,
     setCollectionSwitchPending: () => {},
     onCollectionSwitchConfirm: () => {},
-    importOpenPending: null,
-    setImportOpenPending: () => {},
     onImportOpenConfirm: () => {},
-    reloadPending: false,
-    setReloadPending: () => {},
     onReloadConfirm: () => {},
-    requestDeletePending: null,
-    setRequestDeletePending: () => {},
+    onReloadCancel: () => {},
     onRequestDeleteConfirm: () => {},
-    folderDeletePending: null,
-    setFolderDeletePending: () => {},
+    onRequestDeleteCancel: () => {},
     onFolderDeleteConfirm: () => {},
-    cookieDeletePending: null,
-    setCookieDeletePending: () => {},
     onCookieDeleteConfirm: () => {},
-    undoAllPending: false,
-    setUndoAllPending: () => {},
     draftRef,
     folderDraftRef,
-    initPending: false,
-    setInitPending: () => {},
     onInitConfirm: () => {},
   })
 
@@ -130,12 +133,12 @@ function CookieDeleteHarness({
   const pending: CookieDeletePending = { kind: "all" }
 
   useDialogIntercepts({
-    activeOverlay: "cookie-delete",
+    overlays: makeOverlayState({
+      activeOverlay: "cookie-delete",
+      cookieDeletePending: pending,
+      setCookieDeletePending: settledValue(onPendingChange),
+    }),
     setSaveState: () => {},
-    envDeletePending: null,
-    setEnvDeletePending: () => {},
-    collectionUnregisterPending: null,
-    setCollectionUnregisterPending: () => {},
     onCollectionUnregisterConfirm: () => {},
     envEditorRef,
     clearSaveTimer: () => {},
@@ -143,27 +146,15 @@ function CookieDeleteHarness({
     collectionSwitchPending: null,
     setCollectionSwitchPending: () => {},
     onCollectionSwitchConfirm: () => {},
-    importOpenPending: null,
-    setImportOpenPending: () => {},
     onImportOpenConfirm: () => {},
-    reloadPending: false,
-    setReloadPending: () => {},
     onReloadConfirm: () => {},
-    requestDeletePending: null,
-    setRequestDeletePending: () => {},
+    onReloadCancel: () => {},
     onRequestDeleteConfirm: () => {},
-    folderDeletePending: null,
-    setFolderDeletePending: () => {},
+    onRequestDeleteCancel: () => {},
     onFolderDeleteConfirm: () => {},
-    cookieDeletePending: pending,
-    setCookieDeletePending: onPendingChange,
     onCookieDeleteConfirm: onConfirm,
-    undoAllPending: false,
-    setUndoAllPending: () => {},
     draftRef,
     folderDraftRef,
-    initPending: false,
-    setInitPending: () => {},
     onInitConfirm: () => {},
   })
 


### PR DESCRIPTION
### Type of change

- [x] Refactor / code improvement

### What does this PR do?

`useOverlayState` returned 66 fields that `AppInner` destructured and re-threaded individually into `AppOverlays` (45/100 props) and `useOverlayIntercepts` (48/85). Adding one overlay meant editing ~9 sites.

Now `AppInner` keeps the `OverlayState` object intact and passes it whole. Props that other hooks own (`useReloadGuard`, `useCollectionSwitcher`) stay explicit, and two setters only used to clear state become `onReloadCancel` / `onRequestDeleteCancel`.

- `AppOverlaysProps` 100 → 56, `useOverlayIntercepts` 84 → 37, `useDialogIntercepts` 35 → 19
- `AppInner` 1880 → 1733 lines
- Adds `tests/unit/AppOverlays.test.tsx` (renders each overlay from its own state field) + `tests/unit/_overlayState.ts` default `OverlayState` helper. Overlay layer had no rendering test before.

### How did you verify your code works?

- `bun test` — 2910 pass, 0 fail
- `bun run lint` — pass
- `bun run typecheck` — pass

### Screenshots / recordings

N/A — refactor, no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated overlay visibility, pending actions, and controls into a single overlay state, improving consistency across dialogs, menus, and interceptors.
  * Preserved existing overlay interactions while streamlining cancellation and routing behavior.

* **Bug Fixes**
  * Improved request deletion cancellation by clearing associated pending state and repair actions.

* **Tests**
  * Added comprehensive coverage for overlay routing, confirmation dialogs, pickers, and reload flows.
  * Expanded the full test suite to 2,910 tests across 188 files.

* **Documentation**
  * Updated overlay state conventions and test suite documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->