### PR TITLE
feat(response): add prefix-aware expression completion with timeline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Noodle are documented in this file.
 
 ### ✨ Features
 
-- Split request authoring into focused Assert and Capture tabs, keep tags in Settings, and preserve shared validation and response-aware expression completion.
+- Split request authoring into focused Assert and Capture tabs, keep tags in Settings, preserve shared validation, and complete response expressions from the current response or latest retained timeline response.
 - Add persistent per-row Assert and Capture checkboxes, with disabled declarations retained in YAML and excluded from evaluation and results.
 - Evaluate captures and assertions on every manual send with a fresh RunScope, keep Results available, and mark the tab when a send has assertion or capture outcomes.
 - Add a transient collection Runner with request selection, local environment and tag filters, fail-fast execution, progress, and detailed in-memory results.

--- a/src/hooks/useResponse.ts
+++ b/src/hooks/useResponse.ts
@@ -31,6 +31,7 @@ import type { CaptureResult } from "../runScope"
 type CachedResult =
   | {
       status: "done"
+      requestId: string
       response: Response
       execution?: ResponseExecutionResults
     }
@@ -205,7 +206,7 @@ async function runSend(
       await onEnvironmentPersisted?.().catch(() => {})
     }
     const result = { status: "done" as const, response: res, execution }
-    cacheRef.current.set(req.id, result)
+    cacheRef.current.set(req.id, { ...result, requestId: req.id })
     setState((prev) => finishSend(prev, req, res, execution))
     onCompleteRef.current?.(req, result)
   } catch (e) {

--- a/src/response.ts
+++ b/src/response.ts
@@ -21,6 +21,15 @@ export type ResponseExpressionResult =
 
 export type ResponseResolver = (expression: string) => ResponseExpressionResult
 
+export interface ResponseExpressionSuggestion {
+  value: string
+  label: string
+}
+
+export type ResponseExpressionCompleter = (
+  prefix: string,
+) => ResponseExpressionSuggestion[]
+
 const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
 const PROPERTY_RE = /^[A-Za-z_][A-Za-z0-9_-]*/
 
@@ -35,46 +44,75 @@ export function parseResponseBody(body: string): ParsedResponseBody {
   }
 }
 
