### PR TITLE
fix(hooks): prevent cursor from landing on folder when selected request is deleted

### DIFF
--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -167,8 +167,8 @@ export function useTreeNavigation(
       }
       if (targetId) {
         const currentNode = visRef.current[cursorIndexRef.current]
-        if (currentNode?.type !== "folder") {
-          const idx = vis.findIndex(
+        if (currentNode?.type !== "folder" || targetId !== selectedId) {
+          const idx = visRef.current.findIndex(
             (n) => n.type === "request" && n.id === targetId,
           )
           if (idx >= 0) setCursorIndex(idx)
@@ -280,14 +280,34 @@ export function useTreeNavigation(
   })
 
   const renderedSelectedId = selectedId === null ? null : targetId
-  let clampedCursor = Math.min(cursorIndex, Math.max(0, vis.length - 1))
+  let renderedExpanded = expanded
+  if (renderedSelectedId !== selectedId && renderedSelectedId) {
+    const parts = renderedSelectedId.split("/")
+    if (parts.length > 1) {
+      renderedExpanded = new Set(expanded)
+      for (let i = 1; i < parts.length; i++) {
+        renderedExpanded.add(parts.slice(0, i).join("/"))
+      }
+    }
+  }
+  const renderedVisibleItems =
+    renderedExpanded === expanded ? vis : visibleNodes(items, renderedExpanded)
+  let clampedCursor = Math.min(
+    cursorIndex,
+    Math.max(0, renderedVisibleItems.length - 1),
+  )
   if (renderedSelectedId !== selectedId) {
-    const targetIndex = vis.findIndex(
+    const targetIndex = renderedVisibleItems.findIndex(
       (node) => node.type === "request" && node.id === renderedSelectedId,
     )
     if (targetIndex >= 0) clampedCursor = targetIndex
   }
-  const focusedNode = vis[clampedCursor]
+  selectedIdRef.current = renderedSelectedId
+  expandedRef.current = renderedExpanded
+  visRef.current = renderedVisibleItems
+  cursorIndexRef.current = clampedCursor
+
+  const focusedNode = renderedVisibleItems[clampedCursor]
   const focusedFolderPath =
     focusedNode?.type === "folder" ? focusedNode.id : null
   const focusedFolderName =
@@ -302,8 +322,8 @@ export function useTreeNavigation(
     selectedRequest,
     focusedFolderPath,
     focusedFolderName,
-    expanded,
-    visibleItems: vis,
+    expanded: renderedExpanded,
+    visibleItems: renderedVisibleItems,
     cursorIndex: clampedCursor,
     setSelectedId,
     revealRequest,

--- a/src/hooks/useTreeNavigation.ts
+++ b/src/hooks/useTreeNavigation.ts
@@ -66,6 +66,15 @@ export function useTreeNavigation(
   const prevSelectedIdRef = useRef(selectedId)
 
   const flatReqs = flattenRequests(items)
+  let targetId = selectedId
+    ? (findRequestById(items, selectedId)?.id ?? null)
+    : null
+  if (!targetId && initialSelectedId && !initialSelectedId.endsWith("/")) {
+    targetId = findRequestById(items, initialSelectedId)?.id ?? null
+  }
+  if (!targetId && !(initialSelectedId && initialSelectedId.endsWith("/"))) {
+    targetId = flatReqs[0]?.id ?? null
+  }
 
   const setSelectedId = useCallback((id: string) => {
     selectedIdRef.current = id
@@ -142,22 +151,6 @@ export function useTreeNavigation(
   useEffect(() => {
     if (flatReqs.length > 0) {
       initialCursorSet.current = false
-
-      let targetId: string | null = null
-      if (selectedId) {
-        const found = findRequestById(items, selectedId)
-        if (found) targetId = selectedId
-      }
-      if (!targetId && initialSelectedId && !initialSelectedId.endsWith("/")) {
-        const found = findRequestById(items, initialSelectedId)
-        if (found) targetId = initialSelectedId
-      }
-      if (
-        !targetId &&
-        !(initialSelectedId && initialSelectedId.endsWith("/"))
-      ) {
-        targetId = flatReqs[0].id
-      }
       if (targetId && targetId !== selectedId) {
         selectedIdRef.current = targetId
         setSelectedIdState(targetId)
@@ -172,11 +165,11 @@ export function useTreeNavigation(
           })
         }
       }
-      if (selectedId) {
+      if (targetId) {
         const currentNode = visRef.current[cursorIndexRef.current]
         if (currentNode?.type !== "folder") {
           const idx = vis.findIndex(
-            (n) => n.type === "request" && n.id === selectedId,
+            (n) => n.type === "request" && n.id === targetId,
           )
           if (idx >= 0) setCursorIndex(idx)
         }
@@ -286,18 +279,25 @@ export function useTreeNavigation(
     }
   })
 
-  const clampedCursor = Math.min(cursorIndex, Math.max(0, vis.length - 1))
+  const renderedSelectedId = selectedId === null ? null : targetId
+  let clampedCursor = Math.min(cursorIndex, Math.max(0, vis.length - 1))
+  if (renderedSelectedId !== selectedId) {
+    const targetIndex = vis.findIndex(
+      (node) => node.type === "request" && node.id === renderedSelectedId,
+    )
+    if (targetIndex >= 0) clampedCursor = targetIndex
+  }
   const focusedNode = vis[clampedCursor]
   const focusedFolderPath =
     focusedNode?.type === "folder" ? focusedNode.id : null
   const focusedFolderName =
     focusedNode?.type === "folder" ? focusedNode.name : null
-  const selectedRequest = selectedId
-    ? findRequestById(itemsRef.current, selectedId)
+  const selectedRequest = renderedSelectedId
+    ? findRequestById(itemsRef.current, renderedSelectedId)
     : null
 
   return {
-    selectedId,
+    selectedId: renderedSelectedId,
     selectedIdRef,
     selectedRequest,
     focusedFolderPath,

--- a/tests/unit/useTreeNavigation.test.tsx
+++ b/tests/unit/useTreeNavigation.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { act, useEffect, useState, type ReactNode } from "react"
+import {
+  act,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type ReactNode,
+} from "react"
 import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import { setupKeymap } from "./_helpers"
@@ -39,6 +45,7 @@ interface Props {
   initialSelectedId?: string
   initialItems: CollectionItem[]
   onStateChange?: (state: string) => void
+  onSelectionRefChange?: (selectedId: string, refId: string) => void
   afterMount?: (
     setSelectedId: (id: string) => void,
     setItems: (items: CollectionItem[]) => void,
@@ -53,6 +60,7 @@ function Harness({
   initialSelectedId,
   initialItems,
   onStateChange,
+  onSelectionRefChange,
   afterMount,
 }: Props): ReactNode {
   const [items, setItems] = useState(initialItems)
@@ -83,6 +91,10 @@ function Harness({
       `${selectedId ?? ""}|${cursorIndex}|${focusedFolderPath ?? "request"}`,
     )
   }, [cursorIndex, focusedFolderPath, onStateChange, selectedId])
+
+  useLayoutEffect(() => {
+    onSelectionRefChange?.(selectedId ?? "", selectedIdRef.current ?? "")
+  }, [onSelectionRefChange, selectedId, selectedIdRef])
 
   return <text>{`s:${selectedId ?? ""}|c:${cursorIndex}`}</text>
 }
@@ -271,8 +283,12 @@ describe("useTreeNavigation", () => {
   })
 
   it("does not expose a folder cursor while replacing a deleted request", async () => {
-    const initialItems = [req("root"), fld("users", [req("users/second")])]
-    const nextItems = [req("root"), fld("users", [])]
+    const initialItems = [
+      req("first"),
+      req("deleted"),
+      fld("users", [req("users/remaining")]),
+    ]
+    const nextItems = [req("first"), fld("users", [req("users/remaining")])]
     const states: string[] = []
     let replaceItems: ((items: CollectionItem[]) => void) | undefined
     let reveal: ((id: string) => void) | undefined
@@ -294,14 +310,47 @@ describe("useTreeNavigation", () => {
     )
 
     await view.renderOnce()
-    await act(async () => reveal?.("users/second"))
+    await act(async () => reveal?.("deleted"))
     await view.renderOnce()
-    expect(view.captureCharFrame()).toContain("s:users/second|c:2")
+    expect(view.captureCharFrame()).toContain("s:deleted|c:1")
 
     states.length = 0
     await act(async () => replaceItems?.(nextItems))
     await view.renderOnce()
 
-    expect(states).toEqual(["root|0|request"])
+    expect(states).toEqual(["first|0|request"])
+  })
+
+  it("reveals a hidden fallback with its selection ref synchronized", async () => {
+    const initialItems = [
+      req("deleted"),
+      fld("users", [req("users/remaining")]),
+    ]
+    const nextItems = [fld("users", [req("users/remaining")])]
+    const states: string[] = []
+    const refStates: string[] = []
+    let replaceItems: ((items: CollectionItem[]) => void) | undefined
+
+    const view = await render(
+      <Harness
+        initialItems={initialItems}
+        onStateChange={(state) => states.push(state)}
+        onSelectionRefChange={(selectedId, refId) =>
+          refStates.push(`${selectedId}|${refId}`)
+        }
+        afterMount={(_setSelectedId, setItems) => {
+          replaceItems = setItems
+        }}
+      />,
+    )
+
+    await view.renderOnce()
+    states.length = 0
+    refStates.length = 0
+    await act(async () => replaceItems?.(nextItems))
+    await view.renderOnce()
+
+    expect(states).toEqual(["users/remaining|1|request"])
+    expect(refStates).toEqual(["users/remaining|users/remaining"])
   })
 })

--- a/tests/unit/useTreeNavigation.test.tsx
+++ b/tests/unit/useTreeNavigation.test.tsx
@@ -38,6 +38,7 @@ function fld(path: string, children: CollectionItem[]): CollectionItem {
 interface Props {
   initialSelectedId?: string
   initialItems: CollectionItem[]
+  onStateChange?: (state: string) => void
   afterMount?: (
     setSelectedId: (id: string) => void,
     setItems: (items: CollectionItem[]) => void,
@@ -51,6 +52,7 @@ interface Props {
 function Harness({
   initialSelectedId,
   initialItems,
+  onStateChange,
   afterMount,
 }: Props): ReactNode {
   const [items, setItems] = useState(initialItems)
@@ -62,6 +64,7 @@ function Harness({
     revealRequest,
     revealFolder,
     cursorIndex,
+    focusedFolderPath,
   } = useTreeNavigation(items, () => true, initialSelectedId)
 
   useEffect(() => {
@@ -74,6 +77,12 @@ function Harness({
       selectedIdRef,
     )
   }, [])
+
+  useEffect(() => {
+    onStateChange?.(
+      `${selectedId ?? ""}|${cursorIndex}|${focusedFolderPath ?? "request"}`,
+    )
+  }, [cursorIndex, focusedFolderPath, onStateChange, selectedId])
 
   return <text>{`s:${selectedId ?? ""}|c:${cursorIndex}`}</text>
 }
@@ -259,5 +268,40 @@ describe("useTreeNavigation", () => {
 
     // Cursor position should land on users/admin folder (index 2: root/list=0, users=1, users/admin=2)
     expect(frame).toContain("c:2")
+  })
+
+  it("does not expose a folder cursor while replacing a deleted request", async () => {
+    const initialItems = [req("root"), fld("users", [req("users/second")])]
+    const nextItems = [req("root"), fld("users", [])]
+    const states: string[] = []
+    let replaceItems: ((items: CollectionItem[]) => void) | undefined
+    let reveal: ((id: string) => void) | undefined
+
+    const view = await render(
+      <Harness
+        initialItems={initialItems}
+        onStateChange={(state) => states.push(state)}
+        afterMount={(
+          _setSelectedId,
+          setItems,
+          _expandFolder,
+          revealRequest,
+        ) => {
+          replaceItems = setItems
+          reveal = revealRequest
+        }}
+      />,
+    )
+
+    await view.renderOnce()
+    await act(async () => reveal?.("users/second"))
+    await view.renderOnce()
+    expect(view.captureCharFrame()).toContain("s:users/second|c:2")
+
+    states.length = 0
+    await act(async () => replaceItems?.(nextItems))
+    await view.renderOnce()
+
+    expect(states).toEqual(["root|0|request"])
   })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes `useTreeNavigation` flicker where deleting the selected request briefly exposes a folder-focused cursor/selection before the fallback sync. Derives `targetId` synchronously during render and clamps/returns the replacement `selectedId` immediately, so no intermediate folder state is rendered.

### How did you verify your code works?

- Added regression test `does not expose a folder cursor while replacing a deleted request` in `tests/unit/useTreeNavigation.test.tsx`
- `bun test` passes (3110 pass)
- `bun run lint` passes
- `bun run typecheck` passes

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree navigation state handling when the selected request or folder contents change.
  * Selection, cursor positioning, and focused-folder behavior now remain consistent after request removal.
  * Prevented stale folder cursor state from being exposed when a request is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->