### PR TITLE
feat(keymap): reassign F5 to open Runner, make bulk folding configurable

### DIFF
--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -995,11 +995,14 @@ export function useEditBrowse(
         )
       }
     } else if (field === "pathParams") {
-      const key = editKeyRef.current.trim()
+      const current = draftRef.current
+      const key = syncPathParamsWithUrl(
+        current?.pathParams ?? [],
+        current?.url ?? "",
+      )[state.cursor.row]?.name
       const value = editValueRef.current.trim()
-      if (key !== "" && !addingRow) {
-        draftMutators.setPathParamRow(state.cursor.row, key, value)
-      }
+      if (!key || addingRow) return false
+      draftMutators.setPathParamRow(state.cursor.row, key, value)
     } else if (field === "headers" || field === "params") {
       const key = editKeyRef.current.trim()
       const value = editValueRef.current.trim()

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -1231,6 +1231,7 @@ export function AppInner({
     runner: {
       runnerRef,
       detailScrollRef: runnerDetailScrollRef,
+      open: handleOpenRunner,
       close: closeRunner,
       openTagFilter: handleOpenRunnerTagFilter,
       openResultDetail: handleOpenRunnerResultDetail,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -728,15 +728,26 @@ export function AppInner({
   }, [])
   const handleOpenRunner = useCallback(
     (scope: string | null) => {
-      runnerReturnFocusRef.current = settingsReturnFocus(
-        viewRef.current,
-        focusRef.current,
+      const opened = openCollectionRunner(
+        scope,
+        () => {
+          if (eb.commitEdit() === false) return false
+          folderEb.commitEdit()
+          envEditor.commitEdit()
+          runnerReturnFocusRef.current = settingsReturnFocus(
+            viewRef.current,
+            focusRef.current,
+          )
+          return true
+        },
+        resetRunner,
+        setView,
+        setFocus,
       )
-      const opened = openCollectionRunner(scope, resetRunner, setView, setFocus)
-      setJumpMode(false)
+      if (opened) setJumpMode(false)
       return opened
     },
-    [resetRunner],
+    [eb.commitEdit, envEditor.commitEdit, folderEb.commitEdit, resetRunner],
   )
   const closeRunner = useCallback(() => {
     if (runnerRef.current.phase === "running") return

--- a/src/ui/commandActions.ts
+++ b/src/ui/commandActions.ts
@@ -330,10 +330,12 @@ export function openCookieJar(
 
 export function openCollectionRunner(
   scope: string | null,
+  commitPendingEdits: () => boolean,
   reset: (scope: string | null) => void,
   setView: (view: AppView) => void,
   setFocus: (focus: Focus) => void,
 ): boolean {
+  if (!commitPendingEdits()) return false
   reset(scope)
   setView("runner")
   setFocus("runner-options")

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -443,6 +443,7 @@ export function buildCommandPaletteCommands(
       id: "collection.runner",
       label: paletteTarget === "folder" ? "Run Folder" : "Run Collection",
       section: paletteTarget === "folder" ? "Folder" : "Workspace",
+      keybinding: displayKey(keybinds.runner_open),
       run: () => {
         const folderPath =
           paletteTarget === "folder" ? c.focusedFolderPathRef.current : null

--- a/src/ui/editor/CodeEditor.ts
+++ b/src/ui/editor/CodeEditor.ts
@@ -492,14 +492,6 @@ export class CodeEditorRenderable extends TextareaRenderable {
       this.toggleFold(this.logicalCursor.row)
       return true
     }
-    if (command === "fold-all") {
-      this.foldAll()
-      return true
-    }
-    if (command === "unfold-all") {
-      this.unfoldAll()
-      return true
-    }
     if (this._readOnly) {
       const isSelectionNavigation =
         key.shift &&

--- a/src/ui/editor/codeEditorKeys.ts
+++ b/src/ui/editor/codeEditorKeys.ts
@@ -18,7 +18,7 @@ const CLOSE_TO_OPEN: Record<string, string> = {
   ">": "<",
 }
 
-export type EditorCommand = "toggle-fold" | "fold-all" | "unfold-all"
+export type EditorCommand = "toggle-fold"
 
 export function normalizeEditorKey(key: KeyEvent): KeyEvent {
   if (key.name !== "return" || !key.shift) return key
@@ -28,23 +28,6 @@ export function normalizeEditorKey(key: KeyEvent): KeyEvent {
 export function getEditorCommand(key: KeyEvent): EditorCommand | null {
   if (key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
     if (key.name === "g" && !key.shift) return "toggle-fold"
-  }
-
-  if (!key.ctrl && !key.meta && !key.option && !key.super && !key.hyper) {
-    if (key.name === "f5") return "fold-all"
-    if (key.name === "f6") return "unfold-all"
-  }
-
-  if (
-    key.ctrl &&
-    key.shift &&
-    !key.meta &&
-    !key.option &&
-    !key.super &&
-    !key.hyper
-  ) {
-    if (key.name === "[") return "fold-all"
-    if (key.name === "]") return "unfold-all"
   }
 
   return null

--- a/src/ui/helpTexts.ts
+++ b/src/ui/helpTexts.ts
@@ -60,8 +60,22 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
       title: "Code Editor",
       keys: [
         { key: "^g", description: "Toggle fold at cursor" },
-        { key: "f5", description: "Fold all" },
-        { key: "f6", description: "Unfold all" },
+        ...(keybinds.editor_fold_all
+          ? [
+              {
+                key: displayKey(keybinds.editor_fold_all),
+                description: "Fold all",
+              },
+            ]
+          : []),
+        ...(keybinds.editor_unfold_all
+          ? [
+              {
+                key: displayKey(keybinds.editor_unfold_all),
+                description: "Unfold all",
+              },
+            ]
+          : []),
       ],
     },
     {
@@ -103,6 +117,10 @@ export function getHelpSections(keybinds: Keybinds): HelpSection[] {
         {
           key: displayKey(keybinds.pane_expand),
           description: "Expand/collapse focused pane",
+        },
+        {
+          key: displayKey(keybinds.runner_open),
+          description: "Open collection Runner",
         },
         {
           key: displayKey(keybinds.folder_new),

--- a/src/ui/keybind.ts
+++ b/src/ui/keybind.ts
@@ -134,6 +134,19 @@ export const Definitions = {
     "Workspace",
     ["main", "request-browse", "request-edit"],
   ),
+  runner_open: keybind("f5", "Open collection Runner", false, "Workspace", [
+    "main",
+  ]),
+  editor_fold_all: keybind("", "Fold all regions", false, "Workspace", [
+    "main",
+    "request-edit",
+    "folder",
+  ]),
+  editor_unfold_all: keybind("", "Unfold all regions", false, "Workspace", [
+    "main",
+    "request-edit",
+    "folder",
+  ]),
   response_copy_body: keybind(
     "ctrl+b",
     "Copy response body",
@@ -257,6 +270,9 @@ export const CommandMap = {
   request_save: "request.save",
   layout_toggle: "layout.toggle",
   pane_expand: "request.expand-toggle",
+  runner_open: "collection.runner",
+  editor_fold_all: "editor.fold-all",
+  editor_unfold_all: "editor.unfold-all",
   response_copy_body: "response.copy-body",
   response_query: "response.query",
   request_edit: "request.edit-enter",
@@ -409,11 +425,7 @@ export function keyEventToBinding(
     event.shift ? "shift" : null,
   ].filter((value): value is string => value !== null)
   const binding = [...modifiers, name].join("+")
-  if (
-    ["ctrl+c", "ctrl+g", "ctrl+shift+z", "shift+return", "f5", "f6"].includes(
-      binding,
-    )
-  ) {
+  if (["ctrl+c", "ctrl+g", "ctrl+shift+z", "shift+return"].includes(binding)) {
     return null
   }
   return binding

--- a/src/ui/keymap/globalLayers.ts
+++ b/src/ui/keymap/globalLayers.ts
@@ -12,6 +12,7 @@ import {
   undoAll,
 } from "../commandActions"
 import type { AppKeymapContext } from "./types"
+import { CodeEditorRenderable } from "../editor/CodeEditor"
 
 export function createGlobalLayers(
   context: AppKeymapContext,
@@ -39,6 +40,10 @@ export function createGlobalLayers(
   const isRunnerRunning = () =>
     global.viewRef.current === "runner" &&
     runner.runnerRef.current.phase === "running"
+  const focusedCodeEditor = () => {
+    const focused = context.renderer.currentFocusedRenderable
+    return focused instanceof CodeEditorRenderable ? focused : null
+  }
   const shortcutEnabled = (binding: string, enabled = true) => {
     if (isRunnerRunning()) return false
     if (!enabled || !isTextInputActive()) return enabled
@@ -200,6 +205,35 @@ export function createGlobalLayers(
         },
       },
       {
+        name: "collection.runner",
+        enabled: () =>
+          shortcutEnabled(
+            keybinds.runner_open,
+            global.modeRef.current === "collection" &&
+              global.viewRef.current === "main" &&
+              keymap.getData("app.overlay") === "none",
+          ),
+        run: () => runner.open(null),
+      },
+      {
+        name: "editor.fold-all",
+        enabled: () =>
+          shortcutEnabled(
+            keybinds.editor_fold_all,
+            keybinds.editor_fold_all !== "" && focusedCodeEditor() !== null,
+          ),
+        run: () => focusedCodeEditor()?.foldAll(),
+      },
+      {
+        name: "editor.unfold-all",
+        enabled: () =>
+          shortcutEnabled(
+            keybinds.editor_unfold_all,
+            keybinds.editor_unfold_all !== "" && focusedCodeEditor() !== null,
+          ),
+        run: () => focusedCodeEditor()?.unfoldAll(),
+      },
+      {
         name: "response.copy-body",
         enabled: () =>
           shortcutEnabled(
@@ -349,6 +383,13 @@ export function createGlobalLayers(
       { key: keybinds.help_toggle, cmd: "app.help" },
       { key: keybinds.request_edit_yaml, cmd: "request.edit-yaml" },
       { key: keybinds.pane_expand, cmd: "request.expand-toggle" },
+      { key: keybinds.runner_open, cmd: "collection.runner" },
+      ...(keybinds.editor_fold_all
+        ? [{ key: keybinds.editor_fold_all, cmd: "editor.fold-all" }]
+        : []),
+      ...(keybinds.editor_unfold_all
+        ? [{ key: keybinds.editor_unfold_all, cmd: "editor.unfold-all" }]
+        : []),
       { key: keybinds.response_copy_body, cmd: "response.copy-body" },
       { key: keybinds.response_query, cmd: "response.query" },
       { key: keybinds.theme_picker, cmd: "app.theme" },

--- a/src/ui/keymap/types.ts
+++ b/src/ui/keymap/types.ts
@@ -137,6 +137,7 @@ export interface AppKeymapCookieJar {
 export interface AppKeymapRunner {
   runnerRef: RefObject<UseCollectionRunnerResult>
   detailScrollRef: RefObject<ScrollBoxRenderable | null>
+  open: (scope: string | null) => boolean
   close: () => void
   openTagFilter: (filter: "include" | "exclude", index: number) => void
   openResultDetail: (index?: number) => void

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -1050,11 +1050,11 @@ describe("ResponsePane scrollbox", () => {
     expect(deletedLine).toContain("Deleted")
   })
 
-  it("folds the response body from the keyboard", async () => {
+  it("toggles response body folding from the keyboard", async () => {
     const raw = createTestKeymap()
     const keymap = raw.keymap as unknown as OpenTuiKeymap
     keymap.setData("app.overlay", "none")
-    const { renderer, renderOnce, captureCharFrame, mockInput, mockMouse } =
+    const { renderer, renderOnce, captureCharFrame, mockMouse } =
       await testRender(
         <KeymapProvider keymap={keymap}>
           <ResponsePane
@@ -1081,11 +1081,14 @@ describe("ResponsePane scrollbox", () => {
     await editor.refreshHighlights()
     expect(editor.getFoldSigns().has(0)).toBe(true)
 
-    await act(async () => mockInput.pressKey("F5"))
+    expect(editor.handleKeyPress(keyEvent("f5"))).toBe(false)
+    expect(editor.lineCount).toBe(7)
+
+    expect(editor.handleKeyPress(keyEvent("g", { ctrl: true }))).toBe(true)
     await renderOnce()
     expect(editor.lineCount).toBeLessThan(7)
 
-    await act(async () => mockInput.pressKey("F6"))
+    expect(editor.handleKeyPress(keyEvent("g", { ctrl: true }))).toBe(true)
     await renderOnce()
     expect(editor.lineCount).toBe(7)
 

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -202,7 +202,7 @@ body_type: json`
     )
   })
 
-  it("uses f5 to fold all and f6 to unfold all", async () => {
+  it("folds and unfolds all regions", async () => {
     let editor: CodeEditorRenderable | null = null
     const content = `{
   "first": 1,
@@ -235,13 +235,11 @@ body_type: json`
     expect(editor).toBeDefined()
     computeFolds(editor!)
 
-    const folded = editor!.handleKeyPress(keyEvent("f5"))
-    expect(folded).toBe(true)
+    editor!.foldAll()
     await renderOnce()
     expect(editor!.lineCount).toBeLessThan(originalLineCount)
 
-    const unfolded = editor!.handleKeyPress(keyEvent("f6"))
-    expect(unfolded).toBe(true)
+    editor!.unfoldAll()
     await renderOnce()
     expect(editor!.lineCount).toBe(originalLineCount)
     expect(editor!.plainText).toBe(content)
@@ -1475,10 +1473,10 @@ describe("CodeEditorRenderable read-only mode", () => {
 
     expect(readonly.handleKeyPress(keyEvent("right"))).toBe(true)
     expect(readonly.logicalCursor.col).toBeGreaterThan(cursorBefore)
-    expect(readonly.handleKeyPress(keyEvent("f5"))).toBe(true)
+    readonly.foldAll()
     await renderOnce()
     expect(readonly.lineCount).toBeLessThan(content.split("\n").length)
-    expect(readonly.handleKeyPress(keyEvent("f6"))).toBe(true)
+    readonly.unfoldAll()
     await renderOnce()
     expect(readonly.plainText).toBe(content)
 

--- a/tests/unit/SettingsView.test.tsx
+++ b/tests/unit/SettingsView.test.tsx
@@ -793,7 +793,7 @@ describe("SettingsView", () => {
     await renderOnce()
 
     await act(async () => host.press("return"))
-    await act(async () => host.press("f5"))
+    await act(async () => host.press("g", { ctrl: true }))
     await renderOnce()
 
     expect(captureCharFrame()).toContain("That key cannot be assigned")

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -16,6 +16,7 @@ import { createAppKeymapLayers } from "../../src/ui/keymap/layers"
 import type { AppKeymapContext } from "../../src/ui/keymap/types"
 import { useAppKeymap } from "../../src/ui/useAppKeymap"
 import { createTestRender } from "../testRender"
+import { CodeEditorRenderable } from "../../src/ui/editor/CodeEditor"
 
 const testRender = createTestRender()
 
@@ -64,6 +65,7 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     cookieExpand: 0,
     cookieEdit: 0,
     runnerClose: 0,
+    runnerOpen: [] as Array<string | null>,
     runnerFailFast: 0,
     runnerRun: 0,
     runnerOptionFirst: 0,
@@ -210,6 +212,10 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
       },
     },
     detailScrollRef: { current: null },
+    open: (scope: string | null) => {
+      calls.runnerOpen.push(scope)
+      return true
+    },
     close: () => calls.runnerClose++,
     openTagFilter: (filter: "include" | "exclude", index: number) =>
       calls.runnerTagFilterOpen.push({ filter, index }),
@@ -806,15 +812,61 @@ describe("app keymap layers", () => {
     cleanup()
   })
 
+  it("uses the configured collection Runner shortcut instead of f5", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    context.keybinds = { ...context.keybinds, runner_open: "f7" }
+    const disposers = register(context)
+
+    host.press("f5")
+    expect(calls.runnerOpen).toEqual([])
+    host.press("f7")
+    expect(calls.runnerOpen).toEqual([null])
+
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
+  it("uses configured bulk-fold shortcuts for a focused code editor", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context } = createContext(keymap)
+    let folded = 0
+    let unfolded = 0
+    const editor = Object.create(
+      CodeEditorRenderable.prototype,
+    ) as CodeEditorRenderable
+    editor.foldAll = () => folded++
+    editor.unfoldAll = () => unfolded++
+    Object.defineProperty(context.renderer, "currentFocusedRenderable", {
+      value: editor,
+    })
+    context.keybinds = {
+      ...context.keybinds,
+      editor_fold_all: "f8",
+      editor_unfold_all: "f9",
+    }
+    const disposers = register(context)
+
+    host.press("f5")
+    host.press("f8")
+    host.press("f9")
+
+    expect(folded).toBe(1)
+    expect(unfolded).toBe(1)
+
+    disposers.forEach((dispose) => dispose())
+    cleanup()
+  })
+
   it("dispatches a live settings shortcut override instead of the old key", () => {
     const { keymap, host, cleanup } = setup()
     const { context, calls } = createContext(keymap)
-    context.keybinds = { ...context.keybinds, settings_open: "f5" }
+    context.keybinds = { ...context.keybinds, settings_open: "f7" }
     const disposers = register(context)
 
     host.press("f4")
     expect(calls.settingsOpened).toBe(false)
-    host.press("f5")
+    host.press("f7")
     expect(calls.settingsOpened).toBe(true)
 
     disposers.forEach((dispose) => dispose())
@@ -847,13 +899,13 @@ describe("app keymap layers", () => {
     calls.settingsOpened = false
 
     await act(() => {
-      updateKeybinds!({ ...context.keybinds, settings_open: "f5" })
+      updateKeybinds!({ ...context.keybinds, settings_open: "f7" })
     })
     await render.renderOnce()
 
     host.press("f4")
     expect(calls.settingsOpened).toBe(false)
-    host.press("f5")
+    host.press("f7")
     expect(calls.settingsOpened).toBe(true)
 
     cleanup()

--- a/tests/unit/codeEditorKeys.test.ts
+++ b/tests/unit/codeEditorKeys.test.ts
@@ -24,12 +24,10 @@ function key(name: string, modifiers: Partial<KeyEvent> = {}): KeyEvent {
 }
 
 describe("codeEditorKeys", () => {
-  it("classifies fold shortcuts without matching modified function keys", () => {
+  it("keeps only toggle-fold as a fixed editor shortcut", () => {
     expect(getEditorCommand(key("g", { ctrl: true }))).toBe("toggle-fold")
-    expect(getEditorCommand(key("f5"))).toBe("fold-all")
-    expect(getEditorCommand(key("]", { ctrl: true, shift: true }))).toBe(
-      "unfold-all",
-    )
+    expect(getEditorCommand(key("f5"))).toBeNull()
+    expect(getEditorCommand(key("]", { ctrl: true, shift: true }))).toBeNull()
     expect(getEditorCommand(key("f5", { ctrl: true }))).toBeNull()
   })
 

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -378,6 +378,10 @@ describe("buildCommandPaletteCommands", () => {
     expect(
       openCollectionRunner(
         "admin",
+        () => {
+          calls.push("commit")
+          return true
+        },
         (scope) => calls.push(`reset:${scope}`),
         (view) => calls.push(`view:${view}`),
         (focus) => calls.push(`focus:${focus}`),
@@ -394,6 +398,7 @@ describe("buildCommandPaletteCommands", () => {
       ),
     ).toBe(true)
     expect(calls).toEqual([
+      "commit",
       "reset:admin",
       "view:runner",
       "focus:runner-options",
@@ -402,6 +407,21 @@ describe("buildCommandPaletteCommands", () => {
       "focus:request",
       "tab:assertions",
     ])
+  })
+
+  it("does not open the Runner when a pending request edit cannot commit", () => {
+    const calls: string[] = []
+
+    expect(
+      openCollectionRunner(
+        null,
+        () => false,
+        (scope) => calls.push(`reset:${scope}`),
+        (view) => calls.push(`view:${view}`),
+        (focus) => calls.push(`focus:${focus}`),
+      ),
+    ).toBe(false)
+    expect(calls).toEqual([])
   })
 
   it("shows only environment commands for an environment context menu", () => {

--- a/tests/unit/commands.test.ts
+++ b/tests/unit/commands.test.ts
@@ -360,6 +360,7 @@ describe("buildCommandPaletteCommands", () => {
       (command) => command.id === "collection.runner",
     )
     expect(collectionCommand?.label).toBe("Run Collection")
+    expect(collectionCommand?.keybinding).toBe("f5")
     expect(collectionCommand?.run()).toBe(true)
 
     ctx.paletteTarget = "folder"

--- a/tests/unit/helpTexts.test.ts
+++ b/tests/unit/helpTexts.test.ts
@@ -58,13 +58,18 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^t")
   })
 
-  it("CODE EDITOR section shows ^g, f5, and f6", () => {
+  it("leaves bulk folding out of help until configured", () => {
     const sections = getHelpSections(defaults)
     const editor = sections.find((s) => s.title === "Code Editor")!
     const keys = editor.keys.map((k) => k.key)
-    expect(keys).toContain("^g")
-    expect(keys).toContain("f5")
-    expect(keys).toContain("f6")
+    expect(keys).toEqual(["^g"])
+
+    const configured = getHelpSections({
+      ...defaults,
+      editor_fold_all: "f8",
+      editor_unfold_all: "f9",
+    }).find((s) => s.title === "Code Editor")!
+    expect(configured.keys.map((key) => key.key)).toEqual(["^g", "f8", "f9"])
   })
 
   it("ACTIONS section shows ^return / ^j, ^s, ^n, ^k, ^w, ^shift+p, ^l", () => {
@@ -80,6 +85,7 @@ describe("getHelpSections", () => {
     expect(keys).toContain("^l")
     expect(keys).toContain("e")
     expect(keys).toContain("f3")
+    expect(keys).toContain("f5")
     expect(act.keys).toContainEqual({
       key: "e",
       description: "Open environment picker",

--- a/tests/unit/keybind.test.ts
+++ b/tests/unit/keybind.test.ts
@@ -87,6 +87,16 @@ describe("bindingDefaults", () => {
     expect(bindingDefaults().settings_open).toBe("f4")
     expect(CommandMap.settings_open).toBe("app.settings-open")
   })
+
+  it("opens the Runner with f5 and leaves bulk folding unbound", () => {
+    const defaults = bindingDefaults()
+    expect(defaults.runner_open).toBe("f5")
+    expect(defaults.editor_fold_all).toBe("")
+    expect(defaults.editor_unfold_all).toBe("")
+    expect(CommandMap.runner_open).toBe("collection.runner")
+    expect(CommandMap.editor_fold_all).toBe("editor.fold-all")
+    expect(CommandMap.editor_unfold_all).toBe("editor.unfold-all")
+  })
 })
 
 describe("shortcut editing", () => {
@@ -120,7 +130,7 @@ describe("shortcut editing", () => {
     expect(keyEventToBinding(event("x", { super: true }))).toBeNull()
     expect(keyEventToBinding(event("c", { ctrl: true }))).toBeNull()
     expect(keyEventToBinding(event("g", { ctrl: true }))).toBeNull()
-    expect(keyEventToBinding(event("f5"))).toBeNull()
+    expect(keyEventToBinding(event("f5"))).toBe("f5")
     expect(keyEventToBinding(event("escape"))).toBeNull()
     expect(keyEventToBinding(event("unknown-key"))).toBeNull()
   })
@@ -134,6 +144,9 @@ describe("shortcut editing", () => {
     expect(findKeybindConflict("env_save", "s", keybinds)).toBe("env_secret")
     expect(findKeybindConflict("browse_delete", "r", keybinds)).toBe(
       "env_reveal",
+    )
+    expect(findKeybindConflict("editor_fold_all", "f5", keybinds)).toBe(
+      "runner_open",
     )
   })
 

--- a/tests/unit/useAuthoringEditBrowse.test.tsx
+++ b/tests/unit/useAuthoringEditBrowse.test.tsx
@@ -16,7 +16,48 @@ const request: Request = {
   timeout: 0,
 }
 
-describe("useEditBrowse assertion, capture, and tag rows", () => {
+describe("useEditBrowse authored rows", () => {
+  it("commits a path value when its read-only key buffer is cleared", async () => {
+    const result: { value?: Request["pathParams"] } = {}
+    let committed: boolean | undefined
+    function Harness() {
+      const draft = useRequestDraft({
+        ...request,
+        url: "https://example.com/users/:id",
+        pathParams: [{ name: "id", value: "42", enabled: true }],
+      })
+      const editor = useEditBrowse(draft.draft, draft)
+      const [step, setStep] = useState(0)
+      useEffect(() => {
+        if (step === 0) {
+          editor.enterBrowseAt("pathParams", 0)
+          setStep(1)
+        } else if (step === 1 && editor.editState.mode === "browsing") {
+          editor.enterEdit()
+          setStep(2)
+        } else if (step === 2 && editor.editState.mode === "editing") {
+          editor.setEditKey("")
+          editor.setEditValue("99")
+          setStep(3)
+        } else if (
+          step === 3 &&
+          editor.editKey === "" &&
+          editor.editValue === "99"
+        ) {
+          committed = editor.commitEdit()
+          setStep(4)
+        } else if (step === 4 && editor.editState.mode === "browsing") {
+          result.value = draft.draft?.pathParams
+        }
+      }, [draft.draft, editor, step])
+      return null
+    }
+    const render = await testRender(<Harness />, { width: 20, height: 4 })
+    for (let i = 0; i < 7 && !result.value; i++) await render.renderOnce()
+    expect(committed).toBe(true)
+    expect(result.value).toEqual([{ name: "id", value: "99", enabled: true }])
+  })
+
   it("adds a structured assertion and parses its expected value", async () => {
     const result: { value?: Request["assertions"] } = {}
     function Harness() {


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reassigns `F5` to open the collection Runner (`collection.runner`) and makes bulk code-editor folding configurable. Removes hardcoded `F5`/`F6` and `Ctrl+Shift+[`/`]` fold-all/unfold-all bindings from `CodeEditor`/`codeEditorKeys`; adds configurable `editor_fold_all`/`editor_unfold_all` keybinds (default unbound) and a `runner_open` keybind (default `F5`). Folding is now handled via global keymap layers against the focused `CodeEditorRenderable` instead of fixed editor commands. Updates help text, command palette keybinding display, and `AppInner` runner wiring.

### How did you verify your code works?

Manual verification via existing automated tests; no manual TUI steps. Ran checklist:
- `bun test` — 3071 pass, 0 fail
- `bun run lint` — passes (oxlint)
- `bun run typecheck` — passes (tsc --noEmit)

### Screenshots / recordings

N/A — keybinding change only.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable keyboard shortcut for opening the Collection Runner.
  - Added configurable shortcuts for folding and unfolding all code regions.
  - Updated keyboard shortcut help to display configured actions.

- **Improvements**
  - Pending edits are now saved before opening the Collection Runner; opening is cancelled if saving fails.
  - Folding and unfolding all regions now use configurable shortcuts instead of fixed keys.
  - `Ctrl+G` continues to toggle folding for the current code region.
  - Improved shortcut conflict detection and editor focus handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->