### PR TITLE
fix(requests): preserve literal dollars and redact structured values

### DIFF
--- a/collections/.environments/development.env
+++ b/collections/.environments/development.env
@@ -1,5 +1,6 @@
 _color=success
-base_url=https://jsonplaceholder.typicode.com
+# @secret base_url
+base_url=
 # @secret api_token
 api_token=
 # @secret x_api_key

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -63,6 +63,7 @@ import {
   redactResponseHeaders,
   requestSensitiveValues,
   responseSensitiveValues,
+  type RedactionSecret,
 } from "../secrets/redact"
 import type { AssertionResult } from "../assertions"
 import { RunScope, type CaptureResult } from "../runScope"
@@ -723,7 +724,7 @@ async function runRequest(
   onDetail?: RunDetail,
 ): Promise<RequestRunResult> {
   const effectiveEnvironment = runScope.environment(environment)
-  const secretValues = executionSecretValues(
+  const secretValues: RedactionSecret[] = executionSecretValues(
     [environment, effectiveEnvironment],
     proxyPolicy,
     tlsPolicy,

--- a/src/codegen/buildHar.ts
+++ b/src/codegen/buildHar.ts
@@ -43,11 +43,10 @@ export function buildHar(
 ): BuildHarOutput {
   const shouldInterpolate = interpolate ?? false
 
-  let working = request
-
-  if (shouldInterpolate && env) {
-    working = interpolateRequest(request, env)
-  }
+  let working = interpolateRequest(
+    request,
+    shouldInterpolate && env ? env : { name: "", vars: {} },
+  )
 
   const { hashed: hashedUrl, restore: unhash } = hashVars(working.url)
   working = { ...working, url: hashedUrl }

--- a/src/codegen/variableHash.ts
+++ b/src/codegen/variableHash.ts
@@ -21,12 +21,16 @@ export function hashVars(url: string): VarHasher {
 
   let counter = 0
   const map = new Map<number, string>()
-  let hashed = replaceVariableReferences(working, (_name, reference) => {
-    const id = counter++
-    const placeholder = `${VAR_PREFIX}${id}`
-    map.set(id, working.slice(reference.start, reference.end))
-    return placeholder
-  })
+  let hashed = replaceVariableReferences(
+    working,
+    (_name, reference) => {
+      const id = counter++
+      const placeholder = `${VAR_PREFIX}${id}`
+      map.set(id, working.slice(reference.start, reference.end))
+      return placeholder
+    },
+    () => "$$",
+  )
   const authority = hashed.match(HTTP_AUTHORITY_RE)?.[1] ?? ""
   const host = authority.slice(authority.lastIndexOf("@") + 1)
   if (!host || host.startsWith(":") || !URL.canParse(hashed)) {

--- a/src/executionResults.ts
+++ b/src/executionResults.ts
@@ -2,13 +2,19 @@ import { evaluateAssertions, type AssertionResult } from "./assertions"
 import type { Environment, JsonValue, Request, Response } from "./schema"
 import type { ProxyPolicy } from "./proxy"
 import type { TlsPolicy } from "./tls"
-import { createResponseResolver, parseResponseExpression } from "./response"
+import {
+  createResponseResolver,
+  parseResponseExpression,
+  type ResponseExpression,
+} from "./response"
 import { evaluateCaptures, type CaptureResult, RunScope } from "./runScope"
 import {
   environmentSecretValues,
+  executionResultSecrets,
   isSensitiveHeader,
   REDACTED,
   redactKnownSecrets,
+  type RedactionSecret,
 } from "./secrets/redact"
 
 export interface ExecutionResultGroup<T> {
@@ -25,7 +31,7 @@ export function executionSecretValues(
   environments: (Environment | null | undefined)[],
   proxyPolicy?: ProxyPolicy,
   tlsPolicy?: TlsPolicy,
-): string[] {
+): RedactionSecret[] {
   return [
     ...environments.flatMap((environment) =>
       environmentSecretValues(environment),
@@ -56,7 +62,7 @@ export function evaluateResponseExecution(
   request: Pick<Request, "assertions" | "captures">,
   response: Response,
   runScope: RunScope,
-  secretValues: string[] = [],
+  secretValues: RedactionSecret[] = [],
   onRawCaptures?: (results: CaptureResult[]) => void,
 ): ResponseExecutionResults {
   const resolve = createResponseResolver(response)
@@ -71,6 +77,7 @@ export function evaluateResponseExecution(
   const rawCaptures = hasCaptures
     ? evaluateCaptures(request.captures!, resolve)
     : undefined
+  const sensitiveExpressions: ResponseExpression[] = []
   for (const result of rawCaptures ?? []) {
     if (result.success) {
       const parsed = parseResponseExpression(result.expression)
@@ -78,32 +85,54 @@ export function evaluateResponseExecution(
         request.captures?.[result.variable]?.persist === "secret" ||
         (parsed.kind === "header" && isSensitiveHeader(parsed.name))
       runScope.set(result.variable, result.value, sensitive)
+      if (sensitive) sensitiveExpressions.push(parsed)
     }
   }
+  const isSensitiveExpression = (expression: string) => {
+    const parsed = parseResponseExpression(expression)
+    return sensitiveExpressions.some((sensitive) =>
+      responseExpressionsOverlap(sensitive, parsed),
+    )
+  }
+  const redactResult = (value: string) =>
+    redactKnownSecrets(
+      value,
+      executionResultSecrets([...secretValues, ...runScope.secretValues()]),
+    )
   if (rawCaptures) onRawCaptures?.(rawCaptures)
   const captures = rawCaptures?.map((result): CaptureResult =>
     result.success
       ? {
           ...result,
-          value:
-            request.captures?.[result.variable]?.persist === "secret"
-              ? REDACTED
-              : redactExecutionValue(result.value, redact),
+          value: isSensitiveExpression(result.expression)
+            ? REDACTED
+            : redactExecutionValue(result.value, redactResult),
         }
       : { ...result, message: redact(result.message) },
   )
   const assertions = hasAssertions
     ? evaluateAssertions(request.assertions!, response, resolve).map(
-        (result): AssertionResult => ({
-          ...result,
-          ...(Object.hasOwn(result, "expected")
-            ? { expected: redactExecutionValue(result.expected!, redact) }
-            : {}),
-          ...(Object.hasOwn(result, "actual")
-            ? { actual: redactExecutionValue(result.actual!, redact) }
-            : {}),
-          message: redact(result.message),
-        }),
+        (result) => {
+          const sensitive = isSensitiveExpression(result.expression)
+          return {
+            ...result,
+            ...(Object.hasOwn(result, "expected")
+              ? {
+                  expected: sensitive
+                    ? REDACTED
+                    : redactExecutionValue(result.expected!, redactResult),
+                }
+              : {}),
+            ...(Object.hasOwn(result, "actual")
+              ? {
+                  actual: sensitive
+                    ? REDACTED
+                    : redactExecutionValue(result.actual!, redactResult),
+                }
+              : {}),
+            message: redact(result.message),
+          } as AssertionResult
+        },
       )
     : undefined
 
@@ -134,4 +163,36 @@ export function redactExecutionValue(
       redactExecutionValue(item, redact),
     ]),
   )
+}
+
+function responseExpressionsOverlap(
+  left: ResponseExpression,
+  right: ResponseExpression,
+): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind === "header" && right.kind === "header") {
+    return left.name.toLowerCase() === right.name.toLowerCase()
+  }
+  if (left.kind !== "body" || right.kind !== "body") return true
+  const length = Math.min(left.path.length, right.path.length)
+  for (let index = 0; index < length; index++) {
+    const leftPart = left.path[index]!
+    const rightPart = right.path[index]!
+    if (leftPart.kind !== rightPart.kind) return false
+    if (
+      leftPart.kind === "property" &&
+      rightPart.kind === "property" &&
+      leftPart.name !== rightPart.name
+    ) {
+      return false
+    }
+    if (
+      leftPart.kind === "index" &&
+      rightPart.kind === "index" &&
+      leftPart.index !== rightPart.index
+    ) {
+      return false
+    }
+  }
+  return true
 }

--- a/src/executionResults.ts
+++ b/src/executionResults.ts
@@ -120,16 +120,18 @@ export function redactExecutionValue(
   redact: (value: string) => string,
 ): JsonValue {
   if (typeof value === "string") return redact(value)
+  if (value === null || typeof value !== "object") {
+    const serialized = JSON.stringify(value)
+    const redacted = redact(serialized)
+    return redacted === serialized ? value : redacted
+  }
   if (Array.isArray(value)) {
     return value.map((item) => redactExecutionValue(item, redact))
   }
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [
-        key,
-        redactExecutionValue(item, redact),
-      ]),
-    )
-  }
-  return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      redactExecutionValue(item, redact),
+    ]),
+  )
 }

--- a/src/hooks/useResponse.ts
+++ b/src/hooks/useResponse.ts
@@ -30,6 +30,7 @@ import type { CaptureResult } from "../runScope"
 import {
   requestSensitiveValues,
   responseSensitiveValues,
+  type RedactionSecret,
 } from "../secrets/redact"
 
 type CachedResult =
@@ -72,7 +73,7 @@ export function useResponse(
     req: Request,
     result: SendCompleteResult,
     dispatchEnvironment?: Environment,
-    runSecretValues?: string[],
+    runSecretValues?: RedactionSecret[],
   ) => void,
   collection?: Collection,
   requestPath?: string,
@@ -164,7 +165,7 @@ async function runSend(
         req: Request,
         result: SendCompleteResult,
         dispatchEnvironment?: Environment,
-        runSecretValues?: string[],
+        runSecretValues?: RedactionSecret[],
       ) => void)
     | undefined
   >,

--- a/src/lang/serialize.ts
+++ b/src/lang/serialize.ts
@@ -95,8 +95,9 @@ export function serializeRequest(req: Request): string {
   if (req.captures && Object.keys(req.captures).length > 0) {
     out += "capture:\n"
     for (const [variable, capture] of Object.entries(req.captures)) {
+      const variableName = yamlVal(variable, 2)
       const value = yamlVal(capture.value, 4)
-      out += `  ${variable}:\n`
+      out += `  ${variableName}:\n`
       out += `    value: ${value}\n`
       if (capture.persist) out += `    persist: ${capture.persist}\n`
       if (!capture.enabled) out += "    enabled: false\n"

--- a/src/requests/oauth2.ts
+++ b/src/requests/oauth2.ts
@@ -170,6 +170,7 @@ async function resolveOAuth2Endpoints(
       collectionDir: context.collectionDir,
       oauthMode: "disabled",
       allowCrossOriginRedirects: false,
+      resolveVariables: false,
     },
   )
   if (response.status !== 200) {
@@ -572,6 +573,7 @@ async function requestToken(
     collectionDir: context.collectionDir,
     oauthMode: "disabled",
     allowCrossOriginRedirects: false,
+    resolveVariables: false,
   })
   if (response.status < 200 || response.status >= 300) {
     let detail = ""

--- a/src/requests/send.ts
+++ b/src/requests/send.ts
@@ -69,6 +69,7 @@ export interface RequestExecutionOptions {
   oauthMode?: OAuth2Mode
   openOAuthBrowser?: OAuthBrowserLauncher
   allowCrossOriginRedirects?: boolean
+  resolveVariables?: boolean
 }
 
 export function interpolatePathParams(
@@ -133,13 +134,18 @@ export async function send(
     oauthMode = "cached-only",
     openOAuthBrowser,
     allowCrossOriginRedirects = true,
+    resolveVariables = true,
   } = options
   const merged =
     collection && requestPath
       ? mergeFolderOverrides(req, collection, requestPath)
       : req
 
-  const substituted = substitute(merged, env ?? { name: "", vars: {} })
+  const substituted = substitute(
+    merged,
+    env ?? { name: "", vars: {} },
+    resolveVariables,
+  )
 
   if (cookies && substituted.sendCookies !== false) {
     // Storage failures are reflected by the jar status; HTTP still runs jar-less.

--- a/src/requests/substitute.ts
+++ b/src/requests/substitute.ts
@@ -15,16 +15,22 @@ export type SubstitutedRequest = Omit<Request, "headers" | "params"> & {
   params: ParamEntry[]
 }
 
-export function substitute(req: Request, env: Environment): SubstitutedRequest {
+export function substitute(
+  req: Request,
+  env: Environment,
+  resolveVariables = true,
+): SubstitutedRequest {
   const resolve = (s: string, field: string): string =>
-    replaceVariableReferences(s, (name) => {
-      if (!Object.hasOwn(env.vars, name)) {
-        throw new Error(
-          `requests.substitute: unresolved variable "${name}" in ${field}`,
-        )
-      }
-      return env.vars[name]!
-    })
+    resolveVariables
+      ? replaceVariableReferences(s, (name) => {
+          if (!Object.hasOwn(env.vars, name)) {
+            throw new Error(
+              `requests.substitute: unresolved variable "${name}" in ${field}`,
+            )
+          }
+          return env.vars[name]!
+        })
+      : s
 
   const headers: Record<string, string> = {}
   for (const [k, v] of Object.entries(req.headers)) {

--- a/src/runScope.ts
+++ b/src/runScope.ts
@@ -70,12 +70,8 @@ function secretValueStrings(value: JsonValue): string[] {
   if (value === null || typeof value !== "object") return [serialized]
   return [
     serialized,
-    ...(Array.isArray(value) ? value : Object.values(value)).flatMap((item) =>
-      typeof item === "string"
-        ? [item]
-        : item !== null && typeof item === "object"
-          ? secretValueStrings(item)
-          : [],
+    ...(Array.isArray(value) ? value : Object.values(value)).flatMap(
+      secretValueStrings,
     ),
   ]
 }

--- a/src/runScope.ts
+++ b/src/runScope.ts
@@ -1,5 +1,6 @@
 import type { CaptureEntry, Environment, JsonValue } from "./schema"
 import type { ResponseResolver } from "./response"
+import type { RedactionSecret } from "./secrets/redact"
 
 export type CaptureValueType =
   | "null"
@@ -40,15 +41,25 @@ export class RunScope {
     return this.values.get(variable)
   }
 
-  secretValues(): string[] {
+  secretValues(): RedactionSecret[] {
+    const values = [...this.secretVariables].flatMap((variable) => {
+      const value = this.values.get(variable)
+      return value === undefined ? [] : secretRedactionValues(value)
+    })
     return [
-      ...new Set(
-        [...this.secretVariables].flatMap((variable) => {
-          const value = this.values.get(variable)
-          return value === undefined ? [] : secretValueStrings(value)
-        }),
-      ),
-    ].sort((a, b) => b.length - a.length)
+      ...new Map(
+        values.map((value) => [
+          typeof value === "string"
+            ? `text:${value}`
+            : `${value.kind}:${value.value}`,
+          value,
+        ]),
+      ).values(),
+    ].sort((a, b) => {
+      const aValue = typeof a === "string" ? a : a.value
+      const bValue = typeof b === "string" ? b : b.value
+      return bValue.length - aValue.length
+    })
   }
 
   environment(base?: Environment): Environment {
@@ -65,13 +76,16 @@ export class RunScope {
   }
 }
 
-function secretValueStrings(value: JsonValue): string[] {
+function secretRedactionValues(value: JsonValue): RedactionSecret[] {
   const serialized = typeof value === "string" ? value : JSON.stringify(value)
-  if (value === null || typeof value !== "object") return [serialized]
+  if (typeof value === "string") return [value]
+  if (value === null || typeof value !== "object") {
+    return [{ kind: "json-primitive", value: serialized }]
+  }
   return [
     serialized,
     ...(Array.isArray(value) ? value : Object.values(value)).flatMap(
-      secretValueStrings,
+      secretRedactionValues,
     ),
   ]
 }

--- a/src/secrets/redact.ts
+++ b/src/secrets/redact.ts
@@ -3,6 +3,22 @@ import type { Environment, KvEntry, Request, Response } from "../schema"
 export const REDACTED = "[REDACTED]"
 
 const MIN_COOKIE_SUBSTRING_LENGTH = 4
+const MIN_PRIMITIVE_SECRET_LENGTH = 4
+
+export type RedactionSecret = string | { kind: "json-primitive"; value: string }
+
+export function executionResultSecrets(
+  values: readonly RedactionSecret[],
+): RedactionSecret[] {
+  return values.filter(
+    (secret) =>
+      typeof secret === "string" ||
+      (secret.value.length >= MIN_PRIMITIVE_SECRET_LENGTH &&
+        secret.value !== "true" &&
+        secret.value !== "false" &&
+        secret.value !== "null"),
+  )
+}
 
 export function environmentSecretValues(
   environment: Environment | null | undefined,
@@ -17,12 +33,40 @@ export function environmentSecretValues(
   ].sort((a, b) => b.length - a.length)
 }
 
-export function redactKnownSecrets(input: string, values: string[]): string {
+export function redactKnownSecrets(
+  input: string,
+  values: readonly RedactionSecret[],
+): string {
   let output = input
-  for (const value of [...new Set(values.filter(Boolean))].sort(
-    (a, b) => b.length - a.length,
-  )) {
-    output = output.split(value).join(REDACTED)
+  const secrets = [
+    ...new Map(
+      values.flatMap((secret) => {
+        const value = typeof secret === "string" ? secret : secret.value
+        return value
+          ? [
+              [
+                `${typeof secret === "string" ? "text" : secret.kind}:${value}`,
+                secret,
+              ] as const,
+            ]
+          : []
+      }),
+    ).values(),
+  ].sort((a, b) => {
+    const aValue = typeof a === "string" ? a : a.value
+    const bValue = typeof b === "string" ? b : b.value
+    return bValue.length - aValue.length
+  })
+  for (const secret of secrets) {
+    if (typeof secret === "string") {
+      output = output.split(secret).join(REDACTED)
+      continue
+    }
+    const escaped = secret.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    output = output.replace(
+      new RegExp(`(^|[\\s\\[{:;,=?&])${escaped}(?=$|[\\s\\]},;&#])`, "g"),
+      (_match, prefix: string) => `${prefix}${REDACTED}`,
+    )
   }
   return output
 }
@@ -46,7 +90,7 @@ export function isSensitiveHeader(name: string): boolean {
 
 export function redactResponseHeaders(
   headers: Record<string, string>,
-  secretValues: string[],
+  secretValues: readonly RedactionSecret[],
 ): Record<string, string> {
   return Object.fromEntries(
     Object.entries(headers).map(([name, value]) => [

--- a/src/timelineEntry.ts
+++ b/src/timelineEntry.ts
@@ -56,10 +56,11 @@ export function buildTimelineEntry(
   const resolvePublicVars = (value: string) =>
     environment
       ? replaceVariableReferences(value, (key) =>
-          !Object.hasOwn(environment.secretVars ?? {}, key) &&
-          Object.hasOwn(environment.vars, key)
-            ? environment.vars[key]!
-            : `$${key}`,
+          Object.hasOwn(environment.secretVars ?? {}, key)
+            ? REDACTED
+            : Object.hasOwn(environment.vars, key)
+              ? environment.vars[key]!
+              : `$${key}`,
         )
       : replaceVariableReferences(value, (key) => `$${key}`)
   secretValues.push(

--- a/src/timelineEntry.ts
+++ b/src/timelineEntry.ts
@@ -11,12 +11,14 @@ import { redactExecutionValue } from "./executionResults"
 import { interpolatePathParams } from "./requests/send"
 import {
   environmentSecretValues,
+  executionResultSecrets,
   isSensitiveHeader,
   redactKnownSecrets,
   redactResponseHeaders,
   REDACTED,
   requestSensitiveValues,
   responseSensitiveValues,
+  type RedactionSecret,
 } from "./secrets/redact"
 import {
   replaceVariableReferences,
@@ -45,7 +47,7 @@ export function buildTimelineEntry(
   result: TimelineExecutionResult,
   envName?: string,
   environment?: Environment | null,
-  settingsSecrets: string[] = [],
+  settingsSecrets: RedactionSecret[] = [],
 ): TimelineEntry {
   const secretValues = [
     ...environmentSecretValues(environment),
@@ -69,6 +71,8 @@ export function buildTimelineEntry(
       : []),
   )
   const redact = (value: string) => redactKnownSecrets(value, secretValues)
+  const redactResult = (value: string) =>
+    redactKnownSecrets(value, executionResultSecrets(secretValues))
   const assertions = result.execution?.assertions
     ? {
         evaluated: result.execution.assertions.evaluated,
@@ -76,11 +80,16 @@ export function buildTimelineEntry(
           ...assertion,
           ...(Object.hasOwn(assertion, "expected")
             ? {
-                expected: redactExecutionValue(assertion.expected!, redact),
+                expected: redactExecutionValue(
+                  assertion.expected!,
+                  redactResult,
+                ),
               }
             : {}),
           ...(Object.hasOwn(assertion, "actual")
-            ? { actual: redactExecutionValue(assertion.actual!, redact) }
+            ? {
+                actual: redactExecutionValue(assertion.actual!, redactResult),
+              }
             : {}),
           message: redact(assertion.message),
         })),

--- a/src/ui/AppInner.tsx
+++ b/src/ui/AppInner.tsx
@@ -58,6 +58,7 @@ import { useEnvironments } from "../hooks/useEnvironments"
 import { useEnvironmentEditor } from "../hooks/useEnvironmentEditor"
 import { useCollectionCookieJar } from "../hooks/useCollectionCookieJar"
 import { useCookieJarView } from "../hooks/useCookieJarView"
+import type { RedactionSecret } from "../secrets/redact"
 import { settingsReturnFocus, type Focus, type UrlBarSubFocus } from "./focus"
 import {
   buildCommandPaletteCommands,
@@ -545,7 +546,7 @@ export function AppInner({
       req: NoodleRequest,
       result: SendCompleteResult,
       dispatchEnvironment?: Environment,
-      runSecretValues: string[] = [],
+      runSecretValues: RedactionSecret[] = [],
     ) => {
       timeline.appendEntry(
         buildTimelineEntry(
@@ -558,7 +559,7 @@ export function AppInner({
             ...Object.values(collectionProxyCredentials),
             ...Object.values(tlsPassphrases),
             ...runSecretValues,
-          ].filter((value): value is string => Boolean(value)),
+          ].filter((value) => typeof value !== "string" || Boolean(value)),
         ),
       )
     },

--- a/src/ui/timeline/formatTimeline.ts
+++ b/src/ui/timeline/formatTimeline.ts
@@ -1,4 +1,5 @@
 import type { TimelineEntry, Method } from "../../schema"
+import { REDACTED } from "../../secrets/redact"
 
 export function relativeTime(ts: number): string {
   const diff = Date.now() - ts
@@ -73,10 +74,20 @@ export function formatRequestUrl(entry: TimelineEntry): string {
   const enabled = params.filter((p) => p.enabled)
   if (enabled.length === 0) return u
   const qs = enabled
-    .map((p) => `${encodeURIComponent(p.name)}=${encodeURIComponent(p.value)}`)
+    .map(
+      (p) =>
+        `${encodeTimelineQueryPart(p.name)}=${encodeTimelineQueryPart(p.value)}`,
+    )
     .join("&")
   if (u.includes("?")) return `${u}&${qs}`
   return `${u}?${qs}`
+}
+
+function encodeTimelineQueryPart(value: string): string {
+  return encodeURIComponent(value).replaceAll(
+    encodeURIComponent(REDACTED),
+    REDACTED,
+  )
 }
 
 export function maskedAuthHeader(

--- a/tests/lang.test.ts
+++ b/tests/lang.test.ts
@@ -1229,6 +1229,19 @@ describe("lang.parseRequest: response captures", () => {
     )
   })
 
+  it("round-trips numeric-looking capture names", () => {
+    const request = lang.parseRequest(
+      "captures",
+      `${prefix}capture:\n  "001": { value: status }\n`,
+    )
+
+    const reparsed = lang.parseRequest(
+      "captures",
+      lang.serializeRequest(request),
+    )
+    expect(Object.keys(reparsed.captures!)).toEqual(["001"])
+  })
+
   it("persists disabled captures canonically and normalizes enabled objects", () => {
     const request = lang.parseRequest(
       "captures",

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -827,6 +827,7 @@ describe("OAuth 2 execution", () => {
           const body = new URLSearchParams(await request.text())
           expect(body.get("grant_type")).toBe("client_credentials")
           expect(body.get("client_id")).toBe("client")
+          expect(body.get("client_secret")).toBe("pa$word")
           return Response.json({
             access_token: "vault-token",
             expires_in: 3600,
@@ -841,8 +842,12 @@ describe("OAuth 2 execution", () => {
       grant_type: "client_credentials" as const,
       access_token_url: `http://127.0.0.1:${server.port}/token`,
       client_id: "client",
-      client_secret: "secret",
+      client_secret: "$CLIENT_SECRET",
       credentials_id: "client-credentials-test",
+    }
+    const environment = {
+      name: "dev",
+      vars: { CLIENT_SECRET: "pa$word" },
     }
     authToClear.push({ auth, dir })
     const request = resourceRequest(
@@ -850,11 +855,20 @@ describe("OAuth 2 execution", () => {
       auth,
     )
     const [first, second] = await Promise.all([
-      send(request, { collectionDir: dir, oauthMode: "cached-only" }),
-      send(request, { collectionDir: dir, oauthMode: "cached-only" }),
+      send(request, {
+        collectionDir: dir,
+        environment,
+        oauthMode: "cached-only",
+      }),
+      send(request, {
+        collectionDir: dir,
+        environment,
+        oauthMode: "cached-only",
+      }),
     ])
     const third = await send(request, {
       collectionDir: dir,
+      environment,
       oauthMode: "cached-only",
     })
     expect(first.body).toBe("Bearer vault-token")

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -825,6 +825,60 @@ describe("buildTimelineEntry", () => {
     expect(JSON.stringify(entry)).not.toContain("timeline-assertion-secret")
   })
 
+  it("preserves common primitives and redacts distinctive primitive secrets", () => {
+    const entry = buildTimelineEntry(
+      {
+        id: "public-primitive",
+        name: "Public primitive",
+        method: "GET",
+        url: "https://api.example.com",
+        headers: {},
+        params: [],
+        timeout: 0,
+      },
+      {
+        status: "done",
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: '{"count":1}',
+          timeMs: 1,
+        },
+        execution: {
+          assertions: {
+            evaluated: true,
+            results: [
+              {
+                expression: "body.count",
+                operator: "isNumber",
+                actual: 1,
+                passed: true,
+                message: "Assertion passed",
+              },
+              {
+                expression: "body.otp",
+                operator: "isNumber",
+                actual: 123456,
+                passed: true,
+                message: "Assertion passed",
+              },
+            ],
+          },
+        },
+      },
+      undefined,
+      undefined,
+      [
+        { kind: "json-primitive", value: "1" },
+        { kind: "json-primitive", value: "123456" },
+      ],
+    )
+
+    expect(entry.assertions?.results[0]?.actual).toBe(1)
+    expect(entry.assertions?.results[1]?.actual).toBe("[REDACTED]")
+  })
+
   it("supports assertion not-evaluated state and old entries", () => {
     const oldEntry: TimelineEntry = {
       timestamp: 1,

--- a/tests/timeline-format.test.ts
+++ b/tests/timeline-format.test.ts
@@ -337,6 +337,24 @@ describe("formatRequestUrl", () => {
     ).toBe("https://example.com?q=hello%20world&tag=a%26b")
   })
 
+  it("preserves redaction markers in encoded params", () => {
+    expect(
+      formatRequestUrl({
+        ...makeEntry(),
+        request: {
+          ...makeEntry().request,
+          params: [
+            {
+              name: "secret [REDACTED]",
+              value: "prefix [REDACTED]",
+              enabled: true,
+            },
+          ],
+        },
+      }),
+    ).toBe("https://example.com?secret%20[REDACTED]=prefix%20[REDACTED]")
+  })
+
   it("uses ampersand when URL already has a query", () => {
     expect(
       formatRequestUrl({
@@ -938,7 +956,7 @@ describe("buildTimelineEntry", () => {
       vars: { TOKEN: secret },
       secretVars: { TOKEN: "keychain" },
     })
-    expect(entry.request.url).toBe("https://api.example.com/$TOKEN")
+    expect(entry.request.url).toBe("https://api.example.com/[REDACTED]")
     expect(entry.request.headers.Authorization!.value).toBe("[REDACTED]")
     expect(entry.response?.statusText).toBe("[REDACTED]")
     expect(entry.response?.headers["set-cookie"]).toBe("[REDACTED]")
@@ -1134,7 +1152,7 @@ describe("buildTimelineEntry", () => {
     expect(entry.network).toEqual(error.network)
   })
 
-  it("resolves public variables and path params while preserving secret placeholders", () => {
+  it("resolves public variables and redacts secret placeholders", () => {
     const req = {
       id: "req-3",
       name: "Env",
@@ -1150,7 +1168,7 @@ describe("buildTimelineEntry", () => {
         { name: "disabled", value: "$comment_id", enabled: false },
       ],
       pathParams: [{ name: "commentId", value: "$comment_id", enabled: true }],
-      body: '{"id":"$comment_id","token":"$TOKEN"}',
+      body: '{"id":"$comment_id","token":"$TOKEN","missing":"$MISSING"}',
       auth: { type: "basic" as const, user: "$comment_id", pass: "$TOKEN" },
       timeout: 0,
     }
@@ -1176,7 +1194,9 @@ describe("buildTimelineEntry", () => {
       },
       secretVars: { TOKEN: "keychain" },
     })
-    expect(entry.request.url).toBe("https://api.example.com/comments/42/$TOKEN")
+    expect(entry.request.url).toBe(
+      "https://api.example.com/comments/42/[REDACTED]",
+    )
     expect(entry.request.headers).toEqual({
       "X-Comment": { value: "42", enabled: true },
       "X-Disabled": { value: "$comment_id", enabled: false },
@@ -1189,7 +1209,9 @@ describe("buildTimelineEntry", () => {
     expect(entry.request.pathParams).toEqual([
       { name: "commentId", value: "42", enabled: true },
     ])
-    expect(entry.request.body).toBe('{"id":"42","token":"$TOKEN"}')
+    expect(entry.request.body).toBe(
+      '{"id":"42","token":"[REDACTED]","missing":"$MISSING"}',
+    )
     expect(entry.request.auth).toEqual({
       type: "basic",
       user: "42",

--- a/tests/unit/codegen.test.ts
+++ b/tests/unit/codegen.test.ts
@@ -69,6 +69,31 @@ describe("buildHar", () => {
     })
   })
 
+  it("decodes literal-dollar escapes across generated request values", () => {
+    const { har, unhash } = buildHar(
+      makeRequest({
+        url: "https://api.example.com/$$NAME",
+        headers: { "X-Name": { value: "$$NAME", enabled: true } },
+        body: "$$NAME",
+        auth: { type: "none" },
+      }),
+    )
+
+    expect(unhash(har.url)).toBe("https://api.example.com/$NAME")
+    expect(har.headers).toContainEqual({ name: "X-Name", value: "$NAME" })
+    expect(har.postData?.text).toBe("$NAME")
+  })
+
+  it("decodes interpolated URL escapes only once", () => {
+    const { har, unhash } = buildHar(
+      makeRequest({ url: "https://api.example.com/$$$$NAME" }),
+      { name: "dev", vars: {} },
+      true,
+    )
+
+    expect(unhash(har.url)).toBe("https://api.example.com/$$NAME")
+  })
+
   it("includes query params in queryString", () => {
     const { har } = buildHar(makeRequest())
     expect(har.queryString).toContainEqual({ name: "page", value: "1" })

--- a/tests/unit/executionResults.test.ts
+++ b/tests/unit/executionResults.test.ts
@@ -71,6 +71,29 @@ describe("response execution results", () => {
     })
   })
 
+  it("redacts numeric leaves from structured secret captures", () => {
+    const scope = new RunScope()
+    const results = evaluateResponseExecution(
+      {
+        captures: {
+          credentials: {
+            value: "body.credentials",
+            enabled: true,
+            persist: "secret",
+          },
+        },
+        assertions: [
+          { expression: "body.credentials.otp", operator: "isNumber" },
+        ],
+      },
+      { ...response, body: '{"credentials":{"otp":123456}}' },
+      scope,
+    )
+
+    expect(scope.get("credentials")).toEqual({ otp: 123456 })
+    expect(results.assertions?.results[0]?.actual).toBe("[REDACTED]")
+  })
+
   it("treats captures from sensitive response headers as secret", () => {
     const scope = new RunScope()
     const results = evaluateResponseExecution(

--- a/tests/unit/executionResults.test.ts
+++ b/tests/unit/executionResults.test.ts
@@ -71,7 +71,7 @@ describe("response execution results", () => {
     })
   })
 
-  it("redacts numeric leaves from structured secret captures", () => {
+  it("redacts structured secret paths without masking public primitives", () => {
     const scope = new RunScope()
     const results = evaluateResponseExecution(
       {
@@ -83,15 +83,83 @@ describe("response execution results", () => {
           },
         },
         assertions: [
-          { expression: "body.credentials.otp", operator: "isNumber" },
+          { expression: "body.credentials.attempts", operator: "isNumber" },
+          { expression: "body.credentials.enabled", operator: "isBoolean" },
+          { expression: "body.credentials.empty", operator: "isNull" },
+          { expression: "body.requestId", operator: "isString" },
+          { expression: "body.attempts", operator: "isNumber" },
+          { expression: "body.enabled", operator: "isBoolean" },
+          { expression: "body.empty", operator: "isNull" },
+          { expression: "body.version", operator: "isString" },
+          { expression: "body.active", operator: "isString" },
+          { expression: "body.nothing", operator: "isString" },
         ],
       },
-      { ...response, body: '{"credentials":{"otp":123456}}' },
+      {
+        ...response,
+        body: JSON.stringify({
+          credentials: { attempts: 1, enabled: true, empty: null },
+          requestId: "request-1",
+          attempts: 1,
+          enabled: true,
+          empty: null,
+          version: "1",
+          active: "true",
+          nothing: "null",
+        }),
+      },
       scope,
     )
 
-    expect(scope.get("credentials")).toEqual({ otp: 123456 })
-    expect(results.assertions?.results[0]?.actual).toBe("[REDACTED]")
+    expect(scope.get("credentials")).toEqual({
+      attempts: 1,
+      enabled: true,
+      empty: null,
+    })
+    expect(results.assertions?.results.map((result) => result.actual)).toEqual([
+      "[REDACTED]",
+      "[REDACTED]",
+      "[REDACTED]",
+      "request-1",
+      1,
+      true,
+      null,
+      "1",
+      "true",
+      "null",
+    ])
+  })
+
+  it("redacts distinctive primitive secrets across responses", () => {
+    const scope = new RunScope()
+    evaluateResponseExecution(
+      {
+        captures: {
+          otp: { value: "body.otp", persist: "secret", enabled: true },
+        },
+      },
+      { ...response, body: '{"otp":123456}' },
+      scope,
+    )
+
+    const results = evaluateResponseExecution(
+      {
+        assertions: [
+          { expression: "body.otp", operator: "isNumber" },
+          { expression: "body.requestId", operator: "isString" },
+        ],
+      },
+      {
+        ...response,
+        body: '{"otp":123456,"requestId":"request-123456"}',
+      },
+      scope,
+    )
+
+    expect(results.assertions?.results.map((result) => result.actual)).toEqual([
+      "[REDACTED]",
+      "request-123456",
+    ])
   })
 
   it("treats captures from sensitive response headers as secret", () => {

--- a/tests/unit/redact.test.ts
+++ b/tests/unit/redact.test.ts
@@ -5,6 +5,21 @@ import {
 } from "../../src/secrets/redact"
 
 describe("response redaction", () => {
+  it("redacts primitive query values without replacing IDs or URL paths", () => {
+    expect(
+      redactKnownSecrets(
+        'request-1 https://example.com/true/null?count=1 {"n":1,"b":true,"v":null}',
+        [
+          { kind: "json-primitive", value: "1" },
+          { kind: "json-primitive", value: "true" },
+          { kind: "json-primitive", value: "null" },
+        ],
+      ),
+    ).toBe(
+      'request-1 https://example.com/true/null?count=[REDACTED] {"n":[REDACTED],"b":[REDACTED],"v":[REDACTED]}',
+    )
+  })
+
   it("does not use short cookie values as global substring secrets", () => {
     const secrets = responseSensitiveValues({
       headers: { "set-cookie": "session=1" },

--- a/tests/unit/runScope.test.ts
+++ b/tests/unit/runScope.test.ts
@@ -186,9 +186,9 @@ describe("RunScope", () => {
       '[null,"inner"]',
       "secret",
       "inner",
-      "true",
-      "null",
-      "1",
+      { kind: "json-primitive", value: "true" },
+      { kind: "json-primitive", value: "null" },
+      { kind: "json-primitive", value: "1" },
     ])
 
     scope.set("token", "public")

--- a/tests/unit/runScope.test.ts
+++ b/tests/unit/runScope.test.ts
@@ -186,6 +186,9 @@ describe("RunScope", () => {
       '[null,"inner"]',
       "secret",
       "inner",
+      "true",
+      "null",
+      "1",
     ])
 
     scope.set("token", "public")

--- a/tests/unit/useResponseExecution.test.tsx
+++ b/tests/unit/useResponseExecution.test.tsx
@@ -104,7 +104,7 @@ describe("useResponse execution results", () => {
       }
       expect(completedWith).toBe(first)
       expect(timelineEntry?.envName).toBe("a")
-      expect(timelineEntry?.request.url).toBe("https://a.example/$TOKEN")
+      expect(timelineEntry?.request.url).toBe("https://a.example/[REDACTED]")
       expect(timelineEntry?.network?.[0]?.message).toBe(
         "GET https://a.example/[REDACTED]",
       )


### PR DESCRIPTION
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves literal `$$` escapes through request interpolation and HAR/codegen, prevents unwanted variable resolution for OAuth endpoint/token requests, correctly quotes numeric-looking capture names during YAML serialization, and ensures structured/primitive secret values are fully redacted (including numeric, boolean and null leaves via `JSON.stringify`).

### How did you verify your code works?

Ran `bun test` (3177 tests), `bun run lint`, and `bun run typecheck` locally — all passing. Verified new and updated tests cover: literal-dollar decoding in HAR, numeric capture name round-trip, OAuth secret with `$`, and secret redaction for structured numeric values.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added control over variable resolution during request execution.
  * Improved handling of literal dollar signs and escaped variable references.
  * OAuth 2 token requests now use environment-provided credentials without variable resolution.

* **Bug Fixes**
  * Improved redaction of primitive and nested secret values while preserving unrelated text.
  * Sensitive response fields overlapping captured secrets are now redacted.
  * YAML serialization preserves capture names such as `"001"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->