### PR TITLE
feat(runner): add --delay option to collection run for waiting between requests

### DIFF
--- a/.agents/skills/noodle-use/workflows/automation.md
+++ b/.agents/skills/noodle-use/workflows/automation.md
@@ -23,7 +23,7 @@ Use Noodle's non-interactive CLI for supported collection operations. Never star
 | Delete a local vault value without removing its declaration | `noodle secret delete <key> --env <name> --collection <dir> --json` |
 | Inspect collection cookies and storage health | `noodle cookie list --collection <dir> --json` |
 | Clear cookies or recover unreadable cookie storage | `noodle cookie clear --collection <dir> --json` |
-| Run one, selected, or all requests | `noodle request run <id> ... --json` or `noodle collection run <dir> [<target>...] [--tag <tag>]... [--exclude-tag <tag>]... [--fail-fast] ... --json` |
+| Run one, selected, or all requests | `noodle request run <id> ... --json` or `noodle collection run <dir> [<target>...] [--tag <tag>]... [--exclude-tag <tag>]... [--fail-fast] [--delay <milliseconds>] ... --json` |
 
 ## Rules
 
@@ -36,6 +36,7 @@ Use Noodle's non-interactive CLI for supported collection operations. Never star
 - Each repeated `--tag <tag>` requires that effective request tag, so Include tags use AND matching. Each repeated `--exclude-tag <tag>` removes matching requests, so Exclude tags use OR matching and win when both filters match. Targets resolve first, then include and exclude filters run before environment, proxy, TLS, cookie, or request setup. Tag values and YAML tags are case-sensitive; duplicate filters have no additional effect.
 - Request tags combine with all ancestor folder tags. Duplicates have no additional effect, tags cannot be removed downstream, and root `folder.yml` remains ignored. A tag-filtered selection with no requests is a configuration failure. An empty collection or explicitly selected empty folder still succeeds when no tag filter is present.
 - `--fail-fast` stops after the first failed request. Read executed requests from ordered `data.results` and the remaining selected IDs from ordered `data.skipped` entries with `reason: "fail-fast"`. Filtered requests appear in neither array and cannot change RunScope captures.
+- `--delay <milliseconds>` accepts a non-negative safe integer and waits after a completed request only when another selected request remains. Failed requests are followed by the delay when execution continues; fail-fast skips the delay.
 - Every request result has `failureCategories` in fixed order. Categories are `configuration`, `execution`, `transport`, `http`, `capture`, and `assertion`; response-based `http`, `capture`, and `assertion` failures may coexist. Collection results include `failed`, optional configuration `failure`, and `summary` counts for selection, execution, skips, request outcomes, assertions, captures, duration, and unique failure categories.
 - Every target is validated before the first request is sent. An HTTP status of
   400 or higher, a failed response capture, or a failed response assertion makes the command exit nonzero.

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ the collection Runner, and CLI runs.
 In jump mode, `v` opens Assert, `c` opens Capture, and `t` opens Settings.
 
 Run Collection from the command palette opens a transient collection runner for
-choosing requests, environment, tag filters, and fail-fast behavior before
-inspecting ordered results. A folder's context palette opens the same runner
-scoped to that folder.
+choosing requests, environment, tag filters, fail-fast behavior, and an optional
+delay between requests before inspecting ordered results. A folder's context
+palette opens the same runner scoped to that folder.
 
 Noodle supports JSON and XML bodies, JSONPath filtering, redirects, proxies,
 TLS, mTLS, and request authentication including OAuth 1.0a and OAuth 2.0.
@@ -106,6 +106,7 @@ noodle collection audit ./my-api --json
 noodle collection run ./my-api --json
 noodle collection run ./my-api auth/ health users/get --json
 noodle collection run ./my-api --tag smoke --tag api --exclude-tag destructive --json
