### PR TITLE
feat(ui): add optional scrollbar to Select dropdown and improve scroll-into-view behavior

### DIFF
--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, isValidElement } from "react"
 import type { ReactNode } from "react"
 import {
+  CliRenderEvents,
   MouseButton,
   TextAttributes,
   type ScrollBoxRenderable,
@@ -30,6 +31,7 @@ export interface SelectProps {
   placeholder?: string
   width?: number
   maxDropdownHeight?: number
+  showDropdownScrollbar?: boolean
   dropdownAlign?: "left" | "right"
   badge?: boolean
   fitContent?: boolean
@@ -49,6 +51,7 @@ export function Select({
   placeholder = "Select...",
   width,
   maxDropdownHeight = 16,
+  showDropdownScrollbar = false,
   dropdownAlign = "left",
   badge = false,
   fitContent = false,
@@ -90,12 +93,19 @@ export function Select({
   }, [open, safeInitialIndex])
 
   useEffect(() => {
-    if (open) {
+    if (!open) return
+    const scrollHighlightedIntoView = () => {
       const idx = Math.min(highlightIndex, Math.max(0, items.length - 1))
       const id = items[idx]?.id
       if (id) scrollRef.current?.scrollChildIntoView(`${uid}${id}`)
     }
-  }, [highlightIndex, open, items])
+
+    scrollHighlightedIntoView()
+    renderer.once(CliRenderEvents.FRAME, scrollHighlightedIntoView)
+    return () => {
+      renderer.off(CliRenderEvents.FRAME, scrollHighlightedIntoView)
+    }
+  }, [highlightIndex, open, items, renderer, uid])
 
   useEffect(() => {
     if (open || !focused || !interactive) return
@@ -301,7 +311,17 @@ export function Select({
                 ref={ref}
                 scrollY
                 maxHeight={dropdownMaxHeight}
-                scrollbarOptions={{ visible: false }}
+                horizontalScrollbarOptions={{ visible: false }}
+                verticalScrollbarOptions={
+                  showDropdownScrollbar
+                    ? {
+                        trackOptions: {
+                          backgroundColor: theme.background,
+                          foregroundColor: theme.borderActive,
+                        },
+                      }
+                    : { visible: false }
+                }
               >
                 <box style={{ flexDirection: "column" }}>
                   {items.map((item, i) => {

--- a/src/ui/request-pane/AssertTab.tsx
+++ b/src/ui/request-pane/AssertTab.tsx
@@ -228,6 +228,8 @@ export function AssertTab({
                   interactive={interactive}
                   triggerColor={dimmed ? theme.textMuted : undefined}
                   width={OPERATOR_WIDTH}
+                  maxDropdownHeight={10}
+                  showDropdownScrollbar
                 />
               </box>
               <box

--- a/tests/unit/AssertTab.test.tsx
+++ b/tests/unit/AssertTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { RGBA, type BoxRenderable } from "@opentui/core"
+import { RGBA, ScrollBoxRenderable, type BoxRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { act, useState } from "react"
 import { createTestKeymap } from "@opentui/keymap/testing"
@@ -224,8 +224,9 @@ describe("AssertTab", () => {
   })
 
   it("uses the normal select surface and opens with one mouse click", async () => {
-    const { keymap, cleanup } = setup()
+    const { keymap, host, cleanup } = setup()
     function Harness() {
+      const [operator, setOperator] = useState<AssertionOperator>("exists")
       const [editState, setEditState] = useState<EditState>({
         mode: "inactive",
         cursor: { field: "assertions", row: 0, addingRow: false },
@@ -243,11 +244,11 @@ describe("AssertTab", () => {
               editState={editState}
               editKey="body.id"
               editValue=""
-              editOperator="exists"
+              editOperator={operator}
               editError={null}
               setEditKey={() => {}}
               setEditValue={() => {}}
-              setEditOperator={() => {}}
+              setEditOperator={setOperator}
               onActivateRow={(row, addingRow, subfield) => {
                 setEditState({
                   mode: "editing",
@@ -283,8 +284,40 @@ describe("AssertTab", () => {
           trigger.y,
           MouseButtons.LEFT,
         )
+        await render.renderOnce()
       })
-      await render.renderOnce()
+      await act(async () => render.renderOnce())
+
+      const dropdown = render.renderer.root.getChildren().at(-1)
+      const scrollbox = dropdown?.getChildren()[0]
+      expect(scrollbox).toBeInstanceOf(ScrollBoxRenderable)
+      const operatorScrollbox = scrollbox as ScrollBoxRenderable
+      expect(operatorScrollbox.height).toBe(10)
+      expect(operatorScrollbox.verticalScrollBar.visible).toBe(true)
+      expect(
+        operatorScrollbox.verticalScrollBar.slider.backgroundColor.equals(
+          RGBA.fromHex(THEMES[0]!.background),
+        ),
+      ).toBe(true)
+      expect(
+        operatorScrollbox.verticalScrollBar.slider.foregroundColor.equals(
+          RGBA.fromHex(THEMES[0]!.borderActive),
+        ),
+      ).toBe(true)
+      expect(render.captureCharFrame()).not.toContain("notEquals")
+
+      await act(async () => {
+        for (let i = 0; i < 10; i++) host.press("down")
+        await render.renderOnce()
+      })
+      await act(async () => render.renderOnce())
+      expect(operatorScrollbox.scrollTop).toBeGreaterThan(0)
+      expect(render.captureCharFrame()).toContain("notEquals")
+
+      await act(async () => {
+        host.press("return")
+        await render.renderOnce()
+      })
       expect(render.captureCharFrame()).toContain("notEquals")
     } finally {
       cleanup()

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import { act } from "react"
 import { createTestRender } from "../testRender"
+import { ScrollBoxRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { ThemeProvider } from "../../src/ui/theme"
@@ -96,6 +97,82 @@ describe("Select", () => {
     await renderOnce()
     expect(open).toBe(true)
     cleanup()
+  })
+
+  for (const [name, maxHeight, height, showScrollbar, visible] of [
+    ["shows the scrollbar when items overflow", 2, 2, true, true],
+    ["hides the scrollbar when items fit", 4, 3, true, false],
+    ["keeps the scrollbar hidden when items overflow", 2, 2, false, false],
+  ] as const) {
+    it(`${name} an explicit max height`, async () => {
+      const { keymap, host, cleanup } = setupKeymap()
+      try {
+        const render = await testRender(
+          <KeymapProvider keymap={keymap}>
+            <ThemeProvider activeIndex={0} previewIndex={null}>
+              <Select
+                items={testItems}
+                focused
+                maxDropdownHeight={maxHeight}
+                showDropdownScrollbar={showScrollbar}
+              />
+            </ThemeProvider>
+          </KeymapProvider>,
+          { width: 40, height: 10 },
+        )
+        await render.renderOnce()
+
+        act(() => host.press("return"))
+        await render.renderOnce()
+        await render.renderOnce()
+
+        const dropdown = render.renderer.root.getChildren().at(-1)
+        const scrollbox = dropdown?.getChildren()[0]
+        expect(scrollbox).toBeInstanceOf(ScrollBoxRenderable)
+        expect((scrollbox as ScrollBoxRenderable).height).toBe(height)
+        expect(
+          (scrollbox as ScrollBoxRenderable).verticalScrollBar.visible,
+        ).toBe(visible)
+      } finally {
+        cleanup()
+      }
+    })
+  }
+
+  it("opens with the selected item scrolled into view", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    try {
+      const items = Array.from({ length: 18 }, (_, index) => ({
+        id: `item-${index}`,
+        label: `Item ${index}`,
+      }))
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <Select
+              items={items}
+              value="item-15"
+              focused
+              maxDropdownHeight={10}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 40, height: 20 },
+      )
+      await render.renderOnce()
+
+      act(() => host.press("return"))
+      await render.renderOnce()
+      await render.renderOnce()
+
+      const dropdown = render.renderer.root.getChildren().at(-1)
+      const scrollbox = dropdown?.getChildren()[0]
+      expect(scrollbox).toBeInstanceOf(ScrollBoxRenderable)
+      expect((scrollbox as ScrollBoxRenderable).scrollTop).toBeGreaterThan(0)
+      expect(render.captureCharFrame().match(/Item 15/g)).toHaveLength(2)
+    } finally {
+      cleanup()
+    }
   })
 
   it("opens and selects with left clicks", async () => {


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `showDropdownScrollbar` and `maxDropdownHeight` support to `Select` (`src/ui/Select.tsx:31`, `src/ui/Select.tsx:54`) with themed scrollbar styling when enabled, defers `scrollChildIntoView` to next `FRAME` to ensure selected item is visible on open (`src/ui/Select.tsx:95`), and applies it to the assertion operator select (`src/ui/request-pane/AssertTab.tsx:231`).

### How did you verify your code works?

- `bun test` — 3059 pass, 0 fail (added coverage in `tests/unit/Select.test.tsx` and `tests/unit/AssertTab.test.tsx`)
- `bun run lint` — pass
- `bun run typecheck` — pass
- Manual verification via existing unit tests: scrollbar visibility when overflowing vs fitting, hidden when disabled, and pre-selected item scrolled into view on open.

### Screenshots / recordings

N/A — terminal UI change covered by unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional scrollbars to dropdown menus.
  * Long dropdown lists can now use a fixed height and scroll vertically.
  * Dropdowns automatically bring the selected option into view when opened.
  * Assertion operator selection now supports a scrollable, themed dropdown.

* **Bug Fixes**
  * Improved dropdown scrolling behavior across renders and when navigating options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->