### PR TITLE
feat(ui): unclutter request pane with optional tabs add menu

### DIFF
--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -394,12 +394,10 @@ export function useEditBrowse(
     setOptionalTabMenuActive(false)
   }, [draft?.id, options?.initialTab])
 
-  const isFirstTabChange = useRef(true)
+  const lastNotifiedTabRef = useRef(inactiveTab)
   useEffect(() => {
-    if (isFirstTabChange.current) {
-      isFirstTabChange.current = false
-      return
-    }
+    if (lastNotifiedTabRef.current === inactiveTab) return
+    lastNotifiedTabRef.current = inactiveTab
     onTabChangeRef.current?.(inactiveTab)
   }, [inactiveTab])
 
@@ -415,6 +413,7 @@ export function useEditBrowse(
   useEffect(() => {
     if (editState.mode !== "inactive" || activeTab === requestedTab) return
     setInactiveTab(activeTab)
+    lastNotifiedTabRef.current = activeTab
     onTabChangeRef.current?.(activeTab)
   }, [activeTab, editState.mode, requestedTab])
 

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -429,14 +429,7 @@ export function useEditBrowse(
   }, [editState.cursor.field, editState.mode, revealOptionalTab])
 
   const optionalTabMenuVisible =
-    (options?.optionalTabMenuEnabled ?? true) &&
-    draft !== null &&
-    ((activeTab !== "assertions" &&
-      !revealedOptionalTabs.includes("assertions") &&
-      !draft.assertions?.length) ||
-      (activeTab !== "captures" &&
-        !revealedOptionalTabs.includes("captures") &&
-        !Object.keys(draft.captures ?? {}).length))
+    (options?.optionalTabMenuEnabled ?? true) && draft !== null
 
   useEffect(() => {
     if (!optionalTabMenuVisible) setOptionalTabMenuActive(false)

--- a/src/hooks/useEditBrowse.ts
+++ b/src/hooks/useEditBrowse.ts
@@ -32,7 +32,7 @@ import {
   cancelEditing,
   toggleSubfield,
   cursorForField,
-  FIELD_ORDER,
+  cycleField,
   type EditState,
   type SectionRowCount,
   type FieldKind,
@@ -77,6 +77,16 @@ function rowCount(req: Request | null): SectionRowCount {
     captures: Object.keys(req.captures ?? {}).length,
     settings: 6 + (req.tags?.length ?? 0),
   }
+}
+
+function isEmptyOptionalTab(
+  request: Request | null,
+  field: FieldKind,
+): boolean {
+  if (!request) return false
+  if (field === "assertions") return !request.assertions?.length
+  if (field === "captures") return !Object.keys(request.captures ?? {}).length
+  return false
 }
 
 function assertionEditValues(
@@ -235,12 +245,6 @@ function currentKeyValueFor(
   return { key: "", value: "" }
 }
 
-function cycleField(current: FieldKind, delta: 1 | -1): FieldKind {
-  const idx = FIELD_ORDER.indexOf(current)
-  const next = (idx + delta + FIELD_ORDER.length) % FIELD_ORDER.length
-  return FIELD_ORDER[next]!
-}
-
 export function detectFormType(value: string): {
   formType: "text" | "file"
   cleanValue: string
@@ -265,6 +269,11 @@ export interface UseEditBrowseResult {
   editError: string | null
   isActive: boolean
   activeTab: FieldKind
+  revealedOptionalTabs: readonly FieldKind[]
+  revealOptionalTab: (tab: FieldKind) => void
+  optionalTabMenuVisible: boolean
+  optionalTabMenuActive: boolean
+  setOptionalTabMenuActive: (active: boolean) => void
   enterBrowse: () => void
   exitBrowse: () => void
   browseUp: () => void
@@ -303,6 +312,7 @@ export interface UseEditBrowseOptions {
   initialTab?: FieldKind
   onTabChange?: (tab: FieldKind) => void
   onTagEdit?: (index: number, value: string) => void
+  optionalTabMenuEnabled?: boolean
 }
 
 export function useEditBrowse(
@@ -321,12 +331,29 @@ export function useEditBrowse(
   const [inactiveTab, setInactiveTab] = useState<FieldKind>(
     options?.initialTab ?? "headers",
   )
+  const [revealedOptionalTabsByRequest, setRevealedOptionalTabsByRequest] =
+    useState(() => new Map<string, FieldKind[]>())
+  const [optionalTabMenuActive, setOptionalTabMenuActiveState] = useState(false)
 
   const draftRef = useRef(draft)
   draftRef.current = draft
+  const revealedOptionalTabs = draft
+    ? (revealedOptionalTabsByRequest.get(draft.id) ?? [])
+    : []
+  const revealedOptionalTabsRef = useRef(revealedOptionalTabs)
+  revealedOptionalTabsRef.current = revealedOptionalTabs
 
   const editStateRef = useRef(editState)
   editStateRef.current = editState
+
+  const setOptionalTabMenuActive = useCallback((active: boolean) => {
+    setOptionalTabMenuActiveState(active)
+    if (active) {
+      setEditState((prev) =>
+        prev.mode === "browsing" ? exitEditBrowse(prev) : prev,
+      )
+    }
+  }, [])
 
   const editValueRef = useRef(editValue)
   editValueRef.current = editValue
@@ -349,10 +376,23 @@ export function useEditBrowse(
   const onTagEditRef = useRef(options?.onTagEdit)
   onTagEditRef.current = options?.onTagEdit
 
+  const revealOptionalTab = useCallback((tab: FieldKind) => {
+    const requestId = draftRef.current?.id
+    if (!requestId) return
+    setRevealedOptionalTabsByRequest((revealed) => {
+      const requestTabs = revealed.get(requestId) ?? []
+      if (requestTabs.includes(tab)) return revealed
+      const next = new Map(revealed)
+      next.set(requestId, [...requestTabs, tab])
+      return next
+    })
+  }, [])
+
   // Sync inactiveTab when initialTab prop changes (request switch)
   useEffect(() => {
     setInactiveTab(options?.initialTab ?? "headers")
-  }, [options?.initialTab])
+    setOptionalTabMenuActive(false)
+  }, [draft?.id, options?.initialTab])
 
   const isFirstTabChange = useRef(true)
   useEffect(() => {
@@ -363,10 +403,44 @@ export function useEditBrowse(
     onTabChangeRef.current?.(inactiveTab)
   }, [inactiveTab])
 
+  const requestedTab = options?.initialTab ?? inactiveTab
   const activeTab =
     editState.mode !== "inactive"
       ? editState.cursor.field
-      : (options?.initialTab ?? inactiveTab)
+      : isEmptyOptionalTab(draft, requestedTab) &&
+          !revealedOptionalTabs.includes(requestedTab)
+        ? "headers"
+        : requestedTab
+
+  useEffect(() => {
+    if (editState.mode !== "inactive" || activeTab === requestedTab) return
+    setInactiveTab(activeTab)
+    onTabChangeRef.current?.(activeTab)
+  }, [activeTab, editState.mode, requestedTab])
+
+  useEffect(() => {
+    const field = editState.cursor.field
+    if (
+      editState.mode !== "inactive" &&
+      (field === "assertions" || field === "captures")
+    ) {
+      revealOptionalTab(field)
+    }
+  }, [editState.cursor.field, editState.mode, revealOptionalTab])
+
+  const optionalTabMenuVisible =
+    (options?.optionalTabMenuEnabled ?? true) &&
+    draft !== null &&
+    ((activeTab !== "assertions" &&
+      !revealedOptionalTabs.includes("assertions") &&
+      !draft.assertions?.length) ||
+      (activeTab !== "captures" &&
+        !revealedOptionalTabs.includes("captures") &&
+        !Object.keys(draft.captures ?? {}).length))
+
+  useEffect(() => {
+    if (!optionalTabMenuVisible) setOptionalTabMenuActive(false)
+  }, [optionalTabMenuVisible])
 
   const enterBrowse = useCallback(() => {
     const c = rowCount(draftRef.current)
@@ -378,6 +452,7 @@ export function useEditBrowse(
   }, [activeTab])
 
   const enterBrowseAt = useCallback((field: FieldKind, row?: number) => {
+    setOptionalTabMenuActive(false)
     setInactiveTab(field)
     const c = rowCount(draftRef.current)
     setEditState((prev) => {
@@ -404,6 +479,7 @@ export function useEditBrowse(
       addingRow = false,
       subfield?: FieldSubfield,
     ) => {
+      setOptionalTabMenuActive(false)
       setInactiveTab(field)
       const currentDraft = draftRef.current
       setEditError(null)
@@ -476,6 +552,7 @@ export function useEditBrowse(
 
   const toggleAt = useCallback(
     (field: FieldKind, row: number) => {
+      setOptionalTabMenuActive(false)
       setInactiveTab(field)
       setEditState((prev) => {
         const browsed =
@@ -731,21 +808,29 @@ export function useEditBrowse(
     const c = rowCount(draftRef.current)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
-      const next = moveFieldCursor(prev, -1, c)
+      if (optionalTabMenuVisible && prev.cursor.field === "headers") {
+        setOptionalTabMenuActiveState(true)
+        return exitEditBrowse(prev)
+      }
+      const next = moveFieldCursor(prev, -1, c, revealedOptionalTabsRef.current)
       setInactiveTab(next.cursor.field)
       return next
     })
-  }, [])
+  }, [optionalTabMenuVisible])
 
   const browseRight = useCallback(() => {
     const c = rowCount(draftRef.current)
     setEditState((prev) => {
       if (prev.mode !== "browsing") return prev
-      const next = moveFieldCursor(prev, +1, c)
+      if (optionalTabMenuVisible && prev.cursor.field === "settings") {
+        setOptionalTabMenuActiveState(true)
+        return exitEditBrowse(prev)
+      }
+      const next = moveFieldCursor(prev, +1, c, revealedOptionalTabsRef.current)
       setInactiveTab(next.cursor.field)
       return next
     })
-  }, [])
+  }, [optionalTabMenuVisible])
 
   const enterEdit = useCallback(() => {
     const state = editStateRef.current
@@ -1169,9 +1254,32 @@ export function useEditBrowse(
     draftMutators.setFormRow(formIdx, entry.name, entry.value, newType)
   }, [draftMutators])
 
-  const cycleInactiveTab = useCallback((delta: 1 | -1) => {
-    setInactiveTab((prev) => cycleField(prev, delta))
-  }, [])
+  const cycleInactiveTab = useCallback(
+    (delta: 1 | -1) => {
+      if (optionalTabMenuActive) {
+        setOptionalTabMenuActive(false)
+        setInactiveTab(delta === 1 ? "headers" : "settings")
+        return
+      }
+      if (
+        optionalTabMenuVisible &&
+        ((activeTab === "settings" && delta === 1) ||
+          (activeTab === "headers" && delta === -1))
+      ) {
+        setOptionalTabMenuActive(true)
+        return
+      }
+      setInactiveTab((prev) =>
+        cycleField(
+          prev,
+          delta,
+          rowCount(draftRef.current),
+          revealedOptionalTabsRef.current,
+        ),
+      )
+    },
+    [activeTab, optionalTabMenuActive, optionalTabMenuVisible],
+  )
 
   const canEnterTextBodyEditor =
     editState.mode === "browsing" &&
@@ -1198,6 +1306,11 @@ export function useEditBrowse(
       editError,
       isActive: editState.mode !== "inactive",
       activeTab,
+      revealedOptionalTabs,
+      revealOptionalTab,
+      optionalTabMenuVisible,
+      optionalTabMenuActive,
+      setOptionalTabMenuActive,
       enterBrowse,
       exitBrowse,
       browseUp,
@@ -1234,6 +1347,10 @@ export function useEditBrowse(
       editCapturePersistence,
       editError,
       activeTab,
+      revealedOptionalTabs,
+      revealOptionalTab,
+      optionalTabMenuVisible,
+      optionalTabMenuActive,
       enterBrowse,
       enterBrowseAt,
       activateAt,

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -432,22 +432,6 @@ export function AppInner({
     [draft.markSaved, updateCollection],
   )
 
-  const availableJumpTargets = useMemo(
-    () =>
-      getAvailableTargets(
-        draft.draft !== null,
-        expanded,
-        focusedFolder !== null,
-        view === "env-editor",
-        view === "settings",
-        view === "cookie-jar",
-      ),
-    [draft.draft, expanded, focusedFolder, view],
-  )
-  useEffect(() => {
-    jumpTargetsRef.current = availableJumpTargets
-  }, [availableJumpTargets])
-
   const tabPrefs = getTab(selectedRequest?.id ?? "")
   const initialRequestTab = tabPrefs?.requestTab
   const initialResponseTab = tabPrefs?.responseTab
@@ -490,7 +474,26 @@ export function AppInner({
     initialTab: initialRequestTab,
     onTabChange: onRequestTabChange,
     onTagEdit: (index, value) => openTagEditorRef.current(index, value),
+    optionalTabMenuEnabled: isCollection,
   })
+
+  const requestTabAddVisible = eb.optionalTabMenuVisible
+  const availableJumpTargets = useMemo(
+    () =>
+      getAvailableTargets(
+        draft.draft !== null,
+        expanded,
+        focusedFolder !== null,
+        view === "env-editor",
+        view === "settings",
+        view === "cookie-jar",
+        requestTabAddVisible,
+      ),
+    [draft.draft, expanded, focusedFolder, requestTabAddVisible, view],
+  )
+  useEffect(() => {
+    jumpTargetsRef.current = availableJumpTargets
+  }, [availableJumpTargets])
 
   // ── Save logic (provides saveState needed by keymap.setData below) ──
   const {

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -219,7 +219,7 @@ export function RequestPane({
     }
   }, [editState.cursor, editState.mode, request?.bodyType])
 
-  const { tabs, hiddenOptionalTabs } = useMemo(() => {
+  const { tabs, optionalTabMenuItems } = useMemo(() => {
     const labels = computeRequestTabLabels(request)
     const hiddenOptionalTabs = BASE_TAB_DEFS.filter(
       (tab) =>
@@ -231,7 +231,9 @@ export function RequestPane({
     )
     const hiddenIds = new Set(hiddenOptionalTabs.map((tab) => tab.id))
     return {
-      hiddenOptionalTabs,
+      optionalTabMenuItems: BASE_TAB_DEFS.filter(
+        (tab) => tab.id === "assertions" || tab.id === "captures",
+      ).map((tab) => ({ ...tab, disabled: !hiddenIds.has(tab.id) })),
       tabs: BASE_TAB_DEFS.filter((tab) => !hiddenIds.has(tab.id)).map(
         (tab) => ({
           ...tab,
@@ -317,7 +319,7 @@ export function RequestPane({
             activeId={activeTab}
             onChange={changeTab}
             rightChildren={
-              interactive && hiddenOptionalTabs.length ? (
+              interactive ? (
                 <box
                   id="request-tab-add"
                   onMouseDown={(event) => event.stopPropagation()}
@@ -330,7 +332,7 @@ export function RequestPane({
                     />
                   ) : null}
                   <Select
-                    items={hiddenOptionalTabs}
+                    items={optionalTabMenuItems}
                     placeholder="+"
                     focused={tabMenuActive}
                     visualFocused={tabMenuActive}

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -19,7 +19,11 @@ import { useTheme } from "./theme"
 import { FullBorder } from "./borders"
 import { KeyValueSection } from "./KeyValueSection"
 import { AuthEditor } from "./AuthEditor"
-import { computeRequestTabLabels, REQUEST_TAB_HINTS } from "./useJumpMode"
+import {
+  computeRequestTabLabels,
+  REQUEST_TAB_ADD_HINT,
+  REQUEST_TAB_HINTS,
+} from "./useJumpMode"
 import { Frame } from "./Frame"
 import { Badge } from "./Badge"
 import { BodyTypeSelector, BodySection } from "./request-pane/RequestBodyTab"
@@ -29,6 +33,7 @@ import type { CodeEditorRenderable } from "./editor/CodeEditor"
 import { AssertTab } from "./request-pane/AssertTab"
 import { createResponseExpressionCompleter } from "../response"
 import { Select } from "./Select"
+import { JumpBadge } from "./JumpBadge"
 
 interface Props {
   request: Request | null
@@ -49,6 +54,9 @@ interface Props {
   editError?: string | null
   focused?: boolean
   activeTab: FieldKind
+  revealedOptionalTabs?: readonly FieldKind[]
+  tabMenuActive?: boolean
+  onTabMenuActiveChange?: (active: boolean) => void
   activeEnv?: Environment | null
   onAuthTypeChange?: (t: Auth["type"]) => void
   onApiKeyPlacementChange?: (placement: "header" | "query") => void
@@ -64,6 +72,7 @@ interface Props {
   jumpMode?: boolean
   onPaneFocus?: () => void
   onTabChange?: (tab: FieldKind) => void
+  onOptionalTabReveal?: (tab: FieldKind) => void
   onBodyTypeFocus?: () => void
   onAuthFocusRow?: (row: number) => void
   onBodyEditorFocus?: (bodyType: BodyType) => void
@@ -109,6 +118,9 @@ export function RequestPane({
   editError = null,
   focused = false,
   activeTab,
+  revealedOptionalTabs,
+  tabMenuActive: controlledTabMenuActive,
+  onTabMenuActiveChange,
   activeEnv,
   onAuthTypeChange,
   onApiKeyPlacementChange,
@@ -120,6 +132,7 @@ export function RequestPane({
   jumpMode = false,
   onPaneFocus,
   onTabChange,
+  onOptionalTabReveal,
   onBodyTypeFocus,
   onAuthFocusRow,
   onBodyEditorFocus,
@@ -137,8 +150,17 @@ export function RequestPane({
   const browseActive = editState.mode === "browsing"
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
   const bodyEditorRef = useRef<CodeEditorRenderable | null>(null)
-  const [tabMenuActive, setTabMenuActive] = useState(false)
+  const [localTabMenuActive, setLocalTabMenuActive] = useState(false)
+  const tabMenuActive = controlledTabMenuActive ?? localTabMenuActive
+  const setTabMenuActive = onTabMenuActiveChange ?? setLocalTabMenuActive
   const keymap = useKeymap()
+
+  useEffect(() => {
+    if (!focused && controlledTabMenuActive) {
+      onTabMenuActiveChange?.(false)
+    }
+  }, [controlledTabMenuActive, focused, onTabMenuActiveChange])
+
   const completeResponseExpression = useMemo(
     () => createResponseExpressionCompleter(response),
     [response],
@@ -202,6 +224,7 @@ export function RequestPane({
     const hiddenOptionalTabs = BASE_TAB_DEFS.filter(
       (tab) =>
         tab.id !== activeTab &&
+        !revealedOptionalTabs?.includes(tab.id as FieldKind) &&
         ((tab.id === "assertions" && !request?.assertions?.length) ||
           (tab.id === "captures" &&
             !Object.keys(request?.captures ?? {}).length)),
@@ -209,15 +232,15 @@ export function RequestPane({
     const hiddenIds = new Set(hiddenOptionalTabs.map((tab) => tab.id))
     return {
       hiddenOptionalTabs,
-      tabs: BASE_TAB_DEFS.filter(
-        (tab) => jumpMode || !hiddenIds.has(tab.id),
-      ).map((tab) => ({
-        ...tab,
-        label: labels[tab.id] ?? tab.label,
-        jumpHint: jumpMode ? REQUEST_TAB_HINTS[tab.id] : undefined,
-      })),
+      tabs: BASE_TAB_DEFS.filter((tab) => !hiddenIds.has(tab.id)).map(
+        (tab) => ({
+          ...tab,
+          label: labels[tab.id] ?? tab.label,
+          jumpHint: jumpMode ? REQUEST_TAB_HINTS[tab.id] : undefined,
+        }),
+      ),
     }
-  }, [request, activeTab, jumpMode])
+  }, [request, activeTab, jumpMode, revealedOptionalTabs])
 
   const changeTab = useCallback(
     (tab: string) => {
@@ -225,8 +248,16 @@ export function RequestPane({
       setTabMenuActive(false)
       onPaneFocus?.()
       onTabChange?.(tab as FieldKind)
+      return true
     },
     [onInteraction, onPaneFocus, onTabChange],
+  )
+  const addOptionalTab = useCallback(
+    (tab: string) => {
+      if (!changeTab(tab)) return
+      onOptionalTabReveal?.(tab as FieldKind)
+    },
+    [changeTab, onOptionalTabReveal],
   )
   const activateTabMenu = useCallback(() => {
     onPaneFocus?.()
@@ -286,22 +317,30 @@ export function RequestPane({
             activeId={activeTab}
             onChange={changeTab}
             rightChildren={
-              interactive && !jumpMode && hiddenOptionalTabs.length ? (
+              interactive && hiddenOptionalTabs.length ? (
                 <box
                   id="request-tab-add"
                   onMouseDown={(event) => event.stopPropagation()}
+                  style={{ position: "relative", overflow: "visible" }}
                 >
+                  {jumpMode ? (
+                    <JumpBadge
+                      letter={REQUEST_TAB_ADD_HINT}
+                      style={{ top: -1, left: 0 }}
+                    />
+                  ) : null}
                   <Select
                     items={hiddenOptionalTabs}
                     placeholder="+"
                     focused={tabMenuActive}
                     visualFocused={tabMenuActive}
+                    triggerColor={theme.primary}
                     fitContent
                     showIndicator={false}
                     dropdownAlign="right"
                     maxDropdownHeight={2}
                     onActivate={activateTabMenu}
-                    onChange={changeTab}
+                    onChange={addOptionalTab}
                     onOpenChange={handleTabMenuOpenChange}
                   />
                 </box>

--- a/src/ui/RequestPane.tsx
+++ b/src/ui/RequestPane.tsx
@@ -1,7 +1,7 @@
 import { type ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/react"
 import { useKeymap } from "@opentui/keymap/react"
-import { useEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type {
   AssertionOperator,
   Auth,
@@ -28,6 +28,7 @@ import { syncPathParamsWithUrl } from "./urlParams"
 import type { CodeEditorRenderable } from "./editor/CodeEditor"
 import { AssertTab } from "./request-pane/AssertTab"
 import { createResponseExpressionCompleter } from "../response"
+import { Select } from "./Select"
 
 interface Props {
   request: Request | null
@@ -136,6 +137,7 @@ export function RequestPane({
   const browseActive = editState.mode === "browsing"
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
   const bodyEditorRef = useRef<CodeEditorRenderable | null>(null)
+  const [tabMenuActive, setTabMenuActive] = useState(false)
   const keymap = useKeymap()
   const completeResponseExpression = useMemo(
     () => createResponseExpressionCompleter(response),
@@ -195,14 +197,49 @@ export function RequestPane({
     }
   }, [editState.cursor, editState.mode, request?.bodyType])
 
-  const tabs = useMemo(() => {
+  const { tabs, hiddenOptionalTabs } = useMemo(() => {
     const labels = computeRequestTabLabels(request)
-    return BASE_TAB_DEFS.map((tab) => ({
-      ...tab,
-      label: labels[tab.id] ?? tab.label,
-      jumpHint: jumpMode ? REQUEST_TAB_HINTS[tab.id] : undefined,
-    }))
-  }, [request, jumpMode])
+    const hiddenOptionalTabs = BASE_TAB_DEFS.filter(
+      (tab) =>
+        tab.id !== activeTab &&
+        ((tab.id === "assertions" && !request?.assertions?.length) ||
+          (tab.id === "captures" &&
+            !Object.keys(request?.captures ?? {}).length)),
+    )
+    const hiddenIds = new Set(hiddenOptionalTabs.map((tab) => tab.id))
+    return {
+      hiddenOptionalTabs,
+      tabs: BASE_TAB_DEFS.filter(
+        (tab) => jumpMode || !hiddenIds.has(tab.id),
+      ).map((tab) => ({
+        ...tab,
+        label: labels[tab.id] ?? tab.label,
+        jumpHint: jumpMode ? REQUEST_TAB_HINTS[tab.id] : undefined,
+      })),
+    }
+  }, [request, activeTab, jumpMode])
+
+  const changeTab = useCallback(
+    (tab: string) => {
+      if (onInteraction?.() === false) return
+      setTabMenuActive(false)
+      onPaneFocus?.()
+      onTabChange?.(tab as FieldKind)
+    },
+    [onInteraction, onPaneFocus, onTabChange],
+  )
+  const activateTabMenu = useCallback(() => {
+    onPaneFocus?.()
+    setTabMenuActive(true)
+  }, [onPaneFocus])
+  const handleTabMenuOpenChange = useCallback(
+    (open: boolean) => {
+      setTabMenuActive(open)
+      onSelectOpenChange?.(open)
+    },
+    [onSelectOpenChange],
+  )
+
   return (
     <Frame
       visible={visible}
@@ -247,11 +284,29 @@ export function RequestPane({
           <Tabs
             tabs={tabs}
             activeId={activeTab}
-            onChange={(tab) => {
-              if (onInteraction?.() === false) return
-              onPaneFocus?.()
-              onTabChange?.(tab as FieldKind)
-            }}
+            onChange={changeTab}
+            rightChildren={
+              interactive && !jumpMode && hiddenOptionalTabs.length ? (
+                <box
+                  id="request-tab-add"
+                  onMouseDown={(event) => event.stopPropagation()}
+                >
+                  <Select
+                    items={hiddenOptionalTabs}
+                    placeholder="+"
+                    focused={tabMenuActive}
+                    visualFocused={tabMenuActive}
+                    fitContent
+                    showIndicator={false}
+                    dropdownAlign="right"
+                    maxDropdownHeight={2}
+                    onActivate={activateTabMenu}
+                    onChange={changeTab}
+                    onOpenChange={handleTabMenuOpenChange}
+                  />
+                </box>
+              ) : undefined
+            }
           >
             <box
               style={{

--- a/src/ui/RequestResponseView.tsx
+++ b/src/ui/RequestResponseView.tsx
@@ -127,6 +127,9 @@ export function RequestResponseView({
       editError={eb.editError}
       focused={requestVisible && focus === "request"}
       activeTab={eb.activeTab}
+      revealedOptionalTabs={eb.revealedOptionalTabs}
+      tabMenuActive={eb.optionalTabMenuActive}
+      onTabMenuActiveChange={eb.setOptionalTabMenuActive}
       activeEnv={activeEnv}
       onAuthTypeChange={draft.setAuthType}
       onApiKeyPlacementChange={draft.setApiKeyPlacement}
@@ -138,6 +141,7 @@ export function RequestResponseView({
       jumpMode={jumpMode}
       onPaneFocus={() => onPaneFocus("request")}
       onTabChange={onRequestTabChange}
+      onOptionalTabReveal={eb.revealOptionalTab}
       onBodyTypeFocus={onRequestBodyTypeFocus}
       onAuthFocusRow={onRequestAuthFocusRow}
       onBodyEditorFocus={onRequestBodyEditorFocus}

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -78,7 +78,13 @@ export function Select({
     () => items.findIndex((i) => i.id === value),
     [items, value],
   )
-  const safeInitialIndex = currentIndex >= 0 ? currentIndex : 0
+  const safeInitialIndex =
+    currentIndex >= 0 && !items[currentIndex]?.disabled
+      ? currentIndex
+      : Math.max(
+          0,
+          items.findIndex((item) => !item.disabled),
+        )
 
   useEffect(() => {
     if ((!focused || !interactive) && open) setOpen(false)

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -295,7 +295,11 @@ export function Select({
                 focused && selectedBadgeBg ? TextAttributes.BOLD : undefined,
               )
             ) : (
-              <text fg={theme.textMuted} style={{ flexShrink: 0 }}>
+              <text
+                fg={visualFocused || open ? labelColor : theme.textMuted}
+                attributes={visualFocused ? TextAttributes.BOLD : undefined}
+                style={{ flexShrink: 0 }}
+              >
                 {placeholder}
               </text>
             )}

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -35,6 +35,7 @@ export interface SelectProps {
   dropdownAlign?: "left" | "right"
   badge?: boolean
   fitContent?: boolean
+  showIndicator?: boolean
   onOpenChange?: (open: boolean) => void
   onActivate?: () => void
   interactive?: boolean
@@ -55,6 +56,7 @@ export function Select({
   dropdownAlign = "left",
   badge = false,
   fitContent = false,
+  showIndicator = true,
   onOpenChange,
   onActivate,
   interactive = true,
@@ -244,7 +246,7 @@ export function Select({
     width !== undefined
       ? width
       : fitContent || badge
-        ? selectedText.length + 4
+        ? selectedText.length + (showIndicator ? 4 : 2)
         : "100%"
 
   return (
@@ -298,10 +300,12 @@ export function Select({
               </text>
             )}
           </box>
-          <text fg={indicatorColor} style={{ flexShrink: 0 }}>
-            {" "}
-            ▼
-          </text>
+          {showIndicator ? (
+            <text fg={indicatorColor} style={{ flexShrink: 0 }}>
+              {" "}
+              ▼
+            </text>
+          ) : null}
         </box>
 
         {open &&

--- a/src/ui/editMode.ts
+++ b/src/ui/editMode.ts
@@ -138,8 +138,22 @@ export function exitEditBrowse(prev: EditState): EditState {
   return { ...prev, mode: "inactive" }
 }
 
-function fieldIndex(field: FieldKind): number {
-  return FIELD_ORDER.indexOf(field)
+export function cycleField(
+  current: FieldKind,
+  delta: 1 | -1,
+  counts: SectionRowCount,
+  revealedOptionalTabs: readonly FieldKind[] = [],
+): FieldKind {
+  const fields = FIELD_ORDER.filter(
+    (field) =>
+      field === current ||
+      (field !== "assertions" && field !== "captures") ||
+      revealedOptionalTabs.includes(field) ||
+      (field === "assertions" && !!counts.assertions) ||
+      (field === "captures" && !!counts.captures),
+  )
+  const idx = fields.indexOf(current)
+  return fields[(idx + delta + fields.length) % fields.length]!
 }
 
 export function folderFieldIndex(field: FolderFieldKind): number {
@@ -243,11 +257,15 @@ export function moveFieldCursor(
   prev: EditState,
   delta: 1 | -1,
   counts: SectionRowCount,
+  revealedOptionalTabs: readonly FieldKind[] = [],
 ): EditState {
   if (prev.mode !== "browsing") return prev
-  const idx = fieldIndex(prev.cursor.field)
-  const nextIdx = (idx + delta + FIELD_ORDER.length) % FIELD_ORDER.length
-  const nextField = FIELD_ORDER[nextIdx]!
+  const nextField = cycleField(
+    prev.cursor.field,
+    delta,
+    counts,
+    revealedOptionalTabs,
+  )
   return {
     ...prev,
     cursor: cursorForField(nextField, counts),

--- a/src/ui/keymap/requestLayers.ts
+++ b/src/ui/keymap/requestLayers.ts
@@ -116,7 +116,11 @@ export function createRequestLayers(
   }
 
   const requestFocus: UseBindingsLayer = {
-    enabled: () => isMainBase() && keymap.getData("app.focus") === "request",
+    enabled: () =>
+      (isMainBase() || request.ebRef.current.optionalTabMenuActive) &&
+      keymap.getData("app.focus") === "request" &&
+      keymap.getData("app.overlay") === "none" &&
+      keymap.getData("app.view") === "main",
     commands: [
       {
         name: "request.edit-enter",
@@ -145,6 +149,7 @@ export function createRequestLayers(
   const browse: UseBindingsLayer = {
     enabled: () =>
       keymap.getData("app.mode") === "browse" &&
+      !request.ebRef.current.optionalTabMenuActive &&
       keymap.getData("app.focus") === "request" &&
       keymap.getData("app.overlay") === "none" &&
       keymap.getData("app.view") === "main",

--- a/src/ui/useJumpMode.ts
+++ b/src/ui/useJumpMode.ts
@@ -18,6 +18,7 @@ export type JumpTarget =
   | { kind: "method" }
   | { kind: "url" }
   | { kind: "request-tab"; field: FieldKind }
+  | { kind: "request-tab-add" }
   | { kind: "folder-tab"; field: FolderFieldKind }
   | { kind: "response-tab"; tab: ResponseTabKind }
   | { kind: "env-sidebar" }
@@ -98,6 +99,10 @@ export function useJumpMode(opts: UseJumpModeOpts): void {
             ebRef.current.enterBrowseAt(target.field)
             setFocus("request")
             break
+          case "request-tab-add":
+            ebRef.current.setOptionalTabMenuActive(true)
+            setFocus("request")
+            break
           case "folder-tab":
             folderEbRef.current.enterBrowseAt(target.field)
             setFocus("folder")
@@ -166,6 +171,7 @@ export function getAvailableTargets(
   environmentView = false,
   settingsView = false,
   cookieJarView = false,
+  requestTabAddVisible = false,
 ): Map<string, JumpTarget> {
   const targets = new Map<string, JumpTarget>()
   if (settingsView) {
@@ -206,6 +212,9 @@ export function getAvailableTargets(
       targets.set("v", { kind: "request-tab", field: "assertions" })
       targets.set("c", { kind: "request-tab", field: "captures" })
       targets.set("t", { kind: "request-tab", field: "settings" })
+      if (requestTabAddVisible) {
+        targets.set(REQUEST_TAB_ADD_HINT, { kind: "request-tab-add" })
+      }
     }
     if (expanded !== "request") {
       targets.set("r", { kind: "response-tab", tab: "body" })
@@ -229,6 +238,8 @@ export const REQUEST_TAB_HINTS: Record<string, string> = {
   captures: "c",
   settings: "t",
 }
+
+export const REQUEST_TAB_ADD_HINT = "o"
 
 export const RESPONSE_TAB_HINTS: Record<string, string> = {
   body: "r",

--- a/tests/editMode.test.ts
+++ b/tests/editMode.test.ts
@@ -11,7 +11,9 @@ import {
   commitEditing,
   cancelEditing,
   toggleSubfield,
+  cycleField,
   type EditState,
+  type FieldKind,
 } from "../src/ui/editMode"
 import { applyDraft } from "../src/hooks/useRequestDraft"
 import { detectFormType } from "../src/hooks/useEditBrowse"
@@ -98,56 +100,81 @@ describe("exitEditBrowse", () => {
 
 describe("moveFieldCursor", () => {
   it("+1 walks headers → params → pathParams → body → auth → assertions → captures → settings → headers", () => {
+    const counts = { ...c(2, 1), assertions: 1, captures: 1 }
     let s = enterEditBrowse(inactive, c(2, 0))
-    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("params")
     expect(s.cursor.row).toBe(0)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("pathParams")
     expect(s.cursor.addingRow).toBe(false)
     expect(s.cursor.row).toBe(-1)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("body")
     expect(s.cursor.row).toBe(0)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(0)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("assertions")
-    expect(s.cursor.row).toBe(-1)
-    expect(s.cursor.addingRow).toBe(true)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    expect(s.cursor.row).toBe(0)
+    expect(s.cursor.addingRow).toBe(false)
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("captures")
-    expect(s.cursor.row).toBe(-1)
-    expect(s.cursor.addingRow).toBe(true)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    expect(s.cursor.row).toBe(0)
+    expect(s.cursor.addingRow).toBe(false)
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("settings")
     expect(s.cursor.row).toBe(0)
-    s = moveFieldCursor(s, +1, c(2, 1))
+    s = moveFieldCursor(s, +1, counts)
     expect(s.cursor.field).toBe("headers")
     expect(s.cursor.row).toBe(0)
   })
   it("-1 walks headers → settings → captures → assertions → auth → body → pathParams → params → headers", () => {
+    const counts = { ...c(2, 1), assertions: 1, captures: 1 }
     let s = enterEditBrowse(inactive, c(2, 0))
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("settings")
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("captures")
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("assertions")
-    expect(s.cursor.addingRow).toBe(true)
-    s = moveFieldCursor(s, -1, c(2, 1))
+    expect(s.cursor.addingRow).toBe(false)
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("auth")
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("body")
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("pathParams")
     expect(s.cursor.addingRow).toBe(false)
     expect(s.cursor.row).toBe(-1)
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("params")
-    s = moveFieldCursor(s, -1, c(2, 1))
+    s = moveFieldCursor(s, -1, counts)
     expect(s.cursor.field).toBe("headers")
+  })
+  it("skips empty assertion and capture sections", () => {
+    let s = enterEditBrowse(inactive, c(0, 0), "auth")
+    s = moveFieldCursor(s, +1, c(0, 0))
+    expect(s.cursor.field).toBe("settings")
+    s = moveFieldCursor(s, -1, c(0, 0))
+    expect(s.cursor.field).toBe("auth")
+  })
+  it("skips empty optional tabs outside browse mode", () => {
+    expect(cycleField("auth", +1, c(0, 0))).toBe("settings")
+    expect(cycleField("assertions", +1, c(0, 0))).toBe("settings")
+    expect(cycleField("captures", -1, c(0, 0))).toBe("auth")
+  })
+  it("includes explicitly revealed empty optional tabs", () => {
+    const revealed: FieldKind[] = ["assertions", "captures"]
+    let s = enterEditBrowse(inactive, c(0, 0), "auth")
+    s = moveFieldCursor(s, +1, c(0, 0), revealed)
+    expect(s.cursor).toEqual({
+      field: "assertions",
+      row: -1,
+      addingRow: true,
+    })
+    expect(cycleField("assertions", +1, c(0, 0), revealed)).toBe("captures")
   })
   it("+1 from headers (empty) lands on params [+] (addingRow true, row -1)", () => {
     let s = enterEditBrowse(inactive, c(0, 0))
@@ -381,11 +408,7 @@ describe("moveRowLast", () => {
       auth: 4,
       settings: 3,
     }
-    let s = enterEditBrowse(inactive, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
+    const s = enterEditBrowse(inactive, counts, "auth")
     expect(s.cursor.field).toBe("auth")
     const last = moveRowLast(s, counts)
     expect(last.cursor.row).toBe(3)
@@ -451,11 +474,7 @@ describe("beginEditing", () => {
       auth: 2,
       settings: 3,
     }
-    let s = enterEditBrowse(inactive, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
+    const s = enterEditBrowse(inactive, counts, "auth")
     expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(0)
     const e = beginEditing(s)
@@ -471,11 +490,7 @@ describe("beginEditing", () => {
       auth: 2,
       settings: 3,
     }
-    let s = enterEditBrowse(inactive, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
+    let s = enterEditBrowse(inactive, counts, "auth")
     expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(0)
     s = moveRowCursor(s, +1, counts)
@@ -494,11 +509,7 @@ describe("beginEditing", () => {
       auth: 3,
       settings: 3,
     }
-    let s = enterEditBrowse(inactive, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
+    let s = enterEditBrowse(inactive, counts, "auth")
     expect(s.cursor.row).toBe(0)
     s = moveRowCursor(s, +1, counts)
     expect(s.cursor.row).toBe(1)
@@ -517,11 +528,7 @@ describe("beginEditing", () => {
       auth: 4,
       settings: 3,
     }
-    let s = enterEditBrowse(inactive, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
+    let s = enterEditBrowse(inactive, counts, "auth")
     expect(s.cursor.row).toBe(0)
     s = moveRowCursor(s, +1, counts)
     expect(s.cursor.row).toBe(1)
@@ -680,11 +687,7 @@ describe("toggleSubfield", () => {
       auth: 2,
       settings: 3,
     }
-    let s = enterEditBrowse(inactive, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
-    s = moveFieldCursor(s, -1, counts)
+    const s = enterEditBrowse(inactive, counts, "auth")
     expect(s.cursor.field).toBe("auth")
     expect(s.cursor.row).toBe(0)
     const e = beginEditing(s)

--- a/tests/unit/RequestPane-clickCommit.test.tsx
+++ b/tests/unit/RequestPane-clickCommit.test.tsx
@@ -108,7 +108,7 @@ describe("RequestPane blank click commit", () => {
     }
   })
 
-  it("keeps multiple explicitly added optional tabs visible while empty", async () => {
+  it("keeps and disables optional menu items after adding their tabs", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     const changes: FieldKind[] = []
 
@@ -201,7 +201,7 @@ describe("RequestPane blank click commit", () => {
         await render.renderOnce()
       })
       const remainingMenu = render.captureCharFrame()
-      expect(remainingMenu.match(/Assert/g)).toHaveLength(1)
+      expect(remainingMenu.match(/Assert/g)).toHaveLength(2)
       expect(remainingMenu.match(/Capture/g)).toHaveLength(1)
       act(() => host.press("return"))
       await act(async () => {
@@ -215,6 +215,37 @@ describe("RequestPane blank click commit", () => {
       expect(
         render.renderer.root.findDescendantById("tab-captures"),
       ).toBeDefined()
+
+      const completedFrame = render.captureCharFrame().split("\n")
+      const completedAddRow = completedFrame.findIndex((line) =>
+        line.includes("+"),
+      )
+      expect(completedAddRow).toBeGreaterThanOrEqual(0)
+      const completedAddColumn =
+        completedFrame[completedAddRow]!.lastIndexOf("+")
+      await act(async () => {
+        await render.mockMouse.click(
+          completedAddColumn,
+          completedAddRow,
+          MouseButtons.LEFT,
+        )
+      })
+      await act(async () => {
+        await render.renderOnce()
+        await render.renderOnce()
+      })
+      const completedMenu = render.captureCharFrame()
+      expect(completedMenu.match(/Assert/g)).toHaveLength(2)
+      expect(completedMenu.match(/Capture/g)).toHaveLength(2)
+      act(() => host.press("return"))
+      await act(async () => {
+        await render.renderOnce()
+      })
+      expect(changes).toEqual(["assertions", "captures"])
+      act(() => host.press("escape"))
+      await act(async () => {
+        await render.renderOnce()
+      })
 
       const headers = render.renderer.root.findDescendantById(
         "tab-headers",
@@ -280,7 +311,7 @@ describe("RequestPane blank click commit", () => {
       expect(
         render.renderer.root.findDescendantById("tab-captures"),
       ).toBeDefined()
-      expect(render.captureCharFrame()).not.toContain("+")
+      expect(render.captureCharFrame()).toContain("+")
     } finally {
       cleanup()
     }

--- a/tests/unit/RequestPane-clickCommit.test.tsx
+++ b/tests/unit/RequestPane-clickCommit.test.tsx
@@ -2,9 +2,10 @@ import { describe, expect, it } from "bun:test"
 import { act, useState } from "react"
 import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
-import type { BoxRenderable } from "@opentui/core"
+import { RGBA, TextAttributes, type BoxRenderable } from "@opentui/core"
 import { MouseButtons } from "@opentui/core/testing"
 import { ThemeProvider } from "../../src/ui/theme"
+import { THEMES } from "../../src/ui/theme-data"
 import { RequestPane } from "../../src/ui/RequestPane"
 import type { FieldKind } from "../../src/ui/editMode"
 import type { Request } from "../../src/schema"
@@ -107,12 +108,13 @@ describe("RequestPane blank click commit", () => {
     }
   })
 
-  it("adds an optional tab and hides it after switching away empty", async () => {
+  it("keeps multiple explicitly added optional tabs visible while empty", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     const changes: FieldKind[] = []
 
     function Harness() {
       const [activeTab, setActiveTab] = useState<FieldKind>("headers")
+      const [revealedTabs, setRevealedTabs] = useState<FieldKind[]>([])
       return (
         <RequestPane
           request={request}
@@ -126,7 +128,11 @@ describe("RequestPane blank click commit", () => {
           setEditKey={() => {}}
           setEditValue={() => {}}
           activeTab={activeTab}
+          revealedOptionalTabs={revealedTabs}
           onInteraction={() => true}
+          onOptionalTabReveal={(tab) =>
+            setRevealedTabs((current) => [...current, tab])
+          }
           onTabChange={(tab) => {
             changes.push(tab)
             setActiveTab(tab)
@@ -197,11 +203,18 @@ describe("RequestPane blank click commit", () => {
       const remainingMenu = render.captureCharFrame()
       expect(remainingMenu.match(/Assert/g)).toHaveLength(1)
       expect(remainingMenu.match(/Capture/g)).toHaveLength(1)
-      act(() => host.press("escape"))
+      act(() => host.press("return"))
       await act(async () => {
         await render.renderOnce()
         await render.renderOnce()
       })
+      expect(changes).toEqual(["assertions", "captures"])
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeDefined()
+      expect(
+        render.renderer.root.findDescendantById("tab-captures"),
+      ).toBeDefined()
 
       const headers = render.renderer.root.findDescendantById(
         "tab-headers",
@@ -216,10 +229,13 @@ describe("RequestPane blank click commit", () => {
       await act(async () => {
         await render.renderOnce()
       })
-      expect(changes).toEqual(["assertions", "headers"])
+      expect(changes).toEqual(["assertions", "captures", "headers"])
       expect(
         render.renderer.root.findDescendantById("tab-assertions"),
-      ).toBeUndefined()
+      ).toBeDefined()
+      expect(
+        render.renderer.root.findDescendantById("tab-captures"),
+      ).toBeDefined()
     } finally {
       cleanup()
     }
@@ -270,7 +286,7 @@ describe("RequestPane blank click commit", () => {
     }
   })
 
-  it("temporarily exposes optional tabs during jump mode", async () => {
+  it("shows the optional-tab add shortcut during jump mode", async () => {
     const { keymap, cleanup } = setupKeymap()
     try {
       const render = await testRender(
@@ -294,14 +310,63 @@ describe("RequestPane blank click commit", () => {
       await render.renderOnce()
       expect(
         render.renderer.root.findDescendantById("tab-assertions"),
-      ).toBeDefined()
+      ).toBeUndefined()
       expect(
         render.renderer.root.findDescendantById("tab-captures"),
-      ).toBeDefined()
+      ).toBeUndefined()
       const frame = render.captureCharFrame()
-      expect(frame).toContain(" v ")
-      expect(frame).toContain(" c ")
-      expect(frame).not.toContain("+")
+      expect(frame).not.toContain(" v ")
+      expect(frame).not.toContain(" c ")
+      const add = render.renderer.root.findDescendantById(
+        "request-tab-add",
+      ) as BoxRenderable
+      expect(add).toBeDefined()
+      expect(frame).toContain("+")
+      expect(
+        frame.split("\n")[add.y - 1]!.slice(add.x, add.x + add.width),
+      ).toContain("o")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("makes the focused optional-tab add control visually distinct", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <RequestPane
+              request={request}
+              editState={{
+                mode: "inactive",
+                cursor: {
+                  field: "headers",
+                  row: -1,
+                  addingRow: false,
+                },
+                editingRow: -1,
+              }}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              activeTab="headers"
+              focused
+              tabMenuActive
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 100, height: 20 },
+      )
+
+      await render.renderOnce()
+      const plus = render
+        .captureSpans()
+        .lines.flatMap((line) => line.spans)
+        .find((span) => span.text.trim() === "+")
+      expect(plus?.fg.equals(RGBA.fromHex(THEMES[0]!.primary))).toBe(true)
+      expect((plus?.attributes ?? 0) & TextAttributes.BOLD).not.toBe(0)
     } finally {
       cleanup()
     }
@@ -393,6 +458,9 @@ describe("RequestPane blank click commit", () => {
       expect(
         render.renderer.root.findDescendantById("tab-captures"),
       ).toBeDefined()
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeUndefined()
     } finally {
       cleanup()
     }

--- a/tests/unit/RequestPane-clickCommit.test.tsx
+++ b/tests/unit/RequestPane-clickCommit.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { act } from "react"
+import { act, useState } from "react"
 import { createTestRender } from "../testRender"
 import { KeymapProvider } from "@opentui/keymap/react"
 import type { BoxRenderable } from "@opentui/core"
@@ -30,6 +30,12 @@ const automationRequest: Request = {
   ...request,
   assertions: [{ expression: "status", operator: "exists" }],
   captures: { token: { value: "body.token", enabled: true } },
+}
+
+const browsingHeaders = {
+  mode: "browsing" as const,
+  cursor: { field: "headers" as const, row: -1, addingRow: true },
+  editingRow: -1,
 }
 
 function EditingPane({
@@ -64,9 +70,275 @@ function EditingPane({
 }
 
 describe("RequestPane blank click commit", () => {
-  it("does not change tabs when a capture commit is rejected", async () => {
+  it("hides empty optional tabs behind a compact add control", async () => {
     const { keymap, cleanup } = setupKeymap()
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <RequestPane
+              request={request}
+              editState={browsingHeaders}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              activeTab="headers"
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 42, height: 12 },
+      )
+
+      await act(async () => {
+        await render.renderOnce()
+      })
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeUndefined()
+      expect(
+        render.renderer.root.findDescendantById("tab-captures"),
+      ).toBeUndefined()
+      const frame = render.captureCharFrame()
+      expect(frame).toContain("+")
+      expect(frame).not.toContain("▼")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("adds an optional tab and hides it after switching away empty", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
     const changes: FieldKind[] = []
+
+    function Harness() {
+      const [activeTab, setActiveTab] = useState<FieldKind>("headers")
+      return (
+        <RequestPane
+          request={request}
+          editState={{
+            mode: "browsing",
+            cursor: { field: activeTab, row: -1, addingRow: true },
+            editingRow: -1,
+          }}
+          editKey=""
+          editValue=""
+          setEditKey={() => {}}
+          setEditValue={() => {}}
+          activeTab={activeTab}
+          onInteraction={() => true}
+          onTabChange={(tab) => {
+            changes.push(tab)
+            setActiveTab(tab)
+          }}
+        />
+      )
+    }
+
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <Harness />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 16 },
+      )
+
+      await act(async () => {
+        await render.renderOnce()
+      })
+      const lines = render.captureCharFrame().split("\n")
+      const addRow = lines.findIndex((line) => line.includes("+"))
+      const addColumn = lines[addRow]!.lastIndexOf("+")
+      await act(async () => {
+        await render.mockMouse.moveTo(addColumn, addRow)
+      })
+      await act(async () => {
+        await render.renderOnce()
+      })
+      await act(async () => {
+        await render.mockMouse.click(addColumn, addRow, MouseButtons.LEFT)
+      })
+      await act(async () => {
+        await render.renderOnce()
+        await render.renderOnce()
+      })
+      const menu = render.captureCharFrame()
+      expect(menu).toContain("Assert")
+      expect(menu).toContain("Capture")
+
+      act(() => host.press("return"))
+      await act(async () => {
+        await render.renderOnce()
+        await render.renderOnce()
+      })
+      expect(changes).toEqual(["assertions"])
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeDefined()
+
+      const activeFrame = render.captureCharFrame().split("\n")
+      const remainingAddRow = activeFrame.findIndex((line) =>
+        line.includes("+"),
+      )
+      const remainingAddColumn = activeFrame[remainingAddRow]!.lastIndexOf("+")
+      await act(async () => {
+        await render.mockMouse.click(
+          remainingAddColumn,
+          remainingAddRow,
+          MouseButtons.LEFT,
+        )
+      })
+      await act(async () => {
+        await render.renderOnce()
+        await render.renderOnce()
+      })
+      const remainingMenu = render.captureCharFrame()
+      expect(remainingMenu.match(/Assert/g)).toHaveLength(1)
+      expect(remainingMenu.match(/Capture/g)).toHaveLength(1)
+      act(() => host.press("escape"))
+      await act(async () => {
+        await render.renderOnce()
+        await render.renderOnce()
+      })
+
+      const headers = render.renderer.root.findDescendantById(
+        "tab-headers",
+      ) as BoxRenderable
+      await act(async () => {
+        await render.mockMouse.click(
+          headers.x + 1,
+          headers.y,
+          MouseButtons.LEFT,
+        )
+      })
+      await act(async () => {
+        await render.renderOnce()
+      })
+      expect(changes).toEqual(["assertions", "headers"])
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeUndefined()
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("keeps optional tabs with disabled declarations visible", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <RequestPane
+              request={{
+                ...request,
+                assertions: [
+                  {
+                    expression: "status",
+                    operator: "exists",
+                    enabled: false,
+                  },
+                ],
+                captures: {
+                  token: { value: "body.token", enabled: false },
+                },
+              }}
+              editState={browsingHeaders}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              activeTab="headers"
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 12 },
+      )
+
+      await render.renderOnce()
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeDefined()
+      expect(
+        render.renderer.root.findDescendantById("tab-captures"),
+      ).toBeDefined()
+      expect(render.captureCharFrame()).not.toContain("+")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("temporarily exposes optional tabs during jump mode", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <RequestPane
+              request={request}
+              editState={browsingHeaders}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              activeTab="headers"
+              jumpMode
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 12 },
+      )
+
+      await render.renderOnce()
+      expect(
+        render.renderer.root.findDescendantById("tab-assertions"),
+      ).toBeDefined()
+      expect(
+        render.renderer.root.findDescendantById("tab-captures"),
+      ).toBeDefined()
+      const frame = render.captureCharFrame()
+      expect(frame).toContain(" v ")
+      expect(frame).toContain(" c ")
+      expect(frame).not.toContain("+")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("does not offer optional tabs in read-only mode", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    try {
+      const render = await testRender(
+        <KeymapProvider keymap={keymap}>
+          <ThemeProvider activeIndex={0} previewIndex={null}>
+            <RequestPane
+              request={request}
+              editState={browsingHeaders}
+              editKey=""
+              editValue=""
+              setEditKey={() => {}}
+              setEditValue={() => {}}
+              activeTab="headers"
+              interactive={false}
+            />
+          </ThemeProvider>
+        </KeymapProvider>,
+        { width: 80, height: 12 },
+      )
+
+      await render.renderOnce()
+      expect(render.captureCharFrame()).not.toContain("+")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("does not change tabs when a capture commit is rejected", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    const changes: FieldKind[] = []
+    let interactions = 0
     try {
       const render = await testRender(
         <KeymapProvider keymap={keymap}>
@@ -88,7 +360,10 @@ describe("RequestPane blank click commit", () => {
               setEditKey={() => {}}
               setEditValue={() => {}}
               activeTab="captures"
-              onInteraction={() => false}
+              onInteraction={() => {
+                interactions++
+                return false
+              }}
               onTabChange={(tab) => changes.push(tab)}
             />
           </ThemeProvider>
@@ -97,14 +372,27 @@ describe("RequestPane blank click commit", () => {
       )
 
       await render.renderOnce()
-      const target = render.renderer.root.findDescendantById(
-        "tab-headers",
-      ) as BoxRenderable
+      const lines = render.captureCharFrame().split("\n")
+      const addRow = lines.findIndex((line) => line.includes("+"))
+      const addColumn = lines[addRow]!.lastIndexOf("+")
       await act(async () => {
-        await render.mockMouse.click(target.x + 1, target.y, MouseButtons.LEFT)
+        await render.mockMouse.click(addColumn, addRow, MouseButtons.LEFT)
+      })
+      await act(async () => {
+        await render.renderOnce()
+        await render.renderOnce()
+      })
+      expect(interactions).toBe(0)
+      act(() => host.press("return"))
+      await act(async () => {
+        await render.renderOnce()
       })
 
       expect(changes).toEqual([])
+      expect(interactions).toBe(1)
+      expect(
+        render.renderer.root.findDescendantById("tab-captures"),
+      ).toBeDefined()
     } finally {
       cleanup()
     }

--- a/tests/unit/ResponsePaneStatus.test.tsx
+++ b/tests/unit/ResponsePaneStatus.test.tsx
@@ -1012,6 +1012,20 @@ describe("getAvailableTargets", () => {
     expect(targets.size).toBe(17)
   })
 
+  it("includes the optional-tab add target only while its control is visible", () => {
+    const visible = getAvailableTargets(
+      true,
+      null,
+      false,
+      false,
+      false,
+      false,
+      true,
+    )
+    expect(visible.get("o")).toEqual({ kind: "request-tab-add" })
+    expect(getAvailableTargets(true, null, false).has("o")).toBe(false)
+  })
+
   it("keeps the Results jump target when no execution groups are available", () => {
     const targets = getAvailableTargets(true, null, false, false, false, false)
     expect(targets.has("i")).toBe(true)

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -71,6 +71,27 @@ describe("Select", () => {
     cleanup()
   })
 
+  it("can hide the trigger indicator", async () => {
+    const { keymap, cleanup } = setupKeymap()
+    const { renderOnce, captureCharFrame } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Select
+            items={testItems}
+            placeholder="+"
+            fitContent
+            showIndicator={false}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 20, height: 5 },
+    )
+    await renderOnce()
+
+    expect(captureCharFrame().split("\n")[0]!.trim()).toBe("+")
+    cleanup()
+  })
+
   it("opens dropdown on Enter when focused", async () => {
     const { keymap, host, cleanup } = setupKeymap()
     let open = false

--- a/tests/unit/Select.test.tsx
+++ b/tests/unit/Select.test.tsx
@@ -573,6 +573,37 @@ describe("Select", () => {
     cleanup()
   })
 
+  it("opens on the first enabled item", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let selected = ""
+    const { renderOnce } = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <ThemeProvider activeIndex={0} previewIndex={null}>
+          <Select
+            items={[
+              { id: "a", label: "A", disabled: true },
+              { id: "b", label: "B" },
+            ]}
+            focused
+            onChange={(id) => {
+              selected = id
+            }}
+          />
+        </ThemeProvider>
+      </KeymapProvider>,
+      { width: 40, height: 20 },
+    )
+    await renderOnce()
+
+    act(() => host.press("return"))
+    await renderOnce()
+    act(() => host.press("return"))
+    await renderOnce()
+
+    expect(selected).toBe("b")
+    cleanup()
+  })
+
   it("renders with badge mode", async () => {
     const badgeItems: SelectItem[] = [
       { id: "get", label: "GET", color: "primary" },

--- a/tests/unit/appKeymapLayers.test.ts
+++ b/tests/unit/appKeymapLayers.test.ts
@@ -46,6 +46,8 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
     formType: 0,
     requestCommit: 0,
     requestToggle: 0,
+    requestTabCycle: [] as number[],
+    requestBrowseHorizontal: [] as number[],
     folderUp: 0,
     folderCommit: 0,
     envSave: 0,
@@ -101,6 +103,10 @@ function createContext(keymap: ReturnType<typeof createTestKeymap>["keymap"]) {
         },
         toggleFormRowType: () => calls.formType++,
         toggleRow: () => calls.requestToggle++,
+        optionalTabMenuActive: false,
+        cycleInactiveTab: (delta: number) => calls.requestTabCycle.push(delta),
+        browseLeft: () => calls.requestBrowseHorizontal.push(-1),
+        browseRight: () => calls.requestBrowseHorizontal.push(1),
         commitEdit: () => calls.requestCommit++,
         canEnterTextBodyEditor: false,
         isEditingTextBody: false,
@@ -364,6 +370,40 @@ describe("app keymap layers", () => {
       key: "ctrl+d",
       cmd: "cookie.delete-cookie",
     })
+    cleanup()
+  })
+
+  it("routes one arrow through the focused optional-tab add control", () => {
+    const { keymap, host, cleanup } = setup()
+    const { context, calls } = createContext(keymap)
+    const editor = context.request.ebRef.current
+    context.global.focusRef.current = "request"
+    keymap.setData("app.focus", "request")
+    keymap.setData("app.mode", "browse")
+    const disposers = register(context)
+
+    editor.editState.mode = "browsing"
+    host.press("right")
+    expect(calls.requestBrowseHorizontal).toEqual([1])
+
+    editor.optionalTabMenuActive = true
+    editor.editState.mode = "inactive"
+    host.press("right")
+    expect(calls.requestTabCycle).toEqual([1])
+    expect(calls.requestBrowseHorizontal).toEqual([1])
+
+    editor.optionalTabMenuActive = false
+    editor.editState.mode = "browsing"
+    host.press("left")
+    expect(calls.requestBrowseHorizontal).toEqual([1, -1])
+
+    editor.optionalTabMenuActive = true
+    editor.editState.mode = "inactive"
+    host.press("left")
+    expect(calls.requestTabCycle).toEqual([1, -1])
+    expect(calls.requestBrowseHorizontal).toEqual([1, -1])
+
+    disposers.forEach((dispose) => dispose())
     cleanup()
   })
 

--- a/tests/unit/useAuthoringEditBrowse.test.tsx
+++ b/tests/unit/useAuthoringEditBrowse.test.tsx
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test"
-import { useEffect, useState } from "react"
+import { act, useEffect, useState } from "react"
 import { createTestRender } from "../testRender"
 import { useRequestDraft } from "../../src/hooks/useRequestDraft"
-import { useEditBrowse } from "../../src/hooks/useEditBrowse"
+import {
+  useEditBrowse,
+  type UseEditBrowseResult,
+} from "../../src/hooks/useEditBrowse"
 import type { Request } from "../../src/schema"
+import type { FieldKind } from "../../src/ui/editMode"
 
 const testRender = createTestRender()
 const request: Request = {
@@ -456,5 +460,216 @@ describe("useEditBrowse authored rows", () => {
       { index: 1, value: "" },
     ])
     expect(finalMode).toBe("browsing")
+  })
+})
+
+function TabNavigationHarness({
+  initialRequest,
+  initialTab = "settings",
+  optionalTabMenuEnabled = true,
+  onEditor,
+  onTab,
+}: {
+  initialRequest: Request
+  initialTab?: FieldKind
+  optionalTabMenuEnabled?: boolean
+  onEditor: (editor: UseEditBrowseResult) => void
+  onTab?: (tab: FieldKind) => void
+}) {
+  const draft = useRequestDraft(initialRequest)
+  const [tab, setTab] = useState<FieldKind>(initialTab)
+  const editor = useEditBrowse(draft.draft, draft, {
+    initialTab: tab,
+    onTabChange: setTab,
+    optionalTabMenuEnabled,
+  })
+  onEditor(editor)
+  onTab?.(tab)
+  return null
+}
+
+describe("useEditBrowse optional-tab menu navigation", () => {
+  it("does not restore empty optional tabs across sessions", async () => {
+    for (const field of ["assertions", "captures"] as const) {
+      let editor: UseEditBrowseResult | undefined
+      let persistedTab: FieldKind | undefined
+      const render = await testRender(
+        <TabNavigationHarness
+          initialRequest={request}
+          initialTab={field}
+          onEditor={(value) => (editor = value)}
+          onTab={(value) => (persistedTab = value)}
+        />,
+        { width: 20, height: 4 },
+      )
+      await render.renderOnce()
+      await render.renderOnce()
+
+      expect(editor?.activeTab).toBe("headers")
+      expect(persistedTab).toBe("headers")
+    }
+  })
+
+  it("restores optional tabs that contain disabled declarations", async () => {
+    const cases: Array<[FieldKind, Request]> = [
+      [
+        "assertions",
+        {
+          ...request,
+          assertions: [
+            { expression: "status", operator: "exists", enabled: false },
+          ],
+        },
+      ],
+      [
+        "captures",
+        {
+          ...request,
+          captures: { token: { value: "body.token", enabled: false } },
+        },
+      ],
+    ]
+    for (const [field, initialRequest] of cases) {
+      let editor: UseEditBrowseResult | undefined
+      let persistedTab: FieldKind | undefined
+      const render = await testRender(
+        <TabNavigationHarness
+          initialRequest={initialRequest}
+          initialTab={field}
+          onEditor={(value) => (editor = value)}
+          onTab={(value) => (persistedTab = value)}
+        />,
+        { width: 20, height: 4 },
+      )
+      await render.renderOnce()
+
+      expect(editor?.activeTab).toBe(field)
+      expect(persistedTab).toBe(field)
+    }
+  })
+
+  it("keeps explicitly revealed empty tabs for the current session", async () => {
+    let editor: UseEditBrowseResult | undefined
+    let persistedTab: FieldKind | undefined
+    const render = await testRender(
+      <TabNavigationHarness
+        initialRequest={request}
+        onEditor={(value) => (editor = value)}
+        onTab={(value) => (persistedTab = value)}
+      />,
+      { width: 20, height: 4 },
+    )
+    await render.renderOnce()
+
+    act(() => editor!.revealOptionalTab("assertions"))
+    act(() => editor!.enterBrowseAt("assertions"))
+    await render.renderOnce()
+    act(() => editor!.exitBrowse())
+    await render.renderOnce()
+    await render.renderOnce()
+
+    expect(editor?.activeTab).toBe("assertions")
+    expect(editor?.revealedOptionalTabs).toContain("assertions")
+    expect(persistedTab).toBe("assertions")
+  })
+
+  it("cycles Settings → + → Headers and Headers → + → Settings", async () => {
+    let editor: UseEditBrowseResult | undefined
+    const render = await testRender(
+      <TabNavigationHarness
+        initialRequest={request}
+        onEditor={(value) => (editor = value)}
+      />,
+      { width: 20, height: 4 },
+    )
+    await render.renderOnce()
+
+    expect(editor?.activeTab).toBe("settings")
+    expect(editor?.optionalTabMenuVisible).toBe(true)
+
+    act(() => editor!.cycleInactiveTab(1))
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("settings")
+    expect(editor?.optionalTabMenuActive).toBe(true)
+
+    act(() => editor!.cycleInactiveTab(1))
+    await render.renderOnce()
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("headers")
+    expect(editor?.optionalTabMenuActive).toBe(false)
+
+    act(() => editor!.cycleInactiveTab(-1))
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("headers")
+    expect(editor?.optionalTabMenuActive).toBe(true)
+
+    act(() => editor!.cycleInactiveTab(-1))
+    await render.renderOnce()
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("settings")
+    expect(editor?.optionalTabMenuActive).toBe(false)
+  })
+
+  it("reaches + from browse mode without changing the active tab", async () => {
+    let editor: UseEditBrowseResult | undefined
+    const render = await testRender(
+      <TabNavigationHarness
+        initialRequest={request}
+        onEditor={(value) => (editor = value)}
+      />,
+      { width: 20, height: 4 },
+    )
+    await render.renderOnce()
+
+    act(() => editor!.enterBrowseAt("settings"))
+    await render.renderOnce()
+    expect(editor?.editState.mode).toBe("browsing")
+
+    act(() => editor!.browseRight())
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("settings")
+    expect(editor?.optionalTabMenuActive).toBe(true)
+    expect(editor?.editState.mode).toBe("inactive")
+
+    act(() => editor!.enterBrowseAt("settings"))
+    await render.renderOnce()
+    act(() => editor!.setOptionalTabMenuActive(true))
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("settings")
+    expect(editor?.optionalTabMenuActive).toBe(true)
+    expect(editor?.editState.mode).toBe("inactive")
+  })
+
+  it("skips + when it is hidden or disabled", async () => {
+    const cases: Array<[Request, boolean]> = [
+      [
+        {
+          ...request,
+          assertions: [{ expression: "status", operator: "exists" }],
+          captures: { token: { value: "body.token", enabled: true } },
+        },
+        true,
+      ],
+      [request, false],
+    ]
+    for (const [initialRequest, enabled] of cases) {
+      let editor: UseEditBrowseResult | undefined
+      const render = await testRender(
+        <TabNavigationHarness
+          initialRequest={initialRequest}
+          optionalTabMenuEnabled={enabled}
+          onEditor={(value) => (editor = value)}
+        />,
+        { width: 20, height: 4 },
+      )
+      await render.renderOnce()
+
+      expect(editor?.optionalTabMenuVisible).toBe(false)
+      act(() => editor!.cycleInactiveTab(1))
+      await render.renderOnce()
+      await render.renderOnce()
+      expect(editor?.activeTab).toBe("headers")
+      expect(editor?.optionalTabMenuActive).toBe(false)
+    }
   })
 })

--- a/tests/unit/useAuthoringEditBrowse.test.tsx
+++ b/tests/unit/useAuthoringEditBrowse.test.tsx
@@ -640,36 +640,45 @@ describe("useEditBrowse optional-tab menu navigation", () => {
     expect(editor?.editState.mode).toBe("inactive")
   })
 
-  it("skips + when it is hidden or disabled", async () => {
-    const cases: Array<[Request, boolean]> = [
-      [
-        {
+  it("keeps + reachable when both optional tabs are visible", async () => {
+    let editor: UseEditBrowseResult | undefined
+    const render = await testRender(
+      <TabNavigationHarness
+        initialRequest={{
           ...request,
           assertions: [{ expression: "status", operator: "exists" }],
           captures: { token: { value: "body.token", enabled: true } },
-        },
-        true,
-      ],
-      [request, false],
-    ]
-    for (const [initialRequest, enabled] of cases) {
-      let editor: UseEditBrowseResult | undefined
-      const render = await testRender(
-        <TabNavigationHarness
-          initialRequest={initialRequest}
-          optionalTabMenuEnabled={enabled}
-          onEditor={(value) => (editor = value)}
-        />,
-        { width: 20, height: 4 },
-      )
-      await render.renderOnce()
+        }}
+        onEditor={(value) => (editor = value)}
+      />,
+      { width: 20, height: 4 },
+    )
+    await render.renderOnce()
 
-      expect(editor?.optionalTabMenuVisible).toBe(false)
-      act(() => editor!.cycleInactiveTab(1))
-      await render.renderOnce()
-      await render.renderOnce()
-      expect(editor?.activeTab).toBe("headers")
-      expect(editor?.optionalTabMenuActive).toBe(false)
-    }
+    expect(editor?.optionalTabMenuVisible).toBe(true)
+    act(() => editor!.cycleInactiveTab(1))
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("settings")
+    expect(editor?.optionalTabMenuActive).toBe(true)
+  })
+
+  it("skips + when the menu is disabled", async () => {
+    let editor: UseEditBrowseResult | undefined
+    const render = await testRender(
+      <TabNavigationHarness
+        initialRequest={request}
+        optionalTabMenuEnabled={false}
+        onEditor={(value) => (editor = value)}
+      />,
+      { width: 20, height: 4 },
+    )
+    await render.renderOnce()
+
+    expect(editor?.optionalTabMenuVisible).toBe(false)
+    act(() => editor!.cycleInactiveTab(1))
+    await render.renderOnce()
+    await render.renderOnce()
+    expect(editor?.activeTab).toBe("headers")
+    expect(editor?.optionalTabMenuActive).toBe(false)
   })
 })

--- a/tests/unit/useAuthoringEditBrowse.test.tsx
+++ b/tests/unit/useAuthoringEditBrowse.test.tsx
@@ -469,22 +469,27 @@ function TabNavigationHarness({
   optionalTabMenuEnabled = true,
   onEditor,
   onTab,
+  onTabChange,
 }: {
   initialRequest: Request
   initialTab?: FieldKind
   optionalTabMenuEnabled?: boolean
   onEditor: (editor: UseEditBrowseResult) => void
-  onTab?: (tab: FieldKind) => void
+  onTab?: (tab: FieldKind, restoreTab: (tab: FieldKind) => void) => void
+  onTabChange?: (tab: FieldKind) => void
 }) {
   const draft = useRequestDraft(initialRequest)
   const [tab, setTab] = useState<FieldKind>(initialTab)
   const editor = useEditBrowse(draft.draft, draft, {
     initialTab: tab,
-    onTabChange: setTab,
+    onTabChange: (value) => {
+      onTabChange?.(value)
+      setTab(value)
+    },
     optionalTabMenuEnabled,
   })
   onEditor(editor)
-  onTab?.(tab)
+  onTab?.(tab, setTab)
   return null
 }
 
@@ -493,12 +498,14 @@ describe("useEditBrowse optional-tab menu navigation", () => {
     for (const field of ["assertions", "captures"] as const) {
       let editor: UseEditBrowseResult | undefined
       let persistedTab: FieldKind | undefined
+      const changes: FieldKind[] = []
       const render = await testRender(
         <TabNavigationHarness
           initialRequest={request}
           initialTab={field}
           onEditor={(value) => (editor = value)}
           onTab={(value) => (persistedTab = value)}
+          onTabChange={(value) => changes.push(value)}
         />,
         { width: 20, height: 4 },
       )
@@ -507,6 +514,40 @@ describe("useEditBrowse optional-tab menu navigation", () => {
 
       expect(editor?.activeTab).toBe("headers")
       expect(persistedTab).toBe("headers")
+      expect(changes).toEqual(["headers"])
+    }
+  })
+
+  it("notifies once when an empty optional preference loads after mount", async () => {
+    let editor: UseEditBrowseResult | undefined
+    let persistedTab: FieldKind | undefined
+    let restoreTab: (tab: FieldKind) => void
+    const changes: FieldKind[] = []
+    const render = await testRender(
+      <TabNavigationHarness
+        initialRequest={request}
+        initialTab="headers"
+        onEditor={(value) => (editor = value)}
+        onTab={(value, restore) => {
+          persistedTab = value
+          restoreTab = restore
+        }}
+        onTabChange={(value) => changes.push(value)}
+      />,
+      { width: 20, height: 4 },
+    )
+    await render.renderOnce()
+    expect(changes).toEqual([])
+
+    for (const field of ["assertions", "captures"] as const) {
+      changes.length = 0
+      act(() => restoreTab(field))
+      await render.renderOnce()
+      await render.renderOnce()
+
+      expect(editor?.activeTab).toBe("headers")
+      expect(persistedTab).toBe("headers")
+      expect(changes).toEqual(["headers"])
     }
   })
 

--- a/tests/unit/useFolderEditBrowse.test.tsx
+++ b/tests/unit/useFolderEditBrowse.test.tsx
@@ -189,6 +189,53 @@ interface EnvironmentSnapshot {
   headerCalls: string[]
 }
 
+function RequestTabAddJumpHarness({
+  onSnapshot,
+}: {
+  onSnapshot: (value: {
+    focus: Focus
+    jumpMode: boolean
+    tabMenuActive: boolean
+  }) => void
+}) {
+  const [tabMenuActive, setTabMenuActive] = useState(false)
+  const ebRef = useRef({
+    setOptionalTabMenuActive: setTabMenuActive,
+  } as unknown as UseEditBrowseResult)
+  const folderEbRef = useRef({} as UseFolderEditBrowseResult)
+  const selectedIdRef = useRef<string | null>(null)
+  const envHeaderRef = useRef<EnvHeaderPaneHandle | null>(null)
+  const headerFieldRef = useRef<"name" | "color">("name")
+  const pendingHeaderFieldRef = useRef<"name" | "color" | null>(null)
+  const targetsRef = useRef<Map<string, JumpTarget>>(
+    new Map([["o", { kind: "request-tab-add" }]]),
+  )
+  const [jumpMode, setJumpMode] = useState(true)
+  const [focus, setFocus] = useState<Focus>("sidebar")
+
+  useJumpMode({
+    jumpMode,
+    setJumpMode,
+    setFocus,
+    setUrlbarSubFocus: () => {},
+    ebRef,
+    folderEbRef,
+    envHeaderRef,
+    headerFieldRef,
+    pendingHeaderFieldRef,
+    setTab: () => {},
+    selectedIdRef,
+    targetsRef,
+    triggerKey: "g",
+  })
+
+  useEffect(() => {
+    onSnapshot({ focus, jumpMode, tabMenuActive })
+  }, [focus, jumpMode, onSnapshot, tabMenuActive])
+
+  return null
+}
+
 describe("useFolderEditBrowse jump mode", () => {
   it("cancels an active edit before jumping to another folder tab", async () => {
     const { keymap, host, cleanup } = setupKeymap()
@@ -254,5 +301,32 @@ describe("useJumpMode environment editor", () => {
       })
       cleanup()
     }
+  })
+})
+
+describe("useJumpMode request tab add", () => {
+  it("focuses the optional-tab add control", async () => {
+    const { keymap, host, cleanup } = setupKeymap()
+    let snapshot:
+      | { focus: Focus; jumpMode: boolean; tabMenuActive: boolean }
+      | undefined
+    const render = await testRender(
+      <KeymapProvider keymap={keymap}>
+        <RequestTabAddJumpHarness onSnapshot={(value) => (snapshot = value)} />
+      </KeymapProvider>,
+      { width: 1, height: 1 },
+    )
+
+    await render.renderOnce()
+    await act(async () => host.press("o"))
+    await render.renderOnce()
+    await render.renderOnce()
+
+    expect(snapshot).toEqual({
+      focus: "request",
+      jumpMode: false,
+      tabMenuActive: true,
+    })
+    cleanup()
   })
 })


### PR DESCRIPTION
Closes #

### Type of change

- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

Unclutters the request pane by hiding empty optional tabs (`assertions`/`captures`) behind a compact `+` add control. Non-empty or revealed tabs stay visible. The `+` control is a `Select` menu that always lists both optional tabs, disabling already-visible ones. Adds `revealedOptionalTabs`/`tabMenuActive` state plumbing through `AppInner`/`RequestPane`/`Select`, updates `useEditBrowse`/`editMode`/`keymap`/`useJumpMode` and `RequestResponseView` integration.

### How did you verify your code works?

- `bun test` passes (3172 pass, 0 fail)
- `bun run lint` passes (`oxlint`)
- `bun run typecheck` passes (`tsc --noEmit`)
- Manual local verification via existing unit tests for `RequestPane`, `Select`, `editMode`, `useAuthoringEditBrowse`/`useFolderEditBrowse`, `appKeymapLayers`

### Screenshots / recordings

N/A — terminal UI change; covered by updated `RequestPane`/`Select` unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Assertions and Captures tabs can be revealed on demand through a compact add menu.
  * Added keyboard navigation and jump-mode shortcut support for opening the optional-tab menu.
  * Hidden empty tabs are skipped during tab cycling, while revealed or populated tabs remain accessible.
  * Dropdowns can hide their indicator and select the first enabled option when needed.

* **Bug Fixes**
  * Improved focus and keyboard behavior while the optional-tab menu is active.
  * Prevented duplicate tab-change notifications and unnecessary restoration of empty optional tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->