+noodle collection run ./my-api --delay 500 --json
 noodle agent install
 ```
 
@@ -115,7 +116,8 @@ apply to every descendant request, so `collection run --tag smoke` can execute a
 dynamic suite without a second collection format. Repeat `--tag` to require
 every Include tag and repeat `--exclude-tag` to remove requests matching any
 Exclude tag. Exclusion wins, and `--fail-fast` records the remaining selected
-request IDs as skipped.
+request IDs as skipped. `--delay <milliseconds>` waits after each completed
+request when another selected request remains.
 
 Request YAML can also declare response assertions for status, timing, headers,
 and JSON body paths. Edit them in the TUI Assert tab or as YAML. Manual

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -264,6 +264,11 @@ const collection = defineCommand({
           default: false,
           description: "Stop after the first failed request",
         },
+        delay: {
+          type: "string",
+          default: "0",
+          description: "Milliseconds to wait between requests",
+        },
         noproxy: { type: "boolean", default: false },
         insecure: { type: "boolean", default: false },
         json: jsonArg,
@@ -294,6 +299,8 @@ const collection = defineCommand({
                 (values.tag ?? []) as string[],
                 (values["exclude-tag"] ?? []) as string[],
                 args["fail-fast"],
+                undefined,
+                Number(args.delay),
               )
               return {
                 data,

--- a/src/app/commands/automation.ts
+++ b/src/app/commands/automation.ts
@@ -300,7 +300,7 @@ const collection = defineCommand({
                 (values["exclude-tag"] ?? []) as string[],
                 args["fail-fast"],
                 undefined,
-                Number(args.delay),
+                args.delay.trim() === "" ? Number.NaN : Number(args.delay),
               )
               return {
                 data,

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -912,6 +912,7 @@ export async function collectionRun(
   excludeTags: readonly string[] = [],
   failFast = false,
   onDetail?: RunDetail,
+  delayMs = 0,
 ): Promise<CollectionRunResult> {
   const startedAt = performance.now()
   let selected = 0
@@ -924,6 +925,9 @@ export async function collectionRun(
   let tlsPolicy: TlsPolicy | undefined
   let cookieAccess: Awaited<ReturnType<typeof cookieJarFor>>
   try {
+    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+      throw new Error("delay must be a non-negative safe integer")
+    }
     dir = await requireCollectionRoot(path)
     collection = await filestore.loadCollection(dir)
     requests = selectCollectionRunRequests(
@@ -975,6 +979,9 @@ export async function collectionRun(
           })),
         )
         break
+      }
+      if (delayMs > 0 && index < requests.length - 1) {
+        await Bun.sleep(delayMs)
       }
     }
   } finally {

--- a/src/hooks/useCollectionRunner.ts
+++ b/src/hooks/useCollectionRunner.ts
@@ -48,6 +48,8 @@ export interface UseCollectionRunnerResult {
   includeTagIndex: number
   excludeTagIndex: number
   failFast: boolean
+  delayMsInput: string
+  delayError: string | null
   optionIndex: number
   requestIndex: number
   requestRowIndex: number
@@ -65,6 +67,7 @@ export interface UseCollectionRunnerResult {
   deleteTagFilter: (filter: RunnerTagFilter, index: number) => void
   setTagFilterIndex: (filter: RunnerTagFilter, index: number) => void
   setSelectOpen: (open: boolean) => void
+  setDelayMsInput: (value: string) => void
   setOptionIndex: (index: number) => void
   setRequestIndex: (index: number) => void
   setRequestRowIndex: (index: number) => void
@@ -91,7 +94,7 @@ export interface UseCollectionRunnerResult {
   run: () => Promise<void>
 }
 
-export const RUNNER_RUN_OPTION_INDEX = 4
+export const RUNNER_RUN_OPTION_INDEX = 5
 const OPTION_COUNT = RUNNER_RUN_OPTION_INDEX + 1
 
 type RunnerNavigationRow =
@@ -157,6 +160,7 @@ export function useCollectionRunner({
   const [includeTagIndex, setIncludeTagIndex] = useState(0)
   const [excludeTagIndex, setExcludeTagIndex] = useState(0)
   const [failFast, setFailFast] = useState(false)
+  const [delayMsInput, setDelayMsInputState] = useState("0")
   const [optionIndex, setOptionIndexState] = useState(0)
   const [selectOpen, setSelectOpen] = useState(false)
   const [requestIndex, setRequestIndexState] = useState(0)
@@ -170,6 +174,15 @@ export function useCollectionRunner({
   const [runRequestIds, setRunRequestIds] = useState<string[]>([])
   const [runError, setRunError] = useState<string | null>(null)
   const runningRef = useRef(false)
+  const parsedDelayMs = Number(delayMsInput)
+  const delayMs =
+    delayMsInput.trim() !== "" &&
+    Number.isSafeInteger(parsedDelayMs) &&
+    parsedDelayMs >= 0
+      ? parsedDelayMs
+      : null
+  const delayError =
+    delayMs === null ? "Delay must be a non-negative safe integer." : null
   const setOptionIndex = useCallback(
     (index: number) => {
       if (
@@ -240,6 +253,7 @@ export function useCollectionRunner({
     setIncludeTagIndex(0)
     setExcludeTagIndex(0)
     setFailFast(false)
+    setDelayMsInputState("0")
     setOptionIndexState(0)
     setSelectOpen(false)
     setRequestIndexState(0)
@@ -443,10 +457,17 @@ export function useCollectionRunner({
   const toggleFailFast = useCallback(() => {
     if (phase !== "running") setFailFast((value) => !value)
   }, [phase])
+  const setDelayMsInput = useCallback(
+    (value: string) => {
+      if (phase !== "running") setDelayMsInputState(value)
+    },
+    [phase],
+  )
 
   const runAvailable =
     phase !== "running" &&
     !hasUnsavedChanges &&
+    delayMs !== null &&
     selectedRequestIds.length > 0 &&
     preview.ids.size > 0 &&
     preview.error === null
@@ -458,6 +479,7 @@ export function useCollectionRunner({
       runningRef.current ||
       hasUnsavedChanges ||
       selectOpen ||
+      delayMs === null ||
       !collection ||
       selectedRequestIds.length === 0
     )
@@ -497,6 +519,7 @@ export function useCollectionRunner({
         excludeTags,
         failFast,
         (detail) => nextDetails.set(detail.requestId, detail),
+        delayMs,
       )
       setResultDetails(nextDetails)
       setResult(next)
@@ -510,6 +533,7 @@ export function useCollectionRunner({
   }, [
     collection,
     collectionDir,
+    delayMs,
     environmentName,
     excludeTags,
     failFast,
@@ -540,6 +564,8 @@ export function useCollectionRunner({
     includeTagIndex,
     excludeTagIndex,
     failFast,
+    delayMsInput,
+    delayError,
     optionIndex,
     requestIndex,
     requestRowIndex,
@@ -557,6 +583,7 @@ export function useCollectionRunner({
     deleteTagFilter,
     setTagFilterIndex,
     setSelectOpen,
+    setDelayMsInput,
     setOptionIndex,
     setRequestIndex,
     setRequestRowIndex,

--- a/src/ui/CollectionRunnerView.tsx
+++ b/src/ui/CollectionRunnerView.tsx
@@ -43,6 +43,7 @@ const OPTION_LABELS = [
   "Include tags",
   "Exclude tags",
   "Fail fast",
+  "Delay (ms)",
 ] as const
 
 const OPTION_DESCRIPTIONS = [
@@ -50,6 +51,7 @@ const OPTION_DESCRIPTIONS = [
   "Only run requests with every included tag.",
   "Skip requests with any excluded tag.",
   "Stop running after the first failed request.",
+  "Wait between completed requests before starting the next.",
 ] as const
 
 function resultStatusLabel(row: RunnerResultRow): string {
@@ -177,11 +179,13 @@ export function CollectionRunnerView({
   }, [runner.phase])
 
   useEffect(() => {
-    optionScrollRef.current?.scrollChildIntoView(
-      runner.optionIndex === RUNNER_RUN_OPTION_INDEX
-        ? "runner-run-button"
-        : `runner-option-${runner.optionIndex}`,
-    )
+    const scrollbox = optionScrollRef.current
+    if (!scrollbox) return
+    if (runner.optionIndex === RUNNER_RUN_OPTION_INDEX) {
+      scrollbox.scrollTo(scrollbox.scrollHeight)
+      return
+    }
+    scrollbox.scrollChildIntoView(`runner-option-${runner.optionIndex}`)
   }, [runner.optionIndex])
   useEffect(() => {
     requestScrollRef.current?.scrollChildIntoView(
@@ -437,7 +441,7 @@ export function CollectionRunnerView({
               minHeight: 0,
             }}
           >
-            <box style={{ flexDirection: "column", gap: 1 }}>
+            <box style={{ flexDirection: "column", gap: 1, paddingBottom: 1 }}>
               <text fg={theme.textMuted} wrapMode="word">
                 Configure and run requests from your collection.
               </text>
@@ -456,6 +460,9 @@ export function CollectionRunnerView({
                     id={`runner-option-${index}`}
                     title={label}
                     description={OPTION_DESCRIPTIONS[index]}
+                    error={
+                      index === 4 ? (runner.delayError ?? undefined) : undefined
+                    }
                     active={active}
                     alignItems={
                       index === 1 || index === 2 ? "flex-start" : "center"
@@ -555,8 +562,33 @@ export function CollectionRunnerView({
                           )
                         })}
                       </box>
-                    ) : (
+                    ) : index === 3 ? (
                       <Checkbox checked={runner.failFast} theme={theme} />
+                    ) : (
+                      <box
+                        style={{
+                          flexGrow: 1,
+                          minWidth: 0,
+                          height: 1,
+                          overflow: "hidden",
+                        }}
+                      >
+                        <input
+                          id="runner-delay-input"
+                          value={runner.delayMsInput}
+                          onInput={runner.setDelayMsInput}
+                          focused={active && !configurationLocked}
+                          backgroundColor="transparent"
+                          focusedBackgroundColor="transparent"
+                          textColor={theme.text}
+                          cursorColor={theme.primary}
+                          style={{
+                            flexGrow: 1,
+                            flexShrink: 1,
+                            flexBasis: 0,
+                          }}
+                        />
+                      </box>
                     )}
                   </SettingsField>
                 )

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -257,7 +257,14 @@ describe("CLI integration", () => {
   it("rejects invalid collection request delays", async () => {
     const dir = await mkdtemp(join(tmpdir(), "noodle-cli-delay-"))
     try {
-      for (const value of ["-1", "1.5", "nope", "9007199254740992"]) {
+      for (const value of [
+        "",
+        "   ",
+        "-1",
+        "1.5",
+        "nope",
+        "9007199254740992",
+      ]) {
         const proc = Bun.spawnSync(
           ["bun", CLI, "collection", "run", dir, `--delay=${value}`, "--json"],
           { env: { ...process.env, HOME: join(dir, "home") } },

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -250,6 +250,33 @@ describe("CLI integration", () => {
     expect(out).toContain("repeatable; all must match")
     expect(out).toContain("repeatable; any match excludes")
     expect(out).toContain("--fail-fast")
+    expect(out).toContain("--delay=<delay>")
+    expect(out).toContain("Milliseconds to wait between requests")
+  })
+
+  it("rejects invalid collection request delays", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "noodle-cli-delay-"))
+    try {
+      for (const value of ["-1", "1.5", "nope", "9007199254740992"]) {
+        const proc = Bun.spawnSync(
+          ["bun", CLI, "collection", "run", dir, `--delay=${value}`, "--json"],
+          { env: { ...process.env, HOME: join(dir, "home") } },
+        )
+        expect(proc.exitCode).toBe(2)
+        expect(JSON.parse(proc.stdout.toString())).toMatchObject({
+          status: "error",
+          data: {
+            failure: {
+              category: "configuration",
+              message: "delay must be a non-negative safe integer",
+            },
+          },
+          errors: ["delay must be a non-negative safe integer"],
+        })
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   it("accepts repeated tag filters in space and equals forms", async () => {

--- a/tests/integration/automation.test.ts
+++ b/tests/integration/automation.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, jest } from "bun:test"
 import { existsSync } from "node:fs"
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { scheduler } from "node:timers/promises"
 import {
   collectionAudit,
   collectionFormat,
@@ -31,6 +32,7 @@ beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "noodle-automation-"))
 })
 afterEach(async () => {
+  jest.useRealTimers()
   setSecretBackendForTests(undefined)
   await rm(dir, { recursive: true, force: true })
 })
@@ -91,6 +93,31 @@ describe("automation services", () => {
     await expect(
       environmentSet("TOKEN", "value", "development", dir),
     ).rejects.toThrow("not a collection root")
+  })
+
+  it("rejects an invalid delay before collection setup", async () => {
+    expect(
+      await collectionRun(
+        dir,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        false,
+        [],
+        [],
+        [],
+        false,
+        undefined,
+        -1,
+      ),
+    ).toMatchObject({
+      failed: true,
+      failure: {
+        category: "configuration",
+        message: "delay must be a non-negative safe integer",
+      },
+    })
   })
 
   it("defaults collection creation to the current directory", () => {
@@ -370,6 +397,69 @@ describe("automation services", () => {
         [3, 5],
         [4, 5],
         [5, 5],
+      ])
+    } finally {
+      executor.send = send
+    }
+  })
+
+  it("waits only between consecutive collection requests", async () => {
+    jest.useFakeTimers()
+    await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
+    for (const id of ["01-first", "02-second"]) {
+      await writeFile(
+        join(dir, `${id}.yml`),
+        `name: ${id}\nmethod: GET\nurl: https://example.com/${id}\n`,
+      )
+    }
+
+    const sent: string[] = []
+    const firstSent = Promise.withResolvers<void>()
+    const secondSent = Promise.withResolvers<void>()
+    const send = executor.send
+    executor.send = async (request) => {
+      sent.push(request.id)
+      if (request.id === "01-first") firstSent.resolve()
+      else secondSent.resolve()
+      return {
+        status: request.id === "01-first" ? 500 : 200,
+        statusText: request.id === "01-first" ? "Error" : "OK",
+        headers: {},
+        body: "",
+        timeMs: 1,
+      }
+    }
+    try {
+      const pending = collectionRun(
+        dir,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        false,
+        [],
+        [],
+        [],
+        false,
+        undefined,
+        1000,
+      )
+      await firstSent.promise
+      await scheduler.yield()
+      expect(sent).toEqual(["01-first"])
+      expect(jest.getTimerCount()).toBe(1)
+
+      jest.advanceTimersByTime(999)
+      await scheduler.yield()
+      expect(sent).toEqual(["01-first"])
+
+      jest.advanceTimersByTime(1)
+      await secondSent.promise
+      await scheduler.yield()
+      expect(jest.getTimerCount()).toBe(0)
+      expect((await pending).results.map((result) => result.id)).toEqual([
+        "01-first",
+        "02-second",
       ])
     } finally {
       executor.send = send
@@ -668,6 +758,7 @@ describe("automation services", () => {
   })
 
   it("stops on the first failure and records ordered fail-fast skips", async () => {
+    jest.useFakeTimers()
     await writeFile(join(dir, "settings.yml"), "cookies:\n  enabled: false\n")
     for (const id of ["01-fail", "02-skip", "03-skip"]) {
       await writeFile(
@@ -676,9 +767,11 @@ describe("automation services", () => {
       )
     }
     const sent: string[] = []
+    const firstSent = Promise.withResolvers<void>()
     const send = executor.send
     executor.send = async (request) => {
       sent.push(request.id)
+      firstSent.resolve()
       return {
         status: request.id === "01-fail" ? 500 : 200,
         statusText: request.id === "01-fail" ? "Error" : "OK",
@@ -688,7 +781,7 @@ describe("automation services", () => {
       }
     }
     try {
-      const result = await collectionRun(
+      const pending = collectionRun(
         dir,
         undefined,
         undefined,
@@ -699,7 +792,15 @@ describe("automation services", () => {
         undefined,
         undefined,
         true,
+        undefined,
+        1000,
       )
+      await firstSent.promise
+      await scheduler.yield()
+      const timerCount = jest.getTimerCount()
+      if (timerCount > 0) jest.runAllTimers()
+      const result = await pending
+      expect(timerCount).toBe(0)
       expect(sent).toEqual(["01-fail"])
       expect(result.results.map((item) => item.id)).toEqual(["01-fail"])
       expect(result.skipped).toEqual([

--- a/tests/unit/CollectionRunnerView.test.tsx
+++ b/tests/unit/CollectionRunnerView.test.tsx
@@ -253,6 +253,9 @@ describe("CollectionRunnerView", () => {
       .split("\n")
       .filter((row) => ["one", "two", "three"].some((id) => row.includes(id)))
     expect(restoredRows.every((row) => row.includes("[x]"))).toBe(true)
+    await act(async () => current!.setOptionIndex(5))
+    await render.renderOnce()
+    await render.renderOnce()
     const runButton = render.renderer.root.findDescendantById(
       "runner-run-button",
     ) as BoxRenderable
@@ -319,7 +322,7 @@ describe("CollectionRunnerView", () => {
       await Promise.resolve()
     })
     await render.renderOnce()
-    expect(current!.optionIndex).toBe(4)
+    expect(current!.optionIndex).toBe(5)
     const completedButton = render.renderer.root.findDescendantById(
       "runner-run-button",
     ) as BoxRenderable
@@ -434,12 +437,12 @@ describe("CollectionRunnerView", () => {
     for (const label of ["Scope", "Environment", "Health"]) {
       expect(frame).toContain(label)
     }
-    for (const index of [2, 3]) {
+    for (const index of [2, 3, 4]) {
       expect(
         render.renderer.root.findDescendantById(`runner-option-${index}`),
       ).not.toBeNull()
     }
-    for (const index of [0, 1, 2, 3]) {
+    for (const index of [0, 1, 2, 3, 4]) {
       const option = render.renderer.root.findDescendantById(
         `runner-option-${index}`,
       ) as BoxRenderable
@@ -464,24 +467,35 @@ describe("CollectionRunnerView", () => {
       "runner-include-tag-1",
     )!
     expect(secondTag.screenY).toBeGreaterThan(firstTag.screenY)
-    await act(async () => current!.setOptionIndex(4))
+    await act(async () => current!.setOptionIndex(5))
     await render.renderOnce()
     await render.renderOnce()
     const scrolled = render.captureCharFrame()
     const failFast = render.renderer.root.findDescendantById("runner-option-3")!
+    const delay = render.renderer.root.findDescendantById("runner-option-4")!
     const runButton = render.renderer.root.findDescendantById(
       "runner-run-button",
     ) as BoxRenderable
     expect(runButton.screenY).toBeGreaterThan(failFast.screenY)
+    expect(runButton.screenY).toBeGreaterThan(delay.screenY)
     expect(runButton.width).toBe("r Run 0 requests".length + 2)
     expect(runButton.width).toBe(initialRunButtonWidth)
-    expect(current!.optionIndex).toBe(4)
+    expect(current!.optionIndex).toBe(5)
     expect(
       runButton.backgroundColor.equals(RGBA.fromHex(THEMES[0]!.primary)),
     ).toBe(true)
-    expect(scrolled).toContain("Exclude tags")
     expect(scrolled).toContain("Fail fast")
-    expect(scrolled).toContain("+ Add tag")
+    expect(scrolled).toContain("Delay (ms)")
+    expect(scrolled).toContain("r Run 0 requests")
+    expect(
+      render.renderer.root.findDescendantById("runner-include-tag-0"),
+    ).not.toBeNull()
+    expect(
+      render.renderer.root.findDescendantById("runner-exclude-tag-0"),
+    ).not.toBeNull()
+    expect(
+      render.renderer.root.findDescendantById("runner-delay-input"),
+    ).not.toBeNull()
     expect(
       render.renderer.root.findDescendantById("runner-include-tag-input"),
     ).toBeUndefined()
@@ -624,6 +638,19 @@ describe("CollectionRunnerView", () => {
     await clickOption(3)
     expect(current!.failFast).toBe(true)
 
+    await clickOption(4)
+    expect(current!.optionIndex).toBe(4)
+    expect(
+      render.renderer.root.findDescendantById("runner-delay-input"),
+    ).not.toBeNull()
+    await act(async () => {
+      await render.mockInput.pressBackspace()
+      await render.mockInput.typeText("250")
+    })
+    await render.renderOnce()
+    expect(current!.delayMsInput).toBe("250")
+    expect(current!.delayError).toBeNull()
+
     await act(async () => {
       current!.deleteTagFilter("include", 0)
       current!.deleteTagFilter("exclude", 0)
@@ -645,7 +672,7 @@ describe("CollectionRunnerView", () => {
     expect(current!.selectOpen).toBe(false)
     await act(async () => current!.optionLast())
     await render.renderOnce()
-    expect(current!.optionIndex).toBe(4)
+    expect(current!.optionIndex).toBe(5)
     expect(
       runButton.backgroundColor.equals(RGBA.fromHex(THEMES[0]!.primary)),
     ).toBe(true)

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -403,6 +403,8 @@ describe("app keymap layers", () => {
     host.press("return")
     context.runner.runnerRef.current.optionIndex = 4
     host.press("return")
+    context.runner.runnerRef.current.optionIndex = 5
+    host.press("return")
     context.runner.runnerRef.current.canRun = false
     host.press("return")
     context.runner.runnerRef.current.canRun = true

--- a/tests/unit/useCollectionRunner.test.tsx
+++ b/tests/unit/useCollectionRunner.test.tsx
@@ -84,12 +84,12 @@ describe("useCollectionRunner", () => {
     await act(async () => harness.get().optionUp())
     expect(harness.get().optionIndex).toBe(0)
     await act(async () => harness.get().optionLast())
-    expect(harness.get().optionIndex).toBe(4)
+    expect(harness.get().optionIndex).toBe(5)
     expect(harness.get().failFast).toBe(false)
     await act(async () => harness.get().toggleFailFast())
     expect(harness.get().failFast).toBe(true)
     await act(async () => harness.get().optionDown())
-    expect(harness.get().optionIndex).toBe(4)
+    expect(harness.get().optionIndex).toBe(5)
     await act(async () => harness.get().optionFirst())
     expect(harness.get().optionIndex).toBe(0)
   })
@@ -104,6 +104,33 @@ describe("useCollectionRunner", () => {
     await act(async () => harness.get().setSelectOpen(true))
     expect(harness.get().runAvailable).toBe(true)
     expect(harness.get().canRun).toBe(false)
+  })
+
+  it("validates and resets the transient request delay", async () => {
+    const harness = renderHook()
+    const render = await harness.render
+    await render.renderOnce()
+
+    expect(harness.get().delayMsInput).toBe("0")
+    expect(harness.get().delayError).toBeNull()
+    for (const value of ["", "-1", "1.5", "nope", "9007199254740992"]) {
+      await act(async () => harness.get().setDelayMsInput(value))
+      await render.renderOnce()
+      expect(harness.get().delayError).toBe(
+        "Delay must be a non-negative safe integer.",
+      )
+      expect(harness.get().canRun).toBe(false)
+    }
+
+    await act(async () => harness.get().setDelayMsInput("250"))
+    await render.renderOnce()
+    expect(harness.get().delayError).toBeNull()
+    expect(harness.get().canRun).toBe(true)
+
+    await act(async () => harness.reset())
+    await render.renderOnce()
+    expect(harness.get().delayMsInput).toBe("0")
+    expect(harness.get().delayError).toBeNull()
   })
 
   it("initializes a folder scope with every request selected in collection order", async () => {
@@ -297,6 +324,7 @@ describe("useCollectionRunner", () => {
       harness.get().setTagFilter("include", 0, "smoke")
       harness.get().setTagFilter("exclude", 0, "slow")
       harness.get().toggleFailFast()
+      harness.get().setDelayMsInput("250")
     })
     await render.renderOnce()
     await act(async () => harness.get().setTagFilter("exclude", 1, "flaky"))
@@ -308,6 +336,7 @@ describe("useCollectionRunner", () => {
     expect(args?.[7]).toEqual(["smoke"])
     expect(args?.[8]).toEqual(["slow", "flaky"])
     expect(args?.[9]).toBe(true)
+    expect(args?.[11]).toBe(250)
     expect(harness.get().includeTags).toEqual(["smoke"])
     expect(harness.get().progress).toEqual({ completed: 1, total: 1 })
     expect(harness.get().resultRows.map((row) => row.id)).toEqual([


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature

### What does this PR do?

Adds `--delay <milliseconds>` to `noodle collection run` to wait between completed requests when another selected request remains. Validates as non-negative safe integer, sleeps via `Bun.sleep` only between requests (skipped on last request and on fail-fast exit), and exposes the same control in the TUI Collection Runner with input validation.

### How did you verify your code works?

- `bun run lint` passes
- `bun run typecheck` passes
- `bun test` passes (3115 pass, 0 fail)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-request delay for collection runs in the CLI and runner interface.
  * Delays apply only between remaining requests, including after failures when execution continues.
  * Added a “Delay (ms)” input to the collection runner options.

* **Bug Fixes**
  * Invalid, fractional, negative, blank, or non-safe-integer delays now prevent runs with a clear configuration error.

* **Documentation**
  * Updated workflow documentation and README examples with delay configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->