### PR TITLE
feat(ui): show theme-colored status symbols on Results tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Noodle are documented in this file.
 
 - Split request authoring into focused Assert and Capture tabs, keep tags in Settings, preserve shared validation, and complete response expressions from the current response or latest retained timeline response.
 - Add persistent per-row Assert and Capture checkboxes, with disabled declarations retained in YAML and excluded from evaluation and results.
-- Evaluate captures and assertions on every manual send with a fresh RunScope, keep Results available, and mark the tab when a send has assertion or capture outcomes.
+- Evaluate captures and assertions on every manual send with a fresh RunScope, keep Results available, and show theme-colored success, failure, or unevaluated status on the tab.
 - Add a transient collection Runner with request selection, local environment and tag filters, fail-fast execution, progress, and detailed in-memory results.
 - Show effective request and inherited folder tags in request search, and persist redacted assertion status and details in response timeline history.
 - Add strict object-only capture declarations with optional per-capture secret or plaintext environment persistence for manual TUI sends and CLI `request run`, while keeping collection runs transient.

--- a/src/ui/ResponsePane.tsx
+++ b/src/ui/ResponsePane.tsx
@@ -44,6 +44,7 @@ import { ResponseResults } from "./ResponseResults"
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 const AUTO_RENDER_LIMIT = 5 * 1024 * 1024
+const RESULTS_SYMBOLS = { success: "✓", error: "✗", warning: "–" } as const
 const TAB_DEFS: TabDef[] = [
   { id: "body", label: "Body" },
   { id: "headers", label: "Headers" },
@@ -53,11 +54,28 @@ const TAB_DEFS: TabDef[] = [
   { id: "results", label: "Results" },
 ]
 
+function responseResultsStatus(
+  state: SendState,
+): keyof typeof RESULTS_SYMBOLS | null {
+  if (state.status !== "done" && state.status !== "error") return null
+  const assertions = state.execution?.assertions
+  const captures = state.execution?.captures
+  if (!assertions && !captures) return null
+  if (
+    (assertions?.evaluated &&
+      assertions.results.some((result) => !result.passed)) ||
+    (captures?.evaluated && captures.results.some((result) => !result.success))
+  ) {
+    return "error"
+  }
+  if (assertions?.evaluated === false || captures?.evaluated === false) {
+    return "warning"
+  }
+  return "success"
+}
+
 export function hasResponseResults(state: SendState): boolean {
-  return (
-    (state.status === "done" || state.status === "error") &&
-    Boolean(state.execution?.assertions || state.execution?.captures)
-  )
+  return responseResultsStatus(state) !== null
 }
 
 function isDeletedCookie(cookie: ResponseCookie): boolean {
@@ -121,14 +139,20 @@ export function ResponsePane({
   const [activeTab, setActiveTab] = useState<ResponseTabKind>(
     initialTab ?? "body",
   )
-  const hasResults = hasResponseResults(state)
+  const resultsStatus = responseResultsStatus(state)
   const tabs = useMemo(() => {
     return TAB_DEFS.map((tab) => ({
       ...tab,
-      label: tab.id === "results" && hasResults ? "Results •" : tab.label,
+      indicator:
+        tab.id === "results" && resultsStatus
+          ? {
+              symbol: RESULTS_SYMBOLS[resultsStatus],
+              color: theme[resultsStatus],
+            }
+          : undefined,
       jumpHint: jumpMode ? RESPONSE_TAB_HINTS[tab.id] : undefined,
     }))
-  }, [hasResults, jumpMode])
+  }, [jumpMode, resultsStatus, theme])
   const [spinnerIdx, setSpinnerIdx] = useState(0)
   const [queryVisible, setQueryVisible] = useState(false)
   const [query, setQuery] = useState("")

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -7,6 +7,10 @@ export type TabDef = {
   id: string
   label: string
   jumpHint?: string
+  indicator?: {
+    symbol: string
+    color: string
+  }
 }
 
 export function Tabs({
@@ -136,7 +140,9 @@ export function Tabs({
                     />
                   ) : null}
                   <box style={{ paddingLeft: 1, paddingRight: 2 }}>
-                    <text opacity={0}>{tab.label}</text>
+                    <text opacity={0}>
+                      {`${tab.label}${tab.indicator ? ` ${tab.indicator.symbol}` : ""}`}
+                    </text>
                   </box>
                 </box>
               ))}
@@ -227,6 +233,11 @@ export function Tabs({
                       }
                     >
                       {tab.label}
+                      {tab.indicator ? (
+                        <span fg={tab.indicator.color}>
+                          {` ${tab.indicator.symbol}`}
+                        </span>
+                      ) : null}
                     </text>
                   </box>
                   <box

--- a/src/ui/Tips.tsx
+++ b/src/ui/Tips.tsx
@@ -15,7 +15,7 @@ const TIPS = [
   "toggle header or param on/off with {Space} in browse mode",
   "revert a field to its saved value with {^D}",
   "edit assertions in {Assert}, captures in {Capture}, and tags in {Settings}",
-  "response {Results} gains {•} after assertion or capture evaluation",
+  "response {Results} shows {✓}/{✗}/{–} for passed, failed, or unevaluated outcomes",
   "revert all fields to their saved values with {^R}",
   "edit request details with {^E}",
   "change the color theme with {^T}",

--- a/tests/unit/ResponseResultsVisibility.test.tsx
+++ b/tests/unit/ResponseResultsVisibility.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test"
 import { extend } from "@opentui/react"
+import { RGBA } from "@opentui/core"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { createTestKeymap } from "@opentui/keymap/testing"
 import { createTestRender } from "../testRender"
-import { ThemeProvider } from "../../src/ui/theme"
+import { ThemeProvider, THEMES } from "../../src/ui/theme"
 import { ResponsePane, hasResponseResults } from "../../src/ui/ResponsePane"
 import {
   CodeEditorRenderable,
@@ -78,6 +79,7 @@ describe("response Results", () => {
     const frame = render.captureCharFrame()
     expect(frame).toContain("Results")
     expect(frame).not.toContain("Results •")
+    expect(frame).not.toMatch(/Results [✓✗–]/)
     expect(frame).toContain("No execution results.")
     expect(changes).toEqual([])
     cleanup()
@@ -124,31 +126,100 @@ describe("response Results", () => {
     cleanup()
   })
 
-  it("places populated Results last with the request-tab value indicator", async () => {
-    const { keymap, cleanup } = createTestKeymap()
-    keymap.setData("app.overlay", "none")
-    const render = await testRender(
-      <KeymapProvider
-        keymap={
-          keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
-        }
-      >
-        <ThemeProvider activeIndex={0} previewIndex={null}>
-          <ResponsePane
-            state={{
-              status: "done",
-              response,
-              execution: { assertions: { evaluated: true, results: [] } },
-            }}
-          />
-        </ThemeProvider>
-      </KeymapProvider>,
-      { width: 100, height: 14 },
-    )
-    await render.renderOnce()
-    const frame = render.captureCharFrame()
-    expect(frame).toContain("Results •")
-    expect(frame.indexOf("Results •")).toBeGreaterThan(frame.indexOf("Cookies"))
-    cleanup()
+  it("places themed Results status indicators last", async () => {
+    const cases: { state: SendState; symbol: string; color: string }[] = [
+      {
+        state: {
+          status: "done",
+          response,
+          execution: {
+            assertions: {
+              evaluated: true,
+              results: [
+                {
+                  expression: "status",
+                  operator: "equals",
+                  expected: 200,
+                  actual: 200,
+                  passed: true,
+                  message: "Expected values to be equal",
+                },
+              ],
+            },
+          },
+        },
+        symbol: "✓",
+        color: THEMES[0]!.success,
+      },
+      {
+        state: {
+          status: "done",
+          response,
+          execution: {
+            captures: {
+              evaluated: true,
+              results: [
+                {
+                  variable: "token",
+                  expression: "body.missing",
+                  success: false,
+                  failureReason: "missing",
+                  message: 'Expression "body.missing" is missing',
+                },
+              ],
+            },
+          },
+        },
+        symbol: "✗",
+        color: THEMES[0]!.error,
+      },
+      {
+        state: {
+          status: "error",
+          request: {
+            id: "request",
+            name: "Request",
+            method: "GET",
+            url: "https://example.com",
+            headers: {},
+            params: [],
+            timeout: 0,
+          },
+          error: new Error("before response"),
+          execution: { assertions: { evaluated: false, results: [] } },
+        },
+        symbol: "–",
+        color: THEMES[0]!.warning,
+      },
+    ]
+
+    for (const { state, symbol, color } of cases) {
+      const { keymap, cleanup } = createTestKeymap()
+      keymap.setData("app.overlay", "none")
+      const render = await testRender(
+        <KeymapProvider
+          keymap={
+            keymap as unknown as Parameters<typeof KeymapProvider>[0]["keymap"]
+          }
+        >
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <ResponsePane state={state} />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 14 },
+      )
+      await render.renderOnce()
+      const frame = render.captureCharFrame()
+      expect(frame).toContain(`Results ${symbol}`)
+      expect(frame.indexOf(`Results ${symbol}`)).toBeGreaterThan(
+        frame.indexOf("Cookies"),
+      )
+      const indicator = render
+        .captureSpans()
+        .lines.flatMap((line) => line.spans)
+        .find((span) => span.text.trim() === symbol)
+      expect(indicator?.fg.equals(RGBA.fromHex(color))).toBe(true)
+      cleanup()
+    }
   })
 })

--- a/tests/unit/tabs.test.tsx
+++ b/tests/unit/tabs.test.tsx
@@ -31,6 +31,33 @@ describe("Tabs", () => {
     expect(frame).toContain("Tab C")
   })
 
+  it("renders a tab indicator with its own color", async () => {
+    const { renderOnce, captureCharFrame, captureSpans } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Tabs
+          tabs={[
+            {
+              id: "a",
+              label: "Tab A",
+              indicator: { symbol: "✓", color: THEMES[0]!.success },
+            },
+          ]}
+          activeId="a"
+        >
+          <text>content</text>
+        </Tabs>
+      </ThemeProvider>,
+      { width: 30, height: 5 },
+    )
+    await renderOnce()
+
+    expect(captureCharFrame()).toContain("Tab A ✓")
+    const indicator = captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .find((span) => span.text.trim() === "✓")
+    expect(indicator?.fg.equals(RGBA.fromHex(THEMES[0]!.success))).toBe(true)
+  })
+
   it("renders content for the active tab", async () => {
     const { renderOnce, captureCharFrame } = await testRender(
       <Tabs


### PR DESCRIPTION
### Type of change

- [x] New feature

### What does this PR do?

Replaces the generic `Results •` dot with theme-colored status symbols: `✓` (success), `✗` (failed), `–` (unevaluated) based on assertion/capture evaluation. Adds `indicator` support to `Tabs.tsx` (`src/ui/Tabs.tsx:10`, `src/ui/ResponsePane.tsx:47`) and updates the tip text.

### How did you verify your code works?

Manual verification via existing tests plus automated checks:
- `bun test` — 3067 pass, 0 fail
- `bun run lint` — passes
- `bun run typecheck` — passes

### Screenshots / recordings

N/A — terminal UI change, symbols use `theme.success` / `theme.error` / `theme.warning`.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR