### PR TITLE
refactor: remove timeline redaction on secret changes

### DIFF
--- a/collections/.environments/development.env
+++ b/collections/.environments/development.env
@@ -1,6 +1,5 @@
 _color=success
-# @secret base_url
-base_url=
+base_url=https://jsonplaceholder.typicode.com
 # @secret api_token
 api_token=
 # @secret x_api_key

--- a/src/app/services.ts
+++ b/src/app/services.ts
@@ -19,7 +19,6 @@ import {
   saveRequest,
   saveSettings,
   ensureCollectionBootstrapped,
-  redactTimelineSecrets,
 } from "../filestore"
 import { formatJson } from "../lang/formatJson"
 import { lang } from "../lang"
@@ -1358,12 +1357,6 @@ export async function secretSet(
   const current = await env.loadEnvironment(directory, name, {
     resolveSecrets: false,
   })
-  const oldPlaintext = Object.hasOwn(current.vars, key)
-    ? current.vars[key]
-    : Object.hasOwn(current.disabledVars ?? {}, key)
-      ? current.disabledVars?.[key]
-      : undefined
-  if (oldPlaintext) await redactTimelineSecrets(collectionRoot, [oldPlaintext])
 
   const previous = await getStoredSecret(collectionRoot, name, key)
   await setStoredSecret(collectionRoot, name, key, value)

--- a/src/filestore/index.ts
+++ b/src/filestore/index.ts
@@ -25,7 +25,6 @@ import {
   DEFAULT_TIMELINE_MAX_ENTRIES,
   clearTimelineForRequest,
   clearAllTimeline,
-  redactTimelineSecrets,
 } from "./timeline"
 
 export {
@@ -48,7 +47,6 @@ export {
   DEFAULT_TIMELINE_MAX_ENTRIES,
   clearTimelineForRequest,
   clearAllTimeline,
-  redactTimelineSecrets,
 }
 export type { CollectionSettings }
 

--- a/src/filestore/timeline.ts
+++ b/src/filestore/timeline.ts
@@ -6,7 +6,6 @@ import {
   mkdir,
   readFile,
   readdir,
-  rename,
   rm,
   unlink,
   writeFile,
@@ -19,12 +18,6 @@ import type {
   TimelineBodyRef,
   TimelineEntry,
 } from "../schema"
-import {
-  isSensitiveHeader,
-  redactKnownSecrets,
-  REDACTED,
-  sensitiveHeaderValues,
-} from "../secrets/redact"
 
 export const DEFAULT_TIMELINE_MAX_ENTRIES = 50
 const INLINE_BODY_LIMIT = 10_000
@@ -455,149 +448,4 @@ export async function clearAllTimeline(colDir: string): Promise<void> {
   } catch {
     // ignore
   }
-}
-
-function redactValue(value: unknown, secrets: string[]): unknown {
-  if (typeof value === "string") return redactKnownSecrets(value, secrets)
-  if (Array.isArray(value))
-    return value.map((item) => redactValue(item, secrets))
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [
-        redactKnownSecrets(key, secrets),
-        redactValue(item, secrets),
-      ]),
-    )
-  }
-  return value
-}
-
-function redactTimelineEntry(value: unknown, secrets: string[]): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return value
-  const entry = value as Record<string, unknown>
-  let response = redactValue(entry.response, secrets)
-  if (response && typeof response === "object" && !Array.isArray(response)) {
-    const headers = (response as Record<string, unknown>).headers
-    if (headers && typeof headers === "object" && !Array.isArray(headers)) {
-      response = {
-        ...response,
-        headers: Object.fromEntries(
-          Object.entries(headers).map(([name, headerValue]) => [
-            name,
-            isSensitiveHeader(name) ? REDACTED : headerValue,
-          ]),
-        ),
-      }
-    }
-  }
-  return {
-    ...entry,
-    request: redactValue(entry.request, secrets),
-    response,
-    assertions: redactValue(entry.assertions, secrets),
-    network: redactValue(entry.network, secrets),
-    error: redactValue(entry.error, secrets),
-  }
-}
-
-function timelineResponseSensitiveValues(value: unknown): string[] {
-  if (!Array.isArray(value)) return []
-  return value.flatMap((item) => {
-    if (!item || typeof item !== "object" || Array.isArray(item)) return []
-    const response = (item as Record<string, unknown>).response
-    if (!response || typeof response !== "object" || Array.isArray(response)) {
-      return []
-    }
-    const headers = (response as Record<string, unknown>).headers
-    if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
-      return []
-    }
-    return sensitiveHeaderValues(
-      Object.fromEntries(
-        Object.entries(headers).filter(
-          (entry): entry is [string, string] => typeof entry[1] === "string",
-        ),
-      ),
-    )
-  })
-}
-
-async function atomicWrite(
-  path: string,
-  data: string | Uint8Array,
-): Promise<void> {
-  const temporary = `${path}.${randomUUID()}.tmp`
-  await writeFile(temporary, data)
-  try {
-    await rename(temporary, path)
-  } catch (error) {
-    await unlink(temporary).catch(() => {})
-    throw error
-  }
-}
-
-async function collectAllTimelineFiles(dir: string): Promise<string[]> {
-  let entries
-  try {
-    entries = await readdir(dir, { withFileTypes: true })
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
-    throw error
-  }
-  const files = await Promise.all(
-    entries.map(async (entry) => {
-      const path = join(dir, entry.name)
-      return entry.isDirectory() ? collectAllTimelineFiles(path) : [path]
-    }),
-  )
-  return files.flat()
-}
-
-export async function redactTimelineSecrets(
-  colDir: string,
-  values: string[],
-): Promise<void> {
-  const secrets = [...new Set(values.filter(Boolean))].sort(
-    (a, b) => b.length - a.length,
-  )
-  if (secrets.length === 0) return
-  return withTimelineLock(colDir, async () => {
-    try {
-      const paths = await collectAllTimelineFiles(timelineDir(colDir))
-      const responseSecrets: string[] = []
-      for (const path of paths) {
-        if (!path.endsWith(".yml")) continue
-        responseSecrets.push(
-          ...timelineResponseSensitiveValues(
-            yaml.load(await readFile(path, "utf8")),
-          ),
-        )
-      }
-      const allSecrets = [...new Set([...secrets, ...responseSecrets])].sort(
-        (a, b) => b.length - a.length,
-      )
-      for (const path of paths) {
-        if (path.endsWith(".yml")) {
-          const raw = await readFile(path, "utf8")
-          const parsed = yaml.load(raw)
-          const redacted = yaml.dump(
-            Array.isArray(parsed)
-              ? parsed.map((entry) => redactTimelineEntry(entry, allSecrets))
-              : parsed,
-          )
-          if (redacted !== raw) await atomicWrite(path, redacted)
-        } else if (path.endsWith(".gz")) {
-          const raw = await gunzipAsync(await readFile(path))
-          const redacted = redactKnownSecrets(raw.toString("utf8"), allSecrets)
-          if (redacted !== raw.toString("utf8")) {
-            await atomicWrite(path, await gzipAsync(Buffer.from(redacted)))
-          }
-        }
-      }
-    } catch (error) {
-      throw new Error("filestore.redactTimelineSecrets: redaction failed", {
-        cause: error,
-      })
-    }
-  })
 }

