### PR TITLE
fix(ui): pretty-print structured values and align cookie detail labels

### DIFF
--- a/src/ui/CookieRow.tsx
+++ b/src/ui/CookieRow.tsx
@@ -95,6 +95,9 @@ export function CookieRow({
   const displayValue = deleted ? "Deleted" : value || "(empty)"
   const rowValueColor = valueColor ?? theme.textMuted
   const chevron = expanded ? "▾" : "▸"
+  const detailLabelWidth = details
+    ? cookieNameWidth(details.map(({ label }) => ({ name: label })))
+    : 0
 
   return (
     <box
@@ -146,26 +149,57 @@ export function CookieRow({
         </text>
       </box>
       {expanded && details ? (
-        details.map(({ label, value: detailValue }) => (
-          <box
-            key={label}
-            style={{
-              flexDirection: "row",
-              paddingLeft: COOKIE_CHEVRON_WIDTH,
-            }}
-          >
-            <text fg={theme.text} width={nameWidth} wrapMode="none">
-              {label}
-            </text>
-            <text
-              fg={label === "Value" ? rowValueColor : theme.textMuted}
-              wrapMode="char"
-              style={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}
+        details.map(({ label, value: detailValue }) => {
+          const multiline = detailValue.includes("\n")
+          const detailColor =
+            label === "Value" ? rowValueColor : theme.textMuted
+          return (
+            <box
+              key={label}
+              style={{
+                flexDirection: "column",
+                paddingLeft: COOKIE_CHEVRON_WIDTH,
+                minWidth: 0,
+              }}
             >
-              {detailValue}
-            </text>
-          </box>
-        ))
+              <box style={{ flexDirection: "row", minWidth: 0 }}>
+                <text
+                  fg={theme.textMuted}
+                  width={detailLabelWidth}
+                  wrapMode="none"
+                >
+                  {label}
+                </text>
+                {!multiline ? (
+                  <text
+                    fg={detailColor}
+                    wrapMode="char"
+                    style={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}
+                  >
+                    {detailValue}
+                  </text>
+                ) : null}
+              </box>
+              {multiline ? (
+                <box
+                  style={{
+                    paddingLeft: detailLabelWidth,
+                    flexGrow: 1,
+                    minWidth: 0,
+                  }}
+                >
+                  <text
+                    fg={detailColor}
+                    wrapMode="char"
+                    style={{ flexGrow: 1, flexShrink: 1, minWidth: 0 }}
+                  >
+                    {detailValue}
+                  </text>
+                </box>
+              ) : null}
+            </box>
+          )
+        })
       ) : expanded ? (
         <box style={{ paddingLeft: COOKIE_CHEVRON_WIDTH }}>
           <text

--- a/src/ui/ResponseResults.tsx
+++ b/src/ui/ResponseResults.tsx
@@ -8,7 +8,10 @@ import { useTheme } from "./theme"
 
 function formatValue(value: JsonValue | undefined): string {
   if (value === undefined) return "—"
-  return typeof value === "string" ? value : JSON.stringify(value)
+  if (typeof value === "string") return value
+  return typeof value === "object" && value !== null
+    ? JSON.stringify(value, null, 2)
+    : JSON.stringify(value)
 }
 
 export function ResponseResults({
@@ -258,7 +261,7 @@ export function ResponseResults({
             <>
               {activeCaptures.map(([variable, capture]) => (
                 <text key={variable} fg={theme.textMuted}>
-                  {`  – ${variable} ← ${capture.value}`}
+                  {`  – ${variable} ${capture.value}`}
                 </text>
               ))}
             </>
@@ -273,7 +276,7 @@ export function ResponseResults({
                     kindLabel={result.success ? "CAPTURED" : "FAILED"}
                     kindColor={result.success ? theme.success : theme.error}
                     name={result.variable}
-                    value={`← ${result.expression}`}
+                    value={result.expression}
                     nameWidth={captureNameWidth}
                     selected={
                       selectedRowIdx === assertionResults.length + index
@@ -283,9 +286,10 @@ export function ResponseResults({
                     details={
                       result.success
                         ? [
+                            { label: "Type", value: result.type },
                             {
                               label: "Value",
-                              value: `(${result.type}: ${formatValue(result.value)})`,
+                              value: formatValue(result.value),
                             },
                           ]
                         : [{ label: "Message", value: result.message }]

--- a/tests/unit/ResponseResults.test.tsx
+++ b/tests/unit/ResponseResults.test.tsx
@@ -56,7 +56,7 @@ describe("ResponseResults", () => {
     expect(collapsed).toMatch(/Assertions 0 passed · 1 failed/)
     expect(collapsed).toMatch(/Captures 1 captured · 0 failed/)
     expect(collapsed).toMatch(/FAIL\s+status\s+equals/)
-    expect(collapsed).toMatch(/CAPTURED\s+token\s+← body.token/)
+    expect(collapsed).toMatch(/CAPTURED\s+token\s+body.token/)
     expect(collapsed).not.toContain("Expected 201")
     expect(collapsed).not.toContain("[REDACTED]")
 
@@ -80,11 +80,53 @@ describe("ResponseResults", () => {
     await act(async () => host.press("return"))
     await act(async () => renderOnce())
     const expandedCapture = captureCharFrame()
-    expect(expandedCapture).toMatch(/Value\s+\(string: \[REDACTED\]\)/)
+    expect(expandedCapture).toMatch(/Type\s+string/)
+    expect(expandedCapture).toMatch(/Value\s+\[REDACTED\]/)
 
     await act(async () => host.press("return"))
     await act(async () => renderOnce())
     expect(captureCharFrame()).not.toContain("[REDACTED]")
+  })
+
+  it("keeps detail labels compact and pretty-prints structured values", async () => {
+    const { keymap, host } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <ResponseResults
+            execution={{
+              assertions: {
+                evaluated: true,
+                results: [
+                  {
+                    expression: "body.response.payload",
+                    operator: "isObject",
+                    actual: {
+                      title: "Assertion example",
+                      userId: 1,
+                    },
+                    passed: true,
+                    message: "Assertion passed",
+                  },
+                ],
+              },
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 52, height: 14 },
+    )
+    await renderOnce()
+    await act(async () => host.press("return"))
+    await act(async () => renderOnce())
+
+    const lines = captureCharFrame().split("\n")
+    const actualIndex = lines.findIndex((line) => line.includes("Actual"))
+    expect(actualIndex).toBeGreaterThanOrEqual(0)
+    expect(lines[actualIndex]!.trimEnd()).toEndWith("Actual")
+    expect(lines[actualIndex + 1]!.trim()).toBe("{")
+    expect(lines[actualIndex + 2]).toContain('"title": "Assertion example"')
+    expect(lines[actualIndex + 3]).toContain('"userId": 1')
   })
 
   it("renders declarations in the not-evaluated state", async () => {
@@ -112,7 +154,7 @@ describe("ResponseResults", () => {
     const frame = captureCharFrame()
     expect(frame.match(/Not evaluated/g)).toHaveLength(2)
     expect(frame).toContain("status exists")
-    expect(frame).toContain("token ← headers.x-token")
+    expect(frame).toContain("token headers.x-token")
   })
 
   it("excludes disabled declarations from unevaluated Results", async () => {

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -230,7 +230,7 @@ describe("TimelineDetailOverlay", () => {
     await act(async () => host.press("return"))
     await renderOnce()
 
-    expect(captureCharFrame()).toMatch(/Expected\s+201/)
+    expect(captureCharFrame()).toMatch(/Expected[ \t]+201/)
     cleanup()
   })
 

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -230,7 +230,7 @@ describe("TimelineDetailOverlay", () => {
     await act(async () => host.press("return"))
     await renderOnce()
 
-    expect(captureCharFrame()).toContain("Expected 201")
+    expect(captureCharFrame()).toMatch(/Expected\s+201/)
     cleanup()
   })
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pretty-prints structured assertion/capture values (`JSON.stringify` with indent 2 for objects) and aligns cookie detail labels. `ResponseResults` splits capture details into separate `Type`/`Value` rows and removes the `←` prefix; `CookieRow` computes label width and renders multiline values on a new line. Single commit: `fix(ui): pretty-print structured values and align cookie detail labels`.

### How did you verify your code works?

Manual local run + automated checks:
- `bun test` — 3011 pass across 201 files
- `bun run lint` — pass
- `bun run typecheck` — pass

### Screenshots / recordings

N/A — terminal UI change, no static screenshot.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Improved expanded cookie details with clearer label alignment and muted labels.
  - Displayed multiline cookie values on separate, indented rows.
  - Formatted objects and arrays with readable two-space indentation.
  - Simplified capture expression labels by removing the arrow separator.
  - Separated capture details into distinct **Type** and **Value** rows.
- **Bug Fixes**
  - Improved readability of structured assertion values across multiple lines.
- **Tests**
  - Updated coverage for revised capture formatting and flexible detail spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->