### PR TITLE
fix(deps): patch httpsnippet to avoid deprecated url.parse

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
     },
   },
   "patchedDependencies": {
+    "httpsnippet@3.0.10": "patches/httpsnippet@3.0.10.patch",
     "postman-collection@5.3.1": "patches/postman-collection@5.3.1.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     ]
   },
   "patchedDependencies": {
+    "httpsnippet@3.0.10": "patches/httpsnippet@3.0.10.patch",
     "postman-collection@5.3.1": "patches/postman-collection@5.3.1.patch"
   }
 }

--- a/patches/httpsnippet@3.0.10.patch
+++ b/patches/httpsnippet@3.0.10.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/httpsnippet.js b/dist/httpsnippet.js
+--- a/dist/httpsnippet.js
++++ b/dist/httpsnippet.js
+@@ -217,7 +217,8 @@ var HTTPSnippet = /** @class */ (function () {
+             }
+             // create allHeaders object
+             var allHeaders = __assign(__assign({}, request.allHeaders), request.headersObj);
+-            var urlWithParsedQuery = (0, url_1.parse)(request.url, true, true); //?
++            var parsedUrl = new url_1.URL(request.url);
++            var urlWithParsedQuery = __assign(__assign((0, url_1.urlToHttpOptions)(parsedUrl), { host: parsedUrl.host, port: parsedUrl.port || null, slashes: true }), { query: (0, querystring_1.parse)(parsedUrl.search.slice(1)) });
+             // query string key/value pairs in with literal querystrings containd within the url
+             request.queryObj = __assign(__assign({}, request.queryObj), urlWithParsedQuery.query); //?
+             // reset uriObj values for a clean url

--- a/src/codegen/variableHash.ts
+++ b/src/codegen/variableHash.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from "node:crypto"
+
 const VAR_RE = /\$(\w+)/g
-const HOSTLESS_SCHEME_RE = /^(https?:\/\/)(?=[:/?#]|$)/
+const HTTP_AUTHORITY_RE = /^https?:\/\/([^/?#]*)/
 
 const VAR_PREFIX = "noodle-var-"
-const HOST_SENTINEL = "noodle-sentinel.invalid/"
-const SCHEME_SENTINEL = `http://${HOST_SENTINEL}`
 
 export interface VarHasher {
   hashed: string
@@ -11,28 +11,29 @@ export interface VarHasher {
 }
 
 export function hashVars(url: string): VarHasher {
-  let hadScheme = true
+  const schemeSentinel = `http://noodle-sentinel-${randomUUID()}.invalid/`
   let working = url
-  const hostlessScheme = working.match(HOSTLESS_SCHEME_RE)?.[1]
+  let addedSentinel = false
 
-  if (hostlessScheme) {
-    working = `${hostlessScheme}${HOST_SENTINEL}${working.slice(hostlessScheme.length)}`
-  } else if (
-    !working.startsWith("http://") &&
-    !working.startsWith("https://")
-  ) {
-    working = SCHEME_SENTINEL + working
-    hadScheme = false
+  if (!working.startsWith("http://") && !working.startsWith("https://")) {
+    working = schemeSentinel + working
+    addedSentinel = true
   }
 
   let counter = 0
   const map = new Map<number, string>()
-  const hashed = working.replace(VAR_RE, (match) => {
+  let hashed = working.replace(VAR_RE, (match) => {
     const id = counter++
     const placeholder = `${VAR_PREFIX}${id}`
     map.set(id, match)
     return placeholder
   })
+  const authority = hashed.match(HTTP_AUTHORITY_RE)?.[1] ?? ""
+  const host = authority.slice(authority.lastIndexOf("@") + 1)
+  if (!host || host.startsWith(":") || !URL.canParse(hashed)) {
+    hashed = schemeSentinel + hashed
+    addedSentinel = true
+  }
 
   const restore = (input: string): string => {
     let s = input
@@ -42,10 +43,8 @@ export function hashVars(url: string): VarHasher {
         s = s.replaceAll(`${VAR_PREFIX}${i}`, original)
       }
     }
-    if (hostlessScheme) {
-      s = s.replaceAll(`${hostlessScheme}${HOST_SENTINEL}`, hostlessScheme)
-    } else if (!hadScheme) {
-      s = s.replaceAll(SCHEME_SENTINEL, "")
+    if (addedSentinel) {
+      s = s.replace(schemeSentinel, "")
     }
     return s
   }

--- a/src/codegen/variableHash.ts
+++ b/src/codegen/variableHash.ts
@@ -1,7 +1,9 @@
 const VAR_RE = /\$(\w+)/g
+const HOSTLESS_SCHEME_RE = /^(https?:\/\/)(?=[:/?#]|$)/
 
 const VAR_PREFIX = "noodle-var-"
-const SCHEME_SENTINEL = "http://noodle-sentinel.invalid/"
+const HOST_SENTINEL = "noodle-sentinel.invalid/"
+const SCHEME_SENTINEL = `http://${HOST_SENTINEL}`
 
 export interface VarHasher {
   hashed: string
@@ -11,8 +13,14 @@ export interface VarHasher {
 export function hashVars(url: string): VarHasher {
   let hadScheme = true
   let working = url
+  const hostlessScheme = working.match(HOSTLESS_SCHEME_RE)?.[1]
 
-  if (!working.startsWith("http://") && !working.startsWith("https://")) {
+  if (hostlessScheme) {
+    working = `${hostlessScheme}${HOST_SENTINEL}${working.slice(hostlessScheme.length)}`
+  } else if (
+    !working.startsWith("http://") &&
+    !working.startsWith("https://")
+  ) {
     working = SCHEME_SENTINEL + working
     hadScheme = false
   }
@@ -34,7 +42,9 @@ export function hashVars(url: string): VarHasher {
         s = s.replaceAll(`${VAR_PREFIX}${i}`, original)
       }
     }
-    if (!hadScheme) {
+    if (hostlessScheme) {
+      s = s.replaceAll(`${hostlessScheme}${HOST_SENTINEL}`, hostlessScheme)
+    } else if (!hadScheme) {
       s = s.replaceAll(SCHEME_SENTINEL, "")
     }
     return s

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -443,6 +443,24 @@ describe("generateCode", () => {
     }
   })
 
+  it("generates code for incomplete scheme-bearing URLs", () => {
+    for (const url of ["http://", "http://:8080"]) {
+      const result = generateCode(
+        makeRequest({
+          method: "GET",
+          url,
+          headers: {},
+          params: [],
+          bodyType: "none",
+          body: undefined,
+          auth: { type: "none" },
+        }),
+        curlTarget(),
+      )
+      expect(result.code).toBe(`curl --request GET \\\n  --url ${url}`)
+    }
+  })
+
   it("generates code with an XML body", () => {
     const result = generateCode(
       makeRequest({ bodyType: "xml", body: "<root><id>$ID</id></root>" }),

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { createRequire } from "node:module"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { generateCode, findCodeTarget } from "../../src/codegen"
@@ -424,6 +425,22 @@ describe("generateCode", () => {
     const result = generateCode(makeRequest(), curlTarget())
     expect(result.code).toContain("curl")
     expect(result.code.length).toBeGreaterThan(0)
+  })
+
+  it("does not call deprecated url.parse", () => {
+    const nodeUrl = createRequire(import.meta.url)("url") as {
+      parse: typeof import("node:url").parse
+    }
+    const parse = nodeUrl.parse
+    nodeUrl.parse = () => {
+      throw new Error("deprecated url.parse called")
+    }
+
+    try {
+      expect(generateCode(makeRequest(), curlTarget()).code).toContain("curl")
+    } finally {
+      nodeUrl.parse = parse
+    }
   })
 
   it("generates code with an XML body", () => {

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -444,7 +444,12 @@ describe("generateCode", () => {
   })
 
   it("generates code for incomplete scheme-bearing URLs", () => {
-    for (const url of ["http://", "http://:8080"]) {
+    for (const url of [
+      "http://",
+      "http://:8080",
+      "http:///path",
+      "http://user:pass@",
+    ]) {
       const result = generateCode(
         makeRequest({
           method: "GET",
@@ -459,6 +464,26 @@ describe("generateCode", () => {
       )
       expect(result.code).toBe(`curl --request GET \\\n  --url ${url}`)
     }
+  })
+
+  it("preserves sentinel-like text outside an incomplete URL", () => {
+    const sentinelLikeText = "http://noodle-sentinel.invalid/"
+    const result = generateCode(
+      makeRequest({
+        method: "GET",
+        url: "http://",
+        headers: {
+          "X-Sentinel": { value: sentinelLikeText, enabled: true },
+        },
+        params: [],
+        bodyType: "none",
+        body: undefined,
+        auth: { type: "none" },
+      }),
+      curlTarget(),
+    )
+
+    expect(result.code).toContain(`X-Sentinel: ${sentinelLikeText}`)
   })
 
   it("generates code with an XML body", () => {


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Patches `httpsnippet@3.0.10` to replace deprecated `url.parse` with `new URL` + `urlToHttpOptions` + `querystring.parse`, removing the Node deprecation warning during code generation. Adds regression test that fails if `url.parse` is called.

### How did you verify your code works?

- Added test `does not call deprecated url.parse` in `tests/unit/codegen.test.ts:430`
- Tested locally: `bun test` (3075 pass), `bun run lint` pass, `bun run typecheck` pass

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling during cURL code generation, preserving hosts, ports, paths, and query parameters more reliably.
  - Added support for incomplete scheme-based URLs, including URLs without a host or with a port-only host.
  - Prevented failures caused by outdated URL parsing behavior, improving compatibility and stability when generating code from requests.
  - Improved handling of hostless URLs containing paths or query parameters without altering matching header text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->