### PR TITLE
feat: tag autocomplete and repeated tag filters (AND/OR)

### DIFF
--- a/.agents/skills/noodle-use/workflows/automation.md
+++ b/.agents/skills/noodle-use/workflows/automation.md
@@ -23,7 +23,7 @@ Use Noodle's non-interactive CLI for supported collection operations. Never star
 | Delete a local vault value without removing its declaration | `noodle secret delete <key> --env <name> --collection <dir> --json` |
 | Inspect collection cookies and storage health | `noodle cookie list --collection <dir> --json` |
 | Clear cookies or recover unreadable cookie storage | `noodle cookie clear --collection <dir> --json` |
-| Run one, selected, or all requests | `noodle request run <id> ... --json` or `noodle collection run <dir> [<target>...] [--tag <tag>] [--exclude-tag <tag>] [--fail-fast] ... --json` |
+| Run one, selected, or all requests | `noodle request run <id> ... --json` or `noodle collection run <dir> [<target>...] [--tag <tag>]... [--exclude-tag <tag>]... [--fail-fast] ... --json` |
 
 ## Rules
 
@@ -33,7 +33,7 @@ Use Noodle's non-interactive CLI for supported collection operations. Never star
 - `collection format` rewrites every request file with canonical YAML and pretty-prints valid JSON bodies. It leaves invalid JSON body text unchanged. Obtain user authorization before running it because it modifies collection files.
 - Request IDs are relative paths without `.yml`, such as `users/list`. Do not use traversal, empty segments, or hidden segments.
 - `collection run <dir> [<target>...]` accepts bare request IDs and folder paths ending in `/`. Folders include nested requests. Overlapping targets run once in collection order; omit targets to run the whole collection.
-- `--tag <tag>` requires the effective request tag, while `--exclude-tag <tag>` removes matching requests and wins when both filters match. Targets resolve first, then include and exclude filters run before environment, proxy, TLS, cookie, or request setup. Tag values and YAML tags are case-sensitive.
+- Each repeated `--tag <tag>` requires that effective request tag, so Include tags use AND matching. Each repeated `--exclude-tag <tag>` removes matching requests, so Exclude tags use OR matching and win when both filters match. Targets resolve first, then include and exclude filters run before environment, proxy, TLS, cookie, or request setup. Tag values and YAML tags are case-sensitive; duplicate filters have no additional effect.
 - Request tags combine with all ancestor folder tags. Duplicates have no additional effect, tags cannot be removed downstream, and root `folder.yml` remains ignored. A tag-filtered selection with no requests is a configuration failure. An empty collection or explicitly selected empty folder still succeeds when no tag filter is present.
 - `--fail-fast` stops after the first failed request. Read executed requests from ordered `data.results` and the remaining selected IDs from ordered `data.skipped` entries with `reason: "fail-fast"`. Filtered requests appear in neither array and cannot change RunScope captures.
 - Every request result has `failureCategories` in fixed order. Categories are `configuration`, `execution`, `transport`, `http`, `capture`, and `assertion`; response-based `http`, `capture`, and `assertion` failures may coexist. Collection results include `failed`, optional configuration `failure`, and `summary` counts for selection, execution, skips, request outcomes, assertions, captures, duration, and unique failure categories.

--- a/README.md
+++ b/README.md
@@ -100,16 +100,17 @@ noodle request run users/get --collection ./my-api --env staging
 noodle collection audit ./my-api --json
 noodle collection run ./my-api --json
 noodle collection run ./my-api auth/ health users/get --json