-export function responseExpressionSuggestions(
-  response?: Pick<Response, "headers" | "body">,
-): string[] {
-  const suggestions = new Set([
+export function createResponseExpressionCompleter(
+  response?: Pick<Response, "headers"> & { body?: string },
+): ResponseExpressionCompleter {
+  const staticSuggestions = [
     "status",
     "body",
     "body.",
     "headers.",
     "response.time",
-  ])
-  if (!response) return [...suggestions]
-
-  for (const name of Object.keys(response.headers)) {
-    const expression = `headers.${name}`
-    try {
-      parseResponseExpression(expression)
-      suggestions.add(expression)
-    } catch {
-      // Ignore invalid server-provided header names.
-    }
-  }
-
-  const parsed = parseResponseBody(response.body)
-  if (
-    parsed.kind === "success" &&
-    parsed.value !== null &&
-    typeof parsed.value === "object" &&
-    !Array.isArray(parsed.value)
-  ) {
-    for (const key of Object.keys(parsed.value)) {
-      const expression = `body.${key}`
+  ].map((value) => ({ value, label: value }))
+  const headerSuggestions = Object.keys(response?.headers ?? {}).flatMap(
+    (name) => {
+      const value = `headers.${name}`
       try {
-        parseResponseExpression(expression)
-        suggestions.add(expression)
+        parseResponseExpression(value)
+        return [{ value, label: name }]
       } catch {
-        // Only parser-supported top-level keys are useful completions.
+        return []
+      }
+    },
+  )
+  const body = response?.body
+  const parsedBody = body ? parseResponseBody(body) : undefined
+
+  return (prefix) => {
+    const suggestions = [...staticSuggestions]
+    if (prefix.startsWith("headers.")) suggestions.push(...headerSuggestions)
+    if (parsedBody?.kind !== "success") {
+      return matchingSuggestions(suggestions, prefix)
+    }
+
+    const indexMatch = /^(.*)\[(\d*)$/.exec(prefix)
+    const propertyMatch = /^(.*)\.([A-Za-z0-9_-]*)$/.exec(prefix)
+    const parentExpression = indexMatch?.[1] ?? propertyMatch?.[1]
+    if (!parentExpression) return matchingSuggestions(suggestions, prefix)
+
+    let parent: ResponseExpression
+    try {
+      parent = parseResponseExpression(parentExpression)
+    } catch {
+      return matchingSuggestions(suggestions, prefix)
+    }
+    if (parent.kind !== "body") {
+      return matchingSuggestions(suggestions, prefix)
+    }
+
+    const value = bodyPathValue(parsedBody.value, parent.path)
+    const candidates = Array.isArray(value)
+      ? value.map((_, index) => ({
+          value: `${parentExpression}[${index}]`,
+          label: `[${index}]`,
+        }))
+      : value !== null && typeof value === "object"
+        ? Object.keys(value).map((key) => ({
+            value: `${parentExpression}.${key}`,
+            label: key,
+          }))
+        : []
+
+    for (const candidate of candidates) {
+      try {
+        parseResponseExpression(candidate.value)
+        suggestions.push(candidate)
+      } catch {
+        // Ignore JSON keys that response expressions cannot address.
       }
     }
+    return matchingSuggestions(suggestions, prefix)
   }
-  return [...suggestions]
 }
 
 export function parseResponseExpression(
@@ -182,4 +220,36 @@ export function createResponseResolver(
 
 function invalidExpression(expression: string): Error {
   return new Error(`Invalid response expression "${expression}"`)
+}
+
+function bodyPathValue(value: unknown, path: ResponsePathPart[]): unknown {
+  for (const part of path) {
+    if (part.kind === "index") {
+      if (!Array.isArray(value) || !Object.hasOwn(value, part.index)) {
+        return undefined
+      }
+      value = value[part.index]
+      continue
+    }
+    if (
+      value === null ||
+      typeof value !== "object" ||
+      Array.isArray(value) ||
+      !Object.hasOwn(value, part.name)
+    ) {
+      return undefined
+    }
+    value = (value as Record<string, unknown>)[part.name]
+  }
+  return value
+}
+
+function matchingSuggestions(
+  suggestions: ResponseExpressionSuggestion[],
+  prefix: string,
+): ResponseExpressionSuggestion[] {
+  const normalized = prefix.toLowerCase()
+  return suggestions.filter(({ value }) =>
+    value.toLowerCase().startsWith(normalized),
+  )
 }

--- a/src/response.ts
+++ b/src/response.ts
@@ -70,7 +70,9 @@ export function createResponseExpressionCompleter(
 
   return (prefix) => {
     const suggestions = [...staticSuggestions]
-    if (prefix.startsWith("headers.")) suggestions.push(...headerSuggestions)
+    if (prefix.toLowerCase().startsWith("headers.")) {
+      suggestions.push(...headerSuggestions)
+    }
     if (parsedBody?.kind !== "success") {
       return matchingSuggestions(suggestions, prefix)
     }

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -539,6 +539,7 @@ export function AppInner({
     isCollection ? collectionDir : undefined,
     selectedRequest?.id,
     timelineMaxEntries,
+    eb.activeTab === "assertions" || eb.activeTab === "captures",
   )
   const timelineAppendRef = useRef(timeline.appendEntry)
   timelineAppendRef.current = timeline.appendEntry

--- a/src/ui/KeyValueSection.tsx
+++ b/src/ui/KeyValueSection.tsx
@@ -9,7 +9,7 @@ import { Fragment, useState } from "react"
 import type { EditState } from "./editMode"
 import type { Theme } from "./theme"
 import { Checkbox } from "./Checkbox"
-import { VarInput } from "./VarInput"
+import { VarInput, type ValueCompletion } from "./VarInput"
 import { Select } from "./Select"
 
 const CAPTURE_PERSISTENCE_ITEMS = [
@@ -33,7 +33,7 @@ export interface KeyValueSectionProps {
   ) => void
   theme: Theme
   activeEnv?: Environment | null
-  completionValues?: readonly string[]
+  completionValues?: readonly ValueCompletion[]
   editError?: string | null
   onActivateRow?: (
     row: number,

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -27,11 +27,11 @@ import { SettingsSection } from "./request-pane/RequestSettingsTab"
 import { syncPathParamsWithUrl } from "./urlParams"
 import type { CodeEditorRenderable } from "./editor/CodeEditor"
 import { AssertTab } from "./request-pane/AssertTab"
-import { responseExpressionSuggestions } from "../response"
+import { createResponseExpressionCompleter } from "../response"
 
 interface Props {
   request: Request | null
-  response?: Response
+  response?: Pick<Response, "headers"> & { body?: string }
   visible?: boolean
   error?: Error | null
   editState: EditState
@@ -137,6 +137,10 @@ export function RequestPane({
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
   const bodyEditorRef = useRef<CodeEditorRenderable | null>(null)
   const keymap = useKeymap()
+  const completeResponseExpression = useMemo(
+    () => createResponseExpressionCompleter(response),
+    [response],
+  )
   const isTextBody =
     activeTab === "body" &&
     (request?.bodyType === undefined ||
@@ -521,7 +525,7 @@ export function RequestPane({
                   {activeTab === "assertions" && (
                     <AssertTab
                       request={request}
-                      response={response}
+                      completionValues={completeResponseExpression(editKey)}
                       editState={editState}
                       editKey={editKey}
                       editValue={editValue}
@@ -574,7 +578,7 @@ export function RequestPane({
                       setEditCapturePersistence={setEditCapturePersistence}
                       theme={theme}
                       activeEnv={activeEnv}
-                      completionValues={responseExpressionSuggestions(response)}
+                      completionValues={completeResponseExpression(editValue)}
                       editError={editError}
                       onActivateRow={
                         onFieldActivate

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -101,13 +101,15 @@ export function RequestResponseView({
   const responseVisible = expanded !== "request"
   const localSplitContainerRef = useRef<BoxRenderable | null>(null)
   const activeSplitContainerRef = splitContainerRef ?? localSplitContainerRef
+  const expressionResponse =
+    responseState.status === "done"
+      ? responseState.response
+      : timelineEntries.find((entry) => entry.response)?.response
 
   const requestPane = (
     <RequestPane
       request={draft.draft}
-      response={
-        responseState.status === "done" ? responseState.response : undefined
-      }
+      response={expressionResponse}
       visible={requestVisible}
       error={error}
       editState={eb.editState}

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -102,7 +102,8 @@ export function RequestResponseView({
   const localSplitContainerRef = useRef<BoxRenderable | null>(null)
   const activeSplitContainerRef = splitContainerRef ?? localSplitContainerRef
   const expressionResponse =
-    responseState.status === "done"
+    responseState.status === "done" &&
+    responseState.requestId === draft.draft?.id
       ? responseState.response
       : timelineEntries.find(
           (entry) => entry.response && entry.request.id === draft.draft?.id,

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -104,7 +104,9 @@ export function RequestResponseView({
   const expressionResponse =
     responseState.status === "done"
       ? responseState.response
-      : timelineEntries.find((entry) => entry.response)?.response
+      : timelineEntries.find(
+          (entry) => entry.response && entry.request.id === draft.draft?.id,
+        )?.response
 
   const requestPane = (
     <RequestPane

--- a/src/ui/VarInput.tsx
+++ b/src/ui/VarInput.tsx
@@ -93,6 +93,8 @@ export interface VarInputHandle {
   focus: () => void
 }
 
+export type ValueCompletion = string | { value: string; label: string }
+
 export interface VarInputProps {
   value: string
   env: Environment | null
@@ -110,7 +112,7 @@ export interface VarInputProps {
   variableAware?: boolean
   pathParams?: ParamEntry[]
   pathCompletion?: PathCompletionOptions
-  completionValues?: readonly string[]
+  completionValues?: readonly ValueCompletion[]
   stopMousePropagation?: boolean
   onFocus?: () => void
 }
@@ -270,9 +272,15 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       if (!completionValues) return []
       const prefix = value.toLowerCase()
       return completionValues
+        .map((suggestion) =>
+          typeof suggestion === "string"
+            ? { value: suggestion, label: suggestion }
+            : suggestion,
+        )
         .filter(
           (suggestion) =>
-            suggestion !== value && suggestion.toLowerCase().startsWith(prefix),
+            suggestion.value !== value &&
+            suggestion.value.toLowerCase().startsWith(prefix),
         )
         .slice(0, MAX_COMPLETION_VISIBLE)
     }, [completionValues, value])
@@ -282,9 +290,9 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
         const editable = getEditable()
         const suggestion = valueSuggestions[index]
         if (!editable?.focused || !suggestion) return false
-        editable.replaceText(suggestion)
-        editable.cursorOffset = suggestion.length
-        onChange?.(suggestion)
+        editable.replaceText(suggestion.value)
+        editable.cursorOffset = suggestion.value.length
+        onChange?.(suggestion.value)
         setCompletionDismissed(true)
         return true
       },
@@ -403,8 +411,8 @@ export const VarInput = forwardRef<VarInputHandle, VarInputProps>(
       <CompletionPopup
         id="value-completion-menu"
         items={valueSuggestions.map((suggestion) => ({
-          key: suggestion,
-          label: suggestion,
+          key: suggestion.value,
+          label: suggestion.label,
         }))}
         completionIndex={completionIndex}
         isEditing={isEditing && inputFocused}

--- a/src/ui/request-pane/AssertTab.tsx
+++ b/src/ui/request-pane/AssertTab.tsx
@@ -1,21 +1,15 @@
 import { MouseButton } from "@opentui/core"
 import { Fragment, useState } from "react"
-import type {
-  AssertionOperator,
-  Environment,
-  Request,
-  Response,
-} from "../../schema"
+import type { AssertionOperator, Environment, Request } from "../../schema"
 import {
   ASSERTION_OPERATORS,
   assertionOperatorRequiresValue,
 } from "../../assertions"
-import { responseExpressionSuggestions } from "../../response"
 import type { EditState, FieldSubfield } from "../editMode"
 import { Checkbox } from "../Checkbox"
 import { Select } from "../Select"
 import { useTheme } from "../theme"
-import { VarInput } from "../VarInput"
+import { VarInput, type ValueCompletion } from "../VarInput"
 
 const OPERATOR_ITEMS = ASSERTION_OPERATORS.map((value) => ({
   id: value,
@@ -26,7 +20,7 @@ const OPERATOR_WIDTH =
 
 interface Props {
   request: Request
-  response?: Response
+  completionValues?: readonly ValueCompletion[]
   editState: EditState
   editKey: string
   editValue: string
@@ -49,7 +43,7 @@ interface Props {
 
 export function AssertTab({
   request,
-  response,
+  completionValues,
   editState,
   editKey,
   editValue,
@@ -66,7 +60,6 @@ export function AssertTab({
   interactive = true,
 }: Props) {
   const theme = useTheme()
-  const suggestions = responseExpressionSuggestions(response)
   const assertions = request.assertions ?? []
   const [hoveredRow, setHoveredRow] = useState<number | "add" | null>(null)
 
@@ -192,7 +185,7 @@ export function AssertTab({
                   isFocused={editState.cursor.subfield === "key"}
                   onChange={setEditKey}
                   onFocus={() => onSubfieldFocus?.("key")}
-                  completionValues={suggestions}
+                  completionValues={completionValues}
                   baseColor={
                     dimmed || (addingRow && !selected)
                       ? theme.textMuted

--- a/src/ui/sendState.ts
+++ b/src/ui/sendState.ts
@@ -4,7 +4,12 @@ import type { ResponseExecutionResults } from "../executionResults"
 export type SendState =
   | { status: "idle" }
   | { status: "sending"; request: Request; network: NetworkEvent[] }
-  | { status: "done"; response: Response; execution?: ResponseExecutionResults }
+  | {
+      status: "done"
+      requestId?: string
+      response: Response
+      execution?: ResponseExecutionResults
+    }
   | {
       status: "error"
       request: Request
@@ -19,11 +24,11 @@ export function startSend(state: SendState, req: Request): SendState {
 
 export function finishSend(
   _state: SendState,
-  _req: Request,
+  req: Request,
   res: Response,
   execution?: ResponseExecutionResults,
 ): SendState {
-  return { status: "done", response: res, execution }
+  return { status: "done", requestId: req.id, response: res, execution }
 }
 
 export function failSend(

--- a/src/ui/timeline/useTimeline.ts
+++ b/src/ui/timeline/useTimeline.ts
@@ -3,6 +3,7 @@ import type { TimelineEntry } from "../../schema"
 import {
   DEFAULT_TIMELINE_MAX_ENTRIES,
   loadTimeline,
+  loadTimelineBody,
   saveTimelineEntry,
 } from "../../filestore"
 
@@ -17,10 +18,12 @@ export function useTimeline(
   collectionDir: string | undefined,
   requestId: string | undefined,
   maxEntries = DEFAULT_TIMELINE_MAX_ENTRIES,
+  hydrateLatestResponseBody = false,
 ): UseTimelineResult {
   const [entries, setEntries] = useState<TimelineEntry[]>([])
   const [loading, setLoading] = useState(false)
   const lastKeyRef = useRef("")
+  const loadGenerationRef = useRef(0)
   const mountedRef = useRef(true)
   const saveChainRef = useRef<Promise<void>>(Promise.resolve())
 
@@ -32,20 +35,26 @@ export function useTimeline(
   }, [])
 
   const doLoad = useCallback(async () => {
+    const generation = ++loadGenerationRef.current
     if (!collectionDir || !requestId) {
       setEntries([])
+      setLoading(false)
       return
     }
     setLoading(true)
     try {
       const loaded = await loadTimeline(collectionDir, requestId)
-      if (mountedRef.current) {
+      if (mountedRef.current && generation === loadGenerationRef.current) {
         setEntries(loaded.slice(0, maxEntries))
       }
     } catch {
-      if (mountedRef.current) setEntries([])
+      if (mountedRef.current && generation === loadGenerationRef.current) {
+        setEntries([])
+      }
     } finally {
-      if (mountedRef.current) setLoading(false)
+      if (mountedRef.current && generation === loadGenerationRef.current) {
+        setLoading(false)
+      }
     }
   }, [collectionDir, requestId, maxEntries])
 
@@ -53,9 +62,41 @@ export function useTimeline(
     const key = `${collectionDir ?? ""}||${requestId ?? ""}||${maxEntries}`
     if (key !== lastKeyRef.current) {
       lastKeyRef.current = key
+      setEntries([])
       doLoad()
     }
   }, [collectionDir, requestId, maxEntries, doLoad])
+
+  useEffect(() => {
+    if (!hydrateLatestResponseBody || !collectionDir || !requestId) return
+    const target = entries.find((entry) => entry.response)
+    const ref = target?.response?.bodyRef
+    if (
+      !target ||
+      target.request.id !== requestId ||
+      !ref ||
+      target.response?.body !== undefined
+    ) {
+      return
+    }
+
+    let cancelled = false
+    loadTimelineBody(collectionDir, requestId, ref)
+      .then((body) => {
+        if (cancelled || !mountedRef.current) return
+        setEntries((current) =>
+          current.map((entry) =>
+            entry === target
+              ? { ...entry, response: { ...entry.response!, body } }
+              : entry,
+          ),
+        )
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [collectionDir, entries, hydrateLatestResponseBody, requestId])
 
   const appendEntry = useCallback(
     async (entry: TimelineEntry) => {

--- a/tests/sendState.test.ts
+++ b/tests/sendState.test.ts
@@ -87,6 +87,7 @@ describe("finishSend", () => {
     const next = finishSend(sending, makeReq(), res)
     expect(next.status).toBe("done")
     if (next.status !== "done") throw new Error("narrow")
+    expect(next.requestId).toBe("x")
     expect(next.response.status).toBe(201)
     expect(next.response.statusText).toBe("Created")
   })

--- a/tests/unit/AssertTab.test.tsx
+++ b/tests/unit/AssertTab.test.tsx
@@ -14,6 +14,7 @@ import { AssertTab } from "../../src/ui/request-pane/AssertTab"
 import { VariableCompletionInterceptor } from "../../src/ui/variable-completion/variableCompletionInterceptor"
 import type { AssertionOperator, Request } from "../../src/schema"
 import type { EditState } from "../../src/ui/editMode"
+import { createResponseExpressionCompleter } from "../../src/response"
 
 const testRender = createTestRender()
 const request: Request = {
@@ -426,52 +427,60 @@ describe("AssertTab", () => {
     }
   })
 
-  it("offers response-expression completion at narrow widths", async () => {
-    const { keymap, cleanup } = setup()
-    const render = await testRender(
-      <KeymapProvider
-        keymap={
-          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
-        }
-      >
-        <VariableCompletionInterceptor />
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <AssertTab
-            request={request}
-            response={{
-              status: 200,
-              statusText: "OK",
-              headers: { "x-request-id": "123" },
-              body: '{"id":42}',
-              timeMs: 4,
-            }}
-            editState={{
-              mode: "editing",
-              cursor: {
-                field: "assertions",
-                row: 0,
-                addingRow: false,
-                subfield: "key",
-              },
-              editingRow: 0,
-            }}
-            editKey="bo"
-            editValue="42"
-            editOperator="equals"
-            editError={null}
-            setEditKey={() => {}}
-            setEditValue={() => {}}
-            setEditOperator={() => {}}
-          />
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 40, height: 12 },
-    )
-    await render.renderOnce()
-    expect(
-      render.renderer.root.findDescendantById("value-completion-menu"),
-    ).not.toBeNull()
-    cleanup()
+  it("shows a concise expression label and accepts its full value", async () => {
+    const { keymap, host, cleanup } = setup()
+    const complete = createResponseExpressionCompleter({
+      headers: {},
+      body: '{"user":{"profile":{"name":"Noodle"}}}',
+    })
+    let selected = ""
+    function Harness() {
+      const [key, setKey] = useState("body.user.")
+      selected = key
+      return (
+        <KeymapProvider
+          keymap={
+            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+          }
+        >
+          <VariableCompletionInterceptor />
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <AssertTab
+              request={request}
+              completionValues={complete(key)}
+              editState={{
+                mode: "editing",
+                cursor: {
+                  field: "assertions",
+                  row: 0,
+                  addingRow: false,
+                  subfield: "key",
+                },
+                editingRow: 0,
+              }}
+              editKey={key}
+              editValue="42"
+              editOperator="equals"
+              editError={null}
+              setEditKey={setKey}
+              setEditValue={() => {}}
+              setEditOperator={() => {}}
+            />
+          </ThemeProvider>
+        </KeymapProvider>
+      )
+    }
+    try {
+      const render = await testRender(<Harness />, { width: 40, height: 12 })
+      await render.renderOnce()
+      await act(async () => render.renderOnce())
+      expect(render.captureCharFrame()).toContain("profile")
+      await act(async () => host.press("return"))
+      await render.renderOnce()
+      expect(selected).toBe("body.user.profile")
+    } finally {
+      cleanup()
+    }
   })
 
   it("renders shared validation errors inline", async () => {

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -86,14 +86,21 @@ describe("ResponsePane status text truncation and layout tests", () => {
       {
         timestamp: 3,
         request: {
-          id: "request",
-          name: "Request",
+          id: "previous",
+          name: "Previous",
           method: "GET" as const,
           url: "https://example.com",
           headers: {},
           params: [],
         },
-        error: { message: "newer failed request" },
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: '{"previousField":1}',
+          timeMs: 3,
+          size: 19,
+        },
       },
       {
         timestamp: 2,
@@ -157,6 +164,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
               ...draft,
               draft: {
                 ...draft.draft,
+                id: "request",
                 assertions: [
                   { expression: "body.", operator: "exists" as const },
                 ],
@@ -199,6 +207,7 @@ describe("ResponsePane status text truncation and layout tests", () => {
     await render.renderOnce()
     await act(async () => render.renderOnce())
     expect(render.captureCharFrame()).toContain("newestField")
+    expect(render.captureCharFrame()).not.toContain("previousField")
     expect(render.captureCharFrame()).not.toContain("olderField")
 
     await act(async () => showCurrentResponse())

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -141,14 +141,28 @@ describe("ResponsePane status text truncation and layout tests", () => {
         },
       },
     ]
+    let showStaleResponse = () => {}
     let showCurrentResponse = () => {}
     function Harness() {
       const [responseState, setResponseState] = useState<SendState>({
         status: "idle",
       })
+      showStaleResponse = () =>
+        setResponseState({
+          status: "done",
+          requestId: "previous",
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: '{"staleField":1}',
+            timeMs: 1,
+          },
+        })
       showCurrentResponse = () =>
         setResponseState({
           status: "done",
+          requestId: "request",
           response: {
             status: 200,
             statusText: "OK",
@@ -209,6 +223,12 @@ describe("ResponsePane status text truncation and layout tests", () => {
     expect(render.captureCharFrame()).toContain("newestField")
     expect(render.captureCharFrame()).not.toContain("previousField")
     expect(render.captureCharFrame()).not.toContain("olderField")
+
+    await act(async () => showStaleResponse())
+    await render.renderOnce()
+    await act(async () => render.renderOnce())
+    expect(render.captureCharFrame()).toContain("newestField")
+    expect(render.captureCharFrame()).not.toContain("staleField")
 
     await act(async () => showCurrentResponse())
     await render.renderOnce()

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -16,6 +16,7 @@ import {
   getAvailableTargets,
   computeRequestTabLabels,
 } from "../../src/ui/useJumpMode"
+import { VariableCompletionInterceptor } from "../../src/ui/variable-completion/variableCompletionInterceptor"
 
 const testRender = createTestRender()
 
@@ -57,6 +58,155 @@ describe("ResponsePane status text truncation and layout tests", () => {
     }
     return { keymap, draft, eb }
   }
+
+  it("prefers the current response, then the newest timeline response", async () => {
+    const { keymap, draft } = createTestProps()
+    const eb = {
+      editState: {
+        mode: "editing" as const,
+        cursor: {
+          field: "assertions" as const,
+          row: 0,
+          addingRow: false,
+          subfield: "key" as const,
+        },
+        editingRow: 0,
+      },
+      editKey: "body.",
+      editValue: "",
+      editOperator: "exists" as const,
+      editError: null,
+      setEditKey: () => {},
+      setEditValue: () => {},
+      setEditOperator: () => {},
+      activeTab: "assertions" as const,
+      focusSubfield: () => {},
+    }
+    const timelineEntries = [
+      {
+        timestamp: 3,
+        request: {
+          id: "request",
+          name: "Request",
+          method: "GET" as const,
+          url: "https://example.com",
+          headers: {},
+          params: [],
+        },
+        error: { message: "newer failed request" },
+      },
+      {
+        timestamp: 2,
+        request: {
+          id: "request",
+          name: "Request",
+          method: "GET" as const,
+          url: "https://example.com",
+          headers: {},
+          params: [],
+        },
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: '{"newestField":1}',
+          timeMs: 2,
+          size: 17,
+        },
+      },
+      {
+        timestamp: 1,
+        request: {
+          id: "request",
+          name: "Request",
+          method: "GET" as const,
+          url: "https://example.com",
+          headers: {},
+          params: [],
+        },
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: '{"olderField":1}',
+          timeMs: 1,
+          size: 16,
+        },
+      },
+    ]
+    let showCurrentResponse = () => {}
+    function Harness() {
+      const [responseState, setResponseState] = useState<SendState>({
+        status: "idle",
+      })
+      showCurrentResponse = () =>
+        setResponseState({
+          status: "done",
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: '{"currentField":1}',
+            timeMs: 1,
+          },
+        })
+      return (
+        <RequestResponseView
+          draft={
+            {
+              ...draft,
+              draft: {
+                ...draft.draft,
+                assertions: [
+                  { expression: "body.", operator: "exists" as const },
+                ],
+              },
+            } as unknown as Parameters<typeof RequestResponseView>[0]["draft"]
+          }
+          eb={eb as unknown as Parameters<typeof RequestResponseView>[0]["eb"]}
+          error={null}
+          focus="request"
+          layout="stacked"
+          expanded="request"
+          activeEnv={null}
+          responseState={responseState}
+          timelineEntries={timelineEntries}
+          onResponseTabChange={() => {}}
+          setSelectOpen={() => {}}
+          urlbarSubFocus="text"
+          urlbarInteractive
+        />
+      )
+    }
+
+    const render = await testRender(
+      <KeymapProvider
+        keymap={
+          keymap.keymap as unknown as Parameters<
+            typeof KeymapProvider
+          >[0]["keymap"]
+        }
+      >
+        <VariableCompletionInterceptor />
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <box style={{ width: 60, height: 14 }}>
+            <Harness />
+          </box>
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 60, height: 14 },
+    )
+    await render.renderOnce()
+    await act(async () => render.renderOnce())
+    expect(render.captureCharFrame()).toContain("newestField")
+    expect(render.captureCharFrame()).not.toContain("olderField")
+
+    await act(async () => showCurrentResponse())
+    await render.renderOnce()
+    await act(async () => render.renderOnce())
+    expect(render.captureCharFrame()).toContain("currentField")
+    expect(render.captureCharFrame()).not.toContain("newestField")
+  })
 
   it("uses XML highlighting for XML response content types", async () => {
     const { keymap, draft, eb } = createTestProps()

--- a/tests/unit/responseExpression.test.ts
+++ b/tests/unit/responseExpression.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test"
 import {
+  createResponseExpressionCompleter,
   createResponseResolver,
   parseResponseExpression,
-  responseExpressionSuggestions,
 } from "../../src/response"
 import type { Response } from "../../src/schema"
 
@@ -22,19 +22,71 @@ function response(overrides: Partial<Response> = {}): Response {
 }
 
 describe("response expressions", () => {
-  it("suggests grammar roots and current response fields", () => {
-    expect(responseExpressionSuggestions(response())).toEqual(
+  it("suggests static roots and one response segment at a time", () => {
+    const complete = createResponseExpressionCompleter(response())
+
+    expect(complete("").map(({ value }) => value)).toEqual([
+      "status",
+      "body",
+      "body.",
+      "headers.",
+      "response.time",
+    ])
+    expect(complete("headers.")).toEqual([
+      { value: "headers.", label: "headers." },
+      { value: "headers.Content-Type", label: "Content-Type" },
+      { value: "headers.X-Trace", label: "X-Trace" },
+    ])
+    expect(complete("body.")).toEqual([
+      { value: "body.", label: "body." },
+      { value: "body.id", label: "id" },
+      { value: "body.user", label: "user" },
+      { value: "body.users", label: "users" },
+    ])
+    expect(complete("body.user.")).toEqual([
+      { value: "body.user.profile", label: "profile" },
+    ])
+    expect(complete("body.user.profile.")).toEqual([
+      { value: "body.user.profile.name", label: "name" },
+    ])
+    expect(complete("body.users[")).toEqual([
+      { value: "body.users[0]", label: "[0]" },
+    ])
+    expect(complete("body.users[0].")).toEqual([
+      { value: "body.users[0].id", label: "id" },
+    ])
+    expect(complete("body.us").map(({ value }) => value)).toEqual([
+      "body.user",
+      "body.users",
+    ])
+  })
+
+  it("keeps usable suggestions when response fields cannot be completed", () => {
+    const complete = createResponseExpressionCompleter(
+      response({
+        headers: { "X-Trace": "abc", "not valid": "ignored" },
+        body: '{"valid":1,"not valid":2}',
+      }),
+    )
+
+    expect(complete("headers.")).toEqual([
+      { value: "headers.", label: "headers." },
+      { value: "headers.X-Trace", label: "X-Trace" },
+    ])
+    expect(complete("body.")).toEqual([
+      { value: "body.", label: "body." },
+      { value: "body.valid", label: "valid" },
+    ])
+
+    const invalidJson = createResponseExpressionCompleter(
+      response({ body: "{" }),
+    )
+    expect(invalidJson("headers.")).toEqual(
       expect.arrayContaining([
-        "status",
-        "body.",
-        "headers.Content-Type",
-        "headers.X-Trace",
-        "response.time",
-        "body.id",
-        "body.user",
-        "body.users",
+        { value: "headers.Content-Type", label: "Content-Type" },
       ]),
     )
+    expect(invalidJson("body.")).toEqual([{ value: "body.", label: "body." }])
   })
 
   it("parses the supported grammar", () => {

--- a/tests/unit/responseExpression.test.ts
+++ b/tests/unit/responseExpression.test.ts
@@ -37,6 +37,11 @@ describe("response expressions", () => {
       { value: "headers.Content-Type", label: "Content-Type" },
       { value: "headers.X-Trace", label: "X-Trace" },
     ])
+    expect(complete("Headers.")).toEqual([
+      { value: "headers.", label: "headers." },
+      { value: "headers.Content-Type", label: "Content-Type" },
+      { value: "headers.X-Trace", label: "X-Trace" },
+    ])
     expect(complete("body.")).toEqual([
       { value: "body.", label: "body." },
       { value: "body.id", label: "id" },

--- a/tests/unit/rowMouseControls.test.tsx
+++ b/tests/unit/rowMouseControls.test.tsx
@@ -14,8 +14,16 @@ import { initialEditState } from "../../src/ui/editMode"
 import { KeyValueSection } from "../../src/ui/KeyValueSection"
 import { FormEditor } from "../../src/ui/FormEditor"
 import { setupKeymap } from "./_helpers"
+import { VariableCompletionInterceptor } from "../../src/ui/variable-completion/variableCompletionInterceptor"
+import { createResponseExpressionCompleter } from "../../src/response"
 
 const testRender = createTestRender()
+
+function findTextPosition(frame: string, text: string) {
+  const rows = frame.split("\n")
+  const y = rows.findIndex((row) => row.includes(text))
+  return { x: rows[y]!.indexOf(text), y }
+}
 
 describe("request row mouse controls", () => {
   it("activates and toggles key/value rows independently", async () => {
@@ -176,6 +184,71 @@ describe("request row mouse controls", () => {
     expect(frame).toContain("Run only")
     expect(frame.split("\n").every((line) => line.length <= 44)).toBe(true)
     cleanup()
+  })
+
+  it("accepts a concise capture expression completion by mouse", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const complete = createResponseExpressionCompleter({
+      headers: {},
+      body: '{"payload":{"sessionKey":"abc"}}',
+    })
+    let selected = ""
+    function Harness() {
+      const [expression, setExpression] = useState("body.payload.")
+      selected = expression
+      return (
+        <KeyValueSection
+          kind="captures"
+          entries={[
+            {
+              key: "captured",
+              value: { value: "body.payload.sessionKey", enabled: true },
+            },
+          ]}
+          editState={{
+            mode: "editing",
+            cursor: {
+              field: "captures",
+              row: 0,
+              addingRow: false,
+              subfield: "value",
+            },
+            editingRow: 0,
+          }}
+          editKey="captured"
+          editValue={expression}
+          setEditKey={() => {}}
+          setEditValue={setExpression}
+          completionValues={complete(expression)}
+          theme={THEMES[0]!}
+        />
+      )
+    }
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <VariableCompletionInterceptor />
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <box width={48} height={8}>
+              <Harness />
+            </box>
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 48, height: 8 },
+      )
+      await render.renderOnce()
+      await act(async () => render.renderOnce())
+      const frame = render.captureCharFrame()
+      expect(frame).toContain("sessionKey")
+      const position = findTextPosition(frame, "sessionKey")
+      await act(async () => {
+        await render.mockMouse.click(position.x, position.y, MouseButtons.LEFT)
+      })
+      await render.renderOnce()
+      expect(selected).toBe("body.payload.sessionKey")
+    } finally {
+      cleanup()
+    }
   })
 
   it("changes capture persistence with the focused Select", async () => {

--- a/tests/unit/useTimeline.test.tsx
+++ b/tests/unit/useTimeline.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { scheduler } from "node:timers/promises"
+import { act, useState } from "react"
+import { saveTimelineEntry } from "../../src/filestore"
+import { useTimeline } from "../../src/ui/timeline/useTimeline"
+import { createTestRender } from "../testRender"
+
+const testRender = createTestRender()
+
+async function waitForText(
+  renderOnce: () => Promise<void>,
+  captureCharFrame: () => string,
+  text: string,
+) {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    await act(async () => {
+      await scheduler.yield()
+      await renderOnce()
+    })
+    if (captureCharFrame().includes(text)) return
+  }
+  throw new Error(`timed out waiting for ${text}`)
+}
+
+describe("useTimeline", () => {
+  it("hydrates the newest sidecar response body only when opted in", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-timeline-hook-"))
+    const body = JSON.stringify({ hydratedField: "x".repeat(10_050) })
+    try {
+      const persisted = await saveTimelineEntry(
+        dir,
+        "request",
+        {
+          timestamp: 1,
+          request: {
+            id: "request",
+            name: "Request",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+          },
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: { "x-request-id": "123" },
+            body,
+            timeMs: 1,
+            size: body.length,
+          },
+        },
+        50,
+      )
+      expect(persisted.response?.body).toBeUndefined()
+      expect(persisted.response?.bodyRef).toBeDefined()
+
+      let enableHydration = () => {}
+      function Harness() {
+        const [hydrate, setHydrate] = useState(false)
+        enableHydration = () => setHydrate(true)
+        const timeline = useTimeline(dir, "request", 50, hydrate)
+        const response = timeline.entries.find(
+          (entry) => entry.response,
+        )?.response
+        return (
+          <text>
+            {!response
+              ? "loading"
+              : response.body === body
+                ? "hydrated"
+                : `sidecar:${response.headers["x-request-id"]}`}
+          </text>
+        )
+      }
+
+      const render = await testRender(<Harness />, { width: 40, height: 4 })
+      await waitForText(
+        render.renderOnce,
+        render.captureCharFrame,
+        "sidecar:123",
+      )
+      await act(async () => enableHydration())
+      await waitForText(render.renderOnce, render.captureCharFrame, "hydrated")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds prefix-aware response expression completion that suggests members of the current response or the latest retained timeline response. Completer now resolves `headers.*` and `body` paths (including nested objects/arrays) filtered by the current prefix, backed by timeline fallback when no live response exists.

### How did you verify your code works?

Tested locally:
- `bun test` passes (3065 pass, 0 fail across 202 files)
- `bun run lint` passes
- `bun run typecheck` passes
- Added/updated unit tests for response expression completion (`responseExpression.test.ts`), timeline completer (`useTimeline.test.tsx`), AssertTab, Row mouse controls, and ResponsePane status

### Screenshots / recordings

N/A — no visual change requiring screenshot.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split request authoring into focused Assert and Capture tabs while keeping tags in Settings.
  * Added richer response-expression suggestions for nested body paths, array indexes, and headers.
  * Suggestions now show concise labels while inserting complete expressions.
  * Response expressions can use the current response or the latest retained timeline response.

* **Bug Fixes**
  * Prevented stale timeline loads from replacing newer results.
  * Improved loading of retained response bodies when needed.
  * Header suggestions now work regardless of capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->