### PR TITLE
perf(editor): cache line metadata for read-only highlighting

### DIFF
--- a/src/ui/editor/CodeEditor.ts
+++ b/src/ui/editor/CodeEditor.ts
@@ -1,6 +1,7 @@
 import type {
   Highlight,
   KeyEvent,
+  LineInfo,
   PasteEvent,
   RenderContext,
   RenderableOptions,
@@ -89,7 +90,9 @@ export class CodeEditorRenderable extends TextareaRenderable {
   private _selectionDragAnchor: number | null = null
   private _selectionDragDirection: -1 | 1 = 1
   private _readonlyKeyboardSelectionAnchor: number | null = null
-  private _displayedTextLength = 0
+  private _readonlyLineInfo: LineInfo | null = null
+  private _displayedText = ""
+  private _displayedLineStarts = [0]
 
   constructor(ctx: RenderContext, options: CodeEditorOptions) {
     super(ctx, {
@@ -110,11 +113,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
     this._readOnly = options.readOnly ?? false
     this._filetype = options.filetype
     this._theme = options.theme
-    this._displayedTextLength = (
-      options.value ??
-      options.initialValue ??
-      ""
-    ).length
+    this.cacheDisplayedText(options.value ?? options.initialValue ?? "")
     this._debounceMs = options.debounceMs ?? 200
     this._onSourceChange = options.onSourceChange
     this._onFoldsChange = options.onFoldsChange
@@ -201,6 +200,10 @@ export class CodeEditorRenderable extends TextareaRenderable {
   override get plainText(): string {
     return this._foldManager.sourceText
   }
+  override get lineInfo(): LineInfo {
+    if (!this._readOnly) return super.lineInfo
+    return (this._readonlyLineInfo ??= super.lineInfo)
+  }
   override get height(): number {
     const height = super.height
     return Math.min(height, this.parent?.height ?? height)
@@ -226,8 +229,8 @@ export class CodeEditorRenderable extends TextareaRenderable {
     this.clearReadonlyHighlights()
     this._readOnly = next
     this._readonlyNeedsFolds = true
+    this.cacheDisplayedText(super.plainText)
     if (next) {
-      this._displayedTextLength = super.plainText.length
       this.scheduleHighlight()
     } else {
       this._validation.refresh(this.plainText)
@@ -459,6 +462,11 @@ export class CodeEditorRenderable extends TextareaRenderable {
   protected override onUpdate(deltaTime: number): void {
     super.onUpdate(deltaTime)
     this.refreshSelectionDrag(deltaTime)
+  }
+
+  protected override onResize(width: number, height: number): void {
+    this._readonlyLineInfo = null
+    super.onResize(width, height)
   }
 
   override requestRender(): void {
@@ -700,12 +708,27 @@ export class CodeEditorRenderable extends TextareaRenderable {
   private setDisplayedText(text: string): void {
     this._suppressContentChanged = true
     try {
+      this.cacheDisplayedText(text)
       this.editBuffer.setText(text)
-      this._displayedTextLength = text.length
       this.yogaNode.markDirty()
       this.clearReadonlyHighlights()
     } finally {
       this._suppressContentChanged = false
+    }
+  }
+
+  private cacheDisplayedText(text: string): void {
+    this._readonlyLineInfo = null
+    this._displayedLineStarts = [0]
+    if (!this._readOnly) {
+      this._displayedText = ""
+      return
+    }
+    this._displayedText = text
+    for (let offset = 0; offset < text.length; offset++) {
+      if (text.charCodeAt(offset) === 10) {
+        this._displayedLineStarts.push(offset + 1)
+      }
     }
   }
 
@@ -768,9 +791,10 @@ export class CodeEditorRenderable extends TextareaRenderable {
       return
     }
     if (this._filetype !== "json") return
+    const lineSources = this.lineInfo.lineSources
     const viewportStart = Math.max(0, this.scrollY - 2)
     const viewportEnd = Math.min(
-      this.lineInfo.lineSources.length,
+      lineSources.length,
       this.scrollY + this.viewport.height + 2,
     )
     const lines: number[] = []
@@ -779,7 +803,7 @@ export class CodeEditorRenderable extends TextareaRenderable {
       displayLine < viewportEnd;
       displayLine++
     ) {
-      const line = this.lineInfo.lineSources[displayLine]
+      const line = lineSources[displayLine]
       if (line === undefined) continue
       if (this._readonlyHighlightedLines.has(line)) continue
       this._readonlyHighlightedLines.add(line)
@@ -789,13 +813,14 @@ export class CodeEditorRenderable extends TextareaRenderable {
 
     this._highlights.prepare()
     for (const line of lines) {
-      const start = this.editBuffer.getLineStartOffset(line)
+      const start = this._displayedLineStarts[line]
+      if (start === undefined) continue
       const end =
-        line + 1 < this.editBuffer.getLineCount()
-          ? this.editBuffer.getLineStartOffset(line + 1) - 1
-          : this._displayedTextLength
-      const text = this.editBuffer.getTextRange(start, end)
-      if (text.length > 100_000) continue
+        line + 1 < this._displayedLineStarts.length
+          ? this._displayedLineStarts[line + 1]! - 1
+          : this._displayedText.length
+      if (end - start > 100_000) continue
+      const text = this._displayedText.slice(start, end)
       for (const token of highlightJsonTokens(text, this._theme)) {
         this.addHighlight(line, {
           start: token.displayOffset,

--- a/tests/scrollbox.test.tsx
+++ b/tests/scrollbox.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, it, expect, jest } from "bun:test"
+import { afterEach, describe, it, expect, jest, spyOn } from "bun:test"
 import { act, useMemo, useState } from "react"
 import { createTestRender } from "./testRender"
 import { extend } from "@opentui/react"
@@ -1219,6 +1219,44 @@ describe("ResponsePane scrollbox", () => {
     expect(bodyEditor).toBeInstanceOf(CodeEditorRenderable)
     expect((bodyEditor as CodeEditorRenderable).plainText).toBe(body)
     expect(bodyEditorAvailable).toBe(true)
+  })
+
+  it("reuses line metadata for a 2.5 MB response body", async () => {
+    const item = `{"id":1,"payload":"${"x".repeat(80)}"}`
+    const body = `{"data":[${`${item},`.repeat(26_000)}${item}]}`
+    const raw = createTestKeymap()
+    const keymap = raw.keymap as unknown as OpenTuiKeymap
+    keymap.setData("app.overlay", "none")
+    const { renderer, renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ResponsePane
+          state={{
+            status: "done",
+            response: {
+              status: 200,
+              statusText: "OK",
+              headers: {},
+              body,
+              timeMs: 1,
+            },
+          }}
+          focused
+        />
+      </KeymapProvider>,
+      { width: 80, height: 12 },
+    )
+    await renderOnce()
+
+    const editor = renderer.root.findDescendantById(
+      "response-body-editor",
+    ) as CodeEditorRenderable
+    await editor.refreshHighlights()
+    const lineInfo = spyOn(editor.editorView, "getLogicalLineInfo")
+
+    await renderOnce()
+    await editor.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(0)
+    expect(editor.plainText.length).toBeGreaterThan(2.5 * 1024 * 1024)
   })
 })
 

--- a/tests/unit/CodeEditor.test.tsx
+++ b/tests/unit/CodeEditor.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, spyOn } from "bun:test"
 import { act } from "react"
 import { createTestRender } from "../testRender"
 import { extend } from "@opentui/react"
@@ -1658,5 +1658,59 @@ describe("CodeEditorRenderable read-only mode", () => {
     await readonly.refreshHighlights()
     await renderOnce()
     expect(getHighlightCount(readonly)).toBe(0)
+  })
+
+  it("reuses line metadata and displayed text while highlighting", async () => {
+    let editor: CodeEditorRenderable | null = null
+    const content = [
+      "{",
+      ...Array.from({ length: 2_000 }, (_, i) => `  "item${i}": ${i},`),
+      '  "last": true',
+      "}",
+    ].join("\n")
+    const { renderOnce, resize } = await testRender(
+      <box width="100%" height={8}>
+        <code-editor
+          ref={(renderable) => {
+            editor = renderable
+          }}
+          filetype="json"
+          theme={opencodeTheme}
+          value={content}
+          readOnly
+        />
+      </box>,
+      { width: 48, height: 8 },
+    )
+    await renderOnce()
+
+    const readonly = editor!
+    await readonly.refreshHighlights()
+    const initialHighlights = getHighlightCount(readonly)
+    const lineInfo = spyOn(readonly.editorView, "getLogicalLineInfo")
+    const textRange = spyOn(readonly.editBuffer, "getTextRange")
+
+    await readonly.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(0)
+
+    readonly.scrollTo(readonly.totalVirtualLineCount)
+    await readonly.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(0)
+    expect(textRange).toHaveBeenCalledTimes(0)
+    expect(getHighlightCount(readonly)).toBeGreaterThan(initialHighlights)
+
+    resize(40, 8)
+    await renderOnce()
+    await readonly.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(1)
+
+    readonly.value = content.replace('"last"', '"updated"')
+    await readonly.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(2)
+
+    readonly.foldAll()
+    await readonly.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(3)
+    expect(readonly.plainText).toContain('"updated"')
   })
 })

--- a/tests/unit/TimelineDetailOverlay.test.tsx
+++ b/tests/unit/TimelineDetailOverlay.test.tsx
@@ -345,6 +345,39 @@ describe("TimelineDetailOverlay", () => {
     cleanup()
   })
 
+  it("reuses line metadata for a 2.5 MB response body", async () => {
+    const item = `{"id":1,"payload":"${"x".repeat(80)}"}`
+    const body = `{"data":[${`${item},`.repeat(26_000)}${item}]}`
+    const { renderer, renderOnce, cleanup } = await renderOverlay(
+      makeEntry({
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body,
+          timeMs: 12,
+          size: body.length,
+        },
+      }),
+      () => {},
+      true,
+      { initialTab: "response" },
+    )
+    await renderOnce()
+
+    const editor = renderer.root.findDescendantById(
+      "timeline-body-editor",
+    ) as CodeEditorRenderable
+    await editor.refreshHighlights()
+    const lineInfo = spyOn(editor.editorView, "getLogicalLineInfo")
+
+    await renderOnce()
+    await editor.refreshHighlights()
+    expect(lineInfo).toHaveBeenCalledTimes(0)
+    expect(editor.plainText.length).toBeGreaterThan(2.5 * 1024 * 1024)
+    cleanup()
+  })
+
   it("loads a sidecar body before copying or exporting it", async () => {
     const copied: string[] = []
     const exported: string[] = []


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Caches line metadata for read-only CodeEditor highlighting. Avoids repeated `lineInfo` / `editBuffer` traversals by storing displayed text and line starts, invalidating on resize or text change. Improves large response body performance.

### How did you verify your code works?

Manual verification via existing tests; added/updated coverage for scroll and editor highlighting behavior.

### Screenshots / recordings

N/A - performance refactor, no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved read-only code editor performance when viewing very large response bodies.
  - Scrolling, highlighting, and refreshing now reuse cached display information, reducing unnecessary recalculation.
  - Large responses of approximately 2.5 MB or more should remain more responsive in the editor and timeline details view.

- **Bug Fixes**
  - Updated cached display information when content changes, the viewport is resized, or sections are folded to keep highlighting accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->