-noodle collection run ./my-api --tag smoke --exclude-tag destructive --json
+noodle collection run ./my-api --tag smoke --tag api --exclude-tag destructive --json
 noodle agent install
 ```
 
 Commands support structured JSON output for scripts, CI, and agent workflows.
 Requests and non-root folders can declare case-sensitive `tags`. Folder tags
 apply to every descendant request, so `collection run --tag smoke` can execute a
-dynamic suite without a second collection format. Include and exclude filters
-compose, with exclusion winning, and `--fail-fast` records the remaining
-selected request IDs as skipped.
+dynamic suite without a second collection format. Repeat `--tag` to require
+every Include tag and repeat `--exclude-tag` to remove requests matching any
+Exclude tag. Exclusion wins, and `--fail-fast` records the remaining selected
+request IDs as skipped.
 
 Request YAML can also declare response assertions for status, timing, headers,
 and JSON body paths. Edit them in the TUI Assert tab or as YAML. Manual

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty"
+import { parseArgs } from "node:util"
 import { emitCommand } from "../commandResult"
 import {
   createRunProgressReporter,
@@ -252,11 +253,11 @@ const collection = defineCommand({
         env: { type: "string", alias: "e" },
         tag: {
           type: "string",
-          description: "Run requests with this effective tag",
+          description: "Require this tag (repeatable; all must match)",
         },
         "exclude-tag": {
           type: "string",
-          description: "Exclude requests with this effective tag",
+          description: "Exclude this tag (repeatable; any match excludes)",
         },
         "fail-fast": {
           type: "boolean",
@@ -267,8 +268,17 @@ const collection = defineCommand({
         insecure: { type: "boolean", default: false },
         json: jsonArg,
       },
-      run: ({ args }) =>
-        emitCommand(
+      run: ({ args, rawArgs }) => {
+        const { values } = parseArgs({
+          args: rawArgs,
+          options: {
+            tag: { type: "string", multiple: true },
+            "exclude-tag": { type: "string", multiple: true },
+          },
+          allowPositionals: true,
+          strict: false,
+        })
+        return emitCommand(
           args.json,
           async () => {
             const progress = args.json ? undefined : createRunProgressReporter()
@@ -281,8 +291,8 @@ const collection = defineCommand({
                 takeSystemProxyFromEnv(),
                 args.insecure,
                 args._.slice(1),
-                args.tag,
-                args["exclude-tag"],
+                (values.tag ?? []) as string[],
+                (values["exclude-tag"] ?? []) as string[],
                 args["fail-fast"],
               )
               return {
@@ -300,7 +310,8 @@ const collection = defineCommand({
             }
           },
           formatCollectionRun,
-        ),
+        )
+      },
     }),
   },
 })

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -160,46 +160,43 @@ function requestsForTargets(
 function filterRequests(
   items: CollectionItem[],
   requests: Request[],
-  tag?: string,
-  excludeTag?: string,
+  includeTags: readonly string[],
+  excludeTags: readonly string[],
 ): Request[] {
-  for (const [name, value] of [
-    ["--tag", tag],
-    ["--exclude-tag", excludeTag],
+  const includes = [...new Set(includeTags)]
+  const excludes = [...new Set(excludeTags)]
+  for (const [name, values] of [
+    ["--tag", includes],
+    ["--exclude-tag", excludes],
   ] as const) {
-    if (value !== undefined && !isValidTag(value)) {
+    if (values.some((value) => !isValidTag(value)))
       throw new Error(`${name} must be a non-empty trimmed string`)
-    }
   }
 
   const tags = effectiveRequestTags(items)
   const filtered = requests.filter((request) => {
     const effective = tags.get(request.id) ?? new Set<string>()
     return (
-      (!tag || effective.has(tag)) &&
-      (!excludeTag || !effective.has(excludeTag))
+      includes.every((tag) => effective.has(tag)) &&
+      !excludes.some((tag) => effective.has(tag))
     )
   })
-  if (
-    (tag !== undefined || excludeTag !== undefined) &&
-    filtered.length === 0
-  ) {
+  if ((includes.length > 0 || excludes.length > 0) && filtered.length === 0)
     throw new Error("no requests match the tag filters")
-  }
   return filtered
 }
 
 export function selectCollectionRunRequests(
   items: CollectionItem[],
   targets: string[] = [],
-  tag?: string,
-  excludeTag?: string,
+  includeTags: readonly string[] = [],
+  excludeTags: readonly string[] = [],
 ): Request[] {
   return filterRequests(
     items,
     requestsForTargets(items, targets),
-    tag,
-    excludeTag,
+    includeTags,
+    excludeTags,
   )
 }
 export type CollectionTreeItem =
@@ -910,8 +907,8 @@ export async function collectionRun(
   systemProxy?: SystemProxySettings,
   insecure = false,
   targets: string[] = [],
-  tag?: string,
-  excludeTag?: string,
+  includeTags: readonly string[] = [],
+  excludeTags: readonly string[] = [],
   failFast = false,
   onDetail?: RunDetail,
 ): Promise<CollectionRunResult> {
@@ -931,8 +928,8 @@ export async function collectionRun(
     requests = selectCollectionRunRequests(
       collection.items,
       targets,
-      tag,
-      excludeTag,
+      includeTags,
+      excludeTags,
     )
     selected = requests.length
     settings = await loadSettings(dir)

--- a/src/hooks/useCollectionRunner.ts
+++ b/src/hooks/useCollectionRunner.ts
@@ -13,6 +13,7 @@ import { nextIndex } from "../ui/selection"
 import { effectiveRequestTags } from "../tags"
 
 export type RunnerPhase = "configure" | "running" | "results"
+export type RunnerTagFilter = "include" | "exclude"
 export type RunnerResultRow =
   | { kind: "result"; id: string; result: RequestRunResult }
   | { kind: "skipped"; id: string; reason: "fail-fast" }
@@ -42,8 +43,10 @@ export interface UseCollectionRunnerResult {
   previewError: string | null
   environmentName: string | null
   environmentNames: string[]
-  includeTag: string
-  excludeTag: string
+  includeTags: string[]
+  excludeTags: string[]
+  includeTagIndex: number
+  excludeTagIndex: number
   failFast: boolean
   optionIndex: number
   requestIndex: number
@@ -58,7 +61,9 @@ export interface UseCollectionRunnerResult {
   runAvailable: boolean
   canRun: boolean
   setEnvironmentName: (name: string | null) => void
-  setTagFilter: (filter: "include" | "exclude", tag: string) => void
+  setTagFilter: (filter: RunnerTagFilter, index: number, tag: string) => void
+  deleteTagFilter: (filter: RunnerTagFilter, index: number) => void
+  setTagFilterIndex: (filter: RunnerTagFilter, index: number) => void
   setSelectOpen: (open: boolean) => void
   setOptionIndex: (index: number) => void
   setRequestIndex: (index: number) => void
@@ -68,6 +73,8 @@ export interface UseCollectionRunnerResult {
   optionDown: () => void
   optionFirst: () => void
   optionLast: () => void
+  tagPrevious: () => void
+  tagNext: () => void
   requestUp: () => void
   requestDown: () => void
   requestFirst: () => void
@@ -145,8 +152,10 @@ export function useCollectionRunner({
   const [phase, setPhase] = useState<RunnerPhase>("configure")
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [environmentName, setEnvironmentName] = useState<string | null>(null)
-  const [includeTag, setIncludeTag] = useState("")
-  const [excludeTag, setExcludeTag] = useState("")
+  const [includeTags, setIncludeTags] = useState<string[]>([])
+  const [excludeTags, setExcludeTags] = useState<string[]>([])
+  const [includeTagIndex, setIncludeTagIndex] = useState(0)
+  const [excludeTagIndex, setExcludeTagIndex] = useState(0)
   const [failFast, setFailFast] = useState(false)
   const [optionIndex, setOptionIndexState] = useState(0)
   const [selectOpen, setSelectOpen] = useState(false)
@@ -174,21 +183,62 @@ export function useCollectionRunner({
     },
     [phase, selectOpen],
   )
-  const setTagFilter = useCallback(
-    (filter: "include" | "exclude", tag: string) => {
+  const setTagFilterIndex = useCallback(
+    (filter: RunnerTagFilter, index: number) => {
       if (phase === "running") return
-      if (filter === "include") setIncludeTag(tag)
-      else setExcludeTag(tag)
+      const limit =
+        filter === "include" ? includeTags.length : excludeTags.length
+      const next = Math.max(0, Math.min(limit, index))
+      if (filter === "include") setIncludeTagIndex(next)
+      else setExcludeTagIndex(next)
     },
-    [phase],
+    [excludeTags.length, includeTags.length, phase],
+  )
+  const setTagFilter = useCallback(
+    (filter: RunnerTagFilter, index: number, tag: string) => {
+      if (phase === "running") return
+      const current = filter === "include" ? includeTags : excludeTags
+      if (index < 0 || index > current.length) return
+      const next = [...current]
+      if (index === next.length) next.push(tag)
+      else next[index] = tag
+      const unique = [...new Set(next)]
+      if (filter === "include") {
+        setIncludeTags(unique)
+        setIncludeTagIndex(unique.indexOf(tag))
+      } else {
+        setExcludeTags(unique)
+        setExcludeTagIndex(unique.indexOf(tag))
+      }
+    },
+    [excludeTags, includeTags, phase],
+  )
+  const deleteTagFilter = useCallback(
+    (filter: RunnerTagFilter, index: number) => {
+      if (phase === "running") return
+      const current = filter === "include" ? includeTags : excludeTags
+      if (index < 0 || index >= current.length) return
+      const next = current.filter((_, currentIndex) => currentIndex !== index)
+      const nextIndex = next.length === 0 ? 0 : Math.min(index, next.length - 1)
+      if (filter === "include") {
+        setIncludeTags(next)
+        setIncludeTagIndex(nextIndex)
+      } else {
+        setExcludeTags(next)
+        setExcludeTagIndex(nextIndex)
+      }
+    },
+    [excludeTags, includeTags, phase],
   )
 
   useEffect(() => {
     setPhase("configure")
     setSelectedIds(new Set(requests.map((request) => request.id)))
     setEnvironmentName(activeEnvironment)
-    setIncludeTag("")
-    setExcludeTag("")
+    setIncludeTags([])
+    setExcludeTags([])
+    setIncludeTagIndex(0)
+    setExcludeTagIndex(0)
     setFailFast(false)
     setOptionIndexState(0)
     setSelectOpen(false)
@@ -218,8 +268,8 @@ export function useCollectionRunner({
       const selected = selectCollectionRunRequests(
         collection.items,
         selectedRequestIds,
-        includeTag || undefined,
-        excludeTag || undefined,
+        includeTags,
+        excludeTags,
       )
       return {
         ids: new Set(selected.map((request) => request.id)),
@@ -231,7 +281,7 @@ export function useCollectionRunner({
         error: error instanceof Error ? error.message : String(error),
       }
     }
-  }, [collection, excludeTag, includeTag, selectedRequestIds])
+  }, [collection, excludeTags, includeTags, selectedRequestIds])
 
   const resultRows = useMemo(() => {
     if (!result) return []
@@ -261,6 +311,22 @@ export function useCollectionRunner({
     () => setOptionIndex(OPTION_COUNT - 1),
     [setOptionIndex],
   )
+  const moveTag = useCallback(
+    (direction: -1 | 1) => {
+      if (phase === "running" || selectOpen) return
+      if (optionIndex === 1)
+        setIncludeTagIndex((index) =>
+          Math.max(0, Math.min(includeTags.length, index + direction)),
+        )
+      else if (optionIndex === 2)
+        setExcludeTagIndex((index) =>
+          Math.max(0, Math.min(excludeTags.length, index + direction)),
+        )
+    },
+    [excludeTags.length, includeTags.length, optionIndex, phase, selectOpen],
+  )
+  const tagPrevious = useCallback(() => moveTag(-1), [moveTag])
+  const tagNext = useCallback(() => moveTag(1), [moveTag])
   const requestUp = useCallback(
     () =>
       setRequestRowIndex((index) =>
@@ -379,8 +445,8 @@ export function useCollectionRunner({
       nextRequests = selectCollectionRunRequests(
         collection.items,
         selectedRequestIds,
-        includeTag || undefined,
-        excludeTag || undefined,
+        includeTags,
+        excludeTags,
       )
     } catch {
       return
@@ -405,8 +471,8 @@ export function useCollectionRunner({
         systemProxy,
         insecure,
         selectedRequestIds,
-        includeTag || undefined,
-        excludeTag || undefined,
+        includeTags,
+        excludeTags,
         failFast,
         (detail) => nextDetails.set(detail.requestId, detail),
       )
@@ -423,10 +489,10 @@ export function useCollectionRunner({
     collection,
     collectionDir,
     environmentName,
-    excludeTag,
+    excludeTags,
     failFast,
     hasUnsavedChanges,
-    includeTag,
+    includeTags,
     insecure,
     noProxy,
     phase,
@@ -447,8 +513,10 @@ export function useCollectionRunner({
     previewError: preview.error,
     environmentName,
     environmentNames,
-    includeTag,
-    excludeTag,
+    includeTags,
+    excludeTags,
+    includeTagIndex,
+    excludeTagIndex,
     failFast,
     optionIndex,
     requestIndex,
@@ -464,6 +532,8 @@ export function useCollectionRunner({
     canRun,
     setEnvironmentName,
     setTagFilter,
+    deleteTagFilter,
+    setTagFilterIndex,
     setSelectOpen,
     setOptionIndex,
     setRequestIndex,
@@ -473,6 +543,8 @@ export function useCollectionRunner({
     optionDown,
     optionFirst,
     optionLast,
+    tagPrevious,
+    tagNext,
     requestUp,
     requestDown,
     requestFirst,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -803,15 +803,17 @@ export function AppInner({
   ])
 
   const handleOpenRunnerTagFilter = useCallback(
-    (filter: "include" | "exclude") => {
+    (filter: "include" | "exclude", index: number) => {
       if (runnerRef.current.phase === "running") return
+      const tags =
+        filter === "include"
+          ? runnerRef.current.includeTags
+          : runnerRef.current.excludeTags
       overlays.setTagEditPending({
         kind: "runner-filter",
         filter,
-        value:
-          filter === "include"
-            ? runnerRef.current.includeTag
-            : runnerRef.current.excludeTag,
+        index,
+        value: tags[index] ?? "",
       })
     },
     [overlays.setTagEditPending],
@@ -1465,7 +1467,7 @@ export function AppInner({
       const pending = overlays.tagEditPending
       if (!pending) return
       if (pending.kind === "runner-filter") {
-        runnerRef.current.setTagFilter(pending.filter, tag)
+        runnerRef.current.setTagFilter(pending.filter, pending.index, tag)
         overlays.setTagEditPending(null)
         return
       }
@@ -1482,7 +1484,7 @@ export function AppInner({
       const pending = overlays.tagEditPending
       if (!pending) return
       if (pending.kind === "runner-filter") {
-        runnerRef.current.setTagFilter(pending.filter, "")
+        runnerRef.current.deleteTagFilter(pending.filter, pending.index)
         overlays.setTagEditPending(null)
         return
       }

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -121,6 +121,7 @@ import {
 } from "./collectionImport"
 import { extractFileErrors } from "../filestore/load"
 import type { ExternalEditor, ExternalEditorId } from "../externalEditor"
+import { effectiveRequestTags } from "../tags"
 
 export function AppInner({
   appConfigDir,
@@ -784,6 +785,22 @@ export function AppInner({
   const { activeOverlay } = overlays
   openTagEditorRef.current = (index, value) =>
     overlays.setTagEditPending({ kind: "request", index, value })
+
+  const tagSuggestions = useMemo(() => {
+    const groups =
+      overlays.tagEditPending?.kind === "runner-filter"
+        ? [...runner.requestTags.values()]
+        : [
+            ...effectiveRequestTags(items).values(),
+            ...(draft.draft?.tags ? [draft.draft.tags] : []),
+          ]
+    return groups.flatMap((tags) => [...tags])
+  }, [
+    draft.draft?.tags,
+    items,
+    overlays.tagEditPending?.kind,
+    runner.requestTags,
+  ])
 
   const handleOpenRunnerTagFilter = useCallback(
     (filter: "include" | "exclude") => {
@@ -1463,8 +1480,17 @@ export function AppInner({
     },
     onTagClear: () => {
       const pending = overlays.tagEditPending
-      if (pending?.kind !== "runner-filter") return
-      runnerRef.current.setTagFilter(pending.filter, "")
+      if (!pending) return
+      if (pending.kind === "runner-filter") {
+        runnerRef.current.setTagFilter(pending.filter, "")
+        overlays.setTagEditPending(null)
+        return
+      }
+      const current = draftRef.current.draft
+      if (!current || pending.index >= (current.tags?.length ?? 0)) return
+      const tags = [...(current.tags ?? [])]
+      tags.splice(pending.index, 1)
+      draftRef.current.setTags(tags)
       overlays.setTagEditPending(null)
     },
     onFolderDeleteConfirm: handleFolderDeleteConfirm,
@@ -1865,6 +1891,7 @@ export function AppInner({
           cloneRequestActions={overlayActions.cloneRequest}
           newFolderActions={overlayActions.newFolder}
           tagEditorActions={overlayActions.tagEditor}
+          tagSuggestions={tagSuggestions}
           updateFlow={updateFlow}
           envColors={envColors}
           onLoadTimelineBody={onLoadTimelineBody}

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -112,6 +112,7 @@ interface AppOverlaysProps {
     cancel: () => void
     clear: () => void
   }
+  tagSuggestions: readonly string[]
   updateFlow: UpdateFlowState
   envColors: Record<string, string | undefined>
   onLoadTimelineBody: (
@@ -180,6 +181,7 @@ export function AppOverlays({
   cloneRequestActions,
   newFolderActions,
   tagEditorActions,
+  tagSuggestions,
   updateFlow,
   envColors,
   onLoadTimelineBody,
@@ -525,6 +527,7 @@ export function AppOverlays({
           visible
           ref={tagEditorRef}
           initialValue={tagEditPending.value}
+          suggestions={tagSuggestions}
           title={
             tagEditPending.kind === "runner-filter"
               ? tagEditPending.filter === "include"
@@ -535,6 +538,11 @@ export function AppOverlays({
           onConfirm={tagEditorActions.confirm}
           onClear={
             tagEditPending.kind === "runner-filter" && tagEditPending.value
+              ? tagEditorActions.clear
+              : undefined
+          }
+          onDelete={
+            tagEditPending.kind === "request" && tagEditPending.value
               ? tagEditorActions.clear
               : undefined
           }

--- a/src/ui/AppOverlays.tsx
+++ b/src/ui/AppOverlays.tsx
@@ -536,16 +536,7 @@ export function AppOverlays({
               : undefined
           }
           onConfirm={tagEditorActions.confirm}
-          onClear={
-            tagEditPending.kind === "runner-filter" && tagEditPending.value
-              ? tagEditorActions.clear
-              : undefined
-          }
-          onDelete={
-            tagEditPending.kind === "request" && tagEditPending.value
-              ? tagEditorActions.clear
-              : undefined
-          }
+          onDelete={tagEditPending.value ? tagEditorActions.clear : undefined}
           onClose={tagEditorActions.cancel}
         />
       )}

--- a/src/ui/CollectionRunnerView.tsx
+++ b/src/ui/CollectionRunnerView.tsx
@@ -40,15 +40,15 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 
 const OPTION_LABELS = [
   "Environment",
-  "Include tag",
-  "Exclude tag",
+  "Include tags",
+  "Exclude tags",
   "Fail fast",
 ] as const
 
 const OPTION_DESCRIPTIONS = [
   "Select the environment used for this run.",
-  "Only run requests with this tag.",
-  "Skip requests with this tag.",
+  "Only run requests with every included tag.",
+  "Skip requests with any excluded tag.",
   "Stop running after the first failed request.",
 ] as const
 
@@ -150,7 +150,7 @@ export function CollectionRunnerView({
   hasUnsavedChanges: boolean
   detailScrollRef: RefObject<ScrollBoxRenderable | null>
   onPaneFocus: (focus: Focus) => void
-  onEditTagFilter: (filter: "include" | "exclude") => void
+  onEditTagFilter: (filter: "include" | "exclude", index: number) => void
   onOpenResultDetail: (index: number) => void
 }) {
   const theme = useTheme()
@@ -449,13 +449,14 @@ export function CollectionRunnerView({
                     title={label}
                     description={OPTION_DESCRIPTIONS[index]}
                     active={active}
+                    alignItems={
+                      index === 1 || index === 2 ? "flex-start" : "center"
+                    }
                     onMouseDown={() => {
                       if (configurationLocked) return
                       onPaneFocus("runner-options")
                       runner.setOptionIndex(index)
-                      if (index === 1) onEditTagFilter("include")
-                      else if (index === 2) onEditTagFilter("exclude")
-                      else if (index === 3) runner.toggleFailFast()
+                      if (index === 3) runner.toggleFailFast()
                     }}
                   >
                     {index === 0 ? (
@@ -485,19 +486,66 @@ export function CollectionRunnerView({
                             ? "runner-include-tag-value"
                             : "runner-exclude-tag-value"
                         }
+                        style={{
+                          flexDirection: "row",
+                          flexWrap: "wrap",
+                          gap: 0,
+                          flexGrow: 1,
+                          minWidth: 0,
+                        }}
                       >
-                        <Badge
-                          bg={active ? theme.primary : theme.backgroundElement}
-                          fg={active ? theme.backgroundPanel : theme.textMuted}
-                        >
-                          {index === 1
-                            ? runner.includeTag
-                              ? `#${runner.includeTag}`
-                              : "Any"
-                            : runner.excludeTag
-                              ? `#${runner.excludeTag}`
-                              : "Any"}
-                        </Badge>
+                        {[
+                          ...(index === 1
+                            ? runner.includeTags
+                            : runner.excludeTags),
+                          null,
+                        ].map((tag, tagIndex) => {
+                          const filter = index === 1 ? "include" : "exclude"
+                          const tagActive =
+                            active &&
+                            tagIndex ===
+                              (index === 1
+                                ? runner.includeTagIndex
+                                : runner.excludeTagIndex)
+                          return (
+                            <box
+                              key={`${filter}-${tag ?? "add"}-${tagIndex}`}
+                              id={`runner-${filter}-tag-${tagIndex}`}
+                              style={{
+                                flexDirection: "column",
+                                minHeight: 1,
+                                marginRight: 1,
+                              }}
+                              onMouseDown={(event) => {
+                                if (
+                                  event.button !== MouseButton.LEFT ||
+                                  configurationLocked
+                                )
+                                  return
+                                onPaneFocus("runner-options")
+                                runner.setOptionIndex(index)
+                                runner.setTagFilterIndex(filter, tagIndex)
+                                onEditTagFilter(filter, tagIndex)
+                                event.stopPropagation()
+                              }}
+                            >
+                              <Badge
+                                bg={
+                                  tagActive
+                                    ? theme.primary
+                                    : theme.backgroundElement
+                                }
+                                fg={
+                                  tagActive
+                                    ? theme.backgroundPanel
+                                    : theme.textMuted
+                                }
+                              >
+                                {tag === null ? "+ Add tag" : `#${tag}`}
+                              </Badge>
+                            </box>
+                          )
+                        })}
                       </box>
                     ) : (
                       <Checkbox checked={runner.failFast} theme={theme} />

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -9,6 +9,8 @@ import {
   useState,
 } from "react"
 import {
+  BoxRenderable,
+  CliRenderEvents,
   InputRenderable,
   MouseButton,
   ScrollBoxRenderable,
@@ -105,6 +107,7 @@ export interface VarInputProps {
   paddingX?: number
   style?: VarInputStyle
   variableNames?: Iterable<string>
+  variableAware?: boolean
   pathParams?: ParamEntry[]
   pathCompletion?: PathCompletionOptions
   completionValues?: readonly string[]
@@ -128,6 +131,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       paddingX,
       style,
       variableNames,
+      variableAware = true,
       pathParams,
       pathCompletion,
       completionValues,
@@ -150,6 +154,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       return editable && !editable.isDestroyed ? editable : null
     }, [])
     const suggestionNames = useMemo(() => {
+      if (!variableAware) return []
       if (variableNames != null) return [...variableNames]
       return [
         ...new Set([
@@ -157,7 +162,7 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
           ...Object.keys(env?.secretVars ?? {}),
         ]),
       ]
-    }, [variableNames, env?.vars, env?.secretVars])
+    }, [variableAware, variableNames, env?.vars, env?.secretVars])
 
     const inputFocused = isFocused ?? true
 