--- a/src/hooks/useEnvironmentEditor.ts
+++ b/src/hooks/useEnvironmentEditor.ts
@@ -7,7 +7,6 @@ import {
   getStoredSecret,
   setStoredSecret,
 } from "../secrets"
-import { redactTimelineSecrets } from "../filestore"
 import { isValidVariableName } from "../variableReference"
 
 let nextVarId = 1
@@ -750,14 +749,6 @@ export function useEnvironmentEditor({
       const originalById = new Map(
         (curOriginal?.varRows ?? []).map((row) => [row.id, row]),
       )
-      const plaintextToRedact: string[] = []
-      for (const row of curDraft.varRows) {
-        const before = originalById.get(row.id)
-        if (row.secret && !before?.secret && before?.value) {
-          plaintextToRedact.push(before.value)
-        }
-      }
-      await redactTimelineSecrets(collectionDir, plaintextToRedact)
 
       const written: {
         environment: string

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { env } from "../src/env"
-import { loadSettings, saveSettings } from "../src/filestore"
+import {
+  loadSettings,
+  loadTimeline,
+  saveSettings,
+  saveTimelineEntry,
+} from "../src/filestore"
 import { saveRequest } from "../src/filestore"
 import {
   environmentSet,
@@ -374,12 +379,26 @@ describe("secret automation services", () => {
       headers: {},
       params: [],
     })
+    await saveTimelineEntry(root, "example", {
+      timestamp: 1,
+      request: {
+        id: "example",
+        name: "Example",
+        method: "GET",
+        url: "https://example.com/old-plaintext",
+        headers: {},
+        params: [],
+      },
+    })
     setSecretBackendForTests(memoryBackend())
 
     await secretSet("TOKEN", "new-secret", "dev", root)
     const raw = await readFile(join(directory, "dev.env"), "utf8")
     expect(raw).toContain("# @secret TOKEN\nTOKEN=")
     expect(raw).not.toContain("old-plaintext")
+    expect((await loadTimeline(root, "example"))[0]?.request.url).toBe(
+      "https://example.com/old-plaintext",
+    )
     expect(await secretList("dev", root)).toEqual({
       environment: "dev",
       secrets: [{ key: "TOKEN", enabled: true, status: "keychain" }],

--- a/tests/timeline-filestore.test.ts
+++ b/tests/timeline-filestore.test.ts
@@ -9,7 +9,6 @@ import {
   pruneTimeline,
   clearTimelineForRequest,
   clearAllTimeline,
-  redactTimelineSecrets,
 } from "../src/filestore/timeline"
 import type { TimelineEntry } from "../src/schema"
 
@@ -17,66 +16,6 @@ let dir: string
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "noodle-tl-"))
-})
-
-describe("redactTimelineSecrets", () => {
-  it("redacts response fields and compressed sidecars", async () => {
-    const secret = "super-secret-value"
-    const cookie = "unrelated-cookie"
-    await saveTimelineEntry(
-      dir,
-      "redact",
-      makeEntry({
-        request: {
-          ...makeEntry().request,
-          url: `https://example.com?token=${secret}`,
-        },
-        assertions: {
-          evaluated: true,
-          results: [
-            {
-              expression: "body.token",
-              operator: "equals",
-              expected: secret,
-              actual: secret,
-              passed: false,
-              message: `Expected ${secret}`,
-            },
-          ],
-        },
-        response: {
-          status: 200,
-          statusText: "OK",
-          headers: {
-            "content-type": "text/plain",
-            "set-cookie": `session="${cookie}"`,
-            "x-result": secret,
-          },
-          body: `${"x".repeat(10_100)}${secret}:${cookie}`,
-          timeMs: 1,
-          size: 10_101 + secret.length + cookie.length,
-        },
-      }),
-    )
-
-    await redactTimelineSecrets(dir, [secret])
-    const [entry] = await loadTimeline(dir, "redact")
-    expect(entry!.request.url).toContain("[REDACTED]")
-    expect(entry!.assertions?.results[0]?.expected).toBe("[REDACTED]")
-    expect(entry!.assertions?.results[0]?.actual).toBe("[REDACTED]")
-    expect(entry!.assertions?.results[0]?.message).toBe("Expected [REDACTED]")
-    expect(entry!.response!.headers["content-type"]).toBe("text/plain")
-    expect(entry!.response!.headers["set-cookie"]).toBe("[REDACTED]")
-    expect(entry!.response!.headers["x-result"]).toBe("[REDACTED]")
-    const body = await loadTimelineBody(
-      dir,
-      "redact",
-      entry!.response!.bodyRef!,
-    )
-    expect(body).not.toContain(secret)
-    expect(body).not.toContain(cookie)
-    expect(body).toContain("[REDACTED]")
-  })
 })
 
 afterEach(async () => {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path"
 import { ThemeProvider } from "../src/ui/theme"
 import { useEnvironmentEditor } from "../src/hooks/useEnvironmentEditor"
 import { env } from "../src/env"
+import { loadTimeline, saveTimelineEntry } from "../src/filestore/timeline"
 import {
   getStoredSecret,
   setSecretBackendForTests,
@@ -54,6 +55,7 @@ function memoryBackend(): SecretBackend & {
 const testRender = createTestRender()
 
 let dir: string
+let root: string
 
 async function waitForDraft(
   editorRef: { current: ReturnType<typeof useEnvironmentEditor> | null },
@@ -129,7 +131,8 @@ function ExternalNamesHarness({
 
 describe("useEnvironmentEditor onEnvsChanged callback", () => {
   beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), "noodle-onEnvsChanged-"))
+    root = await mkdtemp(join(tmpdir(), "noodle-onEnvsChanged-"))
+    dir = join(root, ".environments")
     await env.saveEnvironment(dir, { name: "alpha", vars: { key: "val" } })
     await env.saveEnvironment(dir, { name: "beta", vars: { key: "val" } })
     await env.saveEnvironment(dir, { name: "gamma", vars: { key: "val" } })
@@ -138,7 +141,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
   afterEach(async () => {
     delete process.env.NOODLE_PROCESS_SECRET
     setSecretBackendForTests(undefined)
-    await rm(dir, { recursive: true, force: true })
+    await rm(root, { recursive: true, force: true })
   })
 
   it("picks up environment names added outside the editor", async () => {
@@ -1116,6 +1119,41 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     act(() => ref.current!.activateVar(0, false, "value"))
     await renderOnce()
     expect(ref.current!.editValue).toBe("val")
+  })
+
+  it("does not rewrite timeline history when marking a variable secret", async () => {
+    setSecretBackendForTests(memoryBackend())
+    await saveTimelineEntry(root, "history", {
+      timestamp: 1,
+      request: {
+        id: "history",
+        name: "History",
+        method: "GET",
+        url: "https://example.com/val",
+        headers: {},
+        params: [],
+      },
+    })
+    const ref: { current: ReturnType<typeof useEnvironmentEditor> | null } = {
+      current: null,
+    }
+    const { renderOnce } = await testRender(
+      <ThemeProvider activeIndex={0} previewIndex={null}>
+        <Harness onEnvsChanged={() => {}} editorRef={ref} />
+      </ThemeProvider>,
+      { width: 40, height: 12 },
+    )
+    await waitForDraft(ref, renderOnce)
+
+    act(() => ref.current!.toggleSecret(0))
+    await renderOnce()
+    await act(async () => ref.current!.save())
+    await renderOnce()
+
+    expect(ref.current!.error).toBeNull()
+    expect((await loadTimeline(root, "history"))[0]?.request.url).toBe(
+      "https://example.com/val",
+    )
   })
 
   it("moves a keychain secret to plaintext with one toggle", async () => {

--- a/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
+++ b/tests/useEnvironmentEditor-onEnvsChanged.test.tsx
@@ -1151,6 +1151,7 @@ describe("useEnvironmentEditor onEnvsChanged callback", () => {
     await renderOnce()
 
     expect(ref.current!.error).toBeNull()
+    expect(await getStoredSecret(root, "alpha", "key")).toBe("val")
     expect((await loadTimeline(root, "history"))[0]?.request.url).toBe(
       "https://example.com/val",
     )


### PR DESCRIPTION
Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes timeline redaction on secret changes. Deletes `redactTimelineSecrets` from `src/filestore/timeline.ts:449` (and exports), and removes its calls from `src/app/services.ts:1360` (`secretSet`) and `src/hooks/useEnvironmentEditor.ts:753` (`useEnvironmentEditor.save`). Timeline history is no longer retroactively rewritten when a variable is marked as secret or a secret value is updated; existing entries keep their original content.

### How did you verify your code works?

Tested locally — `bun test` (3181 pass), `bun run lint`, `bun run typecheck` all pass. Updated `tests/secrets.test.ts:382` and `tests/useEnvironmentEditor-onEnvsChanged.test.tsx:1124` to assert timeline entries are preserved after secret changes; removed the now-obsolete `redactTimelineSecrets` test in `tests/timeline-filestore.test.ts`.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] `bun test` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] I have not included unrelated changes in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Timeline history is no longer rewritten or scrubbed when variables are marked as secrets or updated.
  - Previously recorded plaintext values may remain visible in existing timeline entries.

- **Configuration**
  - The development environment now uses the JSONPlaceholder API as its default base URL.

- **Tests**
  - Added coverage confirming that timeline history remains unchanged when secrets are set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->