@@ -166,14 +171,15 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         getEditor: getEditable,
         variableNames: suggestionNames,
         value,
-        isEditing: isEditing && inputFocused,
+        isEditing: variableAware && isEditing && inputFocused,
       })
 
     const applyHighlights = useCallback(() => {
+      if (!variableAware) return
       const editable = getEditable()
       if (editable)
         highlightVariables(editable, editable.plainText, theme, env, pathParams)
-    }, [env, getEditable, theme, pathParams])
+    }, [env, getEditable, pathParams, theme, variableAware])
 
     const handlePathChange = useCallback(
       (nextValue: string) => {
@@ -552,34 +558,60 @@ function CompletionPopup({
     x: number
     y: number
   } | null>(null)
+  const popupRef = useRef<BoxRenderable | null>(null)
+  const anchorReadyRef = useRef(getEditable() !== null)
 
   useEffect(() => {
-    const editable = getEditable()
-    if (!isEditing || !editable) {
-      setCompletionAnchor((current) => (current === null ? current : null))
-      return
+    const readAnchor = () => {
+      const editable = getEditable()
+      if (!isEditing || !editable) return null
+      const cursor = editable.visualCursor
+      const visibleCount = Math.max(
+        message ? 1 : 0,
+        Math.min(items.length, MAX_COMPLETION_VISIBLE),
+      )
+      const menuHeight = visibleCount + 2
+      const menuWidth = 18
+      const rawX = editable.screenX + cursor.visualCol
+      const rawY = editable.screenY + cursor.visualRow + 1
+      return {
+        x: Math.max(0, Math.min(rawX, terminalWidth - menuWidth)),
+        y: Math.max(0, Math.min(rawY, terminalHeight - menuHeight)),
+      }
     }
-    const cursor = editable.visualCursor
-    const visibleCount = Math.max(
-      message ? 1 : 0,
-      Math.min(items.length, MAX_COMPLETION_VISIBLE),
-    )
-    const menuHeight = visibleCount + 2
-    const menuWidth = 18
-    const rawX = editable.x + cursor.visualCol
-    const rawY = editable.y + cursor.visualRow + 1
-    const next = {
-      x: Math.max(0, Math.min(rawX, terminalWidth - menuWidth)),
-      y: Math.max(0, Math.min(rawY, terminalHeight - menuHeight)),
+    const updateAnchor = () => {
+      const next = readAnchor()
+      setCompletionAnchor((current) =>
+        current?.x === next?.x && current?.y === next?.y ? current : next,
+      )
     }
-    setCompletionAnchor((current) =>
-      current?.x === next.x && current?.y === next.y ? current : next,
-    )
+    updateAnchor()
+    const revealAfterAnchor = () => {
+      const popup = popupRef.current
+      if (popup) popup.visible = true
+    }
+    const syncAfterLayout = () => {
+      const next = readAnchor()
+      const popup = popupRef.current
+      if (!next || !popup) return
+      popup.left = next.x
+      popup.top = next.y
+      if (!anchorReadyRef.current) {
+        anchorReadyRef.current = true
+        renderer.once(CliRenderEvents.FRAME, revealAfterAnchor)
+      }
+    }
+    renderer.once(CliRenderEvents.FRAME, syncAfterLayout)
+    return () => {
+      renderer.off(CliRenderEvents.FRAME, syncAfterLayout)
+      renderer.off(CliRenderEvents.FRAME, revealAfterAnchor)
+    }
   }, [
     getEditable,
     isEditing,
     items.length,
     message,
+    renderer,
     terminalHeight,
     terminalWidth,
     value,
@@ -591,7 +623,9 @@ function CompletionPopup({
 
   return createPortal(
     <box
+      ref={popupRef}
       id={id}
+      visible={anchorReadyRef.current}
       style={{
         position: "absolute",
         top: completionAnchor.y,

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -175,8 +175,11 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       })
 
     const applyHighlights = useCallback(() => {
-      if (!variableAware) return
       const editable = getEditable()
+      if (!variableAware) {
+        editable?.clearAllHighlights()
+        return
+      }
       if (editable)
         highlightVariables(editable, editable.plainText, theme, env, pathParams)
     }, [env, getEditable, pathParams, theme, variableAware])

--- a/src/ui/keymap/runnerLayers.ts
+++ b/src/ui/keymap/runnerLayers.ts
@@ -68,8 +68,10 @@ export function createRunnerLayer(context: AppKeymapContext): UseBindingsLayer {
           if (state().phase === "running") return
           if (state().selectOpen) return
           if (focus() === "runner-options") {
-            if (state().optionIndex === 1) runner.openTagFilter("include")
-            else if (state().optionIndex === 2) runner.openTagFilter("exclude")
+            if (state().optionIndex === 1)
+              runner.openTagFilter("include", state().includeTagIndex)
+            else if (state().optionIndex === 2)
+              runner.openTagFilter("exclude", state().excludeTagIndex)
             else if (state().optionIndex === 3) state().toggleFailFast()
             else if (
               state().optionIndex === RUNNER_RUN_OPTION_INDEX &&
@@ -86,17 +88,20 @@ export function createRunnerLayer(context: AppKeymapContext): UseBindingsLayer {
         },
       },
       {
-        name: "runner.clear-tag-filter",
+        name: "runner.delete-tag-filter",
         enabled: () =>
           unlocked() &&
           focus() === "runner-options" &&
-          ((state().optionIndex === 1 && state().includeTag !== "") ||
-            (state().optionIndex === 2 && state().excludeTag !== "")),
-        run: () =>
-          state().setTagFilter(
-            state().optionIndex === 1 ? "include" : "exclude",
-            "",
-          ),
+          ((state().optionIndex === 1 &&
+            state().includeTagIndex < state().includeTags.length) ||
+            (state().optionIndex === 2 &&
+              state().excludeTagIndex < state().excludeTags.length)),
+        run: () => {
+          if (state().optionIndex === 1)
+            state().deleteTagFilter("include", state().includeTagIndex)
+          else if (state().optionIndex === 2)
+            state().deleteTagFilter("exclude", state().excludeTagIndex)
+        },
       },
       {
         name: "runner.toggle",
@@ -126,25 +131,33 @@ export function createRunnerLayer(context: AppKeymapContext): UseBindingsLayer {
         },
       },
       {
-        name: "runner.configure",
+        name: "runner.left",
         enabled: () =>
           unlocked() &&
-          focus() === "runner-requests" &&
-          state().result !== null,
+          ((focus() === "runner-options" &&
+            (state().optionIndex === 1 || state().optionIndex === 2)) ||
+            (focus() === "runner-requests" && state().result !== null)),
         run: () => {
-          state().showConfigure()
-          global.setFocus("runner-requests")
+          if (focus() === "runner-options") state().tagPrevious()
+          else {
+            state().showConfigure()
+            global.setFocus("runner-requests")
+          }
         },
       },
       {
-        name: "runner.results",
+        name: "runner.right",
         enabled: () =>
           unlocked() &&
-          focus() === "runner-requests" &&
-          state().result !== null,
+          ((focus() === "runner-options" &&
+            (state().optionIndex === 1 || state().optionIndex === 2)) ||
+            (focus() === "runner-requests" && state().result !== null)),
         run: () => {
-          state().showResults()
-          global.setFocus("runner-requests")
+          if (focus() === "runner-options") state().tagNext()
+          else {
+            state().showResults()
+            global.setFocus("runner-requests")
+          }
         },
       },
       {
@@ -185,11 +198,11 @@ export function createRunnerLayer(context: AppKeymapContext): UseBindingsLayer {
       { key: "r", cmd: "runner.run" },
       { key: "return", cmd: "runner.activate" },
       { key: "space", cmd: "runner.toggle" },
-      { key: keybinds.browse_delete, cmd: "runner.clear-tag-filter" },
+      { key: keybinds.browse_delete, cmd: "runner.delete-tag-filter" },
       { key: "pageup", cmd: "runner.page-up" },
       { key: "pagedown", cmd: "runner.page-down" },
-      { key: "left", cmd: "runner.configure" },
-      { key: "right", cmd: "runner.results" },
+      { key: "left", cmd: "runner.left" },
+      { key: "right", cmd: "runner.right" },
       { key: "tab", cmd: "runner.focus-next" },
       { key: "shift+tab", cmd: "runner.focus-prev" },
       { key: "escape", cmd: "runner.escape" },

--- a/src/ui/keymap/types.ts
+++ b/src/ui/keymap/types.ts
@@ -138,7 +138,7 @@ export interface AppKeymapRunner {
   runnerRef: RefObject<UseCollectionRunnerResult>
   detailScrollRef: RefObject<ScrollBoxRenderable | null>
   close: () => void
-  openTagFilter: (filter: "include" | "exclude") => void
+  openTagFilter: (filter: "include" | "exclude", index: number) => void
   openResultDetail: (index?: number) => void
 }
 

--- a/src/ui/overlays/TagEditorOverlay.tsx
+++ b/src/ui/overlays/TagEditorOverlay.tsx
@@ -2,13 +2,14 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react"
-import { type InputRenderable } from "@opentui/core"
 import { isValidTag } from "../../tags"
 import { ActionButton } from "../ActionButton"
 import { useTheme } from "../theme"
+import { VarInput, type VarInputHandle } from "../VarInput"
 import { EscapeClose } from "./EscapeClose"
 import { Overlay } from "./Overlay"
 
@@ -19,9 +20,11 @@ export interface TagEditorOverlayHandle {
 interface TagEditorOverlayProps {
   visible: boolean
   initialValue: string
+  suggestions: readonly string[]
   title?: string
   onConfirm?: () => void
   onClear?: () => void
+  onDelete?: () => void
   onClose?: () => void
 }
 
@@ -29,13 +32,26 @@ export const TagEditorOverlay = forwardRef<
   TagEditorOverlayHandle,
   TagEditorOverlayProps
 >(function TagEditorOverlay(
-  { visible, initialValue, title, onConfirm, onClear, onClose },
+  {
+    visible,
+    initialValue,
+    suggestions,
+    title,
+    onConfirm,
+    onClear,
+    onDelete,
+    onClose,
+  },
   ref,
 ) {
   const theme = useTheme()
   const [value, setValue] = useState(initialValue)
   const [errorText, setErrorText] = useState<string | null>(null)
-  const inputRef = useRef<InputRenderable | null>(null)
+  const inputRef = useRef<VarInputHandle | null>(null)
+  const completionValues = useMemo(
+    () => [...new Set(suggestions)].sort(),
+    [suggestions],
+  )
 
   useEffect(() => {
     if (visible) {
@@ -74,17 +90,18 @@ export const TagEditorOverlay = forwardRef<
 
       <box style={{ paddingX: 2, flexDirection: "column", paddingBottom: 1 }}>
         <text fg={theme.textMuted}>Tag</text>
-        <input
+        <VarInput
           ref={inputRef}
           value={value}
+          env={null}
+          isEditing
+          variableAware={false}
+          completionValues={completionValues}
           placeholder="e.g. smoke"
-          onInput={setValue}
-          focused
+          onChange={setValue}
           backgroundColor={theme.backgroundElement}
           focusedBackgroundColor={theme.borderSubtle}
-          textColor={theme.text}
-          cursorColor={theme.primary}
-          placeholderColor={theme.textMuted}
+          baseColor={theme.text}
         />
       </box>
 
@@ -110,11 +127,15 @@ export const TagEditorOverlay = forwardRef<
           label="save"
           onAction={() => onConfirm?.()}
         />
-        <ActionButton
-          shortcut="esc"
-          label="close"
-          onAction={() => onClose?.()}
-        />
+        {onDelete ? (
+          <ActionButton shortcut="^D" label="delete" onAction={onDelete} />
+        ) : (
+          <ActionButton
+            shortcut="esc"
+            label="close"
+            onAction={() => onClose?.()}
+          />
+        )}
       </box>
     </Overlay>
   )

--- a/src/ui/useOverlayIntercepts.ts
+++ b/src/ui/useOverlayIntercepts.ts
@@ -180,11 +180,7 @@ export function useOverlayIntercepts(opts: {
     handleRef: overlays.tagEditorRef,
     onConfirm: opts.onTagConfirm,
     onCancel: () => overlays.setTagEditPending(null),
-    onClear:
-      overlays.tagEditPending?.kind === "runner-filter" &&
-      overlays.tagEditPending.value
-        ? opts.onTagClear
-        : undefined,
+    onClear: overlays.tagEditPending?.value ? opts.onTagClear : undefined,
   })
 
   useEnvEditorIntercept(opts)

--- a/src/ui/useOverlayState.ts
+++ b/src/ui/useOverlayState.ts
@@ -24,6 +24,7 @@ export type TagEditPending =
   | {
       kind: "runner-filter"
       filter: "include" | "exclude"
+      index: number
       value: string
     }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -247,7 +247,52 @@ describe("CLI integration", () => {
     expect(out).toContain("Request IDs or folder paths ending in /")
     expect(out).toContain("--tag=<tag>")
     expect(out).toContain("--exclude-tag=<exclude_tag>")
+    expect(out).toContain("repeatable; all must match")
+    expect(out).toContain("repeatable; any match excludes")
     expect(out).toContain("--fail-fast")
+  })
+
+  it("accepts repeated tag filters in space and equals forms", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-cli-tags-"))
+    try {
+      await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
+      for (const [id, tags] of [
+        ["match", "smoke, api"],
+        ["missing-api", "smoke"],
+        ["excluded", "smoke, api, destructive"],
+      ]) {
+        await writeFile(
+          join(dir, `${id}.yml`),
+          `name: ${id}\nmethod: GET\nurl: https://example.com/$MISSING\ntags: [${tags}]\n`,
+        )
+      }
+      const proc = Bun.spawnSync(
+        [
+          "bun",
+          CLI,
+          "collection",
+          "run",
+          dir,
+          "--tag",
+          "smoke",
+          "--tag=api",
+          "--exclude-tag=destructive",
+          "--exclude-tag",
+          "slow",
+          "--json",
+        ],
+        { env: { ...process.env, HOME: join(dir, "home") } },
+      )
+      expect(proc.exitCode).toBe(1)
+      expect(JSON.parse(proc.stdout.toString())).toMatchObject({
+        data: {
+          results: [{ id: "match" }],
+          summary: { selected: 1, executed: 1 },
+        },
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   it("runs a folder target with JSON output", async () => {

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -404,7 +404,7 @@ describe("automation services", () => {
         undefined,
         false,
         [],
-        "smoke",
+        ["smoke", "smoke"],
       )
       expect(include.results.map((result) => result.id)).toEqual([
         "admin/drop",
@@ -422,11 +422,10 @@ describe("automation services", () => {
         undefined,
         false,
         [],
-        undefined,
-        "destructive",
+        [],
+        ["destructive", "users"],
       )
       expect(exclude.results.map((result) => result.id)).toEqual([
-        "users/list",
         "root",
         "untagged",
       ])
@@ -439,12 +438,11 @@ describe("automation services", () => {
         undefined,
         false,
         [],
-        "smoke",
-        "destructive",
+        ["smoke", "users"],
+        ["destructive"],
       )
       expect(combined.results.map((result) => result.id)).toEqual([
         "users/list",
-        "root",
       ])
       expect(combined.skipped).toEqual([])
 
@@ -456,8 +454,8 @@ describe("automation services", () => {
         undefined,
         false,
         ["users/"],
-        "smoke",
-        "destructive",
+        ["smoke", "users"],
+        ["destructive"],
       )
       expect(targeted.results.map((result) => result.id)).toEqual([
         "users/list",
@@ -467,8 +465,8 @@ describe("automation services", () => {
         selectCollectionRunRequests(
           loaded.items,
           ["users/"],
-          "smoke",
-          "destructive",
+          ["smoke", "users", "smoke"],
+          ["destructive", "destructive"],
         ).map((request) => request.id),
       ).toEqual(targeted.results.map((result) => result.id))
     } finally {
@@ -501,7 +499,7 @@ describe("automation services", () => {
           undefined,
           false,
           ["missing"],
-          "Smoke",
+          ["Smoke"],
         ),
       ).toMatchObject({
         failure: { message: 'collection target not found: "missing"' },
@@ -514,7 +512,7 @@ describe("automation services", () => {
         undefined,
         false,
         [],
-        "Smoke",
+        ["Smoke"],
       )
       expect(result).toMatchObject({
         failed: true,
@@ -572,7 +570,7 @@ describe("automation services", () => {
         undefined,
         false,
         [],
-        "smoke",
+        ["smoke"],
       )
       expect(sent).toEqual(["01-source", "03-use"])
       expect(result.results.map((item) => item.url)).toEqual([

--- a/tests/unit/AppOverlays.test.tsx
+++ b/tests/unit/AppOverlays.test.tsx
@@ -297,17 +297,18 @@ describe("AppOverlays routing", () => {
     cleanup()
   })
 
-  it("labels Runner filters contextually and offers clear only when set", async () => {
+  it("labels Runner filters contextually and offers delete only when set", async () => {
     const existing = await renderOverlays({
       activeOverlay: "tag-editor",
       tagEditPending: {
         kind: "runner-filter",
         filter: "include",
+        index: 0,
         value: "smoke",
       },
     })
     expect(existing.frame).toContain("Include Tag")
-    expect(existing.frame).toContain("^D clear")
+    expect(existing.frame).toContain("^D delete")
     existing.cleanup()
 
     const empty = await renderOverlays(
@@ -316,13 +317,14 @@ describe("AppOverlays routing", () => {
         tagEditPending: {
           kind: "runner-filter",
           filter: "exclude",
+          index: 0,
           value: "",
         },
       },
       { tagSuggestions: ["users", "smoke", "users"] },
     )
     expect(empty.frame).toContain("Exclude Tag")
-    expect(empty.frame).not.toContain("clear")
+    expect(empty.frame).not.toContain("delete")
     expect(empty.frame.indexOf("smoke")).toBeLessThan(
       empty.frame.indexOf("users"),
     )

--- a/tests/unit/AppOverlays.test.tsx
+++ b/tests/unit/AppOverlays.test.tsx
@@ -78,6 +78,7 @@ function baseProps() {
     cloneRequestActions: actions,
     newFolderActions: actions,
     tagEditorActions: actions,
+    tagSuggestions: [],
     updateFlow: { phase: "idle" as const },
     envColors: {},
     onLoadTimelineBody: async () => "",
@@ -286,6 +287,16 @@ describe("AppOverlays routing", () => {
     })
   }
 
+  it("replaces the footer close action with delete when editing a request tag", async () => {
+    const { frame, cleanup } = await renderOverlays({
+      activeOverlay: "tag-editor",
+      tagEditPending: { kind: "request", index: 0, value: "smoke" },
+    })
+    expect(frame).toContain("^D delete")
+    expect(frame).not.toContain("esc close")
+    cleanup()
+  })
+
   it("labels Runner filters contextually and offers clear only when set", async () => {
     const existing = await renderOverlays({
       activeOverlay: "tag-editor",
@@ -299,16 +310,23 @@ describe("AppOverlays routing", () => {
     expect(existing.frame).toContain("^D clear")
     existing.cleanup()
 
-    const empty = await renderOverlays({
-      activeOverlay: "tag-editor",
-      tagEditPending: {
-        kind: "runner-filter",
-        filter: "exclude",
-        value: "",
+    const empty = await renderOverlays(
+      {
+        activeOverlay: "tag-editor",
+        tagEditPending: {
+          kind: "runner-filter",
+          filter: "exclude",
+          value: "",
+        },
       },
-    })
+      { tagSuggestions: ["users", "smoke", "users"] },
+    )
     expect(empty.frame).toContain("Exclude Tag")
     expect(empty.frame).not.toContain("clear")
+    expect(empty.frame.indexOf("smoke")).toBeLessThan(
+      empty.frame.indexOf("users"),
+    )
+    expect(empty.frame.match(/users/g)).toHaveLength(1)
     empty.cleanup()
   })
 

--- a/tests/unit/CollectionRunnerView.test.tsx
+++ b/tests/unit/CollectionRunnerView.test.tsx
@@ -220,14 +220,14 @@ describe("CollectionRunnerView", () => {
     expect(requestRows[2]).toContain("#a-very-long-regression-tag")
     expect(requestRows.join("\n")).not.toContain("…")
     const tagColumn = requestRows[0]!.indexOf("#smoke")
-    await act(async () => current!.setTagFilter("include", "s"))
+    await act(async () => current!.setTagFilter("include", 0, "s"))
     await render.renderOnce()
     const filteredRows = render
       .captureCharFrame()
       .split("\n")
       .filter((row) => ["one", "two", "three"].some((id) => row.includes(id)))
     expect(filteredRows[0]!.indexOf("#smoke")).toBe(tagColumn)
-    await act(async () => current!.setTagFilter("include", ""))
+    await act(async () => current!.deleteTagFilter("include", 0))
     await render.renderOnce()
     const runButton = render.renderer.root.findDescendantById(
       "runner-run-button",
@@ -263,6 +263,8 @@ describe("CollectionRunnerView", () => {
     expect(current!.phase).toBe("running")
     expect(render.captureCharFrame()).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] Running 1\/3/)
     expect(render.captureCharFrame()).not.toContain("r Run 3 requests")
+    await act(async () => current!.setTagFilter("include", 0, "smoke"))
+    expect(current!.includeTags).toEqual([])
     await act(async () => reportProgress?.(1, 3))
     await render.renderOnce()
     expect(render.captureCharFrame()).toContain("Running 2/3")
@@ -396,6 +398,10 @@ describe("CollectionRunnerView", () => {
     const render = await testRender(<Harness />, { width: 80, height: 24 })
     await render.renderOnce()
     const frame = render.captureCharFrame()
+    const initialRunButton = render.renderer.root.findDescendantById(
+      "runner-run-button",
+    ) as BoxRenderable
+    const initialRunButtonWidth = initialRunButton.width
     for (const label of ["Scope", "Environment", "Health"]) {
       expect(frame).toContain(label)
     }
@@ -414,6 +420,21 @@ describe("CollectionRunnerView", () => {
       "Run every request in the collection or selected folder.",
     )
     expect(frame).toContain("Select the environment used for this run.")
+    await act(async () =>
+      current!.setTagFilter("include", 0, "a-very-long-regression-tag"),
+    )
+    await render.renderOnce()
+    await act(async () =>
+      current!.setTagFilter("include", 1, "another-very-long-runner-tag"),
+    )
+    await render.renderOnce()
+    const firstTag = render.renderer.root.findDescendantById(
+      "runner-include-tag-0",
+    )!
+    const secondTag = render.renderer.root.findDescendantById(
+      "runner-include-tag-1",
+    )!
+    expect(secondTag.screenY).toBeGreaterThan(firstTag.screenY)
     await act(async () => current!.setOptionIndex(4))
     await render.renderOnce()
     await render.renderOnce()
@@ -424,13 +445,14 @@ describe("CollectionRunnerView", () => {
     ) as BoxRenderable
     expect(runButton.screenY).toBeGreaterThan(failFast.screenY)
     expect(runButton.width).toBe("r Run 0 requests".length + 2)
+    expect(runButton.width).toBe(initialRunButtonWidth)
     expect(current!.optionIndex).toBe(4)
     expect(
       runButton.backgroundColor.equals(RGBA.fromHex(THEMES[0]!.primary)),
     ).toBe(true)
-    expect(scrolled).toContain("Exclude tag")
+    expect(scrolled).toContain("Exclude tags")
     expect(scrolled).toContain("Fail fast")
-    expect(scrolled).toContain("Any")
+    expect(scrolled).toContain("+ Add tag")
     expect(
       render.renderer.root.findDescendantById("runner-include-tag-input"),
     ).toBeUndefined()
@@ -441,7 +463,7 @@ describe("CollectionRunnerView", () => {
   it("switches between every Runner option by keyboard and mouse", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     let current: UseCollectionRunnerResult | null = null
-    const opened: Array<"include" | "exclude"> = []
+    const opened: Array<["include" | "exclude", number]> = []
     function Harness() {
       const detailScrollRef = useRef<ScrollBoxRenderable | null>(null)
       const runner = useCollectionRunner({
@@ -466,7 +488,7 @@ describe("CollectionRunnerView", () => {
               hasUnsavedChanges={false}
               detailScrollRef={detailScrollRef}
               onPaneFocus={() => {}}
-              onEditTagFilter={(filter) => opened.push(filter)}
+              onEditTagFilter={(filter, index) => opened.push([filter, index])}
               onOpenResultDetail={() => {}}
             />
           </ThemeProvider>
@@ -491,9 +513,26 @@ describe("CollectionRunnerView", () => {
       })
     }
 
+    const clickTag = async (filter: "include" | "exclude", index: number) => {
+      const tag = render.renderer.root.findDescendantById(
+        `runner-${filter}-tag-${index}`,
+      )!
+      await act(async () => {
+        await render.mockMouse.click(
+          tag.screenX + 1,
+          tag.screenY,
+          MouseButtons.LEFT,
+        )
+        await render.renderOnce()
+        await render.mockMouse.moveTo(0, 0)
+      })
+    }
+
     await clickOption(1)
     expect(current!.optionIndex).toBe(1)
-    expect(opened).toEqual(["include"])
+    expect(opened).toEqual([])
+    await clickTag("include", 0)
+    expect(opened).toEqual([["include", 0]])
     expect(
       render.renderer.root.findDescendantById("runner-include-tag-input"),
     ).toBeUndefined()
@@ -510,16 +549,19 @@ describe("CollectionRunnerView", () => {
         RGBA.fromHex(THEMES[0]!.backgroundElement),
       ),
     ).toBe(true)
-    await act(async () => current!.setTagFilter("include", "smoke"))
+    await act(async () => current!.setTagFilter("include", 0, "smoke"))
     await render.renderOnce()
-    expect(current!.includeTag).toBe("smoke")
+    expect(current!.includeTags).toEqual(["smoke"])
     expect(render.captureCharFrame()).toContain("#smoke")
+    await clickTag("include", 0)
+    expect(opened.at(-1)).toEqual(["include", 0])
     await clickOption(2)
     expect(current!.optionIndex).toBe(2)
-    expect(opened.at(-1)).toBe("exclude")
-    await act(async () => current!.setTagFilter("exclude", "destructive"))
+    await clickTag("exclude", 0)
+    expect(opened.at(-1)).toEqual(["exclude", 0])
+    await act(async () => current!.setTagFilter("exclude", 0, "destructive"))
     await render.renderOnce()
-    expect(current!.excludeTag).toBe("destructive")
+    expect(current!.excludeTags).toEqual(["destructive"])
 
     const environment = render.renderer.root.findDescendantById(
       "runner-option-0",
@@ -536,7 +578,7 @@ describe("CollectionRunnerView", () => {
       await render.mockMouse.moveTo(0, 0)
     })
     expect(current!.selectOpen).toBe(true)
-    expect(current!.excludeTag).toBe("destructive")
+    expect(current!.excludeTags).toEqual(["destructive"])
     const openSelectButton = render.renderer.root.findDescendantById(
       "runner-run-button",
     ) as BoxRenderable
@@ -554,8 +596,8 @@ describe("CollectionRunnerView", () => {
     expect(current!.failFast).toBe(true)
 
     await act(async () => {
-      current!.setTagFilter("include", "")
-      current!.setTagFilter("exclude", "")
+      current!.deleteTagFilter("include", 0)
+      current!.deleteTagFilter("exclude", 0)
       current!.setOptionIndex(0)
     })
     await render.renderOnce()

--- a/tests/unit/TagEditorOverlay.test.tsx
+++ b/tests/unit/TagEditorOverlay.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { act, createRef, useEffect } from "react"
+import { act, createRef, useEffect, useState } from "react"
 import { KeymapProvider, useKeymap } from "@opentui/keymap/react"
 import { MouseButtons } from "@opentui/core/testing"
 import { createTestRender } from "../testRender"
@@ -10,6 +10,7 @@ import {
   type TagEditorOverlayHandle,
 } from "../../src/ui/overlays/TagEditorOverlay"
 import { useSingleFieldFormOverlayIntercept } from "../../src/ui/intercepts/useFormOverlayIntercept"
+import { VariableCompletionInterceptor } from "../../src/ui/variable-completion/variableCompletionInterceptor"
 
 const testRender = createTestRender()
 
@@ -19,14 +20,18 @@ function KeyboardHarness({
   onClose,
   backgroundKeys,
   initialValue = "",
+  suggestions = [],
   onClear,
+  onDelete,
 }: {
   overlayRef: React.RefObject<TagEditorOverlayHandle | null>
   confirmed: string[]
   onClose: () => void
   backgroundKeys: string[]
   initialValue?: string
+  suggestions?: readonly string[]
   onClear?: () => void
+  onDelete?: () => void
 }) {
   const keymap = useKeymap()
   const actions = useSingleFieldFormOverlayIntercept({
@@ -34,7 +39,7 @@ function KeyboardHarness({
     handleRef: overlayRef,
     onConfirm: (tag) => confirmed.push(tag),
     onCancel: onClose,
-    onClear,
+    onClear: onClear ?? onDelete,
   })
 
   useEffect(
@@ -46,14 +51,42 @@ function KeyboardHarness({
   )
 
   return (
+    <>
+      <VariableCompletionInterceptor />
+      <TagEditorOverlay
+        visible
+        ref={overlayRef}
+        initialValue={initialValue}
+        suggestions={suggestions}
+        title={onClear ? "Include Tag" : undefined}
+        onConfirm={actions.confirm}
+        onClear={onClear ? actions.clear : undefined}
+        onDelete={onDelete ? actions.clear : undefined}
+        onClose={actions.cancel}
+      />
+    </>
+  )
+}
+
+function OpeningHarness({
+  overlayRef,
+  suggestions,
+  onReady,
+}: {
+  overlayRef: React.RefObject<TagEditorOverlayHandle | null>
+  suggestions: readonly string[]
+  onReady: (open: () => void) => void
+}) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => onReady(() => setVisible(true)), [onReady])
+
+  return (
     <TagEditorOverlay
-      visible
+      visible={visible}
       ref={overlayRef}
-      initialValue={initialValue}
-      title={onClear ? "Include Tag" : undefined}
-      onConfirm={actions.confirm}
-      onClear={onClear ? actions.clear : undefined}
-      onClose={actions.cancel}
+      initialValue=""
+      suggestions={suggestions}
     />
   )
 }
@@ -65,7 +98,12 @@ describe("TagEditorOverlay", () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <KeymapProvider keymap={keymap}>
         <ThemeProvider activeIndex={0} previewIndex={null}>
-          <TagEditorOverlay visible ref={ref} initialValue=" smoke" />
+          <TagEditorOverlay
+            visible
+            ref={ref}
+            initialValue=" smoke"
+            suggestions={[]}
+          />
         </ThemeProvider>
       </KeymapProvider>,
       { width: 70, height: 20 },
@@ -77,6 +115,125 @@ describe("TagEditorOverlay", () => {
     expect(captureCharFrame()).toContain(
       "Tag must be a non-empty trimmed string",
     )
+    cleanup()
+  })
+
+  it("filters suggestions case-insensitively and accepts before saving", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const ref = createRef<TagEditorOverlayHandle>()
+    const confirmed: string[] = []
+    const backgroundKeys: string[] = []
+    let closed = 0
+    const { renderOnce, captureCharFrame, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <KeyboardHarness
+            overlayRef={ref}
+            confirmed={confirmed}
+            onClose={() => closed++}
+            backgroundKeys={backgroundKeys}
+            suggestions={["users", "smoke-api", "Smoke", "Smoke"]}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 70, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => mockInput.typeText("sM"))
+    await renderOnce()
+    expect(captureCharFrame()).toContain("Smoke")
+    expect(captureCharFrame()).toContain("smoke-api")
+    expect(captureCharFrame()).not.toContain("users")
+
+    act(() => host.press("down"))
+    act(() => host.press("return"))
+    await renderOnce()
+    expect(confirmed).toEqual([])
+    act(() => host.press("return"))
+    expect(confirmed).toEqual(["smoke-api"])
+    expect(closed).toBe(0)
+    expect(backgroundKeys).toEqual([])
+    cleanup()
+  })
+
+  it("dismisses suggestions before closing the overlay", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const ref = createRef<TagEditorOverlayHandle>()
+    let closed = 0
+    const { renderOnce, mockInput } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <KeyboardHarness
+            overlayRef={ref}
+            confirmed={[]}
+            onClose={() => closed++}
+            backgroundKeys={[]}
+            suggestions={["smoke"]}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 70, height: 20 },
+    )
+    await renderOnce()
+    await act(async () => mockInput.typeText("sm"))
+    await renderOnce()
+
+    act(() => host.press("escape"))
+    await renderOnce()
+    expect(closed).toBe(0)
+    act(() => host.press("escape"))
+    expect(closed).toBe(1)
+    cleanup()
+  })
+
+  it("anchors sorted, deduplicated suggestions and accepts by mouse", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const ref = createRef<TagEditorOverlayHandle>()
+    let open = () => {}
+    const handleReady = (next: () => void) => {
+      open = next
+    }
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <OpeningHarness
+            overlayRef={ref}
+            suggestions={["users", "smoke", "users"]}
+            onReady={handleReady}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 70, height: 20 },
+    )
+    await renderOnce()
+    act(() => open())
+    await act(async () => {
+      await renderOnce()
+    })
+    expect(captureCharFrame()).not.toContain("users")
+    await act(async () => {
+      await renderOnce()
+    })
+    const frame = captureCharFrame()
+    expect(frame.indexOf("smoke")).toBeLessThan(frame.indexOf("users"))
+    expect(frame.match(/users/g)).toHaveLength(1)
+
+    const rows = frame.split("\n")
+    const inputY = rows.findIndex((row) => row.includes("e.g. smoke"))
+    const usersY = rows.findIndex((row) => row.includes("users"))
+    expect(usersY).toBe(inputY + 3)
+    expect(rows[usersY]!.indexOf("users")).toBeGreaterThanOrEqual(
+      rows[inputY]!.indexOf("e.g. smoke"),
+    )
+    await act(async () =>
+      mockMouse.click(
+        rows[usersY]!.indexOf("users"),
+        usersY,
+        MouseButtons.LEFT,
+      ),
+    )
+    await renderOnce()
+    act(() => expect(ref.current?.confirm()).toBe("users"))
     cleanup()
   })
 
@@ -147,6 +304,42 @@ describe("TagEditorOverlay", () => {
     expect(cleared).toBe(2)
     expect(confirmed).toEqual([])
     expect(backgroundKeys).toEqual([])
+    cleanup()
+  })
+
+  it("deletes an existing request tag by keyboard or mouse", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const ref = createRef<TagEditorOverlayHandle>()
+    let deleted = 0
+    const { renderOnce, captureCharFrame, mockMouse } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <KeyboardHarness
+            overlayRef={ref}
+            confirmed={[]}
+            onClose={() => {}}
+            backgroundKeys={[]}
+            initialValue="smoke"
+            onDelete={() => deleted++}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 70, height: 20 },
+    )
+    await renderOnce()
+    const frame = captureCharFrame()
+    expect(frame).toContain("^D delete")
+    expect(frame).not.toContain("esc close")
+
+    act(() => host.press("d", { ctrl: true }))
+    expect(deleted).toBe(1)
+
+    const rows = frame.split("\n")
+    const y = rows.findIndex((row) => row.includes("delete"))
+    await act(async () =>
+      mockMouse.click(rows[y]!.indexOf("delete"), y, MouseButtons.LEFT),
+    )
+    expect(deleted).toBe(2)
     cleanup()
   })
 })

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -304,6 +304,28 @@ describe("VarInput — edit mode (isEditing=true)", () => {
     expect(variable!.fg.equals(hexToRgba(theme.error))).toBe(true)
   })
 
+  it("can disable variable highlighting for plain values", async () => {
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <VarInput
+          value="$tag"
+          env={null}
+          isEditing
+          isFocused
+          variableAware={false}
+          onChange={() => {}}
+        />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    await renderOnce()
+    const spans = captureSpans().lines.flatMap((line) => line.spans)
+    const value = spans.find((span) => span.text.includes("$tag"))
+    expect(value).toBeDefined()
+    expect(value!.fg.equals(hexToRgba(theme.text))).toBe(true)
+  })
+
   it("renders input element with value", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>

--- a/tests/unit/VarInput.test.tsx
+++ b/tests/unit/VarInput.test.tsx
@@ -326,6 +326,44 @@ describe("VarInput — edit mode (isEditing=true)", () => {
     expect(value!.fg.equals(hexToRgba(theme.text))).toBe(true)
   })
 
+  it("clears existing highlights when variable awareness is disabled", async () => {
+    let setVariableAware: ((value: boolean) => void) | undefined
+    function Harness() {
+      const [variableAware, setAware] = useState(true)
+      setVariableAware = setAware
+      return (
+        <VarInput
+          value="$host"
+          env={env({ host: "localhost" })}
+          isEditing
+          isFocused
+          variableAware={variableAware}
+          onChange={() => {}}
+        />
+      )
+    }
+
+    const { renderOnce, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness />
+      </ThemeProvider>,
+      { width: 80, height: 5 },
+    )
+    await renderOnce()
+    await renderOnce()
+    let value = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("$host"))
+    expect(value?.fg.equals(hexToRgba(theme.primary))).toBe(true)
+
+    act(() => setVariableAware?.(false))
+    await renderOnce()
+    value = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.includes("$host"))
+    expect(value?.fg.equals(hexToRgba(theme.text))).toBe(true)
+  })
+
   it("renders input element with value", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <ThemeProvider activeIndex={0} previewIndex={null}>

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -72,11 +72,16 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     runnerOptionIndex: -1,
     runnerConfigure: 0,
     runnerResults: 0,
+    runnerTagPrevious: 0,
+    runnerTagNext: 0,
     runnerResultOpen: 0,
-    runnerTagFilterOpen: [] as Array<"include" | "exclude">,
-    runnerTagFilterSet: [] as Array<{
+    runnerTagFilterOpen: [] as Array<{
       filter: "include" | "exclude"
-      value: string
+      index: number
+    }>,
+    runnerTagFilterDelete: [] as Array<{
+      filter: "include" | "exclude"
+      index: number
     }>,
     cookieDelete: [] as Array<{
       kind: string
@@ -180,8 +185,10 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
         resultDetails: new Map(),
         canRun: true,
         optionIndex: 0,
-        includeTag: "",
-        excludeTag: "",
+        includeTags: [] as string[],
+        excludeTags: [] as string[],
+        includeTagIndex: 0,
+        excludeTagIndex: 0,
         setOptionIndex: (index: number) => {
           calls.runnerOptionIndex = index
         },
@@ -189,8 +196,10 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
         optionDown: () => calls.runnerOptionDown++,
         optionFirst: () => calls.runnerOptionFirst++,
         optionLast: () => calls.runnerOptionLast++,
-        setTagFilter: (filter: "include" | "exclude", value: string) =>
-          calls.runnerTagFilterSet.push({ filter, value }),
+        deleteTagFilter: (filter: "include" | "exclude", index: number) =>
+          calls.runnerTagFilterDelete.push({ filter, index }),
+        tagPrevious: () => calls.runnerTagPrevious++,
+        tagNext: () => calls.runnerTagNext++,
         toggleFailFast: () => calls.runnerFailFast++,
         resultUp: () => {},
         resultDown: () => {},
@@ -202,8 +211,8 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     },
     detailScrollRef: { current: null },
     close: () => calls.runnerClose++,
-    openTagFilter: (filter: "include" | "exclude") =>
-      calls.runnerTagFilterOpen.push(filter),
+    openTagFilter: (filter: "include" | "exclude", index: number) =>
+      calls.runnerTagFilterOpen.push({ filter, index }),
     openResultDetail: () => calls.runnerResultOpen++,
   }
   const context = {
@@ -398,14 +407,20 @@ describe("app keymap layers", () => {
     expect(calls.runnerOptionDown).toBe(1)
     expect(calls.runnerOptionFirst).toBe(1)
     expect(calls.runnerOptionLast).toBe(1)
-    expect(calls.runnerTagFilterOpen).toEqual(["include", "exclude"])
+    expect(calls.runnerTagFilterOpen).toEqual([
+      { filter: "include", index: 0 },
+      { filter: "exclude", index: 0 },
+    ])
     expect(calls.runnerFailFast).toBe(1)
     expect(calls.runnerRun).toBe(2)
     expect(calls.focus).toBe("runner-requests")
     expect(calls.runnerClose).toBe(1)
 
     context.runner.runnerRef.current.phase = "running"
+    context.runner.runnerRef.current.optionIndex = 1
+    host.press("return")
     host.press("escape")
+    expect(calls.runnerTagFilterOpen).toHaveLength(2)
     expect(calls.runnerClose).toBe(1)
 
     disposers.forEach((dispose) => dispose())
@@ -505,6 +520,8 @@ describe("app keymap layers", () => {
     expect(calls.runnerFailFast).toBe(0)
     expect(calls.runnerConfigure).toBe(0)
     expect(calls.runnerResults).toBe(0)
+    expect(calls.runnerTagPrevious).toBe(1)
+    expect(calls.runnerTagNext).toBe(1)
 
     host.press("tab")
     expect(calls.focus).toBe("runner-requests")
@@ -537,29 +554,31 @@ describe("app keymap layers", () => {
     cleanup()
   })
 
-  it("clears only the selected Runner tag filter with Ctrl+D", () => {
+  it("deletes only the active Runner tag with Ctrl+D", () => {
     const { keymap, host, cleanup } = setup()
     const { context, calls } = createContext(keymap)
     keymap.setData("app.view", "runner")
     keymap.setData("app.focus", "runner-options")
     context.global.viewRef.current = "runner"
     context.global.focusRef.current = "runner-options"
-    context.runner.runnerRef.current.includeTag = "smoke"
-    context.runner.runnerRef.current.excludeTag = "slow"
+    context.runner.runnerRef.current.includeTags = ["smoke", "api"]
+    context.runner.runnerRef.current.excludeTags = ["slow"]
+    context.runner.runnerRef.current.includeTagIndex = 1
+    context.runner.runnerRef.current.excludeTagIndex = 0
     const disposers = register(context)
 
     context.runner.runnerRef.current.optionIndex = 1
     host.press("d", { ctrl: true })
     context.runner.runnerRef.current.optionIndex = 2
     host.press("d", { ctrl: true })
-    expect(calls.runnerTagFilterSet).toEqual([
-      { filter: "include", value: "" },
-      { filter: "exclude", value: "" },
+    expect(calls.runnerTagFilterDelete).toEqual([
+      { filter: "include", index: 1 },
+      { filter: "exclude", index: 0 },
     ])
 
     keymap.setData("app.overlay", "tag-editor")
     host.press("d", { ctrl: true })
-    expect(calls.runnerTagFilterSet).toHaveLength(2)
+    expect(calls.runnerTagFilterDelete).toHaveLength(2)
 
     disposers.forEach((dispose) => dispose())
     cleanup()

--- a/tests/unit/useCollectionRunner.test.tsx
+++ b/tests/unit/useCollectionRunner.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { createTestRender } from "../testRender"
 import {
   useCollectionRunner,
@@ -47,7 +47,11 @@ function renderHook(
   options: Partial<Parameters<typeof useCollectionRunner>[0]> = {},
 ) {
   let runner: UseCollectionRunnerResult | null = null
+  let resetRunner = () => {}
+  const { resetKey: initialResetKey = 1, ...rest } = options
   function Harness() {
+    const [resetKey, setResetKey] = useState(initialResetKey)
+    resetRunner = () => setResetKey((key) => key + 1)
     runner = useCollectionRunner({
       collection,
       collectionDir: "/tmp/runner",
@@ -58,14 +62,15 @@ function renderHook(
       noProxy: false,
       systemProxy: { bypass: [] },
       insecure: false,
-      resetKey: 1,
-      ...options,
+      resetKey,
+      ...rest,
     })
     return null
   }
   return {
     render: testRender(<Harness />, { width: 20, height: 4 }),
     get: () => runner!,
+    reset: () => resetRunner(),
   }
 }
 
@@ -140,12 +145,12 @@ describe("useCollectionRunner", () => {
     ])
   })
 
-  it("previews inherited filters with exclusion precedence", async () => {
+  it("previews inherited filters with AND matching and exclusion precedence", async () => {
     const harness = renderHook()
     const render = await harness.render
     await render.renderOnce()
     await act(async () => {
-      harness.get().setTagFilter("include", "smoke")
+      harness.get().setTagFilter("include", 0, "smoke")
     })
     await render.renderOnce()
     expect([...harness.get().matchedIds]).toEqual([
@@ -155,10 +160,53 @@ describe("useCollectionRunner", () => {
     ])
 
     await act(async () => {
-      harness.get().setTagFilter("exclude", "destructive")
+      harness.get().setTagFilter("include", 1, "safe")
+    })
+    await render.renderOnce()
+    expect([...harness.get().matchedIds]).toEqual(["admin/second"])
+
+    await act(async () => {
+      harness.get().deleteTagFilter("include", 1)
+      harness.get().setTagFilter("exclude", 0, "destructive")
     })
     await render.renderOnce()
     expect([...harness.get().matchedIds]).toEqual(["root"])
+  })
+
+  it("navigates, deduplicates, deletes, and resets transient tag filters", async () => {
+    const harness = renderHook()
+    const render = await harness.render
+    await render.renderOnce()
+
+    await act(async () => {
+      harness.get().setTagFilter("include", 0, "smoke")
+    })
+    await render.renderOnce()
+    await act(async () => harness.get().setTagFilter("include", 1, "safe"))
+    await render.renderOnce()
+    expect(harness.get().includeTags).toEqual(["smoke", "safe"])
+    expect(harness.get().includeTagIndex).toBe(1)
+
+    await act(async () => {
+      harness.get().setTagFilter("include", 2, "smoke")
+      harness.get().setOptionIndex(1)
+    })
+    await render.renderOnce()
+    expect(harness.get().includeTags).toEqual(["smoke", "safe"])
+    expect(harness.get().includeTagIndex).toBe(0)
+
+    await act(async () => harness.get().tagNext())
+    expect(harness.get().includeTagIndex).toBe(1)
+    await act(async () => harness.get().deleteTagFilter("include", 1))
+    expect(harness.get().includeTags).toEqual(["smoke"])
+    expect(harness.get().includeTagIndex).toBe(0)
+
+    await act(async () => harness.reset())
+    await render.renderOnce()
+    expect(harness.get().includeTags).toEqual([])
+    expect(harness.get().excludeTags).toEqual([])
+    expect(harness.get().includeTagIndex).toBe(0)
+    expect(harness.get().excludeTagIndex).toBe(0)
   })
 
   it("keeps environment local and routes selection, filters, progress, and fail-fast through collectionRun", async () => {
@@ -218,17 +266,21 @@ describe("useCollectionRunner", () => {
     await render.renderOnce()
     await act(async () => {
       harness.get().setEnvironmentName("staging")
-      harness.get().setTagFilter("include", "smoke")
+      harness.get().setTagFilter("include", 0, "smoke")
+      harness.get().setTagFilter("exclude", 0, "slow")
       harness.get().toggleFailFast()
     })
+    await render.renderOnce()
+    await act(async () => harness.get().setTagFilter("exclude", 1, "flaky"))
     await render.renderOnce()
     await act(async () => await harness.get().run())
     await render.renderOnce()
     expect(args?.[1]).toBe("staging")
     expect(args?.[6]).toEqual(["root", "admin/first", "admin/second"])
-    expect(args?.[7]).toBe("smoke")
+    expect(args?.[7]).toEqual(["smoke"])
+    expect(args?.[8]).toEqual(["slow", "flaky"])
     expect(args?.[9]).toBe(true)
-    expect(harness.get().includeTag).toBe("smoke")
+    expect(harness.get().includeTags).toEqual(["smoke"])
     expect(harness.get().progress).toEqual({ completed: 1, total: 1 })
     expect(harness.get().resultRows.map((row) => row.id)).toEqual([
       "root",
@@ -261,14 +313,14 @@ describe("useCollectionRunner", () => {
     await render.renderOnce()
 
     await act(async () => {
-      harness.get().setTagFilter("include", "missing")
+      harness.get().setTagFilter("include", 0, "missing")
     })
     await render.renderOnce()
     expect(harness.get().canRun).toBe(false)
-    expect(harness.get().includeTag).toBe("missing")
+    expect(harness.get().includeTags).toEqual(["missing"])
 
     await act(async () => {
-      harness.get().setTagFilter("include", "smoke")
+      harness.get().setTagFilter("include", 0, "smoke")
     })
     await render.renderOnce()
     expect(harness.get().canRun).toBe(true)


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- `collection run` now accepts repeated `--tag` (AND) and `--exclude-tag` (OR) filters; updates CLI, services, runner hook, and runner view to select/clear/display multiple tags.
- Tag editor adds autocomplete suggestions from existing collection tags and a delete action; `VarInput` exposes suggestion filtering for tags.

### How did you verify your code works?

Ran locally and verified via automated checks:
- `bun test` — 3053 pass, 0 fail
- `bun run lint` — passes
- `bun run typecheck` — passes

Reviewer can run `bun test tests/cli.test.ts tests/integration/automation.test.ts tests/unit/useCollectionRunner.test.tsx tests/unit/TagEditorOverlay.test.tsx` and try `noodle collection run --tag smoke --tag api --exclude-tag destructive`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple Include and Exclude tags when running collections.
  * Include filters require all specified tags; Exclude filters remove requests matching any specified tag.
  * Added tag suggestions, completion, indexed editing, navigation, and individual tag deletion.
  * Added clearer tag-filter controls and improved tag editing.

* **Documentation**
  * Updated CLI help and usage examples for repeatable tag-filter options.

* **Bug Fixes**
  * Exclusion filters take precedence when a request matches both filter types.
  * Duplicate tag filters no longer affect